### PR TITLE
Update model evidence source prefix from SGD to SGD_PWY

### DIFF
--- a/models/YeastPathways_ACETATEUTIL2-PWY.ttl
+++ b/models/YeastPathways_ACETATEUTIL2-PWY.ttl
@@ -1,26 +1,37 @@
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30616_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_ACETATEUTIL2-PWY>
+<http://purl.obolibrary.org/obo/CHEBI_30089>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_456215_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ACETATEUTIL2-PWY" ;
+                "SGD_PWY:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_30089>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_BFO_0000050_YeastPathways_ACETATEUTIL2-PWY/YeastPathways_ACETATEUTIL2-PWY_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ACETATEUTIL2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_57287_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_ACETATEUTIL2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_57287_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -41,24 +52,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ACETATEUTIL2-PWYProtein22539> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002333_YLR153C-MONOMER_ACETATE--COA-LIGASE-RXN_controller_SGD_YeastPathways_ACETATEUTIL2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ACETATEUTIL2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -105,22 +105,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_29888_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ACETATEUTIL2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002333_YAL054C-MONOMER_ACETATE--COA-LIGASE-RXN_controller_SGD_YeastPathways_ACETATEUTIL2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ACETATEUTIL2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_ACETATEUTIL2-PWY/YeastPathways_ACETATEUTIL2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0019427> ;
@@ -131,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -139,15 +139,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002333_YLR153C-MONOMER_ACETATE--COA-LIGASE-RXN_controller_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ACETATEUTIL2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30616_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_ACETATEUTIL2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30616_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -167,25 +178,14 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_29888_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_ACETATEUTIL2-PWY>
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30089_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ACETATEUTIL2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_BFO_0000066_reaction_ACETATE--COA-LIGASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ACETATEUTIL2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ACETATEUTIL2-PWY" ;
+                "SGD_PWY:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -222,11 +222,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002333_YAL054C-MONOMER_ACETATE--COA-LIGASE-RXN_controller_SGD_YeastPathways_ACETATEUTIL2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002333_YAL054C-MONOMER_ACETATE--COA-LIGASE-RXN_controller_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -244,11 +244,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30089_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_ACETATEUTIL2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30089_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -265,17 +265,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_BFO_0000050_YeastPathways_ACETATEUTIL2-PWY/YeastPathways_ACETATEUTIL2-PWY_SGD_YeastPathways_ACETATEUTIL2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ACETATEUTIL2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57288>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -286,11 +275,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_57288_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_ACETATEUTIL2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_57288_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,15 +290,26 @@
           <http://model.geneontology.org/CHEBI_57288_ACETATE--COA-LIGASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_57287_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ACETATEUTIL2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_BFO_0000066_reaction_ACETATE--COA-LIGASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ACETATEUTIL2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_BFO_0000066_reaction_ACETATE--COA-LIGASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -319,17 +319,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_ACETATE--COA-LIGASE-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_456215_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_ACETATEUTIL2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ACETATEUTIL2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003987>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -343,24 +332,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ACETATEUTIL2-PWYSmallMolecule22469> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30089_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_ACETATEUTIL2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ACETATEUTIL2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -378,11 +356,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_456215_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_ACETATEUTIL2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_456215_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -400,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -423,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -440,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "acetate utilization - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -448,15 +426,48 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30616_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ACETATEUTIL2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_BFO_0000066_reaction_ACETATE--COA-LIGASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ACETATEUTIL2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002333_YAL054C-MONOMER_ACETATE--COA-LIGASE-RXN_controller_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ACETATEUTIL2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_BFO_0000050_YeastPathways_ACETATEUTIL2-PWY/YeastPathways_ACETATEUTIL2-PWY_SGD_YeastPathways_ACETATEUTIL2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_BFO_0000050_YeastPathways_ACETATEUTIL2-PWY/YeastPathways_ACETATEUTIL2-PWY_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -470,22 +481,22 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_57288_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_ACETATEUTIL2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ACETATEUTIL2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_57288_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ACETATEUTIL2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57288_ACETATE--COA-LIGASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -496,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -511,11 +522,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_29888_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_ACETATEUTIL2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_29888_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -535,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -547,11 +558,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002333_YLR153C-MONOMER_ACETATE--COA-LIGASE-RXN_controller_SGD_YeastPathways_ACETATEUTIL2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002333_YLR153C-MONOMER_ACETATE--COA-LIGASE-RXN_controller_SGD_PWY_YeastPathways_ACETATEUTIL2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -570,14 +581,3 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_57287_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_ACETATEUTIL2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ACETATEUTIL2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_AERO-GLYCEROL-CAT-PWY.ttl
+++ b/models/YeastPathways_AERO-GLYCEROL-CAT-PWY.ttl
@@ -1,11 +1,11 @@
-<http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002234_CHEBI_15378_GLYCEROL-KIN-RXN_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY>
+<http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002333_YHL032C-MONOMER_GLYCEROL-KIN-RXN_controller_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:AERO-GLYCEROL-CAT-PWY" ;
+                "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -30,11 +30,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002234_CHEBI_57642_RXN3O-9815_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002234_CHEBI_57642_RXN3O-9815_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -49,11 +49,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002234_CHEBI_15378_GLYCEROL-KIN-RXN_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002234_CHEBI_15378_GLYCEROL-KIN-RXN_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,25 +85,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_BFO_0000050_YeastPathways_AERO-GLYCEROL-CAT-PWY/YeastPathways_AERO-GLYCEROL-CAT-PWY_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002234_CHEBI_15378_GLYCEROL-KIN-RXN_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:AERO-GLYCEROL-CAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9815_BFO_0000050_YeastPathways_AERO-GLYCEROL-CAT-PWY/YeastPathways_AERO-GLYCEROL-CAT-PWY_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:AERO-GLYCEROL-CAT-PWY" ;
+                "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -129,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -140,18 +129,62 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_BFO_0000066_reaction_GLYCEROL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_BFO_0000050_YeastPathways_AERO-GLYCEROL-CAT-PWY/YeastPathways_AERO-GLYCEROL-CAT-PWY_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9815_BFO_0000050_YeastPathways_AERO-GLYCEROL-CAT-PWY/YeastPathways_AERO-GLYCEROL-CAT-PWY_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002234_CHEBI_456216_GLYCEROL-KIN-RXN_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002234_CHEBI_52970_RXN3O-9815_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002234_CHEBI_52970_RXN3O-9815_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,11 +202,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002233_CHEBI_30616_GLYCEROL-KIN-RXN_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002233_CHEBI_30616_GLYCEROL-KIN-RXN_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -183,6 +216,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30616_GLYCEROL-KIN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002233_CHEBI_52971_RXN3O-9815_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -199,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -219,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,17 +274,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_17754>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002234_CHEBI_57597_GLYCEROL-KIN-RXN_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:AERO-GLYCEROL-CAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_52971_RXN3O-9815>
         a       <http://purl.obolibrary.org/obo/CHEBI_52971> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -250,7 +283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -265,11 +298,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'glycerol + ATP &rarr; <i>sn</i>-glycerol 3-phosphate + ADP + H<SUP>+</SUP>' 'null' '<i>sn</i>-glycerol 3-phosphate + ubiquinone-<i>6</i> &rarr; glycerone phosphate + ubiquinol-6' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002413_RXN3O-9815_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002413_RXN3O-9815_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -280,17 +313,6 @@
           <http://model.geneontology.org/RXN3O-9815>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002333_YHL032C-MONOMER_GLYCEROL-KIN-RXN_controller_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:AERO-GLYCEROL-CAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -298,11 +320,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002233_CHEBI_57597_GLYCEROL-KIN-RXN_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002233_CHEBI_57597_GLYCEROL-KIN-RXN_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -318,7 +340,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002333_YIL155C-MONOMER_RXN3O-9815_controller_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -326,11 +359,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002233_CHEBI_17754_GLYCEROL-KIN-RXN_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002233_CHEBI_17754_GLYCEROL-KIN-RXN_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -341,20 +374,31 @@
           <http://model.geneontology.org/CHEBI_17754_GLYCEROL-KIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002233_CHEBI_30616_GLYCEROL-KIN-RXN_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004370>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002233_CHEBI_57597_GLYCEROL-KIN-RXN_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002233_CHEBI_57597_GLYCEROL-KIN-RXN_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:AERO-GLYCEROL-CAT-PWY" ;
+                "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -379,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -396,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -408,11 +452,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002333_YHL032C-MONOMER_GLYCEROL-KIN-RXN_controller_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002333_YHL032C-MONOMER_GLYCEROL-KIN-RXN_controller_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -440,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycerol degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -465,26 +509,15 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_BFO_0000066_reaction_GLYCEROL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:AERO-GLYCEROL-CAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002233_CHEBI_52971_RXN3O-9815_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002233_CHEBI_52971_RXN3O-9815_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -495,15 +528,26 @@
           <http://model.geneontology.org/CHEBI_52971_RXN3O-9815>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9815_BFO_0000066_reaction_RXN3O-9815_location_lociGO_0005829_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_BFO_0000066_reaction_GLYCEROL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_BFO_0000066_reaction_GLYCEROL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -514,6 +558,17 @@
           <http://model.geneontology.org/reaction_GLYCEROL-KIN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002234_CHEBI_57597_GLYCEROL-KIN-RXN_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YHL032C-MONOMER_GLYCEROL-KIN-RXN_controller>
         a       <http://identifiers.org/sgd/S000001024> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -521,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -532,25 +587,14 @@
 <http://identifiers.org/sgd/S000001417>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002333_YIL155C-MONOMER_RXN3O-9815_controller_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY>
+<http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002234_CHEBI_52970_RXN3O-9815_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:AERO-GLYCEROL-CAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002413_RXN3O-9815_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:AERO-GLYCEROL-CAT-PWY" ;
+                "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -559,21 +603,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0052591>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002233_CHEBI_30616_GLYCEROL-KIN-RXN_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002234_CHEBI_57642_RXN3O-9815_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:AERO-GLYCEROL-CAT-PWY" ;
+                "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -582,17 +626,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_52970>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002234_CHEBI_456216_GLYCEROL-KIN-RXN_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:AERO-GLYCEROL-CAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -606,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -621,11 +654,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002234_CHEBI_57597_GLYCEROL-KIN-RXN_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002234_CHEBI_57597_GLYCEROL-KIN-RXN_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -645,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -653,40 +686,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002234_CHEBI_57642_RXN3O-9815_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002413_RXN3O-9815_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:AERO-GLYCEROL-CAT-PWY" ;
+                "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002233_CHEBI_52971_RXN3O-9815_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:AERO-GLYCEROL-CAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9815_BFO_0000066_reaction_RXN3O-9815_location_lociGO_0005829_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9815_BFO_0000066_reaction_RXN3O-9815_location_lociGO_0005829_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -701,11 +723,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_BFO_0000050_YeastPathways_AERO-GLYCEROL-CAT-PWY/YeastPathways_AERO-GLYCEROL-CAT-PWY_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_BFO_0000050_YeastPathways_AERO-GLYCEROL-CAT-PWY/YeastPathways_AERO-GLYCEROL-CAT-PWY_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,36 +744,25 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002233_CHEBI_17754_GLYCEROL-KIN-RXN_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0019563>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002233_CHEBI_17754_GLYCEROL-KIN-RXN_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:AERO-GLYCEROL-CAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000001024>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002234_CHEBI_52970_RXN3O-9815_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:AERO-GLYCEROL-CAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -763,11 +774,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002333_YIL155C-MONOMER_RXN3O-9815_controller_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9815_RO_0002333_YIL155C-MONOMER_RXN3O-9815_controller_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -782,11 +793,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002234_CHEBI_456216_GLYCEROL-KIN-RXN_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-KIN-RXN_RO_0002234_CHEBI_456216_GLYCEROL-KIN-RXN_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -801,11 +812,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9815_BFO_0000050_YeastPathways_AERO-GLYCEROL-CAT-PWY/YeastPathways_AERO-GLYCEROL-CAT-PWY_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9815_BFO_0000050_YeastPathways_AERO-GLYCEROL-CAT-PWY/YeastPathways_AERO-GLYCEROL-CAT-PWY_SGD_PWY_YeastPathways_AERO-GLYCEROL-CAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -828,21 +839,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=AERO-GLYCEROL-CAT-PWYSmallMolecule24803> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9815_BFO_0000066_reaction_RXN3O-9815_location_lociGO_0005829_SGD_YeastPathways_AERO-GLYCEROL-CAT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:AERO-GLYCEROL-CAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_ALANINE-DEG3-PWY.ttl
+++ b/models/YeastPathways_ALANINE-DEG3-PWY.ttl
@@ -1,12 +1,23 @@
+<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_ALANINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALANINE-DEG3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALANINE-DEG3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_15361_ALANINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALANINE-DEG3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_15361_ALANINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALANINE-DEG3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -29,24 +40,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALANINE-DEG3-PWYSmallMolecule16924> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ALANINE-DEG3-PWY/YeastPathways_ALANINE-DEG3-PWY_SGD_YeastPathways_ALANINE-DEG3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALANINE-DEG3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16810_ALANINE-AMINOTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16810> ;
@@ -57,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-alanine degradation III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -88,15 +88,26 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_15361_ALANINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALANINE-DEG3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALANINE-DEG3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_57972_ALANINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALANINE-DEG3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_57972_ALANINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALANINE-DEG3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -107,6 +118,17 @@
           <http://model.geneontology.org/CHEBI_57972_ALANINE-AMINOTRANSFERASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ALANINE-DEG3-PWY/YeastPathways_ALANINE-DEG3-PWY_SGD_PWY_YeastPathways_ALANINE-DEG3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALANINE-DEG3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -116,17 +138,28 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://identifiers.org/sgd/S000004079>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_ALANINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALANINE-DEG3-PWY>
+<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_ALANINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALANINE-DEG3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALANINE-DEG3-PWY" ;
+                "SGD_PWY:ALANINE-DEG3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004079>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_57972_ALANINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALANINE-DEG3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -150,7 +183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -161,15 +194,26 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ALANINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALANINE-DEG3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALANINE-DEG3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_ALANINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALANINE-DEG3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_ALANINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALANINE-DEG3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -179,17 +223,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16810_ALANINE-AMINOTRANSFERASE-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ALANINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALANINE-DEG3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALANINE-DEG3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -201,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -219,11 +252,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ALANINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALANINE-DEG3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ALANINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALANINE-DEG3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,23 +272,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004021>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_ALANINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALANINE-DEG3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALANINE-DEG3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_ALANINE-AMINOTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -266,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -277,17 +299,6 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_57972_ALANINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALANINE-DEG3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALANINE-DEG3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -295,11 +306,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002333_YLR089C-MONOMER_ALANINE-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_ALANINE-DEG3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002333_YLR089C-MONOMER_ALANINE-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_ALANINE-DEG3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,11 +337,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ALANINE-DEG3-PWY/YeastPathways_ALANINE-DEG3-PWY_SGD_YeastPathways_ALANINE-DEG3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ALANINE-DEG3-PWY/YeastPathways_ALANINE-DEG3-PWY_SGD_PWY_YeastPathways_ALANINE-DEG3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -344,22 +355,22 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_15361_ALANINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALANINE-DEG3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALANINE-DEG3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002333_YLR089C-MONOMER_ALANINE-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_ALANINE-DEG3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALANINE-DEG3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -371,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -383,11 +394,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_ALANINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALANINE-DEG3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_ALANINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALANINE-DEG3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,17 +415,6 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002333_YLR089C-MONOMER_ALANINE-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_ALANINE-DEG3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALANINE-DEG3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57972_ALANINE-AMINOTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57972> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_ALANINE-SYN2-PWY.ttl
+++ b/models/YeastPathways_ALANINE-SYN2-PWY.ttl
@@ -1,3 +1,14 @@
+<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_29985_ALANINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALANINE-SYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALANINE-SYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_ALANINE-SYN2-PWY/YeastPathways_ALANINE-SYN2-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0019272> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -19,11 +30,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_16810_ALANINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALANINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_16810_ALANINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALANINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,6 +48,17 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ALANINE-SYN2-PWY/YeastPathways_ALANINE-SYN2-PWY_SGD_PWY_YeastPathways_ALANINE-SYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALANINE-SYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15361_ALANINE-AMINOTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -46,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -63,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -74,29 +96,51 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_29985_ALANINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALANINE-SYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_15361_ALANINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALANINE-SYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALANINE-SYN2-PWY" ;
+                "SGD_PWY:ALANINE-SYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002333_YLR089C-MONOMER_ALANINE-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_ALANINE-SYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_16810_ALANINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALANINE-SYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALANINE-SYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_29985_ALANINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALANINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_29985_ALANINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALANINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -110,30 +154,8 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_57972_ALANINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALANINE-SYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALANINE-SYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_15361_ALANINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALANINE-SYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALANINE-SYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004079>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -158,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -173,11 +195,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_15361_ALANINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALANINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_15361_ALANINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALANINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,24 +220,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALANINE-SYN2-PWYProtein50192> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002333_YLR089C-MONOMER_ALANINE-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_ALANINE-SYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALANINE-SYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_ALANINE-SYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -226,7 +237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-alanine biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -237,6 +248,17 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_57972_ALANINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALANINE-SYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALANINE-SYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -244,11 +266,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ALANINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALANINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ALANINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALANINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -264,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -283,7 +305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -297,15 +319,26 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ALANINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALANINE-SYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALANINE-SYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002333_YLR089C-MONOMER_ALANINE-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_ALANINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002333_YLR089C-MONOMER_ALANINE-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_ALANINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,17 +358,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57972>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ALANINE-SYN2-PWY/YeastPathways_ALANINE-SYN2-PWY_SGD_YeastPathways_ALANINE-SYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALANINE-SYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -343,11 +365,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ALANINE-SYN2-PWY/YeastPathways_ALANINE-SYN2-PWY_SGD_YeastPathways_ALANINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ALANINE-SYN2-PWY/YeastPathways_ALANINE-SYN2-PWY_SGD_PWY_YeastPathways_ALANINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -374,11 +396,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_57972_ALANINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALANINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_57972_ALANINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALANINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,28 +417,6 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_16810_ALANINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALANINE-SYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALANINE-SYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ALANINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ALANINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALANINE-SYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALANINE-SYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57972_ALANINE-AMINOTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57972> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -426,7 +426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_ALL-CHORISMATE-PWY-1.ttl
+++ b/models/YeastPathways_ALL-CHORISMATE-PWY-1.ttl
@@ -1,12 +1,23 @@
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000066_reaction_DAHPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,19 +28,16 @@
           <http://model.geneontology.org/reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ab32d8a1-43f7-4b64-b773-3ce45ffb1390_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://purl.obolibrary.org/obo/CHEBI_57701>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -39,7 +47,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_RXN3O-9789_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -62,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -70,47 +89,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_RXN-10814_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_33384_TRYPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -133,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -145,11 +153,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -177,29 +185,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000002414>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000002414>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000066_reaction_RXN3O-9789_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000066_reaction_RXN3O-9789_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -210,14 +218,25 @@
           <http://model.geneontology.org/reaction_RXN3O-9789_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -225,11 +244,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -240,15 +259,37 @@
           <http://model.geneontology.org/CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_f5890a9a-3382-4b93-b34e-b5e2d06e915c_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_d9bfd849-fbd3-4bce-89d2-6395e090ca9c_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -259,22 +300,16 @@
           <http://model.geneontology.org/CHEBI_29934_CHORISMATEMUT-RXN>
 ] .
 
-<http://model.geneontology.org/afdc0c6c-d0d3-46dc-ab3e-5fd4a2160607_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002234_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29888_PRTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -285,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -297,11 +332,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,58 +347,44 @@
           <http://model.geneontology.org/CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/6db60c6f-920b-49cb-be54-f0b567c075fe_GCVMULTI-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_0d02b07c-1a87-49e0-a329-77de5ca31411_1.5.1.15-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002333_YDR007W-MONOMER_PRAISOM-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/9a7ed7a2-c236-4170-8323-c0f2e9170acc_GCVMULTI-RXN>
+<http://model.geneontology.org/1817f982-9134-47ac-b71a-7eeb2ca9d88d_THYMIDYLATESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
+                "a 7,8-dihydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52895> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/FORMATETHFLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004329> ;
@@ -374,9 +395,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/c584c177-99dc-4d97-9443-11827131054b_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/1ba24bbc-5be4-445d-91bf-9644dbd07352_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/d2b47c2a-2c27-42d4-ae25-fc1052448567_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/da9b09e9-6558-4ab5-b250-21fa5ec871b2_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -384,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -396,11 +417,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '6-(hydroxymethyl)-7,8-dihydropterin + ATP &rarr; (7,8-dihydropterin-6-yl)methyl diphosphate + AMP + H<SUP>+</SUP>' 'null' '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -411,17 +432,6 @@
           <http://model.geneontology.org/H2PTEROATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58702_DAHPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58702> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -431,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -443,11 +453,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,37 +468,15 @@
           <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_29985_RXN-10814_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Provides Input For Rule. The relation 'L-glutamine + chorismate &harr; 4-amino-4-deoxychorismate + L-glutamate' 'null' '4-amino-4-deoxychorismate &rarr; 4-aminobenzoate + pyruvate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,7 +492,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_57972_2.6.1.58-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -512,11 +511,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -527,15 +526,26 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -546,48 +556,15 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_57972_RXN3O-4157_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002413_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_15377_IGPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_15377_IGPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -598,26 +575,15 @@
           <http://model.geneontology.org/CHEBI_15377_IGPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YBR249C-MONOMER_DAHPSYN-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YBR249C-MONOMER_DAHPSYN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,17 +597,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -651,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of chorismate metabolism - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -659,37 +614,15 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002333_YDR127W-MONOMER_2.5.1.19-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,26 +633,15 @@
           <http://model.geneontology.org/YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_e777ada8-7abc-4dad-828b-7a07d59f8efd_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000066_reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000066_reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,11 +656,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_57972_2.6.1.58-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_57972_2.6.1.58-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,37 +671,15 @@
           <http://model.geneontology.org/CHEBI_57972_2.6.1.58-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_43474_DAHPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -790,27 +690,22 @@
           <http://model.geneontology.org/CHEBI_17836_ADCLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/f5890a9a-3382-4b93-b34e-b5e2d06e915c_THYMIDYLATESYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_ea984e4d-8467-4689-b942-2f8fae7dd73b_RXN3O-9789_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/1ba24bbc-5be4-445d-91bf-9644dbd07352_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
@@ -821,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -833,11 +728,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,17 +742,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57451>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -881,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -889,40 +773,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000066_reaction_2.5.1.19-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000066_reaction_2.5.1.19-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -936,26 +798,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_32364>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002333_YDR354W-MONOMER_PRTRANS-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002333_YDR354W-MONOMER_PRTRANS-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,17 +817,6 @@
           <http://model.geneontology.org/YDR354W-MONOMER_PRTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16897>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -984,11 +824,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -999,14 +839,36 @@
           <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_58095_RXN-10814_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002233_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_15361_2.6.1.58-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1017,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1025,15 +887,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_15361_RXN3O-4157_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_15361_RXN3O-4157_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1053,7 +926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1089,6 +962,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_73083>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_246422>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1097,7 +992,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1106,7 +1023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1115,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1123,11 +1040,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1138,6 +1055,17 @@
           <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1147,7 +1075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1159,11 +1087,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1177,14 +1105,14 @@
 <http://identifiers.org/sgd/S000001876>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1192,11 +1120,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1207,29 +1135,29 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
-<http://identifiers.org/sgd/S000001378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_58095_2.6.1.58-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1244,11 +1172,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1259,14 +1187,14 @@
           <http://model.geneontology.org/GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_6db60c6f-920b-49cb-be54-f0b567c075fe_GCVMULTI-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_58017_PRTRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1275,40 +1203,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58702>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_44841_H2NEOPTERINALDOL-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1316,11 +1225,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Provides Input For Rule. The relation 'chorismate &harr; prephenate' 'null' 'prephenate + H<SUP>+</SUP> &harr; 3-phenyl-2-oxopropanoate + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1340,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1352,11 +1261,52 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58394_DAHPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_44841_H2NEOPTERINALDOL-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58394_DAHPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1367,51 +1317,21 @@
           <http://model.geneontology.org/CHEBI_58394_DAHPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58394_DAHPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_17001>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/b0631a99-002e-4e22-8e11-aecd42e34eff_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1425,84 +1345,29 @@
 <http://identifiers.org/sgd/S000001788>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YGL125W-MONOMER_RXN3O-9789_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002333_CPLX3O-31_ANTHRANSYN-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002333_YDR127W-MONOMER_2.5.1.19-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002333_YDR127W-MONOMER_2.5.1.19-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1513,15 +1378,26 @@
           <http://model.geneontology.org/YDR127W-MONOMER_2.5.1.19-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_30616_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1535,37 +1411,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_17839>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000066_reaction_DAHPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1585,7 +1439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1596,36 +1450,47 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002413_IGPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1633,11 +1498,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1655,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1663,12 +1528,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_PRAISOM-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1681,7 +1557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1689,15 +1565,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002413_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1708,14 +1595,14 @@
           <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000001694_CPLX3O-31_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1723,11 +1610,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1738,14 +1625,31 @@
           <http://model.geneontology.org/reaction_PRTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ca8a5a3c-2035-4b2d-9589-16f31cc8653e_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1758,7 +1662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1770,11 +1674,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1789,11 +1693,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1804,37 +1708,15 @@
           <http://model.geneontology.org/reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002411_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002411_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1845,17 +1727,6 @@
           <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004146> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1865,9 +1736,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/8a76f25c-c5aa-4325-97a6-db6dc50bfcbb_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/f5890a9a-3382-4b93-b34e-b5e2d06e915c_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/19207aed-d0e1-46ea-86ed-3e3247be92ec_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/ca8a5a3c-2035-4b2d-9589-16f31cc8653e_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1875,7 +1746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1883,15 +1754,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000066_reaction_DAHPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000066_reaction_DAHPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1902,43 +1784,37 @@
           <http://model.geneontology.org/reaction_DAHPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_43474_2.5.1.19-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/dde7f94a-e8c1-423c-b339-ab93a333c77a_RXN3O-9789>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_58394_DAHPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52623> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1953,11 +1829,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'GTP + H<sub>2</sub>O &rarr; formate + 7,8-dihydroneopterin 3'-triphosphate + H<SUP>+</SUP>' 'null' '7,8-dihydroneopterin 3'-triphosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin 3'-phosphate + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1973,7 +1849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1981,11 +1857,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15378_ANTHRANSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15378_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1996,14 +1872,14 @@
           <http://model.geneontology.org/CHEBI_15378_ANTHRANSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2011,11 +1887,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_b59f9c93-ba1f-4651-bda8-087e58813528_FORMATETHFLIG-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_eba63382-d1c4-4210-86e8-e628da863873_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2023,7 +1899,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b59f9c93-ba1f-4651-bda8-087e58813528_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/eba63382-d1c4-4210-86e8-e628da863873_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-31_ANTHRANSYN-RXN_controller>
@@ -2035,7 +1911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2050,11 +1926,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2068,14 +1944,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_58406>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2084,7 +1960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2097,7 +1973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2114,7 +1990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2126,11 +2002,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2150,7 +2026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2158,14 +2034,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000066_reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/dd3235f0-4746-4f47-b410-e968dd91f492_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2176,11 +2069,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_4c303340-4bf5-4633-8fca-5152d525eb1e_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_4ab11f31-7618-4233-bb15-e0b8bd8031cf_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2188,8 +2081,41 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4c303340-4bf5-4633-8fca-5152d525eb1e_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/4ab11f31-7618-4233-bb15-e0b8bd8031cf_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-4157>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -2210,7 +2136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2223,23 +2149,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004107>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58866_IGPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58866> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2250,7 +2165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2262,11 +2177,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2286,7 +2201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2294,51 +2209,45 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002333_YDR354W-MONOMER_PRTRANS-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/064c4446-5e49-4535-82a6-9bfee022ae90_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/reaction_2.5.1.19-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2346,11 +2255,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2365,11 +2274,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2389,7 +2298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2406,35 +2315,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52980> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002234_CHEBI_58613_PRAISOM-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000467>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2444,18 +2331,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000066_reaction_IGPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2463,11 +2350,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2478,59 +2365,15 @@
           <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_8a76f25c-c5aa-4325-97a6-db6dc50bfcbb_THYMIDYLATESYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_f5890a9a-3382-4b93-b34e-b5e2d06e915c_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2538,7 +2381,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8a76f25c-c5aa-4325-97a6-db6dc50bfcbb_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/f5890a9a-3382-4b93-b34e-b5e2d06e915c_THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/H2NEOPTERINALDOL-RXN>
@@ -2560,7 +2403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2568,14 +2411,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2583,11 +2437,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2602,11 +2456,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Provides Input For Rule. The relation '5-enolpyruvoyl-shikimate 3-phosphate &rarr; chorismate + phosphate' 'null' 'L-glutamine + chorismate &harr; 4-amino-4-deoxychorismate + L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_PABASYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_PABASYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2617,26 +2471,15 @@
           <http://model.geneontology.org/PABASYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000066_reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2647,26 +2490,15 @@
           <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2677,14 +2509,14 @@
           <http://model.geneontology.org/CHEBI_456216_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_58613_PRAISOM-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2692,11 +2524,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2707,15 +2539,26 @@
           <http://model.geneontology.org/THYMIDYLATESYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_ADCLY-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_ADCLY-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2730,11 +2573,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2749,11 +2592,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2764,6 +2607,28 @@
           <http://model.geneontology.org/CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_GTP-CYCLOHYDRO-I-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2773,46 +2638,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52843> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_064c4446-5e49-4535-82a6-9bfee022ae90_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_33384_TRYPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33384> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2823,7 +2655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2831,23 +2663,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
         a       <http://identifiers.org/sgd/S000003170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2863,9 +2706,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/6db60c6f-920b-49cb-be54-f0b567c075fe_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/26572fe6-2c51-47b4-87f9-c6a7447c6b53_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/e1de07c1-638b-46c4-a65a-0b8b48294ff9_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/1817f982-9134-47ac-b71a-7eeb2ca9d88d_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2873,7 +2716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2884,25 +2727,47 @@
 <http://purl.obolibrary.org/obo/GO_0004664>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_58702_DAHPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2910,11 +2775,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_15378_RXN3O-9789_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_15378_RXN3O-9789_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2925,26 +2790,15 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-9789>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2955,25 +2809,14 @@
           <http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002333_YGL148W-MONOMER_CHORISMATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2981,11 +2824,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2996,14 +2839,14 @@
           <http://model.geneontology.org/CHEBI_16526_PREPHENATEDEHYDRAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3012,7 +2855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3023,11 +2866,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'shikimate + NADP<sup>+</sup> &larr; 3-dehydroshikimate + NADPH + H<SUP>+</SUP>' 'null' 'shikimate + ATP &harr; shikimate 3-phosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002413_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002413_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3038,14 +2881,36 @@
           <http://model.geneontology.org/SHIKIMATE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_11db363d-4cd7-4532-907b-f22f737f5a3d_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3053,11 +2918,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3068,17 +2933,6 @@
           <http://model.geneontology.org/reaction_RXN-10814_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000066_reaction_2.5.1.19-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3088,7 +2942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3096,19 +2950,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_29985_RXN-10814_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_15378_ADCLY-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3119,7 +2973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3127,18 +2981,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0004765>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3149,26 +3000,18 @@
           <http://model.geneontology.org/reaction_PRAISOM-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004765>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3179,26 +3022,15 @@
           <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3209,15 +3041,51 @@
           <http://model.geneontology.org/CHEBI_15377_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000066_reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/d9bfd849-fbd3-4bce-89d2-6395e090ca9c_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3228,26 +3096,15 @@
           <http://model.geneontology.org/CHEBI_58866_IGPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'phospho<i>enol</i>pyruvate + D-erythrose 4-phosphate + H<sub>2</sub>O &harr; 3-deoxy-D-arabino-heptulosonate 7-phosphate + phosphate' 'null' '3-deoxy-D-arabino-heptulosonate 7-phosphate &rarr; 3-dehydroquinate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3258,18 +3115,15 @@
           <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/8a76f25c-c5aa-4325-97a6-db6dc50bfcbb_THYMIDYLATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3280,41 +3134,15 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002233_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/YGL125W-MONOMER_RXN3O-9789_controller>
-        a       <http://identifiers.org/sgd/S000003093> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "MTHFR" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein52637> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3334,9 +3162,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/0d02b07c-1a87-49e0-a329-77de5ca31411_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/cd05b602-f220-4012-a052-540a611ab56f_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/064c4446-5e49-4535-82a6-9bfee022ae90_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/c6d98108-6b65-4708-890e-cf31f9c0a05b_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3344,7 +3172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3356,11 +3184,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_58095_2.6.1.58-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_58095_2.6.1.58-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3380,7 +3208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3388,16 +3216,20 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_58702_2.5.1.19-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/YGL125W-MONOMER_RXN3O-9789_controller>
+        a       <http://identifiers.org/sgd/S000003093> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "MTHFR" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein52637> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_58702_2.5.1.19-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58702> ;
@@ -3408,7 +3240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3420,11 +3252,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Provides Input For Rule. The relation '4-amino-4-deoxychorismate &rarr; 4-aminobenzoate + pyruvate + H<SUP>+</SUP>' 'null' '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3439,11 +3271,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3454,40 +3286,29 @@
           <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_16897_DAHPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003436>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3507,7 +3328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3515,19 +3336,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://identifiers.org/sgd/S000005316>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002413_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000005316>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/PABASYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0046820> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3548,13 +3369,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1BiochemicalReaction53134> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
         a       <http://identifiers.org/sgd/S000003436> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3563,7 +3395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3571,14 +3403,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_15361_2.6.1.58-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3586,11 +3418,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_58702_2.5.1.19-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_58702_2.5.1.19-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3605,11 +3437,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3620,19 +3452,38 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0004834>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3641,11 +3492,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_6db60c6f-920b-49cb-be54-f0b567c075fe_GCVMULTI-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_26572fe6-2c51-47b4-87f9-c6a7447c6b53_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3653,8 +3504,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6db60c6f-920b-49cb-be54-f0b567c075fe_GCVMULTI-RXN>
+          <http://model.geneontology.org/26572fe6-2c51-47b4-87f9-c6a7447c6b53_GCVMULTI-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/GO_0004834>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_36242> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3665,7 +3519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3680,57 +3534,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein52688> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_30616_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000066_reaction_ANTHRANSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3741,7 +3551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3749,26 +3559,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3779,14 +3578,36 @@
           <http://model.geneontology.org/YHR137W-MONOMER_RXN3O-4157_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_29985_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3797,11 +3618,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3819,11 +3640,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_301096d6-59b1-4077-9f46-56db7bfaa144_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_e461e4ac-41d5-4afe-b697-1cf81fd4821c_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3831,57 +3652,54 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/301096d6-59b1-4077-9f46-56db7bfaa144_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/e461e4ac-41d5-4afe-b697-1cf81fd4821c_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58017>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_b59f9c93-ba1f-4651-bda8-087e58813528_FORMATETHFLIG-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000066_reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_301096d6-59b1-4077-9f46-56db7bfaa144_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_456215>
+<http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_dd3235f0-4746-4f47-b410-e968dd91f492_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3892,12 +3710,48 @@
           <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_456215>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000066_reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3905,11 +3759,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3920,14 +3774,25 @@
           <http://model.geneontology.org/reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3938,11 +3803,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3975,7 +3840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3987,11 +3852,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4011,7 +3876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4023,11 +3888,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4047,7 +3912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4064,7 +3929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4076,11 +3941,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4095,11 +3960,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4110,25 +3975,25 @@
           <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_19207aed-d0e1-46ea-86ed-3e3247be92ec_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4141,7 +4006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4149,14 +4014,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_58315_RXN3O-4157_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4164,11 +4029,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4179,17 +4044,6 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15378_ANTHRANSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -4197,11 +4051,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4212,37 +4066,15 @@
           <http://model.geneontology.org/CHEBI_58406_PABASYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002413_2.5.1.19-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4253,14 +4085,14 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4273,16 +4105,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52675> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_13390>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003436> ;
@@ -4291,7 +4120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4299,16 +4128,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_13390>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0004640>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4317,11 +4138,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4331,6 +4152,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_36242>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4344,7 +4176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4352,15 +4184,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000066_reaction_ANTHRANSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4371,15 +4214,26 @@
           <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_eba63382-d1c4-4210-86e8-e628da863873_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_58017_PRTRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_58017_PRTRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4390,28 +4244,6 @@
           <http://model.geneontology.org/CHEBI_58017_PRTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002333_YGL148W-MONOMER_CHORISMATE-SYNTHASE-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4421,7 +4253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4436,7 +4268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4444,15 +4276,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4463,17 +4306,6 @@
           <http://model.geneontology.org/YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4483,7 +4315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4491,36 +4323,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_58359_ANTHRANSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4543,7 +4353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4551,15 +4361,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4570,26 +4402,15 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_16897_DAHPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_16897_DAHPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4600,26 +4421,15 @@
           <http://model.geneontology.org/CHEBI_16897_DAHPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4634,11 +4444,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4653,11 +4463,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_29985_ANTHRANSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_29985_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4672,11 +4482,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_11db363d-4cd7-4532-907b-f22f737f5a3d_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_47853b41-f278-4702-bc8c-13b8cbf11aba_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4684,29 +4494,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/11db363d-4cd7-4532-907b-f22f737f5a3d_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/47853b41-f278-4702-bc8c-13b8cbf11aba_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YPL023C-MONOMER_RXN3O-9789_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4717,6 +4516,17 @@
           <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58095_RXN-10814>
         a       <http://purl.obolibrary.org/obo/CHEBI_58095> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4726,7 +4536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4734,15 +4544,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/eba63382-d1c4-4210-86e8-e628da863873_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4760,7 +4573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4772,11 +4585,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '3-dehydroquinate &harr; 3-dehydroshikimate + H<sub>2</sub>O' 'null' 'shikimate + NADP<sup>+</sup> &larr; 3-dehydroshikimate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002413_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002413_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4791,11 +4604,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4809,25 +4622,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4840,7 +4642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4848,14 +4650,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_15378_RXN3O-9789_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4866,7 +4679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4874,26 +4687,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_456216_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_456216_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4916,7 +4718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4924,19 +4726,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GCVMULTI-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://purl.obolibrary.org/obo/CHEBI_43474>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_43474>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_17836>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4950,7 +4752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4962,11 +4764,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4977,15 +4779,59 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_881a3509-2a53-4761-a66a-9491b20ea668_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_IGPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_IGPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4996,15 +4842,26 @@
           <http://model.geneontology.org/CHEBI_58866_IGPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_dde7f94a-e8c1-423c-b339-ab93a333c77a_RXN3O-9789_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_ea984e4d-8467-4689-b942-2f8fae7dd73b_RXN3O-9789_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5012,8 +4869,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/dde7f94a-e8c1-423c-b339-ab93a333c77a_RXN3O-9789>
+          <http://model.geneontology.org/ea984e4d-8467-4689-b942-2f8fae7dd73b_RXN3O-9789>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YBR249C-MONOMER_DAHPSYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000453> ;
@@ -5022,13 +4890,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53748> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58394_DAHPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003848> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5049,24 +4939,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1BiochemicalReaction53171> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGL026C-MONOMER_TRYPSYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002994> ;
@@ -5075,7 +4954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5095,7 +4974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5112,7 +4991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5120,32 +4999,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glycine cleavage complex" ;
-        <http://purl.obolibrary.org/obo/BFO_0000051>
-                <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component> , <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Complex52793> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Provides Input For Rule. The relation '7,8-dihydroneopterin 3'-triphosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin 3'-phosphate + diphosphate + H<SUP>+</SUP>' 'null' '7,8-dihydroneopterin 3'-phosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5161,19 +5023,36 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "glycine cleavage complex" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component> , <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Complex52793> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Complex" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000066_reaction_CHORISMATEMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000066_reaction_CHORISMATEMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5193,7 +5072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5204,15 +5083,26 @@
 <http://identifiers.org/sgd/S000003093>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_15378_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5223,14 +5113,14 @@
           <http://model.geneontology.org/THYMIDYLATESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_e1de07c1-638b-46c4-a65a-0b8b48294ff9_THYMIDYLATESYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5243,7 +5133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5255,11 +5145,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5279,7 +5169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5291,11 +5181,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5306,28 +5196,6 @@
           <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_d2b47c2a-2c27-42d4-ae25-fc1052448567_FORMATETHFLIG-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -5335,11 +5203,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5354,11 +5222,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000001694_CPLX3O-31_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000001694_CPLX3O-31_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5369,18 +5237,15 @@
           <http://model.geneontology.org/SGD_S000001694_CPLX3O-31_component>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57783>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5391,6 +5256,31 @@
           <http://model.geneontology.org/CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_57783>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_456216_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004477>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -5398,11 +5288,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5418,7 +5308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5426,11 +5316,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5441,23 +5331,23 @@
           <http://model.geneontology.org/CHEBI_29748_CHORISMATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002333_YDR354W-MONOMER_PRTRANS-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000000892_CPLX3O-31_component>
         a       <http://identifiers.org/sgd/S000000892> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002413_RXN3O-4157_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5469,23 +5359,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://identifiers.org/sgd/S000002994>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_ab32d8a1-43f7-4b64-b773-3ce45ffb1390_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/c6d98108-6b65-4708-890e-cf31f9c0a05b_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000002994>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15377_DAHPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5496,7 +5392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5508,11 +5404,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5523,14 +5419,25 @@
           <http://model.geneontology.org/reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_58095_2.6.1.58-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5551,7 +5458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5559,14 +5466,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_26572fe6-2c51-47b4-87f9-c6a7447c6b53_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5574,11 +5481,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5589,15 +5496,26 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5608,40 +5526,40 @@
           <http://model.geneontology.org/MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000066_reaction_RXN3O-9789_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003116>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_43474_2.5.1.19-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000066_reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000066_reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5651,6 +5569,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003848>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5667,13 +5596,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52654> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_TRYPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -5684,7 +5624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5694,9 +5634,6 @@
 
 <http://purl.obolibrary.org/obo/GO_0004150>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/0d02b07c-1a87-49e0-a329-77de5ca31411_1.5.1.15-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -5708,7 +5645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5720,11 +5657,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_29985_RXN-10814_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_29985_RXN-10814_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5735,30 +5672,19 @@
           <http://model.geneontology.org/CHEBI_29985_RXN-10814>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002413_PRTRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004799>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000066_reaction_CHORISMATEMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004048>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5770,7 +5696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5782,11 +5708,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002234_CHEBI_58613_PRAISOM-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002234_CHEBI_58613_PRAISOM-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5801,11 +5727,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_c584c177-99dc-4d97-9443-11827131054b_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_1ba24bbc-5be4-445d-91bf-9644dbd07352_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5813,54 +5739,32 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c584c177-99dc-4d97-9443-11827131054b_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/1ba24bbc-5be4-445d-91bf-9644dbd07352_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate + H<SUP>+</SUP> &rarr; (1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + CO<SUB>2</SUB> + H<sub>2</sub>O' 'null' '(1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + L-serine &rarr; L-tryptophan + D-glyceraldehyde 3-phosphate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002413_TRYPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002413_TRYPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5871,29 +5775,29 @@
           <http://model.geneontology.org/TRYPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/CHEBI_37565>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_37565>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5904,6 +5808,17 @@
           <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5913,7 +5828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5930,7 +5845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5938,40 +5853,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_29748>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_8a76f25c-c5aa-4325-97a6-db6dc50bfcbb_THYMIDYLATESYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_29748>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5986,11 +5890,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6020,7 +5924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6032,11 +5936,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002333_YGL148W-MONOMER_CHORISMATE-SYNTHASE-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002333_YGL148W-MONOMER_CHORISMATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6046,28 +5950,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YGL148W-MONOMER_CHORISMATE-SYNTHASE-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004764> ;
@@ -6088,7 +5970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6100,11 +5982,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6115,26 +5997,15 @@
           <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6145,6 +6016,17 @@
           <http://model.geneontology.org/CHEBI_30616_DIHYDROFOLATESYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58359_ANTHRANSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58359> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6154,7 +6036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6166,11 +6048,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6181,18 +6063,40 @@
           <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002233_CHEBI_57701_2.5.1.19-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58462>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_47853b41-f278-4702-bc8c-13b8cbf11aba_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6203,6 +6107,17 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YKL211C-MONOMER_IGPSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000001694> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -6210,7 +6125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6227,13 +6142,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52935> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002411_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHORISMATEMUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004106> ;
@@ -6254,7 +6191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6266,11 +6203,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_57701_2.5.1.19-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_57701_2.5.1.19-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6281,17 +6218,6 @@
           <http://model.geneontology.org/CHEBI_57701_2.5.1.19-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_RXN3O-9789>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6301,13 +6227,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52610> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000001694_CPLX3O-31_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003856> ;
@@ -6328,7 +6276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6336,26 +6284,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002413_TRYPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_e1de07c1-638b-46c4-a65a-0b8b48294ff9_THYMIDYLATESYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_1817f982-9134-47ac-b71a-7eeb2ca9d88d_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6363,54 +6300,43 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e1de07c1-638b-46c4-a65a-0b8b48294ff9_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/1817f982-9134-47ac-b71a-7eeb2ca9d88d_THYMIDYLATESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000288>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6421,26 +6347,15 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6451,15 +6366,37 @@
           <http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000000892_CPLX3O-31_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_15378_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_15378_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6473,8 +6410,30 @@
 <http://identifiers.org/sgd/S000004048>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_RXN3O-4157_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16630>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002333_YDR007W-MONOMER_PRAISOM-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_SHIKIMATE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6485,7 +6444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6493,14 +6452,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002233_CHEBI_57701_2.5.1.19-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6508,11 +6478,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_0d02b07c-1a87-49e0-a329-77de5ca31411_1.5.1.15-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_cd05b602-f220-4012-a052-540a611ab56f_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6520,18 +6490,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0d02b07c-1a87-49e0-a329-77de5ca31411_1.5.1.15-RXN>
+          <http://model.geneontology.org/cd05b602-f220-4012-a052-540a611ab56f_1.5.1.15-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6541,45 +6511,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/19207aed-d0e1-46ea-86ed-3e3247be92ec_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6593,7 +6524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -6601,14 +6532,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002234_CHEBI_58613_PRAISOM-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6631,7 +6573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6643,11 +6585,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6658,25 +6600,25 @@
           <http://model.geneontology.org/YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6684,11 +6626,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6718,7 +6660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6726,26 +6668,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6760,11 +6691,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Provides Input For Rule. The relation '7,8-dihydroneopterin 3'-phosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin + phosphate' 'null' '7,8-dihydroneopterin &rarr; glycolaldehyde + 6-(hydroxymethyl)-7,8-dihydropterin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6775,26 +6706,15 @@
           <http://model.geneontology.org/H2NEOPTERINALDOL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6805,15 +6725,26 @@
           <http://model.geneontology.org/THYMIDYLATESYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_58613_PRAISOM-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_58613_PRAISOM-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6828,11 +6759,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_58394_DAHPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_58394_DAHPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6843,23 +6774,67 @@
           <http://model.geneontology.org/CHEBI_58394_DAHPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15361_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002413_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6872,7 +6847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6884,11 +6859,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6908,7 +6883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6920,11 +6895,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6942,7 +6917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6950,25 +6925,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_RXN-10814_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_afdc0c6c-d0d3-46dc-ab3e-5fd4a2160607_GLYOHMETRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6977,7 +6952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6994,11 +6969,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7014,33 +6989,25 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/e461e4ac-41d5-4afe-b697-1cf81fd4821c_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_ADCLY-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7050,17 +7017,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000006264>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -7072,7 +7028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7084,11 +7040,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7099,37 +7055,15 @@
           <http://model.geneontology.org/CHEBI_29888_PRTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7159,7 +7093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7173,26 +7107,15 @@
 <http://identifiers.org/sgd/S000003170>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_57972_RXN3O-4157_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_57972_RXN3O-4157_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7203,6 +7126,17 @@
           <http://model.geneontology.org/CHEBI_57972_RXN3O-4157>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -7212,14 +7146,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_145989>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7227,11 +7161,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7246,11 +7180,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7266,7 +7200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7277,11 +7211,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'chorismate + L-glutamine &rarr; anthranilate + L-glutamate + pyruvate + H<SUP>+</SUP>' 'null' 'anthranilate + 5-phospho-&alpha;-D-ribose 1-diphosphate &rarr; <i>N</i>-(5-phosphoribosyl)-anthranilate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002413_PRTRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002413_PRTRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7292,14 +7226,14 @@
           <http://model.geneontology.org/PRTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7307,11 +7241,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7326,11 +7260,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GCVMULTI-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7341,14 +7275,14 @@
           <http://model.geneontology.org/GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_CHEBI_13390_RXN3O-9789_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7361,7 +7295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7373,11 +7307,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7388,14 +7322,14 @@
           <http://model.geneontology.org/CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_4ab11f31-7618-4233-bb15-e0b8bd8031cf_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7403,11 +7337,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7422,11 +7356,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002333_YPR060C-MONOMER_CHORISMATEMUT-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002333_YPR060C-MONOMER_CHORISMATEMUT-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7437,25 +7371,14 @@
           <http://model.geneontology.org/YPR060C-MONOMER_CHORISMATEMUT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7463,11 +7386,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7487,7 +7410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7502,11 +7425,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'prephenate + NADP<sup>+</sup> &rarr; CO<SUB>2</SUB> + 3-(4-hydroxyphenyl)pyruvate + NADPH' 'null' 'L-tyrosine + pyruvate &harr; 3-(4-hydroxyphenyl)pyruvate + L-alanine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002413_RXN3O-4157_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002413_RXN3O-4157_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7517,17 +7440,6 @@
           <http://model.geneontology.org/RXN3O-4157>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7537,7 +7449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7548,6 +7460,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_58866>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004477> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -7557,9 +7480,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/b59f9c93-ba1f-4651-bda8-087e58813528_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/eba63382-d1c4-4210-86e8-e628da863873_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/11db363d-4cd7-4532-907b-f22f737f5a3d_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/47853b41-f278-4702-bc8c-13b8cbf11aba_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -7567,7 +7490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7588,13 +7511,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53445> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -7603,11 +7537,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7618,48 +7552,15 @@
           <http://model.geneontology.org/CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_ANTHRANSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7670,25 +7571,14 @@
           <http://model.geneontology.org/CHEBI_57912_TRYPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7696,11 +7586,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YPL023C-MONOMER_RXN3O-9789_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YPL023C-MONOMER_RXN3O-9789_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7720,7 +7610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7728,26 +7618,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_PABASYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7758,14 +7637,58 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_IGPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002413_TRYPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7774,7 +7697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7782,11 +7705,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7797,23 +7720,23 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000001694_CPLX3O-31_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001694> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_57701_2.5.1.19-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7821,11 +7744,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7843,11 +7766,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_e777ada8-7abc-4dad-828b-7a07d59f8efd_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_b0631a99-002e-4e22-8e11-aecd42e34eff_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7855,45 +7778,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e777ada8-7abc-4dad-828b-7a07d59f8efd_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/b0631a99-002e-4e22-8e11-aecd42e34eff_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/e1de07c1-638b-46c4-a65a-0b8b48294ff9_THYMIDYLATESYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52895> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_15377_IGPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7901,11 +7796,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7919,15 +7814,26 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7938,25 +7844,58 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_58095_RXN-10814_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7964,11 +7903,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_d2b47c2a-2c27-42d4-ae25-fc1052448567_FORMATETHFLIG-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_da9b09e9-6558-4ab5-b250-21fa5ec871b2_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7976,35 +7915,29 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d2b47c2a-2c27-42d4-ae25-fc1052448567_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/da9b09e9-6558-4ab5-b250-21fa5ec871b2_FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_43474_CHORISMATE-SYNTHASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphate" ;
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52980> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8024,7 +7957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8049,7 +7982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8061,11 +7994,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15361_ANTHRANSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15361_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8076,25 +8009,31 @@
           <http://model.geneontology.org/CHEBI_15361_ANTHRANSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_43474_CHORISMATE-SYNTHASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52980> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_RXN3O-9789_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8107,7 +8046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8115,25 +8054,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8146,7 +8074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8158,11 +8086,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8173,25 +8101,14 @@
           <http://model.geneontology.org/CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002413_2.5.1.19-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8204,7 +8121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8215,8 +8132,41 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_cd05b602-f220-4012-a052-540a611ab56f_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-10814>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004400> ;
@@ -8235,7 +8185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8248,18 +8198,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://purl.obolibrary.org/obo/CHEBI_58349>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8267,11 +8220,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8291,7 +8244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8299,22 +8252,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_58349>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_15378_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_43474_DAHPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16630> ;
@@ -8325,7 +8286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8340,11 +8301,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8355,36 +8316,14 @@
           <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8397,7 +8336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8405,16 +8344,20 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003499> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "GTP-cyclohydrolase I" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53289> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/DAHPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003849> ;
@@ -8435,7 +8378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8447,11 +8390,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_58095_RXN-10814_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_58095_RXN-10814_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8462,14 +8405,47 @@
           <http://model.geneontology.org/CHEBI_58095_RXN-10814>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_PABASYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8482,7 +8458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8490,15 +8466,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8509,31 +8496,38 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003499> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "GTP-cyclohydrolase I" ;
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53289> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008696>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -8541,14 +8535,14 @@
 <http://identifiers.org/sgd/S000001694>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_ADCLY-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8556,11 +8550,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8571,26 +8565,15 @@
           <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8621,7 +8604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8629,15 +8612,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8657,7 +8651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8665,26 +8659,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Provides Input For Rule. The relation '5-enolpyruvoyl-shikimate 3-phosphate &rarr; chorismate + phosphate' 'null' 'chorismate &harr; prephenate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_CHORISMATEMUT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8695,9 +8678,6 @@
           <http://model.geneontology.org/CHORISMATEMUT-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0019177>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
         a       <http://identifiers.org/sgd/S000005762> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -8705,7 +8685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8713,15 +8693,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://purl.obolibrary.org/obo/GO_0019177>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8732,37 +8715,15 @@
           <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8773,26 +8734,15 @@
           <http://model.geneontology.org/CHEBI_43474_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8803,14 +8753,14 @@
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_dde7f94a-e8c1-423c-b339-ab93a333c77a_RXN3O-9789_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRTRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8818,11 +8768,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8833,34 +8783,37 @@
           <http://model.geneontology.org/reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000051> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
-] .
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8871,12 +8824,42 @@
           <http://model.geneontology.org/CHEBI_29934_CHORISMATEMUT-RXN>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8889,7 +8872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8900,14 +8883,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8920,9 +8903,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/301096d6-59b1-4077-9f46-56db7bfaa144_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/e461e4ac-41d5-4afe-b697-1cf81fd4821c_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> , <http://model.geneontology.org/9a7ed7a2-c236-4170-8323-c0f2e9170acc_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/4f0885f3-8f6c-4763-9ac4-263ede2d2767_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -8930,7 +8913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8938,12 +8921,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_DAHPSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_16567_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8951,11 +8956,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8966,15 +8971,48 @@
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000066_reaction_CHORISMATEMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_13392_RXN3O-9789_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_13392_RXN3O-9789_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8985,25 +9023,14 @@
           <http://model.geneontology.org/CHEBI_13392_RXN3O-9789>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_RXN3O-4157_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9016,7 +9043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9028,11 +9055,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9047,11 +9074,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9062,6 +9089,21 @@
           <http://model.geneontology.org/CHEBI_15377_PREPHENATEDEHYDRAT-RXN>
 ] .
 
+<http://model.geneontology.org/YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller>
+        a       <http://identifiers.org/sgd/S000002534> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-dehydroquinate synthase [multifunctional]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53647> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9071,7 +9113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9079,41 +9121,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller>
-        a       <http://identifiers.org/sgd/S000002534> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-dehydroquinate synthase [multifunctional]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53647> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9129,18 +9145,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9153,7 +9169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9161,14 +9177,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15361_ANTHRANSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_58702_2.5.1.19-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9184,24 +9200,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Complex52900> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
-
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002413_IGPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29748_CHORISMATE-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29748> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -9212,7 +9217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9220,26 +9225,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9257,11 +9251,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9272,26 +9266,15 @@
           <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9309,11 +9292,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9324,26 +9307,15 @@
           <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9354,15 +9326,26 @@
           <http://model.geneontology.org/reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9382,7 +9365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9390,26 +9373,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9432,15 +9404,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9789_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_RXN3O-9789> , <http://model.geneontology.org/ab32d8a1-43f7-4b64-b773-3ce45ffb1390_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9789> ;
+                <http://model.geneontology.org/d9bfd849-fbd3-4bce-89d2-6395e090ca9c_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9789> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/dde7f94a-e8c1-423c-b339-ab93a333c77a_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9789> ;
+                <http://model.geneontology.org/ea984e4d-8467-4689-b942-2f8fae7dd73b_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9789> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL125W-MONOMER_RXN3O-9789_controller> , <http://model.geneontology.org/YPL023C-MONOMER_RXN3O-9789_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9454,24 +9426,15 @@
 <http://purl.obolibrary.org/obo/GO_0004487>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Provides Input For Rule. The relation '7,8-dihydroneopterin &rarr; glycolaldehyde + 6-(hydroxymethyl)-7,8-dihydropterin' 'null' '6-(hydroxymethyl)-7,8-dihydropterin + ATP &rarr; (7,8-dihydropterin-6-yl)methyl diphosphate + AMP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9482,26 +9445,15 @@
           <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_15361_2.6.1.58-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_15361_2.6.1.58-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9516,11 +9468,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002233_CHEBI_57701_2.5.1.19-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002233_CHEBI_57701_2.5.1.19-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9531,14 +9483,12 @@
           <http://model.geneontology.org/CHEBI_57701_2.5.1.19-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9546,11 +9496,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9561,36 +9511,14 @@
           <http://model.geneontology.org/MONOMER3O-131_ADCLY-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9598,11 +9526,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9618,32 +9546,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29934>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRTRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000066_reaction_RXN3O-9789_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_16567_ANTHRANSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9654,11 +9571,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9678,9 +9595,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/e777ada8-7abc-4dad-828b-7a07d59f8efd_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/b0631a99-002e-4e22-8e11-aecd42e34eff_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/afdc0c6c-d0d3-46dc-ab3e-5fd4a2160607_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/dd3235f0-4746-4f47-b410-e968dd91f492_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -9688,7 +9605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9703,11 +9620,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Provides Input For Rule. The relation 'anthranilate + 5-phospho-&alpha;-D-ribose 1-diphosphate &rarr; <i>N</i>-(5-phosphoribosyl)-anthranilate + diphosphate' 'null' '<i>N</i>-(5-phosphoribosyl)-anthranilate &rarr; 1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9725,7 +9642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9742,7 +9659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9750,40 +9667,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000002442>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_15361_RXN3O-4157_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9794,20 +9700,6 @@
           <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN>
 ] .
 
-<http://model.geneontology.org/4c303340-4bf5-4633-8fca-5152d525eb1e_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_9a7ed7a2-c236-4170-8323-c0f2e9170acc_GCVMULTI-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15361_2.6.1.58-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15361> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9817,35 +9709,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53124> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58095_2.6.1.58-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58095> ;
@@ -9856,7 +9726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9871,7 +9741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9879,26 +9749,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_33384_TRYPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/4ab11f31-7618-4233-bb15-e0b8bd8031cf_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_58315_RXN3O-4157_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_58315_RXN3O-4157_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9909,14 +9771,47 @@
           <http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_1ba24bbc-5be4-445d-91bf-9644dbd07352_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YPL023C-MONOMER_RXN3O-9789_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9924,11 +9819,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>N</i>-(5-phosphoribosyl)-anthranilate &rarr; 1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate' 'null' '1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate + H<SUP>+</SUP> &rarr; (1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002413_IGPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002413_IGPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9939,37 +9834,32 @@
           <http://model.geneontology.org/IGPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/881a3509-2a53-4761-a66a-9491b20ea668_1.5.1.15-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_16810_RXN-10814_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9985,7 +9875,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9993,11 +9894,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10008,14 +9909,25 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10023,11 +9935,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10038,6 +9950,17 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57972_RXN3O-4157>
         a       <http://purl.obolibrary.org/obo/CHEBI_57972> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -10047,7 +9970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10059,11 +9982,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10078,11 +10001,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Provides Input For Rule. The relation 'chorismate &harr; prephenate' 'null' 'prephenate + NADP<sup>+</sup> &rarr; CO<SUB>2</SUB> + 3-(4-hydroxyphenyl)pyruvate + NADPH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10093,26 +10016,15 @@
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10123,25 +10035,14 @@
           <http://model.geneontology.org/CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002413_PRTRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10149,11 +10050,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10164,15 +10065,26 @@
           <http://model.geneontology.org/CHEBI_58359_PABASYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10187,11 +10099,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_afdc0c6c-d0d3-46dc-ab3e-5fd4a2160607_GLYOHMETRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_dd3235f0-4746-4f47-b410-e968dd91f492_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10199,8 +10111,30 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/afdc0c6c-d0d3-46dc-ab3e-5fd4a2160607_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/dd3235f0-4746-4f47-b410-e968dd91f492_GLYOHMETRANS-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_145989_SHIKIMATE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_145989> ;
@@ -10211,7 +10145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10219,14 +10153,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10239,7 +10173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10251,11 +10185,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'shikimate 3-phosphate + phospho<i>enol</i>pyruvate &harr; 5-enolpyruvoyl-shikimate 3-phosphate + phosphate' 'null' '5-enolpyruvoyl-shikimate 3-phosphate &rarr; chorismate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002413_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002413_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10266,6 +10200,17 @@
           <http://model.geneontology.org/CHORISMATE-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_13392_RXN3O-9789>
         a       <http://purl.obolibrary.org/obo/CHEBI_13392> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -10275,7 +10220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10287,11 +10232,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10302,14 +10247,36 @@
           <http://model.geneontology.org/reaction_ADCLY-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YGL125W-MONOMER_RXN3O-9789_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10332,13 +10299,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1BiochemicalReaction53598> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58359_PABASYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58359> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -10349,7 +10327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10361,11 +10339,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10383,7 +10361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10391,15 +10369,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_15361_RXN3O-4157_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000066_reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000066_reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10410,31 +10399,31 @@
           <http://model.geneontology.org/reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000004801>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_29985_ANTHRANSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_c6d98108-6b65-4708-890e-cf31f9c0a05b_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002411_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10442,11 +10431,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_f153e7b9-1424-4791-a2e6-4f3af81747cf_1.5.1.15-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_881a3509-2a53-4761-a66a-9491b20ea668_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10454,7 +10443,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f153e7b9-1424-4791-a2e6-4f3af81747cf_1.5.1.15-RXN>
+          <http://model.geneontology.org/881a3509-2a53-4761-a66a-9491b20ea668_1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
@@ -10466,24 +10455,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52705> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YDR127W-MONOMER_2.5.1.19-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002534> ;
@@ -10492,7 +10470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10504,11 +10482,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_ANTHRANSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10519,14 +10497,25 @@
           <http://model.geneontology.org/CHEBI_16567_ANTHRANSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10539,7 +10528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10547,37 +10536,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10588,15 +10555,26 @@
           <http://model.geneontology.org/CHEBI_29748_CHORISMATE-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10607,26 +10585,15 @@
           <http://model.geneontology.org/CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000000892_CPLX3O-31_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Provides Input For Rule. The relation '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' 'null' 'L-glutamate + 7,8-dihydropteroate + ATP &rarr; ADP + 7,8-dihydrofolate monoglutamate + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10640,14 +10607,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_58762>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10655,11 +10622,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_15377_DAHPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_15377_DAHPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10673,26 +10640,15 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10707,11 +10663,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10729,7 +10685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10737,30 +10693,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/YDR354W-MONOMER_PRTRANS-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002762> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "anthranilate phosphoribosyl transferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53571> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_16567_ANTHRANSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_16567_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10771,12 +10712,27 @@
           <http://model.geneontology.org/CHEBI_16567_ANTHRANSYN-RXN>
 ] .
 
+<http://model.geneontology.org/YDR354W-MONOMER_PRTRANS-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002762> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "anthranilate phosphoribosyl transferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53571> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 <http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005600> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10784,11 +10740,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10803,11 +10759,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_19207aed-d0e1-46ea-86ed-3e3247be92ec_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_ca8a5a3c-2035-4b2d-9589-16f31cc8653e_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10815,33 +10771,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/19207aed-d0e1-46ea-86ed-3e3247be92ec_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/ca8a5a3c-2035-4b2d-9589-16f31cc8653e_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000004902>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002413_RXN3O-4157_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000066_reaction_IGPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
@@ -10852,7 +10786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10860,31 +10794,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/f153e7b9-1424-4791-a2e6-4f3af81747cf_1.5.1.15-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YBR249C-MONOMER_DAHPSYN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000288> ;
@@ -10893,7 +10823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10901,14 +10831,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10916,11 +10855,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10931,41 +10870,30 @@
           <http://model.geneontology.org/YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002333_CPLX3O-31_ANTHRANSYN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005600>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_32364> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -10976,7 +10904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10993,7 +10921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11013,7 +10941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11026,29 +10954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_13392_RXN3O-9789_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11059,11 +10965,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11074,6 +10980,17 @@
           <http://model.geneontology.org/CHEBI_15378_SHIKIMATE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YHR137W-MONOMER_2.6.1.58-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001179> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -11081,7 +10998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11089,66 +11006,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004329>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller>
-        a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase [multifunctional]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53094> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11159,14 +11028,29 @@
           <http://model.geneontology.org/YIL116W-MONOMER_RXN-10814_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller>
+        a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53094> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11174,11 +11058,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_33384_TRYPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_33384_TRYPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11199,24 +11083,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53454> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_4c303340-4bf5-4633-8fca-5152d525eb1e_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -11227,7 +11100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11235,14 +11108,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11250,11 +11123,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_CHEBI_13390_RXN3O-9789_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_CHEBI_13390_RXN3O-9789_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11265,6 +11138,45 @@
           <http://model.geneontology.org/CHEBI_13390_RXN3O-9789>
 ] .
 
+<http://model.geneontology.org/da9b09e9-6558-4ab5-b250-21fa5ec871b2_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52913> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_63528> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -11274,13 +11186,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52889> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -11291,7 +11214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11299,25 +11222,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000066_reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11325,11 +11248,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11340,6 +11263,17 @@
           <http://model.geneontology.org/CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_4f0885f3-8f6c-4763-9ac4-263ede2d2767_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -11347,11 +11281,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11366,11 +11300,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_RXN3O-9789_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_RXN3O-9789_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11381,14 +11315,25 @@
           <http://model.geneontology.org/RXN3O-9789>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11396,11 +11341,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11430,7 +11375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11442,11 +11387,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11462,7 +11407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11475,7 +11420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11483,14 +11428,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11498,11 +11443,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11517,11 +11462,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11536,11 +11481,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000000892_CPLX3O-31_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000000892_CPLX3O-31_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11560,7 +11505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11575,11 +11520,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11594,11 +11539,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000066_reaction_ANTHRANSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000066_reaction_ANTHRANSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11608,17 +11553,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_ANTHRANSYN-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_f153e7b9-1424-4791-a2e6-4f3af81747cf_1.5.1.15-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/H2PTEROATESYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004156> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -11641,7 +11575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11649,25 +11583,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_58315_RXN3O-4157_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11680,7 +11603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11691,29 +11614,54 @@
 <http://purl.obolibrary.org/obo/GO_0004665>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_58394_DAHPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_ca8a5a3c-2035-4b2d-9589-16f31cc8653e_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/301096d6-59b1-4077-9f46-56db7bfaa144_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ea984e4d-8467-4689-b942-2f8fae7dd73b_RXN3O-9789>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52623> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_ab32d8a1-43f7-4b64-b773-3ce45ffb1390_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_d9bfd849-fbd3-4bce-89d2-6395e090ca9c_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11721,17 +11669,28 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ab32d8a1-43f7-4b64-b773-3ce45ffb1390_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/d9bfd849-fbd3-4bce-89d2-6395e090ca9c_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11744,7 +11703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11756,11 +11715,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-tyrosine + 2-oxoglutarate &harr; 3-(4-hydroxyphenyl)pyruvate + L-glutamate' 'null' 'L-tyrosine + pyruvate &harr; 3-(4-hydroxyphenyl)pyruvate + L-alanine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_RXN3O-4157_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_RXN3O-4157_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11771,6 +11730,17 @@
           <http://model.geneontology.org/RXN3O-4157>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_DIHYDROFOLATESYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -11780,7 +11750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11792,11 +11762,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11807,15 +11777,26 @@
           <http://model.geneontology.org/CHEBI_18005_PREPHENATEDEHYDRAT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11826,25 +11807,14 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11857,7 +11827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11865,15 +11835,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_1817f982-9134-47ac-b71a-7eeb2ca9d88d_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11887,15 +11868,37 @@
 <http://identifiers.org/sgd/S000001179>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_57972_RXN3O-4157_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRTRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRTRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11906,15 +11909,26 @@
           <http://model.geneontology.org/CHEBI_18277_PRTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11929,11 +11943,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11944,15 +11958,26 @@
           <http://model.geneontology.org/CHEBI_37565_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11963,26 +11988,15 @@
           <http://model.geneontology.org/YKL211C-MONOMER_IGPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_ANTHRANSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11996,34 +12010,23 @@
 <http://purl.obolibrary.org/obo/GO_0004489>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12031,11 +12034,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12050,11 +12053,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12069,11 +12072,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12093,7 +12096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12101,15 +12104,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_16810_RXN-10814_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12120,26 +12134,15 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12159,7 +12162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12167,29 +12170,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_15377_DAHPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004425>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000066_reaction_2.5.1.19-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Provides Input For Rule. The relation '3-deoxy-D-arabino-heptulosonate 7-phosphate &rarr; 3-dehydroquinate + phosphate' 'null' '3-dehydroquinate &harr; 3-dehydroshikimate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12207,7 +12232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12224,7 +12249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12244,7 +12269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12252,37 +12277,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_43474_2.5.1.19-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_43474_2.5.1.19-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12296,17 +12299,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -12314,11 +12306,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12329,40 +12321,51 @@
           <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_CHEBI_13390_RXN3O-9789_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_13392_RXN3O-9789_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_59776>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-tyrosine + pyruvate &harr; 3-(4-hydroxyphenyl)pyruvate + L-alanine' 'null' 'L-tyrosine + 2-oxoglutarate &harr; 3-(4-hydroxyphenyl)pyruvate + L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12373,26 +12376,15 @@
           <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_58702_DAHPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12403,14 +12395,14 @@
           <http://model.geneontology.org/CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12418,11 +12410,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000066_reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000066_reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12433,34 +12425,23 @@
           <http://model.geneontology.org/reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_c584c177-99dc-4d97-9443-11827131054b_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_2.6.1.58-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12471,11 +12452,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12486,15 +12467,26 @@
           <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12508,39 +12500,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_15377_IGPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_57972_2.6.1.58-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58462_GTP-CYCLOHYDRO-I-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58462> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -12550,7 +12509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12562,11 +12521,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12581,11 +12540,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12596,23 +12555,12 @@
           <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN-10814_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12620,11 +12568,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12635,15 +12583,26 @@
           <http://model.geneontology.org/CHEBI_58406_PABASYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12654,15 +12613,26 @@
           <http://model.geneontology.org/CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12673,15 +12643,26 @@
           <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_15377_DAHPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12696,11 +12677,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_43474_DAHPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_43474_DAHPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12711,17 +12692,6 @@
           <http://model.geneontology.org/CHEBI_43474_DAHPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_28938> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -12731,7 +12701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12744,7 +12714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12752,11 +12722,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12772,7 +12742,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12780,11 +12761,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12795,17 +12776,6 @@
           <http://model.geneontology.org/CHEBI_15361_ADCLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -12815,13 +12785,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52843> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_da9b09e9-6558-4ab5-b250-21fa5ec871b2_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16897_DAHPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16897> ;
@@ -12832,7 +12813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12840,15 +12821,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15378_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12862,25 +12854,14 @@
 <http://identifiers.org/sgd/S000000370>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000066_reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12889,7 +12870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12897,11 +12878,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12912,15 +12893,18 @@
           <http://model.geneontology.org/CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12931,20 +12915,6 @@
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58394_DAHPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58394> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -12954,7 +12924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12962,15 +12932,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12990,7 +12982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12998,18 +12990,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/e777ada8-7abc-4dad-828b-7a07d59f8efd_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'shikimate + ATP &harr; shikimate 3-phosphate + ADP + H<SUP>+</SUP>' 'null' 'shikimate 3-phosphate + phospho<i>enol</i>pyruvate &harr; 5-enolpyruvoyl-shikimate 3-phosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002413_2.5.1.19-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002413_2.5.1.19-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13023,28 +13012,6 @@
 <http://purl.obolibrary.org/obo/GO_0003855>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002333_YPR060C-MONOMER_CHORISMATEMUT-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -13054,39 +13021,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52720> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/d2b47c2a-2c27-42d4-ae25-fc1052448567_FORMATETHFLIG-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52913> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -13096,26 +13035,32 @@
 <http://purl.obolibrary.org/obo/CHEBI_18277>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/47853b41-f278-4702-bc8c-13b8cbf11aba_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000066_reaction_IGPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000066_reaction_IGPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13126,18 +13071,15 @@
           <http://model.geneontology.org/reaction_IGPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_58702_DAHPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_58702_DAHPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13147,17 +13089,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58702_DAHPSYN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_58017_PRTRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PRAISOM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004640> ;
@@ -13178,7 +13109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13186,36 +13117,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002413_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13223,11 +13146,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13238,15 +13161,30 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
+<http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
+        a       <http://identifiers.org/sgd/S000000288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "mitochondrial C1-tetrahydrofolate synthase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein52688> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13257,21 +13195,6 @@
           <http://model.geneontology.org/CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
-        a       <http://identifiers.org/sgd/S000000288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "mitochondrial C1-tetrahydrofolate synthase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein52688> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://model.geneontology.org/CHEBI_15378_GTP-CYCLOHYDRO-I-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -13281,7 +13204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13293,11 +13216,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002333_CPLX3O-31_ANTHRANSYN-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002333_CPLX3O-31_ANTHRANSYN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13308,25 +13231,17 @@
           <http://model.geneontology.org/CPLX3O-31_ANTHRANSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/26572fe6-2c51-47b4-87f9-c6a7447c6b53_GCVMULTI-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13334,11 +13249,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13349,14 +13264,25 @@
           <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13364,11 +13290,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13388,13 +13314,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53498> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17001> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -13405,7 +13342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13417,11 +13354,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13432,15 +13369,26 @@
           <http://model.geneontology.org/reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13455,11 +13403,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002234_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002234_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13470,6 +13418,17 @@
           <http://model.geneontology.org/CHEBI_29934_CHORISMATEMUT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29888_H2PTEROATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -13479,7 +13438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13487,25 +13446,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YBR249C-MONOMER_DAHPSYN-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000066_reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13518,7 +13466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13530,11 +13478,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13545,14 +13493,25 @@
           <http://model.geneontology.org/YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002234_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13563,11 +13522,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13578,6 +13537,17 @@
           <http://model.geneontology.org/reaction_RXN3O-4157_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_44841_H2NEOPTERINALDOL-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_44841> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -13587,7 +13557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13599,11 +13569,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13617,17 +13587,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33384> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -13637,7 +13596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13645,15 +13604,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YGL125W-MONOMER_RXN3O-9789_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YGL125W-MONOMER_RXN3O-9789_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13664,26 +13645,29 @@
           <http://model.geneontology.org/YGL125W-MONOMER_RXN3O-9789_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_IGPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/cd05b602-f220-4012-a052-540a611ab56f_1.5.1.15-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'prephenate + H<SUP>+</SUP> &harr; 3-phenyl-2-oxopropanoate + CO<SUB>2</SUB> + H<sub>2</sub>O' 'null' 'L-phenylalanine + pyruvate &harr; 3-phenyl-2-oxopropanoate + L-alanine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_2.6.1.58-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_2.6.1.58-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13694,11 +13678,30 @@
           <http://model.geneontology.org/2.6.1.58-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_18005>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/c584c177-99dc-4d97-9443-11827131054b_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000467> ;
@@ -13707,7 +13710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13719,11 +13722,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_1.5.1.15-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13737,18 +13740,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_16567>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/b59f9c93-ba1f-4651-bda8-087e58813528_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-glutamate + 7,8-dihydropteroate + ATP &rarr; ADP + 7,8-dihydrofolate monoglutamate + phosphate + H<SUP>+</SUP>' 'null' 'a tetrahydrofolate + NADP<sup>+</sup> &larr; a 7,8-dihydrofolate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13763,11 +13774,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13783,7 +13794,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13791,11 +13813,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13806,32 +13828,15 @@
           <http://model.geneontology.org/CHEBI_29888_H2PTEROATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/11db363d-4cd7-4532-907b-f22f737f5a3d_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13846,11 +13851,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13870,7 +13875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13878,43 +13883,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CHEBI_17836_ADCLY-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_17836> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4-aminobenzoate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53062> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13925,14 +13902,31 @@
           <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_17836_ADCLY-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_17836> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4-aminobenzoate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53062> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_e461e4ac-41d5-4afe-b697-1cf81fd4821c_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13940,11 +13934,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13959,11 +13953,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_58359_ANTHRANSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_58359_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13974,17 +13968,6 @@
           <http://model.geneontology.org/CHEBI_58359_ANTHRANSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/1.5.1.15-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004487> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -13994,9 +13977,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> , <http://model.geneontology.org/4c303340-4bf5-4633-8fca-5152d525eb1e_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/4ab11f31-7618-4233-bb15-e0b8bd8031cf_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/f153e7b9-1424-4791-a2e6-4f3af81747cf_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/881a3509-2a53-4761-a66a-9491b20ea668_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -14004,7 +13987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14012,25 +13995,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_58613_PRAISOM-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_456216_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14043,11 +14015,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52787> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/4f0885f3-8f6c-4763-9ac4-263ede2d2767_GCVMULTI-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -14056,7 +14045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14064,11 +14053,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002233_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002233_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14079,14 +14068,14 @@
           <http://model.geneontology.org/CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002413_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14099,7 +14088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14111,11 +14100,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14126,15 +14115,37 @@
           <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_58359_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_57701_2.5.1.19-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Provides Input For Rule. The relation 'prephenate + H<SUP>+</SUP> &harr; 3-phenyl-2-oxopropanoate + CO<SUB>2</SUB> + H<sub>2</sub>O' 'null' 'L-phenylalanine + 2-oxoglutarate &harr; 3-phenyl-2-oxopropanoate + L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_RXN-10814_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_RXN-10814_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14144,6 +14155,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN-10814>
 ] .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_2.6.1.58-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004665> ;
@@ -14164,24 +14186,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1BiochemicalReaction53439> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_CHORISMATEMUT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58394>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -14193,11 +14204,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_30616_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_30616_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14215,11 +14226,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_16810_RXN-10814_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_16810_RXN-10814_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14230,25 +14241,14 @@
           <http://model.geneontology.org/CHEBI_16810_RXN-10814>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_1.5.1.15-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_b0631a99-002e-4e22-8e11-aecd42e34eff_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14271,13 +14271,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1BiochemicalReaction53457> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005762>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -14289,7 +14300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14304,7 +14315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14323,7 +14334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14334,11 +14345,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002333_YDR007W-MONOMER_PRAISOM-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002333_YDR007W-MONOMER_PRAISOM-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14358,7 +14369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14373,7 +14384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14385,11 +14396,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14400,26 +14411,15 @@
           <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_15378_RXN3O-9789_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14434,11 +14434,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14458,7 +14458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14466,40 +14466,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://identifiers.org/sgd/S000005200>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_16897_DAHPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14507,11 +14496,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14529,11 +14518,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '5-enolpyruvoyl-shikimate 3-phosphate &rarr; chorismate + phosphate' 'null' 'chorismate + L-glutamine &rarr; anthranilate + L-glutamate + pyruvate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_ANTHRANSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14544,25 +14533,25 @@
           <http://model.geneontology.org/ANTHRANSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002333_YDR127W-MONOMER_2.5.1.19-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002333_YPR060C-MONOMER_CHORISMATEMUT-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14570,11 +14559,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_064c4446-5e49-4535-82a6-9bfee022ae90_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_c6d98108-6b65-4708-890e-cf31f9c0a05b_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14582,7 +14571,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/064c4446-5e49-4535-82a6-9bfee022ae90_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/c6d98108-6b65-4708-890e-cf31f9c0a05b_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000002534>
@@ -14592,11 +14581,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14611,11 +14600,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_9a7ed7a2-c236-4170-8323-c0f2e9170acc_GCVMULTI-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_4f0885f3-8f6c-4763-9ac4-263ede2d2767_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14623,16 +14612,27 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9a7ed7a2-c236-4170-8323-c0f2e9170acc_GCVMULTI-RXN>
+          <http://model.geneontology.org/4f0885f3-8f6c-4763-9ac4-263ede2d2767_GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_ALLANTOINDEG-PWY.ttl
+++ b/models/YeastPathways_ALLANTOINDEG-PWY.ttl
@@ -1,11 +1,11 @@
-<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002413_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002234_CHEBI_16199_UREIDOGLYCOLATE-LYASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -26,7 +26,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,11 +38,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_15377_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_15377_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -57,11 +57,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002333_YIR029W-MONOMER_ALLANTOICASE-RXN_controller_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002333_YIR029W-MONOMER_ALLANTOICASE-RXN_controller_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,28 +72,6 @@
           <http://model.geneontology.org/YIR029W-MONOMER_ALLANTOICASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_BFO_0000066_reaction_ALLOPHANATE-HYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_16526_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16199_UREIDOGLYCOLATE-LYASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16199> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -103,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -128,57 +106,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002413_UREIDOGLYCOLATE-LYASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15377_ALLANTOINASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15832>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_15377_ALLANTOICASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002333_YBR208C-MONOMER_UREA-CARBOXYLASE-RXN_controller_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002333_YBR208C-MONOMER_UREA-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,11 +138,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_17536_ALLANTOINASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_17536_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -211,17 +156,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_16199>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -231,15 +165,37 @@
 <http://purl.obolibrary.org/obo/GO_0004847>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000066_reaction_ALLANTOICASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>S</i>)-ureidoglycolate &rarr; urea + glyoxylate' 'null' 'CO<SUB>2</SUB> + urea + ATP + H<sub>2</sub>O &rarr; ADP + urea-1-carboxylate + phosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002413_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002413_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,11 +210,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002234_CHEBI_16526_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002234_CHEBI_16526_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,14 +228,14 @@
 <http://purl.obolibrary.org/obo/GO_0004037>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_16199_UREIDOGLYCOLATE-LYASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -293,11 +249,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000066_reaction_ALLANTOICASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000066_reaction_ALLANTOICASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -308,14 +264,25 @@
           <http://model.geneontology.org/reaction_ALLANTOICASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_YeastPathways_ALLANTOINDEG-PWY>
+<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002333_YIR032C-MONOMER_UREIDOGLYCOLATE-LYASE-RXN_controller_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002234_CHEBI_36655_UREIDOGLYCOLATE-LYASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -331,7 +298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -339,26 +306,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15678_ALLANTOINASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,36 +325,47 @@
           <http://model.geneontology.org/CHEBI_30616_UREA-CARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000066_reaction_ALLANTOICASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000066_reaction_ALLANTOINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002333_YIR027C-MONOMER_ALLANTOINASE-RXN_controller_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002234_CHEBI_28938_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15832_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_16199_UREIDOGLYCOLATE-LYASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -406,11 +373,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_BFO_0000066_reaction_UREIDOGLYCOLATE-LYASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_BFO_0000066_reaction_UREIDOGLYCOLATE-LYASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -428,11 +395,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -455,24 +422,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALLANTOINDEG-PWYSmallMolecule54373> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YBR208C-MONOMER_UREA-CARBOXYLASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000412> ;
@@ -481,7 +437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -496,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -511,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -538,24 +494,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALLANTOINDEG-PWYBiochemicalReaction54468> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_15832_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_28938_ALLOPHANATE-HYDROLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_28938> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -566,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -578,11 +523,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -600,11 +545,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_16199_ALLANTOICASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_16199_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -615,17 +560,6 @@
           <http://model.geneontology.org/CHEBI_16199_ALLANTOICASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002333_YIR029W-MONOMER_ALLANTOICASE-RXN_controller_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16199_ALLANTOICASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16199> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -635,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -650,11 +584,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -669,11 +603,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15678_ALLANTOINASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15678_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -684,14 +618,36 @@
           <http://model.geneontology.org/CHEBI_15678_ALLANTOINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002333_YIR027C-MONOMER_ALLANTOINASE-RXN_controller_SGD_YeastPathways_ALLANTOINDEG-PWY>
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002333_YBR208C-MONOMER_UREA-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002233_CHEBI_57296_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002413_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -700,7 +656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -711,11 +667,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002234_CHEBI_36655_UREIDOGLYCOLATE-LYASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002234_CHEBI_36655_UREIDOGLYCOLATE-LYASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -730,11 +686,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15378_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15378_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -745,17 +701,6 @@
           <http://model.geneontology.org/CHEBI_15378_ALLOPHANATE-HYDROLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16526_UREA-CARBOXYLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -765,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -775,6 +720,17 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_16526_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -798,7 +754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -810,11 +766,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_16199_UREIDOGLYCOLATE-LYASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_16199_UREIDOGLYCOLATE-LYASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -825,14 +781,14 @@
           <http://model.geneontology.org/CHEBI_16199_UREIDOGLYCOLATE-LYASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002234_CHEBI_36655_UREIDOGLYCOLATE-LYASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_BFO_0000066_reaction_UREA-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -845,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -857,11 +813,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" , "Provides Input For Rule. The relation 'allantoate + H<sub>2</sub>O &rarr; (<i>S</i>)-ureidoglycolate + urea' 'null' '(<i>S</i>)-ureidoglycolate &rarr; urea + glyoxylate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002413_UREIDOGLYCOLATE-LYASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002413_UREIDOGLYCOLATE-LYASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,14 +828,14 @@
           <http://model.geneontology.org/UREIDOGLYCOLATE-LYASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002234_CHEBI_16199_UREIDOGLYCOLATE-LYASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002413_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -895,7 +851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -903,15 +859,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_15832_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" , "Provides Input For Rule. The relation 'CO<SUB>2</SUB> + urea + ATP + H<sub>2</sub>O &rarr; ADP + urea-1-carboxylate + phosphate + 2 H<SUP>+</SUP>' 'null' 'urea-1-carboxylate + 3 H<SUP>+</SUP> + H<sub>2</sub>O &rarr; 2 ammonium + 2 CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002413_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002413_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -927,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -935,11 +902,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002333_YIR027C-MONOMER_ALLANTOINASE-RXN_controller_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002333_YIR027C-MONOMER_ALLANTOINASE-RXN_controller_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -957,38 +924,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALLANTOINDEG-PWYProtein54512> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_BFO_0000066_reaction_UREA-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_15378_ALLOPHANATE-HYDROLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -999,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1007,33 +949,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15377_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1043,33 +966,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_16199_ALLANTOICASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002234_CHEBI_28938_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002234_CHEBI_28938_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1102,7 +1014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1119,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1136,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1148,11 +1060,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_15377_ALLANTOICASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_15377_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1166,14 +1078,47 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002333_YBR208C-MONOMER_UREA-CARBOXYLASE-RXN_controller_SGD_YeastPathways_ALLANTOINDEG-PWY>
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002333_YIR029W-MONOMER_ALLANTOICASE-RXN_controller_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15378_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_15377_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1184,11 +1129,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1203,11 +1148,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000066_reaction_ALLANTOINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000066_reaction_ALLANTOINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1218,14 +1163,14 @@
           <http://model.geneontology.org/reaction_ALLANTOINASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_15378_ALLANTOINASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_15378_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1234,22 +1179,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002233_CHEBI_57296_ALLANTOICASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002233_CHEBI_57296_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1260,14 +1216,14 @@
           <http://model.geneontology.org/CHEBI_57296_ALLANTOICASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002234_CHEBI_16526_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1275,11 +1231,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_BFO_0000066_reaction_ALLOPHANATE-HYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_BFO_0000066_reaction_ALLOPHANATE-HYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1290,6 +1246,17 @@
           <http://model.geneontology.org/reaction_ALLOPHANATE-HYDROLASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15377_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57296_ALLANTOICASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57296> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1299,7 +1266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1307,14 +1274,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_BFO_0000066_reaction_UREIDOGLYCOLATE-LYASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALLANTOINDEG-PWY>
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_17536_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1322,11 +1289,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_BFO_0000066_reaction_UREA-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_BFO_0000066_reaction_UREA-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1346,7 +1313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1358,11 +1325,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_57296_ALLANTOICASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_57296_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1379,30 +1346,30 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002413_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
+<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_BFO_0000066_reaction_UREIDOGLYCOLATE-LYASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002413_UREIDOGLYCOLATE-LYASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001468>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_57296_ALLANTOICASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_36655_UREIDOGLYCOLATE-LYASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36655> ;
@@ -1413,7 +1380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1425,11 +1392,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1444,11 +1411,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_15378_ALLANTOINASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_15378_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1464,7 +1431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1477,26 +1444,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_36655>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_17536_ALLANTOINASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002333_YIR032C-MONOMER_UREIDOGLYCOLATE-LYASE-RXN_controller_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002333_YIR032C-MONOMER_UREIDOGLYCOLATE-LYASE-RXN_controller_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1511,11 +1467,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15832_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15832_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1526,6 +1482,17 @@
           <http://model.geneontology.org/CHEBI_15832_UREA-CARBOXYLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_57296_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YIR029W-MONOMER_ALLANTOICASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001468> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1533,7 +1500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1541,26 +1508,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002333_YIR032C-MONOMER_UREIDOGLYCOLATE-LYASE-RXN_controller_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1574,15 +1530,37 @@
 <http://purl.obolibrary.org/obo/CHEBI_57296>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_17536_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000066_reaction_ALLANTOINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_16526_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_16526_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1592,17 +1570,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16526_UREA-CARBOXYLASE-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0000256>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1616,24 +1583,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of allantoin degradation in yeast - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002233_CHEBI_57296_ALLANTOICASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15678_ALLANTOINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15678> ;
@@ -1644,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1656,11 +1612,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1671,25 +1627,14 @@
           <http://model.geneontology.org/YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002413_ALLANTOICASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_15377_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
+<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1705,7 +1650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1717,11 +1662,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1739,11 +1684,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" , "Provides Input For Rule. The relation '(<i>S</i>)-(+)-allantoin + H<sub>2</sub>O &rarr; allantoate + H<SUP>+</SUP>' 'null' 'allantoate + H<sub>2</sub>O &rarr; (<i>S</i>)-ureidoglycolate + urea' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002413_ALLANTOICASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002413_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1754,30 +1699,19 @@
           <http://model.geneontology.org/ALLANTOICASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15378_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_YeastPathways_ALLANTOINDEG-PWY>
+<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002333_YBR208C-MONOMER_ALLOPHANATE-HYDROLASE-RXN_controller_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1785,15 +1719,26 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002333_YBR208C-MONOMER_ALLOPHANATE-HYDROLASE-RXN_controller_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002333_YBR208C-MONOMER_ALLOPHANATE-HYDROLASE-RXN_controller_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1811,11 +1756,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_17536_ALLANTOINASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_17536_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1826,36 +1771,47 @@
           <http://model.geneontology.org/CHEBI_17536_ALLANTOINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002333_YBR208C-MONOMER_ALLOPHANATE-HYDROLASE-RXN_controller_SGD_YeastPathways_ALLANTOINDEG-PWY>
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15377_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_17536_ALLANTOINASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002234_CHEBI_16526_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
+<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002234_CHEBI_28938_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000050_YeastPathways_ALLANTOINDEG-PWY/YeastPathways_ALLANTOINDEG-PWY_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1881,24 +1837,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALLANTOINDEG-PWYBiochemicalReaction54430> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15832_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALLANTOINDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_UREA-CARBOXYLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1909,7 +1854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1921,11 +1866,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_15832_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_15832_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1940,11 +1885,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15377_ALLANTOINASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15377_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1964,7 +1909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1981,7 +1926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1993,11 +1938,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002234_CHEBI_16199_UREIDOGLYCOLATE-LYASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002234_CHEBI_16199_UREIDOGLYCOLATE-LYASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2008,15 +1953,26 @@
           <http://model.geneontology.org/CHEBI_16199_UREIDOGLYCOLATE-LYASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_15377_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15377_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_ALLANTOINDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15377_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2036,10 +1992,54 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALLANTOINDEG-PWYSmallMolecule54398> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15678_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002413_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_BFO_0000066_reaction_ALLOPHANATE-HYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_16199_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_ALLANTOINDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALLANTOINDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_ARG-PRO-PWY.ttl
+++ b/models/YeastPathways_ARG-PRO-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -47,14 +47,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_13392_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARG-PRO-PWY>
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000050_YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY_SGD_PWY_YeastPathways_ARG-PRO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
+                "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -62,11 +62,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_17388_SPONTPRO-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_17388_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,15 +77,26 @@
           <http://model.geneontology.org/CHEBI_17388_SPONTPRO-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002333_YER023W-MONOMER_PYRROLINECARBREDUCT-RXN_controller_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002333_YLR438W-MONOMER_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002333_YLR438W-MONOMER_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -96,26 +107,18 @@
           <http://model.geneontology.org/YLR438W-MONOMER_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_BFO_0000066_reaction_ARGINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002234_CHEBI_16199_ARGINASE-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002234_CHEBI_16199_ARGINASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -126,15 +129,23 @@
           <http://model.geneontology.org/CHEBI_16199_ARGINASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/reaction_ARGINASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002234_CHEBI_16199_ARGINASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -142,11 +153,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_15377_SPONTPRO-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_15377_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -157,19 +168,41 @@
           <http://model.geneontology.org/CHEBI_15377_SPONTPRO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002234_CHEBI_46911_ARGINASE-RXN_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_46911_ARGINASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
+                "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002413_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_13390_PYRROLINECARBREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_13390> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -180,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -192,11 +225,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_13390_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_13390_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -212,12 +245,34 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_15378_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000006032>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -225,25 +280,14 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002233_CHEBI_15377_ARGINASE-RXN_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_15378_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARG-PRO-PWY>
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000066_reaction_PYRROLINECARBREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARG-PRO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
+                "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -252,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -263,11 +307,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_58066_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_58066_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,11 +326,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002233_CHEBI_32682_ARGINASE-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002233_CHEBI_32682_ARGINASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,11 +345,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_58066_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_58066_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,6 +359,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58066_ORNITHINE-GLU-AMINOTRANSFERASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_15377_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -328,25 +383,14 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_15378_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002413_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
+                "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -357,11 +401,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_17388_SPONTPRO-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_17388_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -399,15 +443,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002413_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_BFO_0000066_reaction_ARGINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000050_YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_13392_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_13392_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -427,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -438,26 +515,15 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_17388_SPONTPRO-RXN_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,13 +543,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARG-PRO-PWYSmallMolecule17595> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/YeastPathways_ARG-PRO-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -494,7 +563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-arginine degradation VI (arginase 2 pathway) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -502,18 +571,15 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,6 +589,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_29985_ORNITHINE-GLU-AMINOTRANSFERASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_58066_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17388>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -536,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -544,15 +621,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002233_CHEBI_15377_ARGINASE-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002233_CHEBI_15377_ARGINASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,11 +655,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -591,7 +679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -599,47 +687,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002413_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_13392>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_15377_SPONTPRO-RXN_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_58066_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000825>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -648,11 +703,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_15378_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_15378_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,41 +718,8 @@
           <http://model.geneontology.org/CHEBI_15378_PYRROLINECARBREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_13390_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0019493>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_60039_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0019493> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -708,7 +730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -719,26 +741,15 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000050_YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000066_reaction_PYRROLINECARBREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000066_reaction_PYRROLINECARBREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,11 +764,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-arginine + H<sub>2</sub>O &rarr; urea + L-ornithine' 'null' 'L-ornithine + 2-oxoglutarate &rarr; L-glutamate + L-glutamate-5-semialdehyde' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002413_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002413_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,6 +779,17 @@
           <http://model.geneontology.org/ORNITHINE-GLU-AMINOTRANSFERASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -775,11 +797,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_46911_ARGINASE-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_46911_ARGINASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,11 +816,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_BFO_0000066_reaction_ARGINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_BFO_0000066_reaction_ARGINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -817,7 +839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -825,11 +847,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000050_YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000050_YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -840,25 +862,25 @@
           <http://model.geneontology.org/YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_58066_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ARG-PRO-PWY>
+<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002333_YLR438W-MONOMER_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_ARG-PRO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
+                "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ARG-PRO-PWY>
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_17388_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
+                "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -871,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -886,7 +908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -897,17 +919,6 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002234_CHEBI_16199_ARGINASE-RXN_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004587>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -917,15 +928,26 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002233_CHEBI_32682_ARGINASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000050_YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000050_YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -936,16 +958,8 @@
           <http://model.geneontology.org/YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002333_YLR438W-MONOMER_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_60039_PYRROLINECARBREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_60039> ;
@@ -956,7 +970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -968,11 +982,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002333_YPL111W-MONOMER_ARGINASE-RXN_controller_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002333_YPL111W-MONOMER_ARGINASE-RXN_controller_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -993,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1001,8 +1015,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_17388_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PYRROLINECARBREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004735> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1021,7 +1043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1032,25 +1054,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_58066>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000050_YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002413_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
+                "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1058,11 +1069,30 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_BFO_0000050_YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ARGINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1082,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1090,14 +1120,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_BFO_0000050_YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY_SGD_YeastPathways_ARG-PRO-PWY>
+<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002333_YPL111W-MONOMER_ARGINASE-RXN_controller_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002234_CHEBI_46911_ARGINASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
+                "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1105,30 +1146,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_BFO_0000050_YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002333_YER023W-MONOMER_PYRROLINECARBREDUCT-RXN_controller_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ARGINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002333_YER023W-MONOMER_PYRROLINECARBREDUCT-RXN_controller_SGD_YeastPathways_ARG-PRO-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1139,14 +1161,14 @@
           <http://model.geneontology.org/YER023W-MONOMER_PYRROLINECARBREDUCT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_17388_SPONTPRO-RXN_SGD_YeastPathways_ARG-PRO-PWY>
+<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_58066_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
+                "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1156,14 +1178,36 @@
 <http://purl.obolibrary.org/obo/CHEBI_13390>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_15378_SPONTPRO-RXN_SGD_YeastPathways_ARG-PRO-PWY>
+<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002233_CHEBI_15377_ARGINASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
+                "SGD_PWY:ARG-PRO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_13390_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_13392_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1176,7 +1220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1190,28 +1234,17 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002233_CHEBI_32682_ARGINASE-RXN_SGD_YeastPathways_ARG-PRO-PWY>
+<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_BFO_0000050_YeastPathways_ARG-PRO-PWY/YeastPathways_ARG-PRO-PWY_SGD_PWY_YeastPathways_ARG-PRO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
+                "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1219,11 +1252,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>S</i>)-1-pyrroline-5-carboxylate + H<SUP>+</SUP> + H<sub>2</sub>O &harr; L-glutamate-5-semialdehyde' 'null' 'L-proline + NAD(P)<sup>+</sup> &larr; (<i>S</i>)-1-pyrroline-5-carboxylate + NAD(P)H + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002413_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002413_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1237,37 +1270,15 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000066_reaction_PYRROLINECARBREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002413_SPONTPRO-RXN_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" , "Provides Input For Rule. The relation 'L-ornithine + 2-oxoglutarate &rarr; L-glutamate + L-glutamate-5-semialdehyde' 'null' '(<i>S</i>)-1-pyrroline-5-carboxylate + H<SUP>+</SUP> + H<sub>2</sub>O &harr; L-glutamate-5-semialdehyde' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002413_SPONTPRO-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002413_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1278,26 +1289,15 @@
           <http://model.geneontology.org/SPONTPRO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002333_YER023W-MONOMER_PYRROLINECARBREDUCT-RXN_controller_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002234_CHEBI_46911_ARGINASE-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002234_CHEBI_46911_ARGINASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1308,15 +1308,26 @@
           <http://model.geneontology.org/CHEBI_46911_ARGINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_15378_SPONTPRO-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_15378_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1327,6 +1338,17 @@
           <http://model.geneontology.org/CHEBI_15378_SPONTPRO-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_60039_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARG-PRO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_13392_PYRROLINECARBREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_13392> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1336,7 +1358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1359,7 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1370,26 +1392,15 @@
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_46911_ARGINASE-RXN_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1402,17 +1413,6 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002333_YPL111W-MONOMER_ARGINASE-RXN_controller_SGD_YeastPathways_ARG-PRO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARG-PRO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ORNITHINE-GLU-AMINOTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004587> ;
@@ -1433,7 +1433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1445,11 +1445,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_60039_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARG-PRO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_60039_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARG-PRO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1469,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1497,7 +1497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_ARGDEG-YEAST-PWY.ttl
+++ b/models/YeastPathways_ARGDEG-YEAST-PWY.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_17388_RXN-14903_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_17388_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,15 +17,26 @@
           <http://model.geneontology.org/CHEBI_17388_RXN-14903>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_15378_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,6 +50,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002413_RXN-14116_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_60039_RXN-14903>
         a       <http://purl.obolibrary.org/obo/CHEBI_60039> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -48,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -60,11 +82,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002333_YPL111W-MONOMER_ARGINASE-RXN_controller_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002333_YPL111W-MONOMER_ARGINASE-RXN_controller_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -84,24 +106,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "arginine degradation (aerobic) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_120a204f-3817-4a3a-94ce-5e38f8a422f1_RXN-14903_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58066_SPONTPRO-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58066> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -112,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,19 +131,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002333_YLR438W-MONOMER_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -146,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -154,52 +165,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_57540_RXN-14116_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_60039_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_CHEBI_60039_RXN-14903_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/120a204f-3817-4a3a-94ce-5e38f8a422f1_RXN-14903>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55328> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,11 +199,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_58066_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_58066_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -256,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -267,53 +252,31 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002411_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000066_reaction_PYRROLINECARBREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15377_SPONTPRO-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_46911_ARGINASE-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_46911_ARGINASE-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -332,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,11 +307,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-proline<SUB>[in]</SUB> + an electron-transfer quinone<SUB>[membrane]</SUB> &rarr; (<i>S</i>)-1-pyrroline-5-carboxylate<SUB>[in]</SUB> + an electron-transfer quinol<SUB>[membrane]</SUB> + H<SUP>+</SUP><SUB>[in]</SUB>' 'null' '(<i>S</i>)-1-pyrroline-5-carboxylate + H<SUP>+</SUP> + H<sub>2</sub>O &harr; L-glutamate-5-semialdehyde' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002413_SPONTPRO-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002413_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -359,15 +322,26 @@
           <http://model.geneontology.org/SPONTPRO-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_8c9fad50-d8bc-4f64-8290-c858a187da75_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_13392_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_13392_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -385,11 +359,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_BFO_0000066_reaction_ARGINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_BFO_0000066_reaction_ARGINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -413,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -424,15 +398,37 @@
 <http://identifiers.org/sgd/S000006032>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_13392_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_17388_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>S</i>)-1-pyrroline-5-carboxylate + H<SUP>+</SUP> + H<sub>2</sub>O &harr; L-glutamate-5-semialdehyde' 'null' 'L-glutamate-5-semialdehyde + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; L-glutamate + NADH + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002413_RXN-14116_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002413_RXN-14116_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -443,6 +439,32 @@
           <http://model.geneontology.org/RXN-14116>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-14903_BFO_0000066_reaction_RXN-14903_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/532e2e14-d9a6-46da-9500-174315986017_RXN-14903>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55328> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://identifiers.org/sgd/S000004430>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -450,11 +472,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_57540_RXN-14116_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_57540_RXN-14116_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -468,36 +490,25 @@
 <http://purl.obolibrary.org/obo/GO_0006527>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_57945_RXN-14116_SGD_YeastPathways_ARGDEG-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_17388_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_58066_SPONTPRO-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002413_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_15377_RXN-14116_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -508,11 +519,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_52404786-86be-455a-bf15-30180b532e3e_RXN-14903_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_8c9fad50-d8bc-4f64-8290-c858a187da75_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -520,7 +531,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-14903> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/52404786-86be-455a-bf15-30180b532e3e_RXN-14903>
+          <http://model.geneontology.org/8c9fad50-d8bc-4f64-8290-c858a187da75_RXN-14903>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -530,11 +541,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-ornithine + 2-oxoglutarate &rarr; L-glutamate + L-glutamate-5-semialdehyde' 'null' 'L-glutamate-5-semialdehyde + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; L-glutamate + NADH + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002413_RXN-14116_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002413_RXN-14116_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -544,6 +555,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN-14116>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -557,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -565,14 +587,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_YeastPathways_ARGDEG-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_58066_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -580,11 +602,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15377_SPONTPRO-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15377_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -619,11 +641,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002333_YER023W-MONOMER_PYRROLINECARBREDUCT-RXN_controller_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002333_YER023W-MONOMER_PYRROLINECARBREDUCT-RXN_controller_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,29 +661,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/CHEBI_57540_RXN-14116>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55408> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15377_SPONTPRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -672,7 +677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -680,15 +685,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/CHEBI_57540_RXN-14116>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55408> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_15377_RXN-14116_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002234_CHEBI_16199_ARGINASE-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002234_CHEBI_16199_ARGINASE-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -708,7 +741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -725,13 +758,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55322> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_15378_RXN-14116_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -757,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -769,11 +813,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_29985_RXN-14116_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_29985_RXN-14116_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -788,11 +832,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_46911_ARGINASE-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_46911_ARGINASE-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -803,17 +847,6 @@
           <http://model.geneontology.org/CHEBI_46911_ARGINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/RXN-14903>
         a       <http://purl.obolibrary.org/obo/GO_0004657> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -823,9 +856,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-14903_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_60039_RXN-14903> , <http://model.geneontology.org/52404786-86be-455a-bf15-30180b532e3e_RXN-14903> ;
+                <http://model.geneontology.org/CHEBI_60039_RXN-14903> , <http://model.geneontology.org/8c9fad50-d8bc-4f64-8290-c858a187da75_RXN-14903> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/120a204f-3817-4a3a-94ce-5e38f8a422f1_RXN-14903> , <http://model.geneontology.org/CHEBI_15378_RXN-14903> , <http://model.geneontology.org/CHEBI_17388_RXN-14903> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN-14903> , <http://model.geneontology.org/CHEBI_17388_RXN-14903> , <http://model.geneontology.org/532e2e14-d9a6-46da-9500-174315986017_RXN-14903> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR142W-MONOMER_RXN-14903_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -833,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -847,33 +880,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_120a204f-3817-4a3a-94ce-5e38f8a422f1_RXN-14903_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-14903> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/120a204f-3817-4a3a-94ce-5e38f8a422f1_RXN-14903>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_29985_RXN-14116_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -881,11 +895,30 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_13390_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_532e2e14-d9a6-46da-9500-174315986017_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-14903> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/532e2e14-d9a6-46da-9500-174315986017_RXN-14903>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_13390_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -903,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -911,19 +944,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15378_SPONTPRO-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_CHEBI_60039_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002413_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_17388_PYRROLINECARBREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17388> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -934,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -942,25 +997,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_17388_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_58066_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002333_YLR438W-MONOMER_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -968,11 +1012,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_58066_SPONTPRO-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_58066_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -988,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -996,11 +1040,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000066_reaction_RXN-14116_location_lociGO_0005829_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000066_reaction_RXN-14116_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1011,15 +1055,37 @@
           <http://model.geneontology.org/reaction_RXN-14116_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_15378_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002234_CHEBI_16199_ARGINASE-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" , "Provides Input For Rule. The relation 'L-arginine + H<sub>2</sub>O &rarr; urea + L-ornithine' 'null' 'L-ornithine + 2-oxoglutarate &rarr; L-glutamate + L-glutamate-5-semialdehyde' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002413_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002413_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1039,7 +1105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1066,7 +1132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1077,14 +1143,14 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_YeastPathways_ARGDEG-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_58066_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1097,7 +1163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1109,11 +1175,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_BFO_0000066_reaction_RXN-14903_location_lociGO_0005829_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_BFO_0000066_reaction_RXN-14903_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1128,11 +1194,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002333_YLR438W-MONOMER_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002333_YLR438W-MONOMER_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1143,12 +1209,23 @@
           <http://model.geneontology.org/YLR438W-MONOMER_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-14903_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1157,6 +1234,28 @@
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000066_reaction_RXN-14116_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15377_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1170,7 +1269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1190,24 +1289,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55490> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_13390_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ARGINASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004053> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1228,7 +1316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1246,11 +1334,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1261,17 +1349,6 @@
           <http://model.geneontology.org/YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_60039_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_13392>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1279,11 +1356,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_15378_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_15378_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1297,6 +1374,21 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/8c9fad50-d8bc-4f64-8290-c858a187da75_RXN-14903>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinone" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55304> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/GO_0004735>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1304,11 +1396,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002233_CHEBI_15377_ARGINASE-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002233_CHEBI_15377_ARGINASE-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1319,14 +1411,14 @@
           <http://model.geneontology.org/CHEBI_15377_ARGINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_17388_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1340,11 +1432,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_58066_SPONTPRO-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_58066_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1355,26 +1447,15 @@
           <http://model.geneontology.org/CHEBI_58066_SPONTPRO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_17388_RXN-14903_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1385,69 +1466,25 @@
           <http://model.geneontology.org/reaction_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002234_CHEBI_16199_ARGINASE-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_17388_RXN-14903_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002333_YER023W-MONOMER_PYRROLINECARBREDUCT-RXN_controller_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002413_SPONTPRO-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002333_YPL111W-MONOMER_ARGINASE-RXN_controller_SGD_YeastPathways_ARGDEG-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_BFO_0000066_reaction_ARGINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1458,11 +1495,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_15378_RXN-14903_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_15378_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1477,11 +1514,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1492,15 +1529,37 @@
           <http://model.geneontology.org/YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002333_YER023W-MONOMER_PYRROLINECARBREDUCT-RXN_controller_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_58066_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15378_SPONTPRO-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15378_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1515,11 +1574,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" , "Provides Input For Rule. The relation 'L-proline + NAD(P)<sup>+</sup> &larr; (<i>S</i>)-1-pyrroline-5-carboxylate + NAD(P)H + 2 H<SUP>+</SUP>' 'null' '(<i>S</i>)-1-pyrroline-5-carboxylate + H<SUP>+</SUP> + H<sub>2</sub>O &harr; L-glutamate-5-semialdehyde' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002413_SPONTPRO-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002413_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1530,6 +1589,28 @@
           <http://model.geneontology.org/SPONTPRO-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_29985_RXN-14116_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002411_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_PYRROLINECARBREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1539,7 +1620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1551,11 +1632,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002234_CHEBI_46911_ARGINASE-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002234_CHEBI_46911_ARGINASE-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1573,7 +1654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1593,7 +1674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1601,14 +1682,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_52404786-86be-455a-bf15-30180b532e3e_RXN-14903_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_57945_RXN-14116_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1621,7 +1702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1633,11 +1714,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_57945_RXN-14116_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_57945_RXN-14116_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1652,11 +1733,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1667,76 +1748,54 @@
           <http://model.geneontology.org/CHEBI_29985_ORNITHINE-GLU-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002413_SPONTPRO-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_13392_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002333_YPL111W-MONOMER_ARGINASE-RXN_controller_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000066_reaction_PYRROLINECARBREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000825>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002333_YLR142W-MONOMER_RXN-14903_controller_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002333_YLR142W-MONOMER_RXN-14903_controller_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1757,11 +1816,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_60039_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_60039_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1772,6 +1831,17 @@
           <http://model.geneontology.org/CHEBI_60039_PYRROLINECARBREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002233_CHEBI_32682_ARGINASE-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29985_RXN-14116>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1781,7 +1851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1789,26 +1859,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002233_CHEBI_15377_ARGINASE-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1819,6 +1878,28 @@
           <http://model.geneontology.org/YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_532e2e14-d9a6-46da-9500-174315986017_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002234_CHEBI_46911_ARGINASE-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_RXN-14903>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1828,7 +1909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1841,18 +1922,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000066_reaction_RXN-14116_location_lociGO_0005829_SGD_YeastPathways_ARGDEG-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15378_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1860,11 +1941,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002411_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002411_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1879,11 +1960,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_15377_RXN-14116_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_15377_RXN-14116_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1913,7 +1994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1921,26 +2002,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002411_SPONTPRO-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1951,17 +2021,6 @@
           <http://model.geneontology.org/YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002413_RXN-14116_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0006527> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1971,7 +2030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1979,14 +2038,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_BFO_0000066_reaction_ARGINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGDEG-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_57540_RXN-14116_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_ARGINASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1999,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2007,12 +2075,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_ARGINASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_13390_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2020,11 +2090,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_CHEBI_60039_RXN-14903_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_CHEBI_60039_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2035,18 +2105,15 @@
           <http://model.geneontology.org/CHEBI_60039_RXN-14903>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002411_SPONTPRO-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002411_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2057,30 +2124,22 @@
           <http://model.geneontology.org/SPONTPRO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002234_CHEBI_46911_ARGINASE-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002333_YLR142W-MONOMER_RXN-14903_controller_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -2091,14 +2150,14 @@
 <http://identifiers.org/sgd/S000004132>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_15378_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002411_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2106,11 +2165,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2125,11 +2184,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_17388_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_17388_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2144,11 +2203,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002233_CHEBI_32682_ARGINASE-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002233_CHEBI_32682_ARGINASE-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2168,7 +2227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2176,15 +2235,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-14903_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_15378_RXN-14116_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_15378_RXN-14116_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2199,11 +2269,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2214,69 +2284,32 @@
           <http://model.geneontology.org/CHEBI_16810_ORNITHINE-GLU-AMINOTRANSFERASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58066>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_32682>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_15378_RXN-14116_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_58066_SPONTPRO-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/52404786-86be-455a-bf15-30180b532e3e_RXN-14903>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinone" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55304> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_15378_RXN-14903_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_17388_RXN-14903_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_17388_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2296,7 +2329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2309,18 +2342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-14903_BFO_0000066_reaction_RXN-14903_location_lociGO_0005829_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2328,11 +2350,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000066_reaction_PYRROLINECARBREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000066_reaction_PYRROLINECARBREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2343,57 +2365,35 @@
           <http://model.geneontology.org/reaction_PYRROLINECARBREDUCT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002233_CHEBI_32682_ARGINASE-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002413_RXN-14116_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGDEG-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002233_CHEBI_15377_ARGINASE-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002413_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002413_RXN-14116_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002333_YLR142W-MONOMER_RXN-14903_controller_SGD_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002413_SPONTPRO-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_ARGSPECAT-PWY.ttl
+++ b/models/YeastPathways_ARGSPECAT-PWY.ttl
@@ -1,35 +1,68 @@
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002333_YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_ARGSPECAT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSPECAT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_16526_SAMDECARB-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSPECAT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_SAMDECARB-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSPECAT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ARGSPECAT-PWY/YeastPathways_ARGSPECAT-PWY_SGD_PWY_YeastPathways_ARGSPECAT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005412>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57834_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_ARGSPECAT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSPECAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_45725_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_ARGSPECAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_45725_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,26 +73,15 @@
           <http://model.geneontology.org/CHEBI_45725_SPERMINE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002333_YOL052C-MONOMER_SAMDECARB-RXN_controller_SGD_YeastPathways_ARGSPECAT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSPECAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_16526_SAMDECARB-RXN_SGD_YeastPathways_ARGSPECAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_16526_SAMDECARB-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -85,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -93,14 +115,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000066_reaction_SAMDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSPECAT-PWY>
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_SAMDECARB-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSPECAT-PWY" ;
+                "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -113,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -124,28 +146,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_57443>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_YeastPathways_ARGSPECAT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSPECAT-PWY" ;
+                "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000066_reaction_SPERMINE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSPECAT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000050_YeastPathways_ARGSPECAT-PWY/YeastPathways_ARGSPECAT-PWY_SGD_PWY_YeastPathways_ARGSPECAT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSPECAT-PWY" ;
+                "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -162,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -179,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -191,11 +213,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_ARGSPECAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -210,11 +232,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_SAMDECARB-RXN_SGD_YeastPathways_ARGSPECAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_SAMDECARB-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -242,7 +264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -262,14 +284,14 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_ARGSPECAT-PWY>
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002333_YOL052C-MONOMER_SAMDECARB-RXN_controller_SGD_PWY_YeastPathways_ARGSPECAT-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSPECAT-PWY" ;
+                "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -282,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "spermine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -293,26 +315,15 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_ARGSPECAT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSPECAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ARGSPECAT-PWY/YeastPathways_ARGSPECAT-PWY_SGD_YeastPathways_ARGSPECAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ARGSPECAT-PWY/YeastPathways_ARGSPECAT-PWY_SGD_PWY_YeastPathways_ARGSPECAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -332,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -340,29 +351,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_SAMDECARB-RXN_SGD_YeastPathways_ARGSPECAT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_45725_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSPECAT-PWY" ;
+                "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_ARGSPECAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -377,11 +388,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_YeastPathways_ARGSPECAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -401,7 +412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -416,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -424,14 +435,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_ARGSPECAT-PWY>
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSPECAT-PWY" ;
+                "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -441,31 +452,20 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000050_YeastPathways_ARGSPECAT-PWY/YeastPathways_ARGSPECAT-PWY_SGD_YeastPathways_ARGSPECAT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSPECAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_45725_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_ARGSPECAT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000066_reaction_SPERMINE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSPECAT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSPECAT-PWY" ;
+                "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -473,11 +473,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" , "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine' 'null' 'spermidine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_ARGSPECAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -491,37 +491,15 @@
 <http://purl.obolibrary.org/obo/GO_0004014>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_16526_SAMDECARB-RXN_SGD_YeastPathways_ARGSPECAT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSPECAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_ARGSPECAT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSPECAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57834_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_ARGSPECAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57834_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -532,15 +510,37 @@
           <http://model.geneontology.org/CHEBI_57834_SPERMINE-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSPECAT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSPECAT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000066_reaction_SAMDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSPECAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000066_reaction_SAMDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSPECAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -560,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -584,11 +584,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002333_YOL052C-MONOMER_SAMDECARB-RXN_controller_SGD_YeastPathways_ARGSPECAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002333_YOL052C-MONOMER_SAMDECARB-RXN_controller_SGD_PWY_YeastPathways_ARGSPECAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -610,7 +610,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -618,11 +629,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_ARGSPECAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -637,11 +648,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000050_YeastPathways_ARGSPECAT-PWY/YeastPathways_ARGSPECAT-PWY_SGD_YeastPathways_ARGSPECAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000050_YeastPathways_ARGSPECAT-PWY/YeastPathways_ARGSPECAT-PWY_SGD_PWY_YeastPathways_ARGSPECAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -664,24 +675,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGSPECAT-PWYSmallMolecule42586> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ARGSPECAT-PWY/YeastPathways_ARGSPECAT-PWY_SGD_YeastPathways_ARGSPECAT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSPECAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -705,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -729,7 +729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -744,11 +744,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002333_YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller_SGD_YeastPathways_ARGSPECAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002333_YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_ARGSPECAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -763,11 +763,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_ARGSPECAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -778,40 +778,40 @@
           <http://model.geneontology.org/CHEBI_57443_SAMDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002333_YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller_SGD_YeastPathways_ARGSPECAT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSPECAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_ARGSPECAT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSPECAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_59789>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57834_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSPECAT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000066_reaction_SAMDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSPECAT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSPECAT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000066_reaction_SPERMINE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSPECAT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000066_reaction_SPERMINE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSPECAT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -834,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_ARGSYNBSUB-PWY.ttl
+++ b/models/YeastPathways_ARGSYNBSUB-PWY.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_N-ACETYLTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_N-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -32,15 +32,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002333_YOL058W-MONOMER_ARGSUCCINSYN-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -60,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -68,8 +79,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000003666>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002234_CHEBI_456215_ARGSUCCINSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29991>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -78,11 +111,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002233_CHEBI_29985_ACETYLORNTRANSAM-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002233_CHEBI_29985_ACETYLORNTRANSAM-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -114,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,14 +155,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002333_YOL058W-MONOMER_ARGSUCCINSYN-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_44337_N-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -137,11 +170,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_43474_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_43474_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -152,26 +185,15 @@
           <http://model.geneontology.org/CHEBI_43474_ORNCARBAMTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002333_YJL088W-MONOMER_ORNCARBAMTRANSFER-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_44337_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_44337_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -182,42 +204,42 @@
           <http://model.geneontology.org/CHEBI_44337_GLUTAMATE-N-ACETYLTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_44337_N-ACETYLTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/GO_0004088>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_15378_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002234_CHEBI_456216_ACETYLGLUTKIN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002413_ACETYLGLUTKIN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004088>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002233_CHEBI_29985_ACETYLORNTRANSAM-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -225,11 +247,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_BFO_0000066_reaction_ARGSUCCINSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_BFO_0000066_reaction_ARGSUCCINSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,6 +261,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_ARGSUCCINSYN-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002333_YER069W-MONOMER_ACETYLGLUTKIN-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_44337>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -250,11 +283,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,11 +305,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002234_CHEBI_58349_N-ACETYLGLUTPREDUCT-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002234_CHEBI_58349_N-ACETYLGLUTPREDUCT-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -287,14 +320,14 @@
           <http://model.geneontology.org/CHEBI_58349_N-ACETYLGLUTPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002234_CHEBI_29888_ARGSUCCINSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
+<http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_RO_0002233_CHEBI_57472_ARGSUCCINSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -307,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -319,11 +352,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -334,18 +367,40 @@
           <http://model.geneontology.org/CHEBI_15377_CARBPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_BFO_0000066_reaction_ACETYLGLUTKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002234_CHEBI_57936_ACETYLGLUTKIN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" , "Provides Input For Rule. The relation 'L-glutamate + acetyl-CoA &rarr; <i>N</i>-acetyl-L-glutamate + coenzyme A + H<SUP>+</SUP>' 'null' '<i>N</i>-acetyl-L-glutamate + ATP &rarr; <i>N</i>-acetylglutamyl-phosphate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002413_ACETYLGLUTKIN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002413_ACETYLGLUTKIN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -356,26 +411,15 @@
           <http://model.geneontology.org/ACETYLGLUTKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,6 +430,17 @@
           <http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002234_CHEBI_43474_N-ACETYLGLUTPREDUCT-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -393,11 +448,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_BFO_0000066_reaction_ARGSUCCINLYA-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_BFO_0000066_reaction_ARGSUCCINLYA-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -417,24 +472,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGSYNBSUB-PWYSmallMolecule18362> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_N-ACETYLTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58228>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -448,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -456,31 +500,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_29123>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLGLUTKIN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_29985_N-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_29123>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002234_CHEBI_57472_ARGSUCCINSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_57743_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -493,7 +537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -505,11 +549,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002233_CHEBI_15378_N-ACETYLGLUTPREDUCT-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002233_CHEBI_15378_N-ACETYLGLUTPREDUCT-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -524,11 +568,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002333_YER069W-MONOMER_ACETYLGLUTKIN-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002333_YER069W-MONOMER_ACETYLGLUTKIN-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -543,11 +587,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002234_CHEBI_57472_ARGSUCCINSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002234_CHEBI_57472_ARGSUCCINSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -561,47 +605,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002413_ACETYLGLUTKIN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_BFO_0000066_reaction_ARGSUCCINSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSYNBSUB-PWY>
+<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_15378_N-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002333_YER069W-MONOMER_ACETYLGLUTKIN-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002233_CHEBI_57783_N-ACETYLGLUTPREDUCT-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -609,11 +631,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_15378_N-ACETYLTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_15378_N-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -624,25 +646,14 @@
           <http://model.geneontology.org/CHEBI_15378_N-ACETYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_15378_N-ACETYLTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002233_CHEBI_29985_ACETYLORNTRANSAM-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_44337_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -650,11 +661,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -701,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -709,14 +720,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002233_CHEBI_57936_ACETYLGLUTKIN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -724,11 +735,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002234_CHEBI_16810_ACETYLORNTRANSAM-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002234_CHEBI_16810_ACETYLORNTRANSAM-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -739,28 +750,6 @@
           <http://model.geneontology.org/CHEBI_16810_ACETYLORNTRANSAM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YOL058W-MONOMER_ARGSUCCINSYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005419> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -768,7 +757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -784,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -795,11 +784,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_57743_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_57743_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -823,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -835,11 +824,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_46911_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_46911_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -850,14 +839,25 @@
           <http://model.geneontology.org/CHEBI_46911_GLUTAMATE-N-ACETYLTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_BFO_0000066_reaction_N-ACETYLGLUTPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSYNBSUB-PWY>
+<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002333_YER069W-MONOMER_N-ACETYLGLUTPREDUCT-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002333_YOL140W-MONOMER_ACETYLORNTRANSAM-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -870,7 +870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -882,11 +882,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002233_CHEBI_29991_ARGSUCCINSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002233_CHEBI_29991_ARGSUCCINSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -909,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -924,11 +924,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_BFO_0000066_reaction_ACETYLGLUTKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_BFO_0000066_reaction_ACETYLGLUTKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -958,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -970,11 +970,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002333_YER069W-MONOMER_N-ACETYLGLUTPREDUCT-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002333_YER069W-MONOMER_N-ACETYLGLUTPREDUCT-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -988,6 +988,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002413_ARGSUCCINLYA-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_ACETYLGLUTKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -997,7 +1008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1009,11 +1020,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1024,25 +1035,14 @@
           <http://model.geneontology.org/CHEBI_17544_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_BFO_0000066_reaction_ACETYLORNTRANSAM-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
+<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002234_CHEBI_29888_ARGSUCCINSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1051,7 +1051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1062,11 +1062,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1080,26 +1080,15 @@
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1115,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1126,11 +1115,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_RO_0002233_CHEBI_57472_ARGSUCCINSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_RO_0002233_CHEBI_57472_ARGSUCCINSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1141,25 +1130,23 @@
           <http://model.geneontology.org/CHEBI_57472_ARGSUCCINSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_YeastPathways_ARGSYNBSUB-PWY>
+<http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_29985_N-ACETYLTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/reaction_CARBPSYN-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1167,11 +1154,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000066_reaction_ORNCARBAMTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000066_reaction_ORNCARBAMTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1182,23 +1169,14 @@
           <http://model.geneontology.org/reaction_ORNCARBAMTRANSFER-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/reaction_CARBPSYN-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002333_YJL071W-MONOMER_N-ACETYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1206,11 +1184,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1230,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-arginine biosynthesis II (acetyl cycle) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1247,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1262,7 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1274,11 +1252,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_RO_0002234_CHEBI_29806_ARGSUCCINLYA-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_RO_0002234_CHEBI_29806_ARGSUCCINLYA-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1289,36 +1267,14 @@
           <http://model.geneontology.org/CHEBI_29806_ARGSUCCINLYA-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002234_CHEBI_57805_ACETYLORNTRANSAM-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002234_CHEBI_58349_N-ACETYLGLUTPREDUCT-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002233_CHEBI_29123_N-ACETYLGLUTPREDUCT-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1329,11 +1285,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002233_CHEBI_57783_N-ACETYLGLUTPREDUCT-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002233_CHEBI_57783_N-ACETYLGLUTPREDUCT-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1348,11 +1304,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>N</i>-acetyl-L-glutamate + ATP &rarr; <i>N</i>-acetylglutamyl-phosphate + ADP' 'null' '<i>N</i>-acetyl-L-glutamate 5-semialdehyde + NADP<sup>+</sup> + phosphate &larr; <i>N</i>-acetylglutamyl-phosphate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002413_N-ACETYLGLUTPREDUCT-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002413_N-ACETYLGLUTPREDUCT-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1363,15 +1319,26 @@
           <http://model.geneontology.org/N-ACETYLGLUTPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002333_YOL058W-MONOMER_ARGSUCCINSYN-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002333_YOL058W-MONOMER_ARGSUCCINSYN-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1394,7 +1361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1402,14 +1369,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_BFO_0000066_reaction_N-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_46911_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1422,7 +1389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1439,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1451,11 +1418,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_44337_N-ACETYLTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_44337_N-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1485,13 +1452,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGSYNBSUB-PWYBiochemicalReaction18276> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57288_N-ACETYLTRANSFER-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57288> ;
@@ -1502,7 +1480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1518,7 +1496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1526,11 +1504,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1550,7 +1528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1561,37 +1539,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_29806>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002234_CHEBI_57805_ACETYLORNTRANSAM-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002234_CHEBI_57805_ACETYLORNTRANSAM-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1602,29 +1558,32 @@
           <http://model.geneontology.org/CHEBI_57805_ACETYLORNTRANSAM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_BFO_0000066_reaction_N-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002333_YJL088W-MONOMER_ORNCARBAMTRANSFER-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002333_YJL088W-MONOMER_ORNCARBAMTRANSFER-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1635,17 +1594,14 @@
           <http://model.geneontology.org/YJL088W-MONOMER_ORNCARBAMTRANSFER-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/BFO_0000051>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002233_CHEBI_15378_N-ACETYLGLUTPREDUCT-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002234_CHEBI_16810_ACETYLORNTRANSAM-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1653,11 +1609,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002333_YMR062C-MONOMER_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002333_YMR062C-MONOMER_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1668,14 +1624,14 @@
           <http://model.geneontology.org/YMR062C-MONOMER_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002234_CHEBI_43474_N-ACETYLGLUTPREDUCT-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002233_CHEBI_30616_ACETYLGLUTKIN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1683,11 +1639,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002233_CHEBI_30616_ARGSUCCINSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002233_CHEBI_30616_ARGSUCCINSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1697,17 +1653,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30616_ARGSUCCINSYN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1721,7 +1666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1733,11 +1678,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002233_CHEBI_30616_ACETYLGLUTKIN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002233_CHEBI_30616_ACETYLGLUTKIN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1752,11 +1697,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>N</i>-acetyl-L-glutamate 5-semialdehyde + NADP<sup>+</sup> + phosphate &larr; <i>N</i>-acetylglutamyl-phosphate + NADPH + H<SUP>+</SUP>' 'null' '2-oxoglutarate + <i>N</i>-acetyl-L-ornithine &larr; <i>N</i>-acetyl-L-glutamate 5-semialdehyde + L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002413_ACETYLORNTRANSAM-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002413_ACETYLORNTRANSAM-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1767,28 +1712,6 @@
           <http://model.geneontology.org/ACETYLORNTRANSAM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_46911_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002233_CHEBI_44337_N-ACETYLTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_ARGSUCCINSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1798,7 +1721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1810,11 +1733,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1825,30 +1748,8 @@
           <http://model.geneontology.org/CHEBI_30616_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0006526>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1863,7 +1764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1883,7 +1784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1891,14 +1792,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_YeastPathways_ARGSYNBSUB-PWY>
+<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002234_CHEBI_15378_ARGSUCCINSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1907,40 +1808,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002413_ARGSUCCINSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_44337_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
+<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1953,7 +1832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1965,11 +1844,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_46911_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_46911_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1984,11 +1863,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1999,26 +1878,15 @@
           <http://model.geneontology.org/reaction_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002413_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_RO_0002234_CHEBI_32682_ARGSUCCINLYA-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_RO_0002234_CHEBI_32682_ARGSUCCINLYA-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2031,6 +1899,17 @@
 
 <http://purl.obolibrary.org/obo/GO_0004055>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002234_CHEBI_29123_N-ACETYLGLUTPREDUCT-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/N-ACETYLTRANSFER-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0103045> ;
@@ -2051,24 +1930,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGSYNBSUB-PWYBiochemicalReaction18173> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57472_ARGSUCCINSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57472> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2079,7 +1947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2091,11 +1959,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002233_CHEBI_57936_ACETYLGLUTKIN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002233_CHEBI_57936_ACETYLGLUTKIN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2110,11 +1978,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2125,15 +1993,26 @@
           <http://model.geneontology.org/YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002413_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-aspartate + L-citrulline + ATP &rarr; L-arginino-succinate + AMP + diphosphate + H<SUP>+</SUP>' 'null' 'L-arginino-succinate &rarr; L-arginine + fumarate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002413_ARGSUCCINLYA-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002413_ARGSUCCINLYA-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2143,6 +2022,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/ARGSUCCINLYA-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_15378_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -2155,7 +2045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2168,7 +2058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2180,11 +2070,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_N-ACETYLTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_N-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2214,7 +2104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2222,37 +2112,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_RO_0002234_CHEBI_29806_ARGSUCCINLYA-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_57743_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2263,25 +2131,14 @@
           <http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000066_reaction_ORNCARBAMTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSYNBSUB-PWY>
+<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_BFO_0000066_reaction_N-ACETYLGLUTPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002234_CHEBI_58349_N-ACETYLGLUTPREDUCT-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2294,7 +2151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2302,14 +2159,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000066_reaction_ORNCARBAMTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2317,11 +2174,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002333_YOL140W-MONOMER_ACETYLORNTRANSAM-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002333_YOL140W-MONOMER_ACETYLORNTRANSAM-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2341,7 +2198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2354,7 +2211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2362,11 +2219,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-ornithine + carbamoyl phosphate &rarr; L-citrulline + phosphate + H<SUP>+</SUP>' 'null' 'L-aspartate + L-citrulline + ATP &rarr; L-arginino-succinate + AMP + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002413_ARGSUCCINSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002413_ARGSUCCINSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2377,14 +2234,14 @@
           <http://model.geneontology.org/ARGSUCCINSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002233_CHEBI_57783_N-ACETYLGLUTPREDUCT-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2397,7 +2254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2409,11 +2266,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" , "Provides Input For Rule. The relation 'L-glutamate + <i>N</i>-acetyl-L-ornithine &rarr; <i>N</i>-acetyl-L-glutamate + L-ornithine' 'null' '<i>N</i>-acetyl-L-glutamate + ATP &rarr; <i>N</i>-acetylglutamyl-phosphate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLGLUTKIN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLGLUTKIN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2433,7 +2290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2445,11 +2302,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002233_CHEBI_57743_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002233_CHEBI_57743_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2463,14 +2320,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_57743>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002333_YMR062C-MONOMER_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY>
+<http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2481,7 +2338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2489,15 +2346,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002233_CHEBI_44337_N-ACETYLTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002233_CHEBI_44337_N-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2508,6 +2376,17 @@
           <http://model.geneontology.org/CHEBI_44337_N-ACETYLTRANSFER-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002233_CHEBI_44337_N-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_CARBPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2517,7 +2396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2529,11 +2408,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2544,25 +2423,36 @@
           <http://model.geneontology.org/YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_RO_0002234_CHEBI_32682_ARGSUCCINLYA-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002233_CHEBI_29991_ARGSUCCINSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_29985_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLGLUTKIN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2570,11 +2460,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2594,7 +2484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2602,40 +2492,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57936>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002413_ARGSUCCINLYA-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_BFO_0000066_reaction_N-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_BFO_0000066_reaction_N-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2655,7 +2523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2666,15 +2534,24 @@
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/reaction_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2685,41 +2562,32 @@
           <http://model.geneontology.org/CHEBI_15378_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_N-ACETYLTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/GO_0003942>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_BFO_0000066_reaction_ACETYLORNTRANSAM-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_BFO_0000066_reaction_ACETYLORNTRANSAM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2749,7 +2617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2761,11 +2629,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2779,6 +2647,17 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_ACETYLGLUTKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2788,7 +2667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2801,7 +2680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2812,11 +2691,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_29985_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_29985_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2844,7 +2723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2852,15 +2731,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57805_ACETYLORNTRANSAM-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_RO_0002333_YHR018C-MONOMER_ARGSUCCINLYA-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_RO_0002333_YHR018C-MONOMER_ARGSUCCINLYA-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2889,7 +2779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2900,25 +2790,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_32682>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_46911_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
+<http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002234_CHEBI_57805_ACETYLORNTRANSAM-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57805_ACETYLORNTRANSAM-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2926,11 +2805,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002234_CHEBI_29123_N-ACETYLGLUTPREDUCT-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002234_CHEBI_29123_N-ACETYLGLUTPREDUCT-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2941,14 +2820,14 @@
           <http://model.geneontology.org/CHEBI_29123_N-ACETYLGLUTPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002233_CHEBI_30616_ARGSUCCINSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_BFO_0000066_reaction_ARGSUCCINSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2959,7 +2838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2971,11 +2850,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2986,41 +2865,8 @@
           <http://model.geneontology.org/YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002233_CHEBI_57936_ACETYLGLUTKIN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002333_YOL140W-MONOMER_ACETYLORNTRANSAM-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_46911>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002234_CHEBI_57936_ACETYLGLUTKIN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58349_N-ACETYLGLUTPREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3031,7 +2877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3039,21 +2885,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002233_CHEBI_30616_ARGSUCCINSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000005419>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000003870>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002333_YJL071W-MONOMER_N-ACETYLTRANSFER-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002333_YJL071W-MONOMER_N-ACETYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3064,26 +2932,15 @@
           <http://model.geneontology.org/YJL071W-MONOMER_N-ACETYLTRANSFER-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002234_CHEBI_15378_ARGSUCCINSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3094,14 +2951,14 @@
           <http://model.geneontology.org/YJL130C-MONOMER_CARBPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002413_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_RO_0002234_CHEBI_29806_ARGSUCCINLYA-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3112,7 +2969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3129,7 +2986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3144,7 +3001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3156,11 +3013,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" , "Provides Input For Rule. The relation '2-oxoglutarate + <i>N</i>-acetyl-L-ornithine &larr; <i>N</i>-acetyl-L-glutamate 5-semialdehyde + L-glutamate' 'null' 'L-glutamate + <i>N</i>-acetyl-L-ornithine &rarr; <i>N</i>-acetyl-L-glutamate + L-ornithine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002413_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002413_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3171,14 +3028,25 @@
           <http://model.geneontology.org/GLUTAMATE-N-ACETYLTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_43474_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
+<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_N-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002333_YJL088W-MONOMER_ORNCARBAMTRANSFER-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3186,11 +3054,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-glutamate + <i>N</i>-acetyl-L-ornithine &rarr; <i>N</i>-acetyl-L-glutamate + L-ornithine' 'null' 'L-ornithine + carbamoyl phosphate &rarr; L-citrulline + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002413_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002413_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3210,7 +3078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3218,51 +3086,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_RO_0002333_YHR018C-MONOMER_ARGSUCCINLYA-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002233_CHEBI_57743_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004358>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_BFO_0000066_reaction_ARGSUCCINLYA-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002234_CHEBI_15378_ARGSUCCINSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002234_CHEBI_15378_ARGSUCCINSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3282,7 +3117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3293,14 +3128,14 @@
 <http://purl.obolibrary.org/obo/GO_0003991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002234_CHEBI_57472_ARGSUCCINSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3308,11 +3143,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002234_CHEBI_456216_ACETYLGLUTKIN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002234_CHEBI_456216_ACETYLGLUTKIN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3326,25 +3161,14 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002333_YMR062C-MONOMER_N-ACETYLTRANSFER-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY>
+<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002233_CHEBI_30616_ACETYLGLUTKIN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3355,7 +3179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3363,29 +3187,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002234_CHEBI_16810_ACETYLORNTRANSAM-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_N-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002233_CHEBI_15378_N-ACETYLGLUTPREDUCT-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_29985_N-ACETYLTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_29985_N-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3396,17 +3231,6 @@
           <http://model.geneontology.org/CHEBI_29985_N-ACETYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002413_N-ACETYLGLUTPREDUCT-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58228_CARBPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58228> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3416,7 +3240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3433,13 +3257,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGSYNBSUB-PWYSmallMolecule18415> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACETYLORNTRANSAM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003992> ;
@@ -3460,7 +3295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3472,11 +3307,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3487,8 +3322,30 @@
           <http://model.geneontology.org/CHEBI_29985_CARBPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000004666>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_43474_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001060>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3496,26 +3353,15 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002234_CHEBI_456215_ARGSUCCINSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002233_CHEBI_29123_N-ACETYLGLUTPREDUCT-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002233_CHEBI_29123_N-ACETYLGLUTPREDUCT-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3535,7 +3381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3543,15 +3389,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_BFO_0000066_reaction_ACETYLORNTRANSAM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYLORNTRANSAM-RXN_RO_0002233_CHEBI_29123_N-ACETYLGLUTPREDUCT-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_15378_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_15378_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3562,17 +3430,6 @@
           <http://model.geneontology.org/CHEBI_15378_ORNCARBAMTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002234_CHEBI_29123_N-ACETYLGLUTPREDUCT-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3580,11 +3437,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57805_ACETYLORNTRANSAM-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57805_ACETYLORNTRANSAM-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3595,6 +3452,17 @@
           <http://model.geneontology.org/CHEBI_57805_ACETYLORNTRANSAM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_ORNCARBAMTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3604,7 +3472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3612,14 +3480,58 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002333_YMR062C-MONOMER_N-ACETYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002234_CHEBI_456216_ACETYLGLUTKIN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002233_CHEBI_29991_ARGSUCCINSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002233_CHEBI_57743_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002413_ARGSUCCINSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3627,11 +3539,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3642,8 +3554,41 @@
           <http://model.geneontology.org/YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_RO_0002333_YHR018C-MONOMER_ARGSUCCINLYA-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456215_ARGSUCCINSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456215> ;
@@ -3654,7 +3599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3666,11 +3611,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002234_CHEBI_43474_N-ACETYLGLUTPREDUCT-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002234_CHEBI_43474_N-ACETYLGLUTPREDUCT-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3684,14 +3629,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_57805>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002333_YJL071W-MONOMER_N-ACETYLTRANSFER-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY>
+<http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_RO_0002234_CHEBI_32682_ARGSUCCINLYA-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3699,11 +3644,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3713,17 +3658,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_CARBPSYN-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002333_YER069W-MONOMER_N-ACETYLGLUTPREDUCT-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004585> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3744,13 +3678,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGSYNBSUB-PWYBiochemicalReaction18531> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3759,11 +3704,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002333_YMR062C-MONOMER_N-ACETYLTRANSFER-RXN_controller_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLTRANSFER-RXN_RO_0002333_YMR062C-MONOMER_N-ACETYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3777,26 +3722,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 ATP + L-glutamine + hydrogencarbonate + H<sub>2</sub>O &rarr; L-glutamate + carbamoyl phosphate + 2 ADP + phosphate + 2 H<SUP>+</SUP>' 'null' 'L-ornithine + carbamoyl phosphate &rarr; L-citrulline + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3807,15 +3741,26 @@
           <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002413_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3826,36 +3771,36 @@
           <http://model.geneontology.org/YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_RO_0002233_CHEBI_57472_ARGSUCCINSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_29985_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
+<http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_BFO_0000066_reaction_ARGSUCCINLYA-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002413_ACETYLORNTRANSAM-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3863,11 +3808,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3878,25 +3823,14 @@
           <http://model.geneontology.org/YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_RO_0002413_ACETYLORNTRANSAM-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3904,11 +3838,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002234_CHEBI_29888_ARGSUCCINSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002234_CHEBI_29888_ARGSUCCINSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3919,18 +3853,48 @@
           <http://model.geneontology.org/CHEBI_29888_ARGSUCCINSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0003992>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_BFO_0000066_reaction_N-ACETYLGLUTPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002234_CHEBI_57936_ACETYLGLUTKIN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ACETYLGLUTKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57936_ACETYLGLUTKIN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_N-ACETYLGLUTPREDUCT-RXN_BFO_0000066_reaction_N-ACETYLGLUTPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3940,6 +3904,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_N-ACETYLGLUTPREDUCT-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002333_YMR062C-MONOMER_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -3953,7 +3928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3961,33 +3936,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002234_CHEBI_57936_ACETYLGLUTKIN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ACETYLGLUTKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57936_ACETYLGLUTKIN-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_BFO_0000066_reaction_ACETYLGLUTKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_ARGSYNBSUB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSYNBSUB-PWY" ;
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3995,11 +3951,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002234_CHEBI_456215_ARGSUCCINSYN-RXN_SGD_YeastPathways_ARGSYNBSUB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARGSUCCINSYN-RXN_RO_0002234_CHEBI_456215_ARGSUCCINSYN-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4010,8 +3966,52 @@
           <http://model.geneontology.org/CHEBI_456215_ARGSUCCINSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETYLGLUTKIN-RXN_RO_0002413_N-ACETYLGLUTPREDUCT-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_46911_GLUTAMATE-N-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000003624>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ARGSUCCINLYA-RXN_BFO_0000050_YeastPathways_ARGSYNBSUB-PWY/YeastPathways_ARGSYNBSUB-PWY_SGD_PWY_YeastPathways_ARGSYNBSUB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSYNBSUB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005500>
         a       <http://www.w3.org/2002/07/owl#Class> .

--- a/models/YeastPathways_ARO-PWY-1.ttl
+++ b/models/YeastPathways_ARO-PWY-1.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,11 +21,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000066_reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000066_reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,6 +36,17 @@
           <http://model.geneontology.org/reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_32364>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -43,11 +54,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,36 +69,14 @@
           <http://model.geneontology.org/YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -100,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -133,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -145,11 +134,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '3-deoxy-D-arabino-heptulosonate 7-phosphate &rarr; 3-dehydroquinate + phosphate' 'null' '3-dehydroquinate &harr; 3-dehydroshikimate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -164,11 +153,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -179,15 +168,26 @@
           <http://model.geneontology.org/YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002413_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YBR249C-MONOMER_DAHPSYN-RXN_controller_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YBR249C-MONOMER_DAHPSYN-RXN_controller_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,6 +198,17 @@
           <http://model.geneontology.org/YBR249C-MONOMER_DAHPSYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_58394_DAHPSYN-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YDR127W-MONOMER_2.5.1.19-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002534> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -205,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -213,14 +224,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_YeastPathways_ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -233,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "chorismate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -266,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -274,36 +285,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002333_YDR127W-MONOMER_2.5.1.19-RXN_controller_SGD_YeastPathways_ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_30616_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000066_reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -311,11 +300,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,11 +322,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -348,6 +337,17 @@
           <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002233_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -355,11 +355,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000066_reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000066_reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -379,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -387,17 +387,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_43474_DAHPSYN-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -405,11 +416,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -420,26 +431,15 @@
           <http://model.geneontology.org/reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -487,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -519,11 +519,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_58702_2.5.1.19-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_58702_2.5.1.19-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,29 +534,29 @@
           <http://model.geneontology.org/CHEBI_58702_2.5.1.19-RXN>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002413_2.5.1.19-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002333_YDR127W-MONOMER_2.5.1.19-RXN_controller_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -579,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -587,36 +587,47 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000066_reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_58702_DAHPSYN-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002413_2.5.1.19-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002413_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -624,11 +635,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,15 +650,26 @@
           <http://model.geneontology.org/CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'shikimate + NADP<sup>+</sup> &larr; 3-dehydroshikimate + NADPH + H<SUP>+</SUP>' 'null' 'shikimate + ATP &harr; shikimate 3-phosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002413_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002413_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,15 +683,26 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -680,14 +713,36 @@
           <http://model.geneontology.org/CHEBI_43474_CHORISMATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_YeastPathways_ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000066_reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -700,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -712,11 +767,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,11 +789,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,11 +811,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_43474_DAHPSYN-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_43474_DAHPSYN-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -780,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -795,7 +850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -803,14 +858,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002233_CHEBI_57701_2.5.1.19-RXN_SGD_YeastPathways_ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_43474_2.5.1.19-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -821,11 +898,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002333_YDR127W-MONOMER_2.5.1.19-RXN_controller_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002333_YDR127W-MONOMER_2.5.1.19-RXN_controller_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -840,11 +917,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -860,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -871,11 +948,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" , "Provides Input For Rule. The relation '3-dehydroquinate &harr; 3-dehydroshikimate + H<sub>2</sub>O' 'null' 'shikimate + NADP<sup>+</sup> &larr; 3-dehydroshikimate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002413_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002413_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -893,11 +970,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_30616_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_30616_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -912,11 +989,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000066_reaction_DAHPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000066_reaction_DAHPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -927,19 +1004,30 @@
           <http://model.geneontology.org/reaction_DAHPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://identifiers.org/sgd/S000002442>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_58702_2.5.1.19-RXN_SGD_YeastPathways_ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000002442>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -953,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,14 +1049,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_57701_2.5.1.19-RXN_SGD_YeastPathways_ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -976,11 +1064,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000066_reaction_2.5.1.19-RXN_location_lociGO_0005829_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000066_reaction_2.5.1.19-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -991,26 +1079,15 @@
           <http://model.geneontology.org/reaction_2.5.1.19-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1021,20 +1098,6 @@
           <http://model.geneontology.org/YDR035W-MONOMER_DAHPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/CHEBI_43474_CHORISMATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1044,24 +1107,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARO-PWY-1SmallMolecule54551> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YDR035W-MONOMER_DAHPSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000002442> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1070,7 +1122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1081,19 +1133,19 @@
 <http://purl.obolibrary.org/obo/CHEBI_16897>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_YeastPathways_ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1107,7 +1159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1115,16 +1167,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000066_reaction_DAHPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1135,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1143,19 +1187,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0003855>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0003855>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1164,11 +1208,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1179,26 +1223,15 @@
           <http://model.geneontology.org/reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58394_DAHPSYN-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1209,26 +1242,15 @@
           <http://model.geneontology.org/CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_15377_DAHPSYN-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002233_CHEBI_57701_2.5.1.19-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002233_CHEBI_57701_2.5.1.19-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1251,7 +1273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1259,40 +1281,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_58349>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_30616_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_YeastPathways_ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58349>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58394_DAHPSYN-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58394_DAHPSYN-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1307,11 +1318,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1329,11 +1340,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_16897_DAHPSYN-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_16897_DAHPSYN-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1343,6 +1354,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16897_DAHPSYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004764> ;
@@ -1363,7 +1396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1390,7 +1423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1407,7 +1440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1415,8 +1448,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002233_CHEBI_57701_2.5.1.19-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0009423>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1425,11 +1480,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_43474_2.5.1.19-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_43474_2.5.1.19-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1444,11 +1499,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000066_reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000066_reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1459,14 +1514,14 @@
           <http://model.geneontology.org/reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_456216_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1477,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1489,11 +1544,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1508,11 +1563,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1523,15 +1578,26 @@
           <http://model.geneontology.org/YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002333_YGL148W-MONOMER_CHORISMATE-SYNTHASE-RXN_controller_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002333_YGL148W-MONOMER_CHORISMATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1548,37 +1614,48 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/CHEBI_58394>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YBR249C-MONOMER_DAHPSYN-RXN_controller_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58394>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_43474_DAHPSYN-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002333_YGL148W-MONOMER_CHORISMATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1589,11 +1666,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1611,11 +1688,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'shikimate + ATP &harr; shikimate 3-phosphate + ADP + H<SUP>+</SUP>' 'null' 'shikimate 3-phosphate + phospho<i>enol</i>pyruvate &harr; 5-enolpyruvoyl-shikimate 3-phosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002413_2.5.1.19-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002413_2.5.1.19-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1626,15 +1703,26 @@
           <http://model.geneontology.org/2.5.1.19-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_58394_DAHPSYN-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_58394_DAHPSYN-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1645,39 +1733,6 @@
           <http://model.geneontology.org/CHEBI_58394_DAHPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_58702_DAHPSYN-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_16897_DAHPSYN-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1687,7 +1742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1695,25 +1750,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000066_reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller_SGD_YeastPathways_ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_57701_2.5.1.19-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1726,7 +1770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1743,45 +1787,12 @@
 <http://purl.obolibrary.org/obo/GO_0004107>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002413_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1789,11 +1800,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" , "Provides Input For Rule. The relation 'shikimate 3-phosphate + phospho<i>enol</i>pyruvate &harr; 5-enolpyruvoyl-shikimate 3-phosphate + phosphate' 'null' '5-enolpyruvoyl-shikimate 3-phosphate &rarr; chorismate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002413_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002413_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1808,11 +1819,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1830,7 +1841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1842,11 +1853,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1860,12 +1871,45 @@
 <http://purl.obolibrary.org/obo/CHEBI_36208>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1876,7 +1920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1893,7 +1937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1905,11 +1949,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1924,11 +1968,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1939,6 +1983,17 @@
           <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000066_reaction_DAHPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16630> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1948,24 +2003,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARO-PWY-1SmallMolecule54697> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002233_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_DAHPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1976,7 +2020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1988,11 +2032,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_15377_DAHPSYN-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_15377_DAHPSYN-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2003,47 +2047,36 @@
           <http://model.geneontology.org/CHEBI_15377_DAHPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002333_YGL148W-MONOMER_CHORISMATE-SYNTHASE-RXN_controller_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_58394_DAHPSYN-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2051,11 +2084,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2066,14 +2099,14 @@
           <http://model.geneontology.org/CHEBI_145989_SHIKIMATE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002413_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2081,11 +2114,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'phospho<i>enol</i>pyruvate + D-erythrose 4-phosphate + H<sub>2</sub>O &harr; 3-deoxy-D-arabino-heptulosonate 7-phosphate + phosphate' 'null' '3-deoxy-D-arabino-heptulosonate 7-phosphate &rarr; 3-dehydroquinate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2108,13 +2141,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARO-PWY-1SmallMolecule54599> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000066_reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0009423> ;
@@ -2125,7 +2169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2133,14 +2177,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_16897_DAHPSYN-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2150,30 +2194,19 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_58702_2.5.1.19-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003856>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002413_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
@@ -2184,7 +2217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2196,11 +2229,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002233_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002233_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2220,7 +2253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2237,7 +2270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2249,11 +2282,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2264,15 +2297,26 @@
           <http://model.geneontology.org/YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000066_reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2283,68 +2327,46 @@
           <http://model.geneontology.org/CHEBI_29748_CHORISMATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_29748>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_57783>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_43474_2.5.1.19-RXN_SGD_YeastPathways_ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ARO-PWY-1>
+<http://purl.obolibrary.org/obo/CHEBI_57783>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16630>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2360,7 +2382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2368,11 +2390,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_456216_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_456216_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2390,11 +2412,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_58702_DAHPSYN-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_58702_DAHPSYN-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2405,14 +2427,14 @@
           <http://model.geneontology.org/CHEBI_58702_DAHPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000066_reaction_2.5.1.19-RXN_location_lociGO_0005829_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000066_reaction_2.5.1.19-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2423,7 +2445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2450,7 +2472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2465,7 +2487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2478,18 +2500,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000050_YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1_SGD_YeastPathways_ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_15377_DAHPSYN-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2512,7 +2534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2524,11 +2546,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_57701_2.5.1.19-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_57701_2.5.1.19-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2539,15 +2561,26 @@
           <http://model.geneontology.org/CHEBI_57701_2.5.1.19-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58394_DAHPSYN-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2563,39 +2596,6 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_456216_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YBR249C-MONOMER_DAHPSYN-RXN_controller_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002413_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARO-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_ASPARAGINE-BIOSYNTHESIS-1.ttl
+++ b/models/YeastPathways_ASPARAGINE-BIOSYNTHESIS-1.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15,14 +15,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -33,11 +33,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -57,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-asparagine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -69,11 +69,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002233_CHEBI_30616_ASNSYNB-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002233_CHEBI_30616_ASNSYNB-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -83,17 +83,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30616_ASNSYNB-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_29888_ASNSYNB-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -112,18 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002233_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -146,7 +124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -163,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -171,15 +149,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2-oxoglutarate + L-aspartate &harr; oxaloacetate + L-glutamate' 'null' 'L-glutamine + L-aspartate + ATP + H<sub>2</sub>O &rarr; L-glutamate + L-asparagine + AMP + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002413_ASNSYNB-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002413_ASNSYNB-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -190,25 +179,14 @@
           <http://model.geneontology.org/ASNSYNB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002413_ASNSYNB-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_456215_ASNSYNB-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_58048_ASNSYNB-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -218,14 +196,25 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_29985_ASNSYNB-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_15378_ASNSYNB-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1/YeastPathways_ASPARAGINE-BIOSYNTHESIS-1_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -236,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -244,48 +233,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002233_CHEBI_58359_ASNSYNB-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_BFO_0000066_reaction_ASNSYNB-RXN_location_lociGO_0005829_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002233_CHEBI_30616_ASNSYNB-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1/YeastPathways_ASPARAGINE-BIOSYNTHESIS-1_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1/YeastPathways_ASPARAGINE-BIOSYNTHESIS-1_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -300,11 +256,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002233_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002233_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,20 +271,42 @@
           <http://model.geneontology.org/CHEBI_29991_ASPAMINOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002233_CHEBI_58359_ASNSYNB-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002333_YPR145W-MONOMER_ASNSYNB-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_456215_ASNSYNB-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -338,6 +316,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_58048>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002333_YGR124W-MONOMER_ASNSYNB-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -345,11 +334,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -360,14 +349,14 @@
           <http://model.geneontology.org/YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_BFO_0000050_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1/YeastPathways_ASPARAGINE-BIOSYNTHESIS-1_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002233_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -375,11 +364,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -397,11 +386,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_29985_ASNSYNB-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_29985_ASNSYNB-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -429,25 +418,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_15378_ASNSYNB-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -460,7 +438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -468,8 +446,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_BFO_0000050_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1/YeastPathways_ASPARAGINE-BIOSYNTHESIS-1_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000006349>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -478,11 +478,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002333_YPR145W-MONOMER_ASNSYNB-RXN_controller_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002333_YPR145W-MONOMER_ASNSYNB-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,11 +503,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002233_CHEBI_15377_ASNSYNB-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002233_CHEBI_15377_ASNSYNB-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -528,11 +528,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,17 +542,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ASNSYNB-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004066> ;
@@ -571,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -579,30 +568,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002333_YGR124W-MONOMER_ASNSYNB-RXN_controller_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002333_YPR145W-MONOMER_ASNSYNB-RXN_controller_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -612,7 +579,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002233_CHEBI_30616_ASNSYNB-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -620,11 +598,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,11 +617,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_29888_ASNSYNB-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_29888_ASNSYNB-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -657,6 +635,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002233_CHEBI_15377_ASNSYNB-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58048_ASNSYNB-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58048> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -666,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -681,11 +670,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002333_YGR124W-MONOMER_ASNSYNB-RXN_controller_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002333_YGR124W-MONOMER_ASNSYNB-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,11 +689,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_BFO_0000066_reaction_ASNSYNB-RXN_location_lociGO_0005829_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_BFO_0000066_reaction_ASNSYNB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -715,14 +704,14 @@
           <http://model.geneontology.org/reaction_ASNSYNB-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_BFO_0000066_reaction_ASNSYNB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -735,13 +724,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ASPARAGINE-BIOSYNTHESIS-1SmallMolecule72511> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002413_ASNSYNB-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_ASNSYNB-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -752,7 +752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -775,30 +775,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002233_CHEBI_15377_ASNSYNB-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_58048_ASNSYNB-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_ASPAMINOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
@@ -809,7 +787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -824,11 +802,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -839,15 +817,26 @@
           <http://model.geneontology.org/CHEBI_29985_ASPAMINOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_29888_ASNSYNB-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_15378_ASNSYNB-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_15378_ASNSYNB-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -861,19 +850,19 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_30616_ASNSYNB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -884,7 +873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -892,26 +881,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_58048_ASNSYNB-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_58048_ASNSYNB-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,11 +904,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_BFO_0000050_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1/YeastPathways_ASPARAGINE-BIOSYNTHESIS-1_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_BFO_0000050_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1/YeastPathways_ASPARAGINE-BIOSYNTHESIS-1_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -941,6 +919,17 @@
           <http://model.geneontology.org/YeastPathways_ASPARAGINE-BIOSYNTHESIS-1/YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000003356>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -950,6 +939,17 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001589> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -957,7 +957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -978,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -989,15 +989,26 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_29985_ASNSYNB-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1012,11 +1023,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002233_CHEBI_58359_ASNSYNB-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002233_CHEBI_58359_ASNSYNB-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1039,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1057,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1071,26 +1082,15 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1/YeastPathways_ASPARAGINE-BIOSYNTHESIS-1_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_456215_ASNSYNB-RXN_SGD_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
+          <http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_RO_0002234_CHEBI_456215_ASNSYNB-RXN_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1110,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1130,7 +1130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_ASPARAGINE-DEG2-PWY.ttl
+++ b/models/YeastPathways_ASPARAGINE-DEG2-PWY.ttl
@@ -1,16 +1,27 @@
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004147>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_BFO_0000050_YeastPathways_ASPARAGINE-DEG2-PWY/YeastPathways_ASPARAGINE-DEG2-PWY_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001589>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -19,11 +30,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YDR321W-MONOMER_ASPARAGHYD-RXN_controller_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YDR321W-MONOMER_ASPARAGHYD-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,11 +49,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,17 +64,6 @@
           <http://model.geneontology.org/CHEBI_16452_ASPAMINOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YLR157C-MONOMER_ASPARAGHYD-RXN_controller_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -93,13 +93,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ASPARAGINE-DEG2-PWYBiochemicalReaction19185> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/YLR155C-MONOMER_ASPARAGHYD-RXN_controller>
+        a       <http://identifiers.org/sgd/S000004145> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "asparaginase II" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ASPARAGINE-DEG2-PWYProtein19176> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_16810_ASPAMINOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16810> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -110,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -118,23 +133,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/YLR155C-MONOMER_ASPARAGHYD-RXN_controller>
-        a       <http://identifiers.org/sgd/S000004145> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "asparaginase II" ;
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ASPARAGINE-DEG2-PWYProtein19176> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_BFO_0000066_reaction_ASPARAGHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29991_ASPARAGHYD-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -145,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -156,29 +178,40 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YLR160C-MONOMER_ASPARAGHYD-RXN_controller_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0006530>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002234_CHEBI_29991_ASPARAGHYD-RXN_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002234_CHEBI_29991_ASPARAGHYD-RXN_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,11 +226,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29991_ASPARAGHYD-RXN_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29991_ASPARAGHYD-RXN_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -211,60 +244,71 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_ASPARAGINE-DEG2-PWY/YeastPathways_ASPARAGINE-DEG2-PWY_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
+<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YLR155C-MONOMER_ASPARAGHYD-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002234_CHEBI_28938_ASPARAGHYD-RXN_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_58048>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YLR155C-MONOMER_ASPARAGHYD-RXN_controller_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
+<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002233_CHEBI_15377_ASPARAGHYD-RXN_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_58048>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_ASPARAGINE-DEG2-PWY/YeastPathways_ASPARAGINE-DEG2-PWY_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YLR160C-MONOMER_ASPARAGHYD-RXN_controller_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YLR160C-MONOMER_ASPARAGHYD-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -284,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "asparagine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -299,11 +343,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_BFO_0000050_YeastPathways_ASPARAGINE-DEG2-PWY/YeastPathways_ASPARAGINE-DEG2-PWY_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_BFO_0000050_YeastPathways_ASPARAGINE-DEG2-PWY/YeastPathways_ASPARAGINE-DEG2-PWY_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,19 +358,19 @@
           <http://model.geneontology.org/YeastPathways_ASPARAGINE-DEG2-PWY/YeastPathways_ASPARAGINE-DEG2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YDR321W-MONOMER_ASPARAGHYD-RXN_controller_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://identifiers.org/sgd/S000004145>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002234_CHEBI_29991_ASPARAGHYD-RXN_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000004145>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YDR321W-MONOMER_ASPARAGHYD-RXN_controller>
         a       <http://identifiers.org/sgd/S000002729> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -335,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -350,11 +394,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002234_CHEBI_28938_ASPARAGHYD-RXN_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002234_CHEBI_28938_ASPARAGHYD-RXN_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -375,11 +419,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -393,6 +437,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002413_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -405,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -420,11 +475,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" , "Provides Input For Rule. The relation 'L-asparagine + H<sub>2</sub>O &rarr; L-aspartate + ammonium' 'null' '2-oxoglutarate + L-aspartate &harr; oxaloacetate + L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002413_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002413_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -435,29 +490,29 @@
           <http://model.geneontology.org/ASPAMINOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002234_CHEBI_29991_ASPARAGHYD-RXN_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29991_ASPARAGHYD-RXN_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YLR158C-MONOMER_ASPARAGHYD-RXN_controller_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YLR158C-MONOMER_ASPARAGHYD-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -472,11 +527,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -487,14 +542,14 @@
           <http://model.geneontology.org/YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002413_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YLR158C-MONOMER_ASPARAGHYD-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -505,11 +560,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002233_CHEBI_58048_ASPARAGHYD-RXN_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002233_CHEBI_58048_ASPARAGHYD-RXN_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,17 +578,6 @@
 <http://identifiers.org/sgd/S000002729>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002233_CHEBI_15377_ASPARAGHYD-RXN_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YLR160C-MONOMER_ASPARAGHYD-RXN_controller>
         a       <http://identifiers.org/sgd/S000004150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -541,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -553,11 +597,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,6 +611,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002234_CHEBI_28938_ASPARAGHYD-RXN_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ASPARAGHYD-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004067> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -587,24 +642,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ASPARAGINE-DEG2-PWYBiochemicalReaction19090> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_BFO_0000066_reaction_ASPARAGHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -618,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -633,11 +677,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YLR157C-MONOMER_ASPARAGHYD-RXN_controller_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YLR157C-MONOMER_ASPARAGHYD-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -648,29 +692,15 @@
           <http://model.geneontology.org/YLR157C-MONOMER_ASPARAGHYD-RXN_controller>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YLR158C-MONOMER_ASPARAGHYD-RXN_controller_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -681,16 +711,8 @@
           <http://model.geneontology.org/YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_BFO_0000050_YeastPathways_ASPARAGINE-DEG2-PWY/YeastPathways_ASPARAGINE-DEG2-PWY_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YLR158C-MONOMER_ASPARAGHYD-RXN_controller>
         a       <http://identifiers.org/sgd/S000004148> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -699,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -710,37 +732,15 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002233_CHEBI_58048_ASPARAGHYD-RXN_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002233_CHEBI_15377_ASPARAGHYD-RXN_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002233_CHEBI_15377_ASPARAGHYD-RXN_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -751,6 +751,17 @@
           <http://model.geneontology.org/CHEBI_15377_ASPARAGHYD-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YLR160C-MONOMER_ASPARAGHYD-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004067>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -758,11 +769,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_ASPARAGINE-DEG2-PWY/YeastPathways_ASPARAGINE-DEG2-PWY_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_ASPARAGINE-DEG2-PWY/YeastPathways_ASPARAGINE-DEG2-PWY_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -780,24 +791,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ASPARAGINE-DEG2-PWYProtein19170> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_ASPARAGINE-DEG2-PWY/YeastPathways_ASPARAGINE-DEG2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0006530> ;
@@ -808,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -818,6 +818,17 @@
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YLR157C-MONOMER_ASPARAGHYD-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004150>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -831,7 +842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -842,17 +853,6 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29991_ASPARAGHYD-RXN_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001589> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -860,24 +860,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ASPARAGINE-DEG2-PWYProtein19244> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29991>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -895,7 +884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -910,11 +899,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YLR155C-MONOMER_ASPARAGHYD-RXN_controller_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YLR155C-MONOMER_ASPARAGHYD-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -930,7 +919,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002333_YDR321W-MONOMER_ASPARAGHYD-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -938,11 +938,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -956,19 +956,19 @@
 <http://purl.obolibrary.org/obo/CHEBI_16452>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
+<http://purl.obolibrary.org/obo/CHEBI_16810>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002233_CHEBI_58048_ASPARAGHYD-RXN_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16810>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -977,11 +977,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_BFO_0000066_reaction_ASPARAGHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_ASPARAGINE-DEG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_BFO_0000066_reaction_ASPARAGHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1001,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1009,14 +1009,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARAGINE-DEG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1029,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_ASPARTATESYN-PWY.ttl
+++ b/models/YeastPathways_ASPARTATESYN-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-aspartate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -18,26 +18,15 @@
 <http://identifiers.org/sgd/S000001589>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARTATESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARTATESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARTATESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARTATESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,7 +45,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARTATESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -77,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -102,20 +102,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_ASPARTATESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARTATESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_ASPARTATESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARTATESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARTATESYN-PWY" ;
+                "SGD_PWY:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -123,11 +134,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARTATESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARTATESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,17 +151,6 @@
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARTATESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARTATESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -171,11 +171,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARTATESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARTATESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -214,11 +214,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_ASPARTATESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_ASPARTATESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,26 +232,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_ASPARTATESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARTATESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_ASPARTATESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPARTATESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -262,17 +251,6 @@
           <http://model.geneontology.org/reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_ASPARTATESYN-PWY/YeastPathways_ASPARTATESYN-PWY_SGD_YeastPathways_ASPARTATESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARTATESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29991_ASPAMINOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -282,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -302,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -313,18 +291,26 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARTATESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARTATESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_ASPARTATESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_ASPARTATESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -335,16 +321,8 @@
           <http://model.geneontology.org/YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_ASPARTATESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARTATESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -353,11 +331,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_ASPARTATESYN-PWY/YeastPathways_ASPARTATESYN-PWY_SGD_YeastPathways_ASPARTATESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_ASPARTATESYN-PWY/YeastPathways_ASPARTATESYN-PWY_SGD_PWY_YeastPathways_ASPARTATESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -367,17 +345,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_ASPARTATESYN-PWY/YeastPathways_ASPARTATESYN-PWY>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARTATESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARTATESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -392,13 +359,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ASPARTATESYN-PWYProtein70748> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARTATESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARTATESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29991>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -413,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -421,18 +399,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_ASPARTATESYN-PWY/YeastPathways_ASPARTATESYN-PWY_SGD_PWY_YeastPathways_ASPARTATESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARTATESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_ASPARTATESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARTATESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPARTATESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARTATESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARTATESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPARTATESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,7 +469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -468,14 +479,3 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPARTATESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARTATESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_ASPBIO-PWY.ttl
+++ b/models/YeastPathways_ASPBIO-PWY.ttl
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -31,15 +31,26 @@
 <http://identifiers.org/sgd/S000001589>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_ASPBIO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPBIO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -54,11 +65,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,28 +83,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPBIO-PWY>
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_ASPBIO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_ASPBIO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
+                "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -113,24 +113,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ASPBIO-PWYProtein19438> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_ASPBIO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ASPAMINOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004069> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -149,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -166,13 +155,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ASPBIO-PWYSmallMolecule19276> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPBIO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000422>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -200,25 +200,14 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_ASPBIO-PWY>
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_ASPBIO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
+                "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -226,11 +215,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -245,11 +234,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -269,17 +258,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_ASPBIO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -289,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -297,18 +275,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -319,26 +294,18 @@
           <http://model.geneontology.org/YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_ASPBIO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_ASPBIO-PWY/YeastPathways_ASPBIO-PWY_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_ASPBIO-PWY/YeastPathways_ASPBIO-PWY_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -349,6 +316,31 @@
           <http://model.geneontology.org/YeastPathways_ASPBIO-PWY/YeastPathways_ASPBIO-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPBIO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPBIO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004017>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -356,11 +348,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -374,18 +366,26 @@
 <http://purl.obolibrary.org/obo/GO_0004069>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000004017>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPBIO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -396,6 +396,17 @@
           <http://model.geneontology.org/CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPBIO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_ASPBIO-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -405,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "aspartate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -419,14 +430,14 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_ASPBIO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
+                "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -434,11 +445,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'hydrogencarbonate + pyruvate + ATP &rarr; oxaloacetate + ADP + phosphate + H<SUP>+</SUP>' 'null' '2-oxoglutarate + L-aspartate &harr; oxaloacetate + L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,17 +463,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPBIO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -475,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -487,11 +487,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,11 +506,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -521,14 +521,14 @@
           <http://model.geneontology.org/YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_ASPBIO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_ASPBIO-PWY/YeastPathways_ASPBIO-PWY_SGD_PWY_YeastPathways_ASPBIO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
+                "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -539,11 +539,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -558,11 +558,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -573,28 +573,6 @@
           <http://model.geneontology.org/reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_ASPBIO-PWY/YeastPathways_ASPBIO-PWY_SGD_YeastPathways_ASPBIO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_ASPBIO-PWY/YeastPathways_ASPBIO-PWY_SGD_YeastPathways_ASPBIO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29991_ASPAMINOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -604,13 +582,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ASPBIO-PWYSmallMolecule19293> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPBIO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -624,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -639,24 +628,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ASPBIO-PWYProtein19444> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_ASPBIO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -665,11 +643,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -689,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -697,18 +675,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -719,39 +694,53 @@
           <http://model.geneontology.org/YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_ASPBIO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_ASPBIO-PWY>
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_ASPBIO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPBIO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPBIO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
+                "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPBIO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
+                "SGD_PWY:ASPBIO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPBIO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -759,11 +748,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,15 +766,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_ASPBIO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPBIO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_ASPBIO-PWY/YeastPathways_ASPBIO-PWY_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_ASPBIO-PWY/YeastPathways_ASPBIO-PWY_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,33 +796,22 @@
           <http://model.geneontology.org/YeastPathways_ASPBIO-PWY/YeastPathways_ASPBIO-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ASPBIO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_ASPBIO-PWY>
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
+                "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -834,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -844,17 +833,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_29991>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPBIO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -875,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -891,7 +869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -899,11 +877,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -914,15 +892,26 @@
           <http://model.geneontology.org/CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPBIO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -945,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -962,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -973,6 +962,9 @@
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -982,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -990,18 +982,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_ASPBIO-PWY/YeastPathways_ASPBIO-PWY_SGD_PWY_YeastPathways_ASPBIO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPBIO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPBIO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ASPBIO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPBIO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1021,24 +1032,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ASPBIO-PWYSmallMolecule19415> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_ASPBIO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPBIO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .

--- a/models/YeastPathways_BIOTIN-SYNTHESIS-PWY.ttl
+++ b/models/YeastPathways_BIOTIN-SYNTHESIS-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11,11 +11,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_CHEBI_57586_2.8.1.6-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_CHEBI_57586_2.8.1.6-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -26,14 +26,25 @@
           <http://model.geneontology.org/CHEBI_57586_2.8.1.6-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002234_CHEBI_57532_7KAPSYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_BFO_0000050_YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002413_DAPASYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -41,11 +52,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002333_YNR058W-MONOMER_DAPASYN-RXN_controller_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002333_YNR058W-MONOMER_DAPASYN-RXN_controller_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,30 +67,19 @@
           <http://model.geneontology.org/YNR058W-MONOMER_DAPASYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002233_Reduced-2Fe-2S-Ferredoxins_2.8.1.6-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+<http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002333_YNR058W-MONOMER_DAPASYN-RXN_controller_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008710>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002333_YGR286C-MONOMER_2.8.1.6-RXN_controller_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -111,11 +111,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002233_CHEBI_57360_7KAPSYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002233_CHEBI_57360_7KAPSYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -126,15 +126,26 @@
           <http://model.geneontology.org/CHEBI_57360_7KAPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_Unsulfurated-Sulfur-Acceptors_2.8.1.6-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002234_CHEBI_15378_DETHIOBIOTIN-SYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002234_CHEBI_15378_DETHIOBIOTIN-SYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,31 +156,42 @@
           <http://model.geneontology.org/CHEBI_15378_DETHIOBIOTIN-SYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57844>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_DAPASYN-RXN_BFO_0000066_reaction_DAPASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002333_YNR058W-MONOMER_DAPASYN-RXN_controller_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+<http://model.geneontology.org/ev_w_id_DAPASYN-RXN_BFO_0000050_YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57844>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002333_YNR057C-MONOMER_DETHIOBIOTIN-SYN-RXN_controller_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002233_Sulfurated-Sulfur-Acceptors_2.8.1.6-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -190,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -203,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -214,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -226,11 +248,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002233_CHEBI_57861_DETHIOBIOTIN-SYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002233_CHEBI_57861_DETHIOBIOTIN-SYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -250,13 +272,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BIOTIN-SYNTHESIS-PWYSmallMolecule38060> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002234_CHEBI_57287_7KAPSYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -265,11 +298,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAPASYN-RXN_BFO_0000066_reaction_DAPASYN-RXN_location_lociGO_0005829_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DAPASYN-RXN_BFO_0000066_reaction_DAPASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -280,28 +313,28 @@
           <http://model.geneontology.org/reaction_DAPASYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002413_DETHIOBIOTIN-SYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002234_CHEBI_16490_DAPASYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002233_Sulfurated-Sulfur-Acceptors_2.8.1.6-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002233_CHEBI_30616_DETHIOBIOTIN-SYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -309,11 +342,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_Unsulfurated-Sulfur-Acceptors_2.8.1.6-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_Unsulfurated-Sulfur-Acceptors_2.8.1.6-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -324,17 +357,6 @@
           <http://model.geneontology.org/Unsulfurated-Sulfur-Acceptors_2.8.1.6-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002234_CHEBI_16526_7KAPSYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/Sulfurated-Sulfur-Acceptors_2.8.1.6-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -344,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -352,14 +374,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002233_CHEBI_57532_7KAPSYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002233_CHEBI_58500_DAPASYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002413_DETHIOBIOTIN-SYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002234_CHEBI_456216_DETHIOBIOTIN-SYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -367,11 +411,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002234_CHEBI_57287_7KAPSYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002234_CHEBI_57287_7KAPSYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -389,11 +433,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002234_CHEBI_57861_DETHIOBIOTIN-SYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002234_CHEBI_57861_DETHIOBIOTIN-SYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -431,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -456,36 +500,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002413_2.8.1.6-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_BFO_0000066_reaction_2.8.1.6-RXN_location_lociGO_0005829_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+<http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002234_CHEBI_58500_DAPASYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_CHEBI_57586_2.8.1.6-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -498,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -510,11 +532,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002233_Sulfurated-Sulfur-Acceptors_2.8.1.6-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002233_Sulfurated-Sulfur-Acceptors_2.8.1.6-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -537,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -549,11 +571,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002234_CHEBI_16490_DAPASYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002234_CHEBI_16490_DAPASYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -564,6 +586,17 @@
           <http://model.geneontology.org/CHEBI_16490_DAPASYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002233_CHEBI_57861_DETHIOBIOTIN-SYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_BIOTIN-SYNTHESIS-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -573,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "biotin biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -588,11 +621,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_BFO_0000066_reaction_7KAPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_BFO_0000066_reaction_7KAPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -624,11 +657,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002233_CHEBI_30616_DETHIOBIOTIN-SYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002233_CHEBI_30616_DETHIOBIOTIN-SYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,11 +672,55 @@
           <http://model.geneontology.org/CHEBI_30616_DETHIOBIOTIN-SYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_17319>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002333_YGR286C-MONOMER_2.8.1.6-RXN_controller_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_17319>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_BFO_0000050_YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_BFO_0000050_YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002413_2.8.1.6-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -652,11 +729,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_BFO_0000050_YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_BFO_0000050_YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,32 +744,54 @@
           <http://model.geneontology.org/YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_BFO_0000050_YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_Reduced-2Fe-2S-Ferredoxins_2.8.1.6-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002233_CHEBI_59789_2.8.1.6-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_BFO_0000066_reaction_7KAPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_CHEBI_57844_2.8.1.6-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_CHEBI_57844_2.8.1.6-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,11 +806,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" , "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + 8-amino-7-oxononanoate &harr; S-adenosyl-4-methylsulfanyl-2-oxobutanoate + 7,8-diaminopelargonate' 'null' 'CO<SUB>2</SUB> + 7,8-diaminopelargonate + ATP &rarr; dethiobiotin + ADP + phosphate + 3 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002413_DETHIOBIOTIN-SYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002413_DETHIOBIOTIN-SYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -721,28 +820,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/DETHIOBIOTIN-SYN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002413_DAPASYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_Unsulfurated-Sulfur-Acceptors_2.8.1.6-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -756,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -767,26 +844,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_57532>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002233_CHEBI_59789_DAPASYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002233_CHEBI_57972_7KAPSYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002233_CHEBI_57972_7KAPSYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -797,26 +863,15 @@
           <http://model.geneontology.org/CHEBI_57972_7KAPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002234_CHEBI_15378_DETHIOBIOTIN-SYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002234_CHEBI_43474_DETHIOBIOTIN-SYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002234_CHEBI_43474_DETHIOBIOTIN-SYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -841,7 +896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -854,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -872,11 +927,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002233_CHEBI_59789_2.8.1.6-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002233_CHEBI_59789_2.8.1.6-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -896,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -923,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -935,11 +990,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002233_CHEBI_57532_7KAPSYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002233_CHEBI_57532_7KAPSYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,29 +1008,51 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002234_CHEBI_16490_DAPASYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_BFO_0000066_reaction_DETHIOBIOTIN-SYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002233_CHEBI_57532_7KAPSYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0009102>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_CHEBI_17319_2.8.1.6-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002333_YGR286C-MONOMER_2.8.1.6-RXN_controller_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002333_YGR286C-MONOMER_2.8.1.6-RXN_controller_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -990,11 +1067,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_BFO_0000066_reaction_DETHIOBIOTIN-SYN-RXN_location_lociGO_0005829_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_BFO_0000066_reaction_DETHIOBIOTIN-SYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1020,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1037,35 +1114,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BIOTIN-SYNTHESIS-PWYSmallMolecule37896> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_BFO_0000066_reaction_7KAPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_BFO_0000066_reaction_DETHIOBIOTIN-SYN-RXN_location_lociGO_0005829_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0009102> ;
@@ -1076,7 +1131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1091,11 +1146,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002234_CHEBI_57532_7KAPSYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002234_CHEBI_57532_7KAPSYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1106,26 +1161,15 @@
           <http://model.geneontology.org/CHEBI_57532_7KAPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002234_CHEBI_57861_DETHIOBIOTIN-SYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002333_YNR057C-MONOMER_DETHIOBIOTIN-SYN-RXN_controller_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002333_YNR057C-MONOMER_DETHIOBIOTIN-SYN-RXN_controller_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1139,6 +1183,17 @@
 <http://identifiers.org/sgd/S000005340>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002333_YNR057C-MONOMER_DETHIOBIOTIN-SYN-RXN_controller_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16526_7KAPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1148,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1175,24 +1230,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BIOTIN-SYNTHESIS-PWYBiochemicalReaction37942> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_DAPASYN-RXN_BFO_0000050_YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YNR057C-MONOMER_DETHIOBIOTIN-SYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005340> ;
@@ -1201,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1213,11 +1257,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_CHEBI_17319_2.8.1.6-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_CHEBI_17319_2.8.1.6-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1232,11 +1276,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002234_CHEBI_58500_DAPASYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002234_CHEBI_58500_DAPASYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1247,57 +1291,24 @@
           <http://model.geneontology.org/CHEBI_58500_DAPASYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002233_CHEBI_57861_DETHIOBIOTIN-SYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_BFO_0000050_YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004141>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_BFO_0000050_YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002233_CHEBI_15378_7KAPSYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002233_CHEBI_15378_7KAPSYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1325,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1333,15 +1344,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002233_Reduced-2Fe-2S-Ferredoxins_2.8.1.6-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002233_CHEBI_58500_DAPASYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002233_CHEBI_58500_DAPASYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1352,14 +1374,25 @@
           <http://model.geneontology.org/CHEBI_58500_DAPASYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002233_CHEBI_59789_2.8.1.6-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002233_CHEBI_16526_DETHIOBIOTIN-SYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002234_CHEBI_16526_7KAPSYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1372,24 +1405,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BIOTIN-SYNTHESIS-PWYSmallMolecule38046> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002233_CHEBI_15378_7KAPSYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1402,7 +1424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1410,11 +1432,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_BFO_0000066_reaction_2.8.1.6-RXN_location_lociGO_0005829_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_BFO_0000066_reaction_2.8.1.6-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1425,14 +1447,25 @@
           <http://model.geneontology.org/reaction_2.8.1.6-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002233_CHEBI_58500_DAPASYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_BFO_0000066_reaction_2.8.1.6-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002233_CHEBI_59789_DAPASYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1445,7 +1478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1460,11 +1493,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAPASYN-RXN_BFO_0000050_YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DAPASYN-RXN_BFO_0000050_YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1475,30 +1508,19 @@
           <http://model.geneontology.org/YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002233_CHEBI_57360_7KAPSYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57972>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_Reduced-2Fe-2S-Ferredoxins_2.8.1.6-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002234_CHEBI_43474_DETHIOBIOTIN-SYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16490_DAPASYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16490> ;
@@ -1509,7 +1531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1521,11 +1543,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_Reduced-2Fe-2S-Ferredoxins_2.8.1.6-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_Reduced-2Fe-2S-Ferredoxins_2.8.1.6-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1540,11 +1562,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_BFO_0000050_YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_BFO_0000050_YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1555,25 +1577,25 @@
           <http://model.geneontology.org/YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DAPASYN-RXN_BFO_0000066_reaction_DAPASYN-RXN_location_lociGO_0005829_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+<http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002233_CHEBI_57972_7KAPSYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002233_CHEBI_30616_DETHIOBIOTIN-SYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+<http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002234_CHEBI_57532_7KAPSYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1581,11 +1603,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002234_CHEBI_16526_7KAPSYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002234_CHEBI_16526_7KAPSYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1600,11 +1622,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002234_CHEBI_456216_DETHIOBIOTIN-SYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002234_CHEBI_456216_DETHIOBIOTIN-SYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1618,32 +1640,54 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002233_CHEBI_16526_DETHIOBIOTIN-SYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002233_CHEBI_15378_7KAPSYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002234_CHEBI_43474_DETHIOBIOTIN-SYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002234_CHEBI_57861_DETHIOBIOTIN-SYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002233_Reduced-2Fe-2S-Ferredoxins_2.8.1.6-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002233_Reduced-2Fe-2S-Ferredoxins_2.8.1.6-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1654,17 +1698,6 @@
           <http://model.geneontology.org/Reduced-2Fe-2S-Ferredoxins_2.8.1.6-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002234_CHEBI_58500_DAPASYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57532_7KAPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57532> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1674,7 +1707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1686,11 +1719,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002233_CHEBI_59789_DAPASYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DAPASYN-RXN_RO_0002233_CHEBI_59789_DAPASYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1701,40 +1734,18 @@
           <http://model.geneontology.org/CHEBI_59789_DAPASYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002233_CHEBI_57360_7KAPSYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58500>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002234_CHEBI_57287_7KAPSYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_BFO_0000050_YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_BFO_0000050_YeastPathways_BIOTIN-SYNTHESIS-PWY/YeastPathways_BIOTIN-SYNTHESIS-PWY_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1754,7 +1765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1766,11 +1777,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002233_CHEBI_16526_DETHIOBIOTIN-SYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002233_CHEBI_16526_DETHIOBIOTIN-SYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1781,6 +1792,17 @@
           <http://model.geneontology.org/CHEBI_16526_DETHIOBIOTIN-SYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002234_CHEBI_15378_DETHIOBIOTIN-SYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_59789_2.8.1.6-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59789> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1790,7 +1812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1798,11 +1820,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/GO_0004076>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://identifiers.org/sgd/S000003518>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004076>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_CHEBI_57844_2.8.1.6-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_DETHIOBIOTIN-SYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -1813,7 +1846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1830,7 +1863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1842,11 +1875,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" , "Provides Input For Rule. The relation 'pimeloyl-CoA + L-alanine + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + 8-amino-7-oxononanoate + coenzyme A' 'null' '<i>S</i>-adenosyl-L-methionine + 8-amino-7-oxononanoate &harr; S-adenosyl-4-methylsulfanyl-2-oxobutanoate + 7,8-diaminopelargonate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002413_DAPASYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002413_DAPASYN-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1861,11 +1894,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" , "Provides Input For Rule. The relation 'CO<SUB>2</SUB> + 7,8-diaminopelargonate + ATP &rarr; dethiobiotin + ADP + phosphate + 3 H<SUP>+</SUP>' 'null' '2 <i>S</i>-adenosyl-L-methionine + a sulfurated [sulfur carrier] + dethiobiotin + 2 a reduced [2Fe-2S] ferredoxin &rarr; an unsulfurated [sulfur carrier] + biotin + 2 5'-deoxyadenosine + 2 L-methionine + 2 an oxidized [2Fe-2S] ferredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002413_2.8.1.6-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002413_2.8.1.6-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1879,49 +1912,16 @@
 <http://identifiers.org/sgd/S000005341>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_CHEBI_17319_2.8.1.6-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_7KAPSYN-RXN_RO_0002233_CHEBI_57972_7KAPSYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57586>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DETHIOBIOTIN-SYN-RXN_RO_0002234_CHEBI_456216_DETHIOBIOTIN-SYN-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_CHEBI_57586_2.8.1.6-RXN_SGD_PWY_YeastPathways_BIOTIN-SYNTHESIS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.8.1.6-RXN_RO_0002234_CHEBI_57844_2.8.1.6-RXN_SGD_YeastPathways_BIOTIN-SYNTHESIS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BIOTIN-SYNTHESIS-PWY" ;
+                "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1.ttl
+++ b/models/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1.ttl
@@ -5,11 +5,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,17 +20,6 @@
           <http://model.geneontology.org/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16810> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -40,7 +29,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -52,11 +41,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,11 +60,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15361_ACETOLACTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15361_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -86,40 +75,29 @@
           <http://model.geneontology.org/CHEBI_15361_ACETOLACTSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000066_reaction_ACETOLACTSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_15378_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_16763_THREDEHYD-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_57287_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_57287_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -134,11 +112,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_17865_RXN-13158_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_17865_RXN-13158_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -149,15 +127,26 @@
           <http://model.geneontology.org/CHEBI_17865_RXN-13158>
 ] .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -171,14 +160,14 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_15378_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -186,11 +175,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002234_CHEBI_58349_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002234_CHEBI_58349_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -201,37 +190,15 @@
           <http://model.geneontology.org/CHEBI_58349_ACETOOHBUTREDUCTOISOM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002413_RXN-13163_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_16763_THREDEHYD-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_16763_THREDEHYD-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,11 +213,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -264,26 +231,15 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002234_CHEBI_49256_ACETOOHBUTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002233_CHEBI_49072_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002233_CHEBI_49072_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -297,6 +253,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_1178>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_16526_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16810> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -306,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -321,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -333,11 +300,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -348,14 +315,14 @@
           <http://model.geneontology.org/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -364,17 +331,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002234_CHEBI_58349_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15361_ACETOOHBUTSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
@@ -385,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -397,11 +353,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" , "Provides Input For Rule. The relation '(<i>R</i>)-2,3-dihydroxy-3-methylpentanoate &rarr; (<i>S</i>)-3-methyl-2-oxopentanoate + H<sub>2</sub>O' 'null' 'L-isoleucine + 2-oxoglutarate &harr; L-glutamate + (<i>S</i>)-3-methyl-2-oxopentanoate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002413_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002413_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -429,14 +385,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002234_CHEBI_49072_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -449,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -461,11 +417,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -476,19 +432,19 @@
           <http://model.geneontology.org/CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57287>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002233_CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15361_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57287>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -497,11 +453,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,11 +472,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -531,36 +487,36 @@
           <http://model.geneontology.org/CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_57427_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_16763_THREDEHYD-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000066_reaction_ACETOLACTSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -583,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -591,25 +547,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_16526_RXN-13158_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -617,11 +573,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002333_YGL009C-MONOMER_RXN-13163_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002333_YGL009C-MONOMER_RXN-13163_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,6 +587,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YGL009C-MONOMER_RXN-13163_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_28938_THREDEHYD-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0052656> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -649,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -661,11 +639,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -685,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -702,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -714,11 +692,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002234_CHEBI_58349_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002234_CHEBI_58349_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -748,7 +726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -756,26 +734,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_49072>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_16763_THREDEHYD-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_16763_THREDEHYD-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -786,37 +756,23 @@
           <http://model.geneontology.org/CHEBI_16763_THREDEHYD-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_49072>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002333_YLR355C-MONOMER_ACETOOHBUTREDUCTOISOM-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002333_YLR355C-MONOMER_ACETOLACTREDUCTOISOM-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_57783_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -825,18 +781,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002234_CHEBI_35121_RXN-13163_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_57287_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -844,11 +800,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYMETVALDEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYMETVALDEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -859,15 +815,48 @@
           <http://model.geneontology.org/reaction_DIHYDROXYMETVALDEHYDRAT-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000066_reaction_RXN-13158_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -878,12 +867,34 @@
           <http://model.geneontology.org/YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_17865_RXN-13158_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_ACETOOHBUTSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -892,7 +903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -900,11 +911,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -924,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -941,7 +952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -973,11 +984,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -992,11 +1003,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_57945_RXN-13158_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_57945_RXN-13158_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1013,6 +1024,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0003861>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1020,11 +1042,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1035,26 +1057,15 @@
           <http://model.geneontology.org/CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002333_YLR355C-MONOMER_ACETOOHBUTREDUCTOISOM-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002333_YLR355C-MONOMER_ACETOOHBUTREDUCTOISOM-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,50 +1076,20 @@
           <http://model.geneontology.org/YLR355C-MONOMER_ACETOOHBUTREDUCTOISOM-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYMETVALDEHYDRAT-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58476>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://identifiers.org/sgd/S000005048>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1116,18 +1097,26 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_57945_RXN-13158_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_28938_THREDEHYD-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_28938_THREDEHYD-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1142,11 +1131,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_BFO_0000066_reaction_ACETOLACTREDUCTOISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_BFO_0000066_reaction_ACETOLACTREDUCTOISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1161,11 +1150,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1176,61 +1165,17 @@
           <http://model.geneontology.org/CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_57288_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002413_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002413_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002413_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1238,11 +1183,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1262,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1270,23 +1215,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_57783_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
         a       <http://identifiers.org/sgd/S000004714> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1295,18 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_16763_THREDEHYD-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1315,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1328,7 +1262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1339,6 +1273,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_57427>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_15378_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1346,11 +1291,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1360,17 +1305,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
 ] .
-
-<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002233_CHEBI_57926_THREDEHYD-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0009082>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1385,7 +1319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1397,11 +1331,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_57427_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_57427_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1424,7 +1358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1432,29 +1366,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57288>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57288>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_BFO_0000066_reaction_ACETOOHBUTREDUCTOISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_BFO_0000066_reaction_ACETOOHBUTREDUCTOISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1470,18 +1404,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_35121_RXN-13163_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1489,11 +1423,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_15377_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_15377_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1508,11 +1442,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000066_reaction_RXN-13158_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000066_reaction_RXN-13158_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1523,29 +1457,29 @@
           <http://model.geneontology.org/reaction_RXN-13158_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://identifiers.org/sgd/S000003909>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002233_CHEBI_57926_THREDEHYD-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000003909>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1556,14 +1490,25 @@
           <http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_58476_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1586,7 +1531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1594,26 +1539,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_15378_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_15378_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1631,7 +1565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1643,11 +1577,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" , "Provides Input For Rule. The relation '(2<i>R</i>,3<i>S</i>)-3-isopropylmalate &harr; (2<i>S</i>)-2-isopropylmalate' 'null' '(2<i>R</i>,3<i>S</i>)-3-isopropylmalate + NAD<sup>+</sup> &rarr; 4-methyl-2-oxopentanoate + CO<SUB>2</SUB> + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002413_RXN-13158_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002413_RXN-13158_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1658,15 +1592,37 @@
           <http://model.geneontology.org/RXN-13158>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1677,6 +1633,17 @@
           <http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002234_CHEBI_58349_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_ACETOOHBUTREDUCTOISOM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1686,7 +1653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1698,11 +1665,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002333_YLR355C-MONOMER_ACETOLACTREDUCTOISOM-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002333_YLR355C-MONOMER_ACETOLACTREDUCTOISOM-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1713,15 +1680,37 @@
           <http://model.geneontology.org/YLR355C-MONOMER_ACETOLACTREDUCTOISOM-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_BFO_0000066_reaction_ACETOLACTREDUCTOISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002234_CHEBI_16526_ACETOOHBUTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002234_CHEBI_16526_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1731,6 +1720,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16526_ACETOOHBUTSYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_16763_THREDEHYD-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACETOOHBUTSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003984> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1751,7 +1751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1769,7 +1769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1786,7 +1786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1794,15 +1794,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002233_CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002233_CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1813,15 +1824,37 @@
           <http://model.geneontology.org/CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002413_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_17865_RXN-13158_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1832,14 +1865,14 @@
           <http://model.geneontology.org/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000066_reaction_RXN-13158_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1852,38 +1885,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1SmallMolecule55630> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/RXN-13158>
-        a       <http://purl.obolibrary.org/obo/GO_0003862> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "(2<i>R</i>,3<i>S</i>)-3-isopropylmalate + NAD<sup>+</sup> &rarr; 4-methyl-2-oxopentanoate + CO<SUB>2</SUB> + NADH" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_RXN-13158_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_35121_RXN-13163> , <http://model.geneontology.org/CHEBI_57540_RXN-13158> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_17865_RXN-13158> , <http://model.geneontology.org/CHEBI_16526_RXN-13158> , <http://model.geneontology.org/CHEBI_57945_RXN-13158> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERLEU-RXN> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1BiochemicalReaction55921> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 <http://model.geneontology.org/DIHYDROXYMETVALDEHYDRAT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004160> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1904,7 +1912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1912,15 +1920,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/RXN-13158>
+        a       <http://purl.obolibrary.org/obo/GO_0003862> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "(2<i>R</i>,3<i>S</i>)-3-isopropylmalate + NAD<sup>+</sup> &rarr; 4-methyl-2-oxopentanoate + CO<SUB>2</SUB> + NADH" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_RXN-13158_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_35121_RXN-13163> , <http://model.geneontology.org/CHEBI_57540_RXN-13158> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_17865_RXN-13158> , <http://model.geneontology.org/CHEBI_16526_RXN-13158> , <http://model.geneontology.org/CHEBI_57945_RXN-13158> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERLEU-RXN> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1BiochemicalReaction55921> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_16526_ACETOLACTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_16526_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1931,31 +1975,42 @@
           <http://model.geneontology.org/CHEBI_16526_ACETOLACTSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002234_CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://purl.obolibrary.org/obo/CHEBI_11851>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYMETVALDEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_11851>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002333_YGL009C-MONOMER_RXN-13163_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002233_CHEBI_49072_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1963,11 +2018,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_YNL104C-MONOMER_2-ISOPROPYLMALATESYN-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_YNL104C-MONOMER_2-ISOPROPYLMALATESYN-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1982,11 +2037,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(2<i>R</i>,3<i>S</i>)-3-isopropylmalate + NAD<sup>+</sup> &rarr; 4-methyl-2-oxopentanoate + CO<SUB>2</SUB> + NADH' 'null' 'L-leucine + 2-oxoglutarate &harr; L-glutamate + 4-methyl-2-oxopentanoate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002413_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002413_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2010,11 +2065,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2025,17 +2080,6 @@
           <http://model.geneontology.org/CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002234_CHEBI_58349_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_49258> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2045,7 +2089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2057,11 +2101,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>R</i>)-2,3-dihydroxy-3-methylpentanoate + NADP<sup>+</sup> &larr; (<i>S</i>)-2-aceto-2-hydroxybutanoate + NADPH + H<SUP>+</SUP>' 'null' '(<i>R</i>)-2,3-dihydroxy-3-methylpentanoate &rarr; (<i>S</i>)-3-methyl-2-oxopentanoate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002413_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002413_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2076,11 +2120,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" , "Provides Input For Rule. The relation '3-methyl-2-oxobutanoate + acetyl-CoA + H<sub>2</sub>O &rarr; (2<i>S</i>)-2-isopropylmalate + coenzyme A + H<SUP>+</SUP>' 'null' '(2<i>R</i>,3<i>S</i>)-3-isopropylmalate &harr; (2<i>S</i>)-2-isopropylmalate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002413_RXN-13163_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002413_RXN-13163_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2091,17 +2135,6 @@
           <http://model.geneontology.org/RXN-13163>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002234_CHEBI_16526_ACETOOHBUTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -2109,11 +2142,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002333_YER086W-MONOMER_THREDEHYD-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002333_YER086W-MONOMER_THREDEHYD-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2124,15 +2157,26 @@
           <http://model.geneontology.org/YER086W-MONOMER_THREDEHYD-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_15378_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_15378_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2147,11 +2191,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2165,26 +2209,15 @@
 <http://identifiers.org/sgd/S000003777>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2207,7 +2240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2218,52 +2251,57 @@
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000066_reaction_THREDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_16526_ACETOLACTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_15378_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002333_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_35121_RXN-13163_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-13158> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_35121_RXN-13163>
+] .
 
 <http://identifiers.org/sgd/S000000515>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_57288_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57288_2-ISOPROPYLMALATESYN-RXN>
+] .
 
 <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0052656> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2282,51 +2320,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1BiochemicalReaction55880> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_57288_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57288_2-ISOPROPYLMALATESYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_35121_RXN-13163_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-13158> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_35121_RXN-13163>
-] .
 
 <http://model.geneontology.org/CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_11851> ;
@@ -2337,7 +2337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2345,26 +2345,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2375,6 +2364,17 @@
           <http://model.geneontology.org/YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_BFO_0000066_reaction_ACETOOHBUTREDUCTOISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2382,11 +2382,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_49256_ACETOOHBUTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_49256_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2400,47 +2400,25 @@
 <http://identifiers.org/sgd/S000001251>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_58476_ACETOLACTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002413_RXN-13163_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000066_reaction_RXN-13163_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2448,11 +2426,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2463,25 +2441,14 @@
           <http://model.geneontology.org/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002233_CHEBI_49072_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2489,11 +2456,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2504,14 +2471,14 @@
           <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002233_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2519,11 +2486,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(2<i>R</i>)-2,3-dihydroxy-3-methylbutanoate + NADP<sup>+</sup> &larr; (<i>S</i>)-2-acetolactate + NADPH + H<SUP>+</SUP>' 'null' '(2<i>R</i>)-2,3-dihydroxy-3-methylbutanoate &rarr; 3-methyl-2-oxobutanoate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002413_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002413_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2539,18 +2506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2558,11 +2514,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002234_CHEBI_49256_ACETOOHBUTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002234_CHEBI_49256_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2591,7 +2547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2608,7 +2564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2625,7 +2581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2642,7 +2598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2650,15 +2606,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2676,24 +2643,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1Protein56002> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller>
         a       <http://identifiers.org/sgd/S000001251> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2702,7 +2658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2710,26 +2666,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2740,14 +2685,14 @@
           <http://model.geneontology.org/reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002333_YLR355C-MONOMER_ACETOLACTREDUCTOISOM-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2755,11 +2700,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_58476_ACETOLACTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_58476_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2770,37 +2715,15 @@
           <http://model.geneontology.org/CHEBI_58476_ACETOLACTSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002413_ACETOOHBUTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002413_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2815,11 +2738,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2830,18 +2753,15 @@
           <http://model.geneontology.org/CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_35146>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2857,9 +2777,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_35146>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CPLX3O-30_ACETOLACTSYN-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2870,7 +2793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2878,14 +2801,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYMETVALDEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002413_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2898,7 +2821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2906,15 +2829,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002413_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" , "Provides Input For Rule. The relation 'L-threonine &rarr; 2-oxobutanoate + ammonium' 'null' 'pyruvate + 2-oxobutanoate + H<SUP>+</SUP> &rarr; (<i>S</i>)-2-aceto-2-hydroxybutanoate + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002413_ACETOOHBUTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002413_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2925,26 +2859,15 @@
           <http://model.geneontology.org/ACETOOHBUTSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_57783_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_57783_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2955,36 +2878,14 @@
           <http://model.geneontology.org/CHEBI_57783_ACETOLACTREDUCTOISOM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_15378_ACETOOHBUTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_BFO_0000066_reaction_ACETOLACTREDUCTOISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002333_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2992,11 +2893,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3007,6 +2908,17 @@
           <http://model.geneontology.org/YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_35121_RXN-13163_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57288_2-ISOPROPYLMALATESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57288> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3016,7 +2928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3024,26 +2936,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_15361_ACETOOHBUTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3054,15 +2955,37 @@
           <http://model.geneontology.org/CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_15377_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" , "Provides Input For Rule. The relation '(2<i>R</i>)-2,3-dihydroxy-3-methylbutanoate &rarr; 3-methyl-2-oxobutanoate + H<sub>2</sub>O' 'null' 'L-valine + 2-oxoglutarate &harr; L-glutamate + 3-methyl-2-oxobutanoate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002413_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002413_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3082,7 +3005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3097,24 +3020,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1Protein55814> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002333_YLR355C-MONOMER_ACETOOHBUTREDUCTOISOM-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3126,7 +3038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3141,11 +3053,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3156,36 +3068,25 @@
           <http://model.geneontology.org/CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_17865_RXN-13158_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000066_reaction_2-ISOPROPYLMALATESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002234_CHEBI_49256_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_57783_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3193,11 +3094,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3212,30 +3113,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_57540_RXN-13158_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-13158> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_RXN-13158>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3246,16 +3128,24 @@
           <http://model.geneontology.org/CHEBI_1178_2-ISOPROPYLMALATESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_YNL104C-MONOMER_2-ISOPROPYLMALATESYN-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_57540_RXN-13158_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-13158> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57540_RXN-13158>
+] .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3263,40 +3153,29 @@
 <http://purl.obolibrary.org/obo/GO_0003984>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_28938_THREDEHYD-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002413_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3310,52 +3189,24 @@
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002233_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN-13158_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glu" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1SmallMolecule55790> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_57783_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_57783_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3366,16 +3217,22 @@
           <http://model.geneontology.org/CHEBI_57783_ACETOOHBUTREDUCTOISOM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "glu" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1SmallMolecule55790> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16810> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3386,7 +3243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3406,7 +3263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3414,23 +3271,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_58476_ACETOLACTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3443,7 +3300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3460,7 +3317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3472,11 +3329,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000066_reaction_THREDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000066_reaction_THREDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3492,18 +3349,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_58476_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3526,7 +3383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3538,11 +3395,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3553,14 +3410,14 @@
           <http://model.geneontology.org/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_57288_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3573,7 +3430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of branched chain amino acid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3581,48 +3438,15 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_49256_ACETOOHBUTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002333_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002333_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3642,13 +3466,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1SmallMolecule55661> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002413_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57762> ;
@@ -3659,7 +3494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3667,20 +3502,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_57427_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_49256>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000004714>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_BFO_0000066_reaction_ACETOOHBUTSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002333_YER086W-MONOMER_THREDEHYD-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3688,11 +3534,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3708,22 +3554,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003852>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002234_CHEBI_58349_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_17865_RXN-13158_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_17865_RXN-13158_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3734,28 +3591,39 @@
           <http://model.geneontology.org/CHEBI_17865_RXN-13158>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://purl.obolibrary.org/obo/CHEBI_57762>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002413_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57762>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_17865_RXN-13158_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_49256_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3768,7 +3636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3780,11 +3648,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3799,11 +3667,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3814,14 +3682,25 @@
           <http://model.geneontology.org/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002413_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_15378_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002413_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3832,11 +3711,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000066_reaction_RXN-13163_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000066_reaction_RXN-13163_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3850,26 +3729,15 @@
 <http://identifiers.org/sgd/S000002977>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_BFO_0000066_reaction_ACETOOHBUTREDUCTOISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3880,16 +3748,35 @@
           <http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_BFO_0000066_reaction_ACETOOHBUTSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ACETOOHBUTSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_ACETOOHBUTSYN-RXN_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/DIHYDROXYISOVALDEHYDRAT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004160> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3910,7 +3797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3918,33 +3805,47 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_BFO_0000066_reaction_ACETOOHBUTSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ACETOOHBUTSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_ACETOOHBUTSYN-RXN_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002413_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002413_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002234_CHEBI_35121_RXN-13163_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3952,11 +3853,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_58476_ACETOLACTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_58476_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3966,28 +3867,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58476_ACETOLACTSYN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002234_CHEBI_49072_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERLEU-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0052656> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4006,7 +3885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4020,29 +3899,51 @@
 <http://purl.obolibrary.org/obo/GO_0004455>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000066_reaction_THREDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000066_reaction_RXN-13163_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(2<i>R</i>)-2,3-dihydroxy-3-methylbutanoate &rarr; 3-methyl-2-oxobutanoate + H<sub>2</sub>O' 'null' '3-methyl-2-oxobutanoate + acetyl-CoA + H<sub>2</sub>O &rarr; (2<i>S</i>)-2-isopropylmalate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002413_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002413_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4053,6 +3954,17 @@
           <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_15378_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003909> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4060,7 +3972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4068,15 +3980,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002333_YGL009C-MONOMER_RXN-13163_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4087,43 +4032,21 @@
           <http://model.geneontology.org/CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004160>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_57287_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000066_reaction_ACETOLACTSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000066_reaction_ACETOLACTSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4153,7 +4076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4161,42 +4084,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000066_reaction_2-ISOPROPYLMALATESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15361_ACETOLACTSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15361> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "pyruvate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1SmallMolecule55647> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_57783_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4204,11 +4099,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_15378_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_15378_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4223,11 +4118,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_16526_RXN-13158_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_16526_RXN-13158_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4238,73 +4133,68 @@
           <http://model.geneontology.org/CHEBI_16526_RXN-13158>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002333_YER086W-MONOMER_THREDEHYD-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/CHEBI_15361_ACETOLACTSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15361> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "pyruvate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1SmallMolecule55647> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15361_ACETOLACTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002413_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4315,15 +4205,48 @@
           <http://model.geneontology.org/reaction_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002234_CHEBI_16526_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000050_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002234_CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002234_CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4341,13 +4264,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1Protein55820> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYMETVALDEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YER086W-MONOMER_THREDEHYD-RXN_controller>
         a       <http://identifiers.org/sgd/S000000888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4356,7 +4290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4368,11 +4302,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002233_CHEBI_57926_THREDEHYD-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002233_CHEBI_57926_THREDEHYD-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4383,17 +4317,6 @@
           <http://model.geneontology.org/CHEBI_57926_THREDEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YJR016C-MONOMER_DIHYDROXYMETVALDEHYDRAT-RXN_controller>
         a       <http://identifiers.org/sgd/S000003777> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4401,7 +4324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4413,11 +4336,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4428,15 +4351,26 @@
           <http://model.geneontology.org/reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'pyruvate + 2-oxobutanoate + H<SUP>+</SUP> &rarr; (<i>S</i>)-2-aceto-2-hydroxybutanoate + CO<SUB>2</SUB>' 'null' '(<i>R</i>)-2,3-dihydroxy-3-methylpentanoate + NADP<sup>+</sup> &larr; (<i>S</i>)-2-aceto-2-hydroxybutanoate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002413_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002413_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4456,7 +4390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4467,17 +4401,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002413_RXN-13158_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_15378_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4485,11 +4430,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYMETVALDEHYDRAT-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYMETVALDEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4509,7 +4454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4521,11 +4466,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4536,17 +4481,6 @@
           <http://model.geneontology.org/CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002413_RXN-13158_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16763>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -4554,11 +4488,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 pyruvate + H<SUP>+</SUP> &rarr; (<i>S</i>)-2-acetolactate + CO<SUB>2</SUB>' 'null' '(2<i>R</i>)-2,3-dihydroxy-3-methylbutanoate + NADP<sup>+</sup> &larr; (<i>S</i>)-2-acetolactate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002413_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002413_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4573,11 +4507,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000066_reaction_2-ISOPROPYLMALATESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000066_reaction_2-ISOPROPYLMALATESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4588,6 +4522,17 @@
           <http://model.geneontology.org/reaction_2-ISOPROPYLMALATESYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002413_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58349_ACETOOHBUTREDUCTOISOM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4597,7 +4542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4614,7 +4559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4626,11 +4571,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002233_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002233_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4641,15 +4586,26 @@
           <http://model.geneontology.org/CHEBI_1178_2-ISOPROPYLMALATESYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4659,6 +4615,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_15361_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/THREDEHYD-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004794> ;
@@ -4679,7 +4657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4696,13 +4674,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1SmallMolecule55630> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004347>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4711,11 +4700,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_15361_ACETOOHBUTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_15361_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4726,6 +4715,17 @@
           <http://model.geneontology.org/CHEBI_15361_ACETOOHBUTSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_YNL104C-MONOMER_2-ISOPROPYLMALATESYN-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003777> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4733,7 +4733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4748,7 +4748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4756,26 +4756,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002234_CHEBI_35121_RXN-13163_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002234_CHEBI_35121_RXN-13163_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4795,7 +4784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4806,15 +4795,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_57926>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4828,15 +4828,26 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_BFO_0000066_reaction_ACETOOHBUTSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002234_CHEBI_49072_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002234_CHEBI_49072_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4847,14 +4858,14 @@
           <http://model.geneontology.org/CHEBI_49072_ACETOLACTREDUCTOISOM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_57540_RXN-13158_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4862,11 +4873,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_15378_ACETOOHBUTSYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_15378_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4877,39 +4888,6 @@
           <http://model.geneontology.org/CHEBI_15378_ACETOOHBUTSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_57945_RXN-13158_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_15377_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002413_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CPLX3O-30_ACETOOHBUTSYN-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4919,7 +4897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4936,13 +4914,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1SmallMolecule55735> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_57540_RXN-13158_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002234_CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002233_CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4953,21 +4964,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1SmallMolecule55790> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_16526_RXN-13158_SGD_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_BSUBPOLYAMSYN-PWY.ttl
+++ b/models/YeastPathways_BSUBPOLYAMSYN-PWY.ttl
@@ -1,20 +1,9 @@
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_15378_SPERMIDINESYN-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BSUBPOLYAMSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_SAMDECARB-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -27,7 +16,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -44,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -55,6 +44,17 @@
 <http://identifiers.org/sgd/S000005412>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_SAMDECARB-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_326268_SPERMIDINESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_326268> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -64,7 +64,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -76,11 +76,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_57834_SPERMIDINESYN-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_57834_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -91,28 +91,6 @@
           <http://model.geneontology.org/CHEBI_57834_SPERMIDINESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000050_YeastPathways_BSUBPOLYAMSYN-PWY/YeastPathways_BSUBPOLYAMSYN-PWY_SGD_YeastPathways_BSUBPOLYAMSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BSUBPOLYAMSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BSUBPOLYAMSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YPR069C-MONOMER_SPERMIDINESYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000006273> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -120,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -132,11 +110,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_16526_SAMDECARB-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_16526_SAMDECARB-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,14 +131,14 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002333_YPR069C-MONOMER_SPERMIDINESYN-RXN_controller_SGD_YeastPathways_BSUBPOLYAMSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BSUBPOLYAMSYN-PWY" ;
+                "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -173,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -193,13 +171,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BSUBPOLYAMSYN-PWYSmallMolecule42684> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_57834_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002333_YPR069C-MONOMER_SPERMIDINESYN-RXN_controller_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57443>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -210,6 +210,28 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000066_reaction_SPERMIDINESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_326268_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YOL052C-MONOMER_SAMDECARB-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005412> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -217,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -225,26 +247,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BSUBPOLYAMSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_17509_SPERMIDINESYN-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_17509_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -259,11 +270,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_SAMDECARB-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_SAMDECARB-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,14 +285,14 @@
           <http://model.geneontology.org/CHEBI_59789_SAMDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000050_YeastPathways_BSUBPOLYAMSYN-PWY/YeastPathways_BSUBPOLYAMSYN-PWY_SGD_YeastPathways_BSUBPOLYAMSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000050_YeastPathways_BSUBPOLYAMSYN-PWY/YeastPathways_BSUBPOLYAMSYN-PWY_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BSUBPOLYAMSYN-PWY" ;
+                "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -291,20 +302,42 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002333_YOL052C-MONOMER_SAMDECARB-RXN_controller_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_17509_SPERMIDINESYN-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY>
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000050_YeastPathways_BSUBPOLYAMSYN-PWY/YeastPathways_BSUBPOLYAMSYN-PWY_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BSUBPOLYAMSYN-PWY" ;
+                "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_15378_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -315,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -330,11 +363,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000050_YeastPathways_BSUBPOLYAMSYN-PWY/YeastPathways_BSUBPOLYAMSYN-PWY_SGD_YeastPathways_BSUBPOLYAMSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000050_YeastPathways_BSUBPOLYAMSYN-PWY/YeastPathways_BSUBPOLYAMSYN-PWY_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -345,14 +378,14 @@
           <http://model.geneontology.org/YeastPathways_BSUBPOLYAMSYN-PWY/YeastPathways_BSUBPOLYAMSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000066_reaction_SAMDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_BSUBPOLYAMSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BSUBPOLYAMSYN-PWY" ;
+                "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -363,11 +396,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_15378_SPERMIDINESYN-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_15378_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,26 +411,15 @@
           <http://model.geneontology.org/CHEBI_15378_SPERMIDINESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_326268_SPERMIDINESYN-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BSUBPOLYAMSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -420,13 +442,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "spermidine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -444,11 +477,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" , "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine' 'null' 'putrescine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermidine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMIDINESYN-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -462,26 +495,15 @@
 <http://purl.obolibrary.org/obo/GO_0004014>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_SAMDECARB-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BSUBPOLYAMSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -496,11 +518,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000066_reaction_SAMDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_BSUBPOLYAMSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000066_reaction_SAMDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -511,6 +533,17 @@
           <http://model.geneontology.org/reaction_SAMDECARB-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000066_reaction_SAMDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57443_SAMDECARB-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57443> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -520,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -528,14 +561,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000066_reaction_SPERMIDINESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_BSUBPOLYAMSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:BSUBPOLYAMSYN-PWY" ;
+                "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -548,15 +581,26 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_17509_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002333_YOL052C-MONOMER_SAMDECARB-RXN_controller_SGD_YeastPathways_BSUBPOLYAMSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002333_YOL052C-MONOMER_SAMDECARB-RXN_controller_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -570,17 +614,6 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_16526_SAMDECARB-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BSUBPOLYAMSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -588,11 +621,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_326268_SPERMIDINESYN-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_326268_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,11 +640,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000050_YeastPathways_BSUBPOLYAMSYN-PWY/YeastPathways_BSUBPOLYAMSYN-PWY_SGD_YeastPathways_BSUBPOLYAMSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000050_YeastPathways_BSUBPOLYAMSYN-PWY/YeastPathways_BSUBPOLYAMSYN-PWY_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -621,17 +654,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_BSUBPOLYAMSYN-PWY/YeastPathways_BSUBPOLYAMSYN-PWY>
 ] .
-
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002333_YOL052C-MONOMER_SAMDECARB-RXN_controller_SGD_YeastPathways_BSUBPOLYAMSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BSUBPOLYAMSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17509>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -645,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -675,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -685,17 +707,6 @@
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_57834_SPERMIDINESYN-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BSUBPOLYAMSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -709,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -734,13 +745,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BSUBPOLYAMSYN-PWYBiochemicalReaction42738> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_16526_SAMDECARB-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -749,11 +771,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002333_YPR069C-MONOMER_SPERMIDINESYN-RXN_controller_SGD_YeastPathways_BSUBPOLYAMSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002333_YPR069C-MONOMER_SPERMIDINESYN-RXN_controller_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -769,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -777,11 +799,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -792,17 +814,6 @@
           <http://model.geneontology.org/CHEBI_57443_SAMDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMIDINESYN-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BSUBPOLYAMSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_59789>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -810,11 +821,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000066_reaction_SPERMIDINESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_BSUBPOLYAMSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000066_reaction_SPERMIDINESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_BSUBPOLYAMSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -827,17 +838,6 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_BSUBPOLYAMSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BSUBPOLYAMSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_326268>
         a       <http://www.w3.org/2002/07/owl#Class> .

--- a/models/YeastPathways_CITRUL-BIO2-PWY.ttl
+++ b/models/YeastPathways_CITRUL-BIO2-PWY.ttl
@@ -1,3 +1,14 @@
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58359_CARBPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58359> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,15 +49,37 @@
 <http://purl.obolibrary.org/obo/GO_0004585>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_CITRUL-BIO2-PWY/YeastPathways_CITRUL-BIO2-PWY_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002333_YJL088W-MONOMER_ORNCARBAMTRANSFER-RXN_controller_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,11 +94,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -85,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -99,30 +132,30 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58228>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -131,11 +164,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_43474_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_43474_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -163,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -180,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -191,41 +224,8 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_46911_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002333_YJL088W-MONOMER_ORNCARBAMTRANSFER-RXN_controller_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -233,16 +233,33 @@
 <http://identifiers.org/sgd/S000003666>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_57743_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_57743_ORNCARBAMTRANSFER-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57743> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "L-citrulline" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=CITRUL-BIO2-PWYSmallMolecule22903> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CARBPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004088> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -263,30 +280,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=CITRUL-BIO2-PWYBiochemicalReaction22715> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/CHEBI_57743_ORNCARBAMTRANSFER-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57743> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "L-citrulline" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=CITRUL-BIO2-PWYSmallMolecule22903> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YeastPathways_CITRUL-BIO2-PWY/YeastPathways_CITRUL-BIO2-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0019240> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -297,7 +297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -309,11 +309,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" , "Provides Input For Rule. The relation '2 ATP + L-glutamine + hydrogencarbonate + H<sub>2</sub>O &rarr; L-glutamate + carbamoyl phosphate + 2 ADP + phosphate + 2 H<SUP>+</SUP>' 'null' 'L-ornithine + carbamoyl phosphate &rarr; L-citrulline + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -324,14 +324,14 @@
           <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -339,11 +339,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,17 +357,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -380,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -398,11 +387,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_15378_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_15378_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -422,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -445,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,11 +446,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_46911_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_46911_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -475,26 +464,15 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -514,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -522,17 +500,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://identifiers.org/sgd/S000003624>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_15378_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_43474_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003624>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000066_reaction_ORNCARBAMTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -543,11 +543,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -562,11 +562,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -580,40 +580,18 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000066_reaction_ORNCARBAMTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,7 +609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -642,23 +620,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000050_YeastPathways_CITRUL-BIO2-PWY/YeastPathways_CITRUL-BIO2-PWY_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_CARBPSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -669,11 +636,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000066_reaction_ORNCARBAMTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000066_reaction_ORNCARBAMTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -689,7 +656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -697,11 +664,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -730,18 +697,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,11 +745,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -780,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -788,23 +777,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -817,46 +806,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=CITRUL-BIO2-PWYSmallMolecule22821> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_43474_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -867,38 +823,8 @@
 <http://purl.obolibrary.org/obo/CHEBI_46911>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000050_YeastPathways_CITRUL-BIO2-PWY/YeastPathways_CITRUL-BIO2-PWY_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_CITRUL-BIO2-PWY/YeastPathways_CITRUL-BIO2-PWY>
-] .
 
 <http://model.geneontology.org/YeastPathways_CITRUL-BIO2-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -909,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "citrulline biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -917,37 +843,37 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000050_YeastPathways_CITRUL-BIO2-PWY/YeastPathways_CITRUL-BIO2-PWY_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ORNCARBAMTRANSFER-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_CITRUL-BIO2-PWY/YeastPathways_CITRUL-BIO2-PWY>
+] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_CITRUL-BIO2-PWY/YeastPathways_CITRUL-BIO2-PWY_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -961,8 +887,38 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58228_CARBPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58228> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -973,13 +929,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=CITRUL-BIO2-PWYSmallMolecule22806> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_CARBPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -990,7 +957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1005,11 +972,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1024,11 +991,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_CITRUL-BIO2-PWY/YeastPathways_CITRUL-BIO2-PWY_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_CITRUL-BIO2-PWY/YeastPathways_CITRUL-BIO2-PWY_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1043,11 +1010,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002333_YJL088W-MONOMER_ORNCARBAMTRANSFER-RXN_controller_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002333_YJL088W-MONOMER_ORNCARBAMTRANSFER-RXN_controller_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1066,12 +1033,34 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002233_CHEBI_46911_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_15378_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1091,7 +1080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1106,11 +1095,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1125,11 +1114,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1140,47 +1129,25 @@
           <http://model.geneontology.org/CHEBI_58359_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_YeastPathways_CITRUL-BIO2-PWY>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CITRUL-BIO2-PWY" ;
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1188,11 +1155,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1210,11 +1177,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_57743_ORNCARBAMTRANSFER-RXN_SGD_YeastPathways_CITRUL-BIO2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_57743_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1225,5 +1192,38 @@
           <http://model.geneontology.org/CHEBI_57743_ORNCARBAMTRANSFER-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_BFO_0000050_YeastPathways_CITRUL-BIO2-PWY/YeastPathways_CITRUL-BIO2-PWY_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ORNCARBAMTRANSFER-RXN_RO_0002234_CHEBI_57743_ORNCARBAMTRANSFER-RXN_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_COMPLETE-ARO-PWY-1.ttl
+++ b/models/YeastPathways_COMPLETE-ARO-PWY-1.ttl
@@ -1,11 +1,11 @@
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000066_reaction_CHORISMATEMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13,11 +13,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Provides Input For Rule. The relation 'anthranilate + 5-phospho-&alpha;-D-ribose 1-diphosphate &rarr; <i>N</i>-(5-phosphoribosyl)-anthranilate + diphosphate' 'null' '<i>N</i>-(5-phosphoribosyl)-anthranilate &rarr; 1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -58,11 +58,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,17 +73,6 @@
           <http://model.geneontology.org/CHEBI_15378_IGPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_57972_RXN3O-4157_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -93,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -101,14 +90,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_15361_RXN3O-4157_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002413_PRTRANS-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -116,11 +127,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000066_reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000066_reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -135,11 +146,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -157,11 +168,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -176,11 +187,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -190,6 +201,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58394_DAHPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004664> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -210,24 +232,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1BiochemicalReaction56640> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
@@ -238,13 +249,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule56766> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002762>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -253,11 +275,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>N</i>-(5-phosphoribosyl)-anthranilate &rarr; 1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate' 'null' '1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate + H<SUP>+</SUP> &rarr; (1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002413_IGPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002413_IGPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,29 +290,29 @@
           <http://model.geneontology.org/IGPSYN-RXN>
 ] .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_58359_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'chorismate &harr; prephenate' 'null' 'prephenate + H<SUP>+</SUP> &harr; 3-phenyl-2-oxopropanoate + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,15 +323,26 @@
           <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -320,14 +353,14 @@
           <http://model.geneontology.org/CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_57701_2.5.1.19-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -338,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -353,11 +386,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -372,11 +405,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,11 +424,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,87 +442,24 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PRTRANS-RXN_location_lociGO_0005829>
-] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -500,6 +470,36 @@
           <http://model.geneontology.org/YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PRTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_PRTRANS-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_TRYPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -522,7 +522,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_16567_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -530,11 +541,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_58394_DAHPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_58394_DAHPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,11 +560,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -570,14 +581,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002233_CHEBI_57701_2.5.1.19-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -593,35 +604,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1Complex56582> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
-
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000066_reaction_DAHPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PRTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004048> ;
@@ -642,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -650,14 +639,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002413_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -680,13 +680,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1BiochemicalReaction57050> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_IGPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -697,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -705,15 +716,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_58095_RXN-10814_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_58095_RXN-10814_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -724,25 +746,36 @@
           <http://model.geneontology.org/CHEBI_58095_RXN-10814>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58394_DAHPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_15378_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -755,7 +788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -763,25 +796,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002413_TRYPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_43474_2.5.1.19-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_2.6.1.58-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -789,11 +811,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Provides Input For Rule. The relation '1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate + H<SUP>+</SUP> &rarr; (1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + CO<SUB>2</SUB> + H<sub>2</sub>O' 'null' '(1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + L-serine &rarr; L-tryptophan + D-glyceraldehyde 3-phosphate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002413_TRYPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002413_TRYPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -808,11 +830,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -828,7 +850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -836,11 +858,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '5-enolpyruvoyl-shikimate 3-phosphate &rarr; chorismate + phosphate' 'null' 'chorismate &harr; prephenate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_CHORISMATEMUT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -855,11 +877,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -870,19 +892,16 @@
           <http://model.geneontology.org/CHEBI_145989_SHIKIMATE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004107>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57972_2.6.1.58-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57972> ;
@@ -893,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -901,52 +920,44 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004107>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_57701_2.5.1.19-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRTRANS-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_CHORISMATEMUT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003866>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_58095_RXN-10814_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -955,11 +966,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '3-dehydroquinate &harr; 3-dehydroshikimate + H<sub>2</sub>O' 'null' 'shikimate + NADP<sup>+</sup> &larr; 3-dehydroshikimate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002413_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002413_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -970,28 +981,6 @@
           <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_29985_RXN-10814_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_43474_DAHPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -999,11 +988,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1018,11 +1007,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,6 +1021,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_30616_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ANTHRANSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004049> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1052,24 +1052,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1BiochemicalReaction56864> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -1080,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1095,11 +1084,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1110,17 +1099,6 @@
           <http://model.geneontology.org/CHEBI_18005_PREPHENATEDEHYDRAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_SHIKIMATE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1130,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1147,7 +1125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1159,11 +1137,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_16567_ANTHRANSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_16567_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1178,11 +1156,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000066_reaction_DAHPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000066_reaction_DAHPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1193,15 +1171,26 @@
           <http://model.geneontology.org/reaction_DAHPSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1212,14 +1201,14 @@
           <http://model.geneontology.org/CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000066_reaction_IGPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1232,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1240,15 +1229,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002413_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002333_YDR007W-MONOMER_PRAISOM-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_58702_2.5.1.19-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_58702_2.5.1.19-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1259,14 +1270,14 @@
           <http://model.geneontology.org/CHEBI_58702_2.5.1.19-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15378_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1274,11 +1285,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1289,25 +1300,25 @@
           <http://model.geneontology.org/YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_RXN3O-4157_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1318,11 +1329,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_58613_PRAISOM-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_58613_PRAISOM-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1333,40 +1344,29 @@
           <http://model.geneontology.org/CHEBI_58613_PRAISOM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000453>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002233_CHEBI_57701_2.5.1.19-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002233_CHEBI_57701_2.5.1.19-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1381,11 +1381,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1405,7 +1405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1413,39 +1413,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_15361_2.6.1.58-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_ANTHRANSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1453,11 +1453,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1468,15 +1468,26 @@
           <http://model.geneontology.org/reaction_TRYPSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_15361_RXN3O-4157_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_15361_RXN3O-4157_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1493,14 +1504,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1508,11 +1530,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1532,7 +1554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1547,11 +1569,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'chorismate &harr; prephenate' 'null' 'prephenate + NADP<sup>+</sup> &rarr; CO<SUB>2</SUB> + 3-(4-hydroxyphenyl)pyruvate + NADPH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1562,17 +1584,6 @@
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YPR060C-MONOMER_CHORISMATEMUT-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006264> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1580,7 +1591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1588,25 +1599,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15361_ANTHRANSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1616,15 +1616,26 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_58095_2.6.1.58-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Provides Input For Rule. The relation 'shikimate + NADP<sup>+</sup> &larr; 3-dehydroshikimate + NADPH + H<SUP>+</SUP>' 'null' 'shikimate + ATP &harr; shikimate 3-phosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002413_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002413_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1639,11 +1650,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000066_reaction_ANTHRANSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000066_reaction_ANTHRANSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1654,14 +1665,14 @@
           <http://model.geneontology.org/reaction_ANTHRANSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002413_RXN3O-4157_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1669,11 +1680,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_ANTHRANSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1688,11 +1699,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Provides Input For Rule. The relation '3-deoxy-D-arabino-heptulosonate 7-phosphate &rarr; 3-dehydroquinate + phosphate' 'null' '3-dehydroquinate &harr; 3-dehydroshikimate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1712,26 +1723,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_36242>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_RXN-10814_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YBR249C-MONOMER_DAHPSYN-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YBR249C-MONOMER_DAHPSYN-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1742,15 +1742,37 @@
           <http://model.geneontology.org/YBR249C-MONOMER_DAHPSYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_58394_DAHPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1764,25 +1786,14 @@
 <http://identifiers.org/sgd/S000002534>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1795,7 +1806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of aromatic amino acid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1803,8 +1814,30 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_58702_DAHPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1813,11 +1846,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1827,17 +1860,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CPLX-9432_RXN-10814_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003855>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1854,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1866,11 +1888,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1885,11 +1907,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1900,35 +1922,56 @@
           <http://model.geneontology.org/CHEBI_18005_PREPHENATEDEHYDRAT-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_43474_CHORISMATE-SYNTHASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule57007> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_58315_RXN3O-4157_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/YBR249C-MONOMER_DAHPSYN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000453> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-deoxy-D-arabino-heptulosonate 7-phosphate synthase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1Protein57178> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1939,21 +1982,6 @@
           <http://model.geneontology.org/YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1>
 ] .
 
-<http://model.geneontology.org/YBR249C-MONOMER_DAHPSYN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000453> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-deoxy-D-arabino-heptulosonate 7-phosphate synthase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1Protein57178> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://model.geneontology.org/CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1963,7 +1991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1971,26 +1999,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2005,11 +2022,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2029,7 +2046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2037,31 +2054,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CHEBI_43474_CHORISMATE-SYNTHASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphate" ;
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002333_YDR127W-MONOMER_2.5.1.19-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule57007> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002333_YDR007W-MONOMER_PRAISOM-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2069,11 +2069,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2083,17 +2083,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_PRAISOM-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002333_YGL148W-MONOMER_CHORISMATE-SYNTHASE-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003856> ;
@@ -2114,7 +2103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2122,26 +2111,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000066_reaction_CHORISMATEMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000066_reaction_CHORISMATEMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2156,11 +2134,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2178,7 +2156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2186,14 +2164,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_33384_TRYPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002233_CHEBI_57701_2.5.1.19-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2201,11 +2201,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2220,11 +2220,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2235,12 +2235,23 @@
           <http://model.geneontology.org/YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_16897_DAHPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_PRTRANS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2253,7 +2264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2265,11 +2276,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2284,11 +2295,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_29985_ANTHRANSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_29985_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2299,25 +2310,14 @@
           <http://model.geneontology.org/CHEBI_29985_ANTHRANSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000001694_CPLX3O-31_component_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_IGPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2328,11 +2328,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_15377_DAHPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_15377_DAHPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2347,11 +2347,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2371,7 +2371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2386,7 +2386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2397,23 +2397,34 @@
 <http://purl.obolibrary.org/obo/GO_0003849>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000066_reaction_CHORISMATEMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_2.6.1.58-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2421,11 +2432,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_43474_2.5.1.19-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_43474_2.5.1.19-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2455,13 +2466,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1BiochemicalReaction57017> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_18277_PRTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_18277> ;
@@ -2472,7 +2494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2483,14 +2505,14 @@
 <http://identifiers.org/sgd/S000002414>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_58017_PRTRANS-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2501,7 +2523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2509,26 +2531,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_58394_DAHPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2539,34 +2550,23 @@
           <http://model.geneontology.org/reaction_RXN-10814_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000000892_CPLX3O-31_component_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000001694_CPLX3O-31_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001694> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2574,11 +2574,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_15377_IGPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_15377_IGPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2596,13 +2596,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1Protein57047> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004640>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2626,7 +2637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2634,37 +2645,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_16810_RXN-10814_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2675,15 +2664,26 @@
           <http://model.geneontology.org/CHEBI_29748_CHORISMATE-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_57972_2.6.1.58-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2697,6 +2697,17 @@
 <http://purl.obolibrary.org/obo/GO_0004048>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_456216_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_43474_DAHPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2706,7 +2717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2723,7 +2734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2734,15 +2745,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_33384_TRYPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_33384_TRYPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2757,11 +2779,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_58315_RXN3O-4157_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_58315_RXN3O-4157_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2778,36 +2800,14 @@
 <http://identifiers.org/sgd/S000000370>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002333_YDR354W-MONOMER_PRTRANS-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_RXN3O-4157_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2820,7 +2820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2828,26 +2828,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000066_reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000066_reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2862,11 +2851,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002233_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002233_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2877,15 +2866,37 @@
           <http://model.geneontology.org/CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2900,11 +2911,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_IGPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_IGPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2920,7 +2931,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2931,7 +2953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2946,11 +2968,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2965,11 +2987,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2980,29 +3002,29 @@
           <http://model.geneontology.org/CHEBI_29748_CHORISMATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://purl.obolibrary.org/obo/GO_0004664>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004664>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_58017_PRTRANS-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_58017_PRTRANS-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3017,11 +3039,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3032,14 +3054,14 @@
           <http://model.geneontology.org/YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3048,38 +3070,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DAHPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR035W-MONOMER_DAHPSYN-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Provides Input For Rule. The relation 'L-tyrosine + 2-oxoglutarate &harr; 3-(4-hydroxyphenyl)pyruvate + L-glutamate' 'null' 'L-tyrosine + pyruvate &harr; 3-(4-hydroxyphenyl)pyruvate + L-alanine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_RXN3O-4157_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_RXN3O-4157_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3090,6 +3104,58 @@
           <http://model.geneontology.org/RXN3O-4157>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DAHPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YDR035W-MONOMER_DAHPSYN-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_57972_RXN3O-4157_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_145989>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3099,25 +3165,36 @@
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_29985_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002234_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3130,7 +3207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3138,17 +3215,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0003856>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0003856>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000066_reaction_IGPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3156,11 +3244,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_57972_2.6.1.58-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_57972_2.6.1.58-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3171,56 +3259,34 @@
           <http://model.geneontology.org/CHEBI_57972_2.6.1.58-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_ANTHRANSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000066_reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3228,11 +3294,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_456216_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_456216_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3247,11 +3313,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3262,25 +3328,77 @@
           <http://model.geneontology.org/YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002413_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002413_RXN3O-4157_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002333_CPLX3O-31_ANTHRANSYN-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002234_CHEBI_58613_PRAISOM-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRTRANS-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PRAISOM-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_18277_PRTRANS-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3293,7 +3411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3301,70 +3419,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRTRANS-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRAISOM-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18277_PRTRANS-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000066_reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58315>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002234_CHEBI_58613_PRAISOM-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3394,7 +3460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3406,11 +3472,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3420,6 +3486,34 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NADP<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule56751> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/DAHPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003849> ;
@@ -3440,7 +3534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3448,42 +3542,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002413_PRTRANS-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000066_reaction_ANTHRANSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NADP<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule56751> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000066_reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3491,11 +3557,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3510,11 +3576,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3528,14 +3594,36 @@
 <http://purl.obolibrary.org/obo/CHEBI_16567>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_15378_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3543,11 +3631,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Provides Input For Rule. The relation 'prephenate + H<SUP>+</SUP> &harr; 3-phenyl-2-oxopropanoate + CO<SUB>2</SUB> + H<sub>2</sub>O' 'null' 'L-phenylalanine + 2-oxoglutarate &harr; 3-phenyl-2-oxopropanoate + L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_RXN-10814_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_RXN-10814_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3558,26 +3646,15 @@
           <http://model.geneontology.org/RXN-10814>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002333_CPLX3O-31_ANTHRANSYN-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002333_CPLX3O-31_ANTHRANSYN-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3592,11 +3669,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_16897_DAHPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_16897_DAHPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3607,26 +3684,15 @@
           <http://model.geneontology.org/CHEBI_16897_DAHPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_16897_DAHPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3637,17 +3703,6 @@
           <http://model.geneontology.org/CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_SHIKIMATE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3657,13 +3712,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule57093> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000066_reaction_DAHPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3677,7 +3743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3688,26 +3754,15 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_456216_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_57701_2.5.1.19-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_57701_2.5.1.19-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3725,7 +3780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3742,7 +3797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3750,29 +3805,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://identifiers.org/sgd/S000002994>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002233_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000002994>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3783,73 +3838,49 @@
           <http://model.geneontology.org/CHEBI_18005_PREPHENATEDEHYDRAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/CHEBI_57972>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002413_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_58613_PRAISOM-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_58095_RXN-10814_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57972>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3860,14 +3891,53 @@
           <http://model.geneontology.org/CHEBI_16526_IGPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002233_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_58702_2.5.1.19-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_16810_RXN-10814_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "tyr" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule56717> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3880,39 +3950,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule57026> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "tyr" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule56717> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YDR127W-MONOMER_2.5.1.19-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002534> ;
@@ -3921,7 +3965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3929,34 +3973,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_29985_ANTHRANSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3977,7 +3999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3989,11 +4011,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4004,24 +4026,10 @@
           <http://model.geneontology.org/CHEBI_43474_CHORISMATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_57972_2.6.1.58-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004049>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0004400>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_57701>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1>
@@ -4033,24 +4041,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_COMPLETE-ARO-PWY-1" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16567_ANTHRANSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16567> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4061,7 +4058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4091,7 +4088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4099,18 +4096,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/CHEBI_58702>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4128,7 +4133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4136,25 +4141,20 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_58359_ANTHRANSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57701>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YBR249C-MONOMER_DAHPSYN-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/CHEBI_58702>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000066_reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4165,11 +4165,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_15378_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_15378_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4184,11 +4184,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4199,39 +4199,28 @@
           <http://model.geneontology.org/CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15378_ANTHRANSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000001694_CPLX3O-31_component_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004834>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000000892_CPLX3O-31_component_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4239,30 +4228,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_TRYPSYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4273,16 +4243,24 @@
           <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_TRYPSYN-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_58394_DAHPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58394> ;
@@ -4293,7 +4271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4305,11 +4283,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000066_reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000066_reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4325,18 +4303,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4344,11 +4322,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_58359_ANTHRANSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_58359_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4359,26 +4337,15 @@
           <http://model.geneontology.org/CHEBI_58359_ANTHRANSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4396,11 +4363,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4411,6 +4378,28 @@
           <http://model.geneontology.org/reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58394>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -4419,59 +4408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.5.1.19-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1>
-] .
-
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRTRANS-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4479,11 +4416,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'phospho<i>enol</i>pyruvate + D-erythrose 4-phosphate + H<sub>2</sub>O &harr; 3-deoxy-D-arabino-heptulosonate 7-phosphate + phosphate' 'null' '3-deoxy-D-arabino-heptulosonate 7-phosphate &rarr; 3-dehydroquinate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4494,25 +4431,55 @@
           <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_43474_2.5.1.19-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.5.1.19-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1>
+] .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000066_reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4520,11 +4487,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4535,22 +4502,22 @@
           <http://model.geneontology.org/CHEBI_29888_PRTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002333_YDR354W-MONOMER_PRTRANS-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGL026C-MONOMER_TRYPSYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002994> ;
@@ -4559,7 +4526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4576,7 +4543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4588,11 +4555,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4603,36 +4570,25 @@
           <http://model.geneontology.org/YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_33384_TRYPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4640,11 +4596,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'chorismate + L-glutamine &rarr; anthranilate + L-glutamate + pyruvate + H<SUP>+</SUP>' 'null' 'anthranilate + 5-phospho-&alpha;-D-ribose 1-diphosphate &rarr; <i>N</i>-(5-phosphoribosyl)-anthranilate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002413_PRTRANS-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002413_PRTRANS-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4659,11 +4615,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_15361_2.6.1.58-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_15361_2.6.1.58-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4683,13 +4639,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule57040> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15361_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_SHIKIMATE-5-DEHYDROGENASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4700,7 +4678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4708,12 +4686,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_15361_RXN3O-4157_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4721,11 +4710,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4740,11 +4729,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4764,7 +4753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4775,14 +4764,14 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002234_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4795,13 +4784,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule56574> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002413_2.5.1.19-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_PREPHENATEDEHYDRAT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4812,7 +4812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4823,15 +4823,26 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002413_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002234_CHEBI_58613_PRAISOM-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002234_CHEBI_58613_PRAISOM-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4841,6 +4852,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58613_PRAISOM-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4854,7 +4876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4869,11 +4891,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002234_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002234_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4888,11 +4910,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58394_DAHPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58394_DAHPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4903,56 +4925,15 @@
           <http://model.geneontology.org/CHEBI_58394_DAHPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_58702_2.5.1.19-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4963,33 +4944,35 @@
           <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_58315_RXN3O-4157_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule57007> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHORISMATE-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004107> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5010,7 +4993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5018,19 +5001,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/CHEBI_36208>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule57007> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_36208>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15361_ANTHRANSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
@@ -5041,7 +5030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5053,11 +5042,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Provides Input For Rule. The relation 'prephenate + H<SUP>+</SUP> &harr; 3-phenyl-2-oxopropanoate + CO<SUB>2</SUB> + H<sub>2</sub>O' 'null' 'L-phenylalanine + pyruvate &harr; 3-phenyl-2-oxopropanoate + L-alanine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_2.6.1.58-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_2.6.1.58-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5080,7 +5069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5092,30 +5081,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_58702_DAHPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_58702_DAHPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5133,7 +5103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5141,16 +5111,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller>
+] .
 
 <http://identifiers.org/sgd/S000001179>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5164,7 +5142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5172,14 +5150,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5188,18 +5166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5207,11 +5174,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002333_YDR127W-MONOMER_2.5.1.19-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002333_YDR127W-MONOMER_2.5.1.19-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5222,25 +5189,25 @@
           <http://model.geneontology.org/YDR127W-MONOMER_2.5.1.19-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_15377_DAHPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000066_reaction_2.5.1.19-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_58017_PRTRANS-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5249,7 +5216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5257,11 +5224,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_29985_RXN-10814_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_29985_RXN-10814_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5276,11 +5243,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'prephenate + NADP<sup>+</sup> &rarr; CO<SUB>2</SUB> + 3-(4-hydroxyphenyl)pyruvate + NADPH' 'null' 'L-tyrosine + pyruvate &harr; 3-(4-hydroxyphenyl)pyruvate + L-alanine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002413_RXN3O-4157_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002413_RXN3O-4157_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5291,6 +5258,28 @@
           <http://model.geneontology.org/RXN3O-4157>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_15361_2.6.1.58-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000066_reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_DAHPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5300,7 +5289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5312,11 +5301,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5331,11 +5320,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'shikimate 3-phosphate + phospho<i>enol</i>pyruvate &harr; 5-enolpyruvoyl-shikimate 3-phosphate + phosphate' 'null' '5-enolpyruvoyl-shikimate 3-phosphate &rarr; chorismate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002413_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002413_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5345,17 +5334,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHORISMATE-SYNTHASE-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PRAISOM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004640> ;
@@ -5376,7 +5354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5384,48 +5362,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002333_YPR060C-MONOMER_CHORISMATEMUT-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002333_YGL148W-MONOMER_CHORISMATE-SYNTHASE-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002333_YGL148W-MONOMER_CHORISMATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5440,11 +5385,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_30616_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_30616_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5455,47 +5400,25 @@
           <http://model.geneontology.org/CHEBI_30616_SHIKIMATE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002413_IGPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_29985_RXN-10814_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_15378_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002333_YGL148W-MONOMER_CHORISMATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5503,11 +5426,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-tyrosine + pyruvate &harr; 3-(4-hydroxyphenyl)pyruvate + L-alanine' 'null' 'L-tyrosine + 2-oxoglutarate &harr; 3-(4-hydroxyphenyl)pyruvate + L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5518,17 +5441,6 @@
           <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_59776_TRYPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59776> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5538,7 +5450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5565,7 +5477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5573,37 +5485,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000066_reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002234_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5612,6 +5502,25 @@
           <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29934_CHORISMATEMUT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58095_2.6.1.58-RXN>
@@ -5623,43 +5532,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule56525> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29934_CHORISMATEMUT-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_15377_IGPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58359_ANTHRANSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58359> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5670,7 +5549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5678,62 +5557,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002333_YPR060C-MONOMER_CHORISMATEMUT-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_59776>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000066_reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_ANTHRANSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_15377_DAHPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000000892_CPLX3O-31_component_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000000892_CPLX3O-31_component_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5748,11 +5605,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5772,13 +5629,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule56694> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58095_RXN-10814>
         a       <http://purl.obolibrary.org/obo/CHEBI_58095> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5789,7 +5657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5801,11 +5669,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15361_ANTHRANSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15361_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5823,7 +5691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5838,11 +5706,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5853,31 +5721,42 @@
           <http://model.geneontology.org/CHEBI_29934_CHORISMATEMUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_58702_DAHPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000006264>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0009073>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002333_YDR127W-MONOMER_2.5.1.19-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_43474_DAHPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0009073>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5885,11 +5764,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000066_reaction_2.5.1.19-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000066_reaction_2.5.1.19-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5899,6 +5778,39 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_2.5.1.19-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004425>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5918,7 +5830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5930,11 +5842,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002333_YDR354W-MONOMER_PRTRANS-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002333_YDR354W-MONOMER_PRTRANS-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5948,6 +5860,17 @@
 <http://identifiers.org/sgd/S000003116>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002413_TRYPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_ANTHRANSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5957,7 +5880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5970,28 +5893,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000066_reaction_IGPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IGPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_IGPSYN-RXN_location_lociGO_0005829>
-] .
 
 <http://model.geneontology.org/CHEBI_29934_CHORISMATEMUT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29934> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6002,13 +5906,43 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule56665> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000066_reaction_IGPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/IGPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_IGPSYN-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_IGPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6019,7 +5953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6037,11 +5971,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6069,7 +6003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6077,15 +6011,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_58095_2.6.1.58-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_58095_2.6.1.58-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6096,45 +6041,37 @@
           <http://model.geneontology.org/CHEBI_58095_2.6.1.58-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000066_reaction_2.5.1.19-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Provides Input For Rule. The relation 'shikimate + ATP &harr; shikimate 3-phosphate + ADP + H<SUP>+</SUP>' 'null' 'shikimate 3-phosphate + phospho<i>enol</i>pyruvate &harr; 5-enolpyruvoyl-shikimate 3-phosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002413_2.5.1.19-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.5.1.19-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_57972_RXN3O-4157_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_57972_RXN3O-4157_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6145,6 +6082,36 @@
           <http://model.geneontology.org/CHEBI_57972_RXN3O-4157>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Provides Input For Rule. The relation 'shikimate + ATP &harr; shikimate 3-phosphate + ADP + H<SUP>+</SUP>' 'null' 'shikimate 3-phosphate + phospho<i>enol</i>pyruvate &harr; 5-enolpyruvoyl-shikimate 3-phosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002413_2.5.1.19-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/2.5.1.19-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_58613_PRAISOM-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57701_2.5.1.19-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57701> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6154,7 +6121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6174,7 +6141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6189,11 +6156,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002333_YDR007W-MONOMER_PRAISOM-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002333_YDR007W-MONOMER_PRAISOM-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6204,6 +6171,17 @@
           <http://model.geneontology.org/YDR007W-MONOMER_PRAISOM-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YDR127W-MONOMER_3-DEHYDROQUINATE-SYNTHASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000002534> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -6211,7 +6189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6219,15 +6197,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002333_YPR060C-MONOMER_CHORISMATEMUT-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002333_YPR060C-MONOMER_CHORISMATEMUT-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6242,11 +6231,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6260,17 +6249,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_58866>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58866_IGPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58866> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6280,7 +6258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6288,15 +6266,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6311,11 +6300,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6326,6 +6315,17 @@
           <http://model.geneontology.org/CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -6333,11 +6333,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6348,15 +6348,37 @@
           <http://model.geneontology.org/YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002413_IGPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YBR249C-MONOMER_DAHPSYN-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_43474_DAHPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002234_CHEBI_43474_DAHPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6367,14 +6389,14 @@
           <http://model.geneontology.org/CHEBI_43474_DAHPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6383,7 +6405,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6396,7 +6429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6404,14 +6437,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_58095_2.6.1.58-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6422,7 +6455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6433,14 +6466,14 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6449,7 +6482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6457,11 +6490,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_16810_RXN-10814_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_16810_RXN-10814_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6472,14 +6505,14 @@
           <http://model.geneontology.org/CHEBI_16810_RXN-10814>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002413_2.5.1.19-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000066_reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6490,7 +6523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6498,25 +6531,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002333_CPLX3O-31_ANTHRANSYN-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002413_CHORISMATE-SYNTHASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6527,11 +6560,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6546,11 +6579,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6560,6 +6593,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1>
 ] .
+
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_IGPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_18005>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6573,7 +6617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6586,30 +6630,38 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Provides Input For Rule. The relation '5-enolpyruvoyl-shikimate 3-phosphate &rarr; chorismate + phosphate' 'null' 'chorismate + L-glutamine &rarr; anthranilate + L-glutamate + pyruvate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_ANTHRANSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Provides Input For Rule. The relation '5-enolpyruvoyl-shikimate 3-phosphate &rarr; chorismate + phosphate' 'null' 'chorismate + L-glutamine &rarr; anthranilate + L-glutamate + pyruvate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6620,24 +6672,16 @@
           <http://model.geneontology.org/ANTHRANSYN-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-KINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_15377_IGPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHORISMATEMUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004106> ;
@@ -6658,7 +6702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6675,7 +6719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6683,40 +6727,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_RXN-10814_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004106>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_16567_ANTHRANSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6731,11 +6764,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6750,11 +6783,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002333_YDR127W-MONOMER_3-DEHYDROQUINATE-DEHYDRATASE-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6782,35 +6815,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1BiochemicalReaction56599> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000066_reaction_ANTHRANSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_30616_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller>
         a       <http://identifiers.org/sgd/S000000370> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6819,7 +6830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6836,7 +6847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6844,15 +6855,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000001694_CPLX3O-31_component_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000001694_CPLX3O-31_component_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6867,11 +6889,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6886,11 +6908,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000066_reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_BFO_0000066_reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6910,7 +6932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6921,26 +6943,15 @@
 <http://identifiers.org/sgd/S000000892>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6973,7 +6984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6985,11 +6996,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15378_ANTHRANSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15378_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7000,23 +7011,12 @@
           <http://model.geneontology.org/CHEBI_15378_ANTHRANSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_CHORISMATEMUT-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7039,7 +7039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7047,15 +7047,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002233_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7070,11 +7081,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7085,28 +7096,17 @@
           <http://model.geneontology.org/CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000002442>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7114,11 +7114,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_YeastPathways_COMPLETE-ARO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7129,24 +7129,24 @@
           <http://model.geneontology.org/CHEBI_145989_SHIKIMATE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_2.6.1.58-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_CYSTEINE-SYN2-PWY.ttl
+++ b/models/YeastPathways_CYSTEINE-SYN2-PWY.ttl
@@ -1,11 +1,11 @@
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000050_YeastPathways_CYSTEINE-SYN2-PWY/YeastPathways_CYSTEINE-SYN2-PWY_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:CYSTEINE-SYN2-PWY" ;
+                "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -26,26 +26,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_CYSTEINE-SYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CYSTEINE-SYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_YeastPathways_CYSTEINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,12 +45,23 @@
           <http://model.geneontology.org/YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CYSTEINE-SYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_CYSTAGLY-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -69,11 +69,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -95,18 +95,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTAGLY-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:CYSTEINE-SYN2-PWY" ;
+                "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -119,7 +119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -155,11 +155,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -177,11 +177,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -192,6 +192,17 @@
           <http://model.geneontology.org/CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CYSTEINE-SYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33384> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -201,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -224,39 +235,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_YeastPathways_CYSTEINE-SYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CYSTEINE-SYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000050_YeastPathways_CYSTEINE-SYN2-PWY/YeastPathways_CYSTEINE-SYN2-PWY_SGD_YeastPathways_CYSTEINE-SYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CYSTEINE-SYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CYSTEINE-SYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16763_CYSTAGLY-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16763> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -266,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -286,7 +264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -298,11 +276,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000050_YeastPathways_CYSTEINE-SYN2-PWY/YeastPathways_CYSTEINE-SYN2-PWY_SGD_YeastPathways_CYSTEINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000050_YeastPathways_CYSTEINE-SYN2-PWY/YeastPathways_CYSTEINE-SYN2-PWY_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -313,14 +291,14 @@
           <http://model.geneontology.org/YeastPathways_CYSTEINE-SYN2-PWY/YeastPathways_CYSTEINE-SYN2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:CYSTEINE-SYN2-PWY" ;
+                "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -331,11 +309,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,11 +331,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,14 +346,14 @@
           <http://model.geneontology.org/CHEBI_15377_CYSTAGLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_CYSTEINE-SYN2-PWY/YeastPathways_CYSTEINE-SYN2-PWY_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:CYSTEINE-SYN2-PWY" ;
+                "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -388,40 +366,29 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:CYSTEINE-SYN2-PWY" ;
+                "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CYSTEINE-SYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_YeastPathways_CYSTEINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -444,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "cysteine biosynthesis from homocysteine - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -455,15 +422,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_58161>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CYSTEINE-SYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -478,11 +456,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_YeastPathways_CYSTEINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -499,28 +477,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_35235>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_YeastPathways_CYSTEINE-SYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CYSTEINE-SYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_YeastPathways_CYSTEINE-SYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CYSTEINE-SYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YAL012W-MONOMER_CYSTAGLY-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000010> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -528,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -536,28 +492,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_35235_CYSTAGLY-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY>
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:CYSTEINE-SYN2-PWY" ;
+                "SGD_PWY:CYSTEINE-SYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_35235_CYSTAGLY-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:CYSTEINE-SYN2-PWY" ;
+                "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -568,11 +535,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_35235_CYSTAGLY-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_35235_CYSTAGLY-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -595,7 +562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -610,11 +577,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -629,11 +596,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_CYSTEINE-SYN2-PWY/YeastPathways_CYSTEINE-SYN2-PWY_SGD_YeastPathways_CYSTEINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_CYSTEINE-SYN2-PWY/YeastPathways_CYSTEINE-SYN2-PWY_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,14 +614,58 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16763_CYSTAGLY-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CYSTEINE-SYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58199>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CYSTEINE-SYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTAGLY-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CYSTEINE-SYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CYSTEINE-SYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CYSTATHIONINE-BETA-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004122> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -675,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -695,7 +706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -707,11 +718,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-homocysteine + L-serine &harr; L-cystathionine + H<sub>2</sub>O' 'null' 'L-cystathionine + H<sub>2</sub>O &harr; 2-oxobutanoate + L-cysteine + ammonia' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTAGLY-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTAGLY-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -739,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -751,11 +762,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16763_CYSTAGLY-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16763_CYSTAGLY-RXN_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -766,17 +777,6 @@
           <http://model.geneontology.org/CHEBI_16763_CYSTAGLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_CYSTEINE-SYN2-PWY/YeastPathways_CYSTEINE-SYN2-PWY_SGD_YeastPathways_CYSTEINE-SYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CYSTEINE-SYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_CYSTEINE-SYN2-PWY/YeastPathways_CYSTEINE-SYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0019344> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -786,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -797,15 +797,26 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CYSTEINE-SYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_CYSTEINE-SYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_CYSTEINE-SYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -825,21 +836,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=CYSTEINE-SYN2-PWYSmallMolecule60691> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16763_CYSTAGLY-RXN_SGD_YeastPathways_CYSTEINE-SYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:CYSTEINE-SYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_DENOVOPURINE2-PWY.ttl
+++ b/models/YeastPathways_DENOVOPURINE2-PWY.ttl
@@ -3,18 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -27,7 +16,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -35,25 +24,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_02fe330b-a3eb-4ceb-97a7-b2abe3506898_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -66,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -83,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -91,30 +69,52 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004385>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/AIRS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004641> ;
@@ -135,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,25 +143,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -169,11 +169,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -183,6 +183,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN0-746_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58564>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -194,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -202,15 +213,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,26 +254,15 @@
           <http://model.geneontology.org/CHEBI_15378_GMP-SYN-GLUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,18 +273,40 @@
           <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004044>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Provides Input For Rule. The relation '5-phospho-&beta;-D-ribosylamine + L-glutamate + diphosphate &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + L-glutamine + H<sub>2</sub>O' 'null' 'ATP + 5-phospho-&beta;-D-ribosylamine + glycine &rarr; ADP + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -273,15 +317,26 @@
           <http://model.geneontology.org/GLYRIBONUCSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -313,11 +368,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,26 +383,15 @@
           <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'GDP + ATP &rarr; GTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -358,26 +402,15 @@
           <http://model.geneontology.org/GDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + 2 H<SUP>+</SUP> &harr; 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + CO<SUB>2</SUB>' 'null' 'ATP + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + L-aspartate &rarr; ADP + 5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -412,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -424,11 +457,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'dGDP + an oxidized thioredoxin + H<sub>2</sub>O &larr; GDP + a reduced thioredoxin' 'null' 'dGDP + ATP &rarr; dGTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -448,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -460,11 +493,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -475,15 +508,26 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,22 +538,16 @@
           <http://model.geneontology.org/YDR226W-MONOMER_ADENYL-KIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/02fe330b-a3eb-4ceb-97a7-b2abe3506898_AICARTRANSFORM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57872> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58467> ;
@@ -520,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -535,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -552,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -569,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -582,23 +620,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004643>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN0-745>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -615,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -623,28 +650,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/BFO_0000051>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -652,11 +679,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,14 +694,25 @@
           <http://model.geneontology.org/CHEBI_43474_SAICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -687,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -695,14 +733,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -710,11 +759,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -729,11 +778,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -744,15 +793,26 @@
           <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-aspartate + IMP + GTP &rarr; adenylo-succinate + GDP + phosphate + 2 H<SUP>+</SUP>' 'null' 'adenylo-succinate &harr; fumarate + AMP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -772,7 +832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -784,11 +844,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,15 +859,26 @@
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -818,14 +889,14 @@
           <http://model.geneontology.org/CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -833,11 +904,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -855,11 +926,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -870,15 +941,26 @@
           <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_228e6828-796c-473b-8218-938cb845a030_GART-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_f6bb3135-3f7e-43e9-91ac-8243cd646d2d_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -886,28 +968,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/228e6828-796c-473b-8218-938cb845a030_GART-RXN>
+          <http://model.geneontology.org/f6bb3135-3f7e-43e9-91ac-8243cd646d2d_GART-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -920,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -928,39 +999,67 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/f6bb3135-3f7e-43e9-91ac-8243cd646d2d_GART-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57894> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57464>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -968,11 +1067,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1002,7 +1101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1010,39 +1109,72 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1050,11 +1182,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,25 +1197,14 @@
           <http://model.geneontology.org/reaction_SAICARSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1106,13 +1227,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYBiochemicalReaction57902> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_61429_RXN0-746>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_61429> ;
@@ -1123,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1135,11 +1267,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1154,11 +1286,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1169,9 +1301,6 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004550>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1181,7 +1310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1189,37 +1318,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004550>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1239,7 +1349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1247,26 +1357,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1286,7 +1385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1294,15 +1393,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1317,11 +1449,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1332,26 +1464,15 @@
           <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1366,11 +1487,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1388,7 +1509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1396,15 +1517,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1415,25 +1547,25 @@
           <http://model.geneontology.org/CHEBI_456216_AIRS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1452,7 +1584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1460,47 +1592,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1513,13 +1623,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57591> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_GLYRIBONUCSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -1530,7 +1662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1541,26 +1673,15 @@
 <http://purl.obolibrary.org/obo/GO_0004019>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1575,11 +1696,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1593,26 +1714,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_61404>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1627,11 +1737,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1642,26 +1752,15 @@
           <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Provides Input For Rule. The relation 'IMP + H<sub>2</sub>O &harr; 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' 'null' 'L-aspartate + IMP + GTP &rarr; adenylo-succinate + GDP + phosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1672,32 +1771,15 @@
           <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/228e6828-796c-473b-8218-938cb845a030_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57894> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1708,15 +1790,26 @@
           <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1727,26 +1820,15 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1761,11 +1843,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_157f2b12-7d24-41a7-9c89-c2404e9eac4c_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_aa6e4ae1-dfd2-447e-a1a3-7731e0e852c4_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1773,28 +1855,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/157f2b12-7d24-41a7-9c89-c2404e9eac4c_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/aa6e4ae1-dfd2-447e-a1a3-7731e0e852c4_AICARTRANSFORM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1807,7 +1878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1815,14 +1886,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1835,7 +1906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1843,25 +1914,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1874,7 +1934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1882,36 +1942,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1919,11 +1979,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1941,11 +2001,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1959,15 +2019,26 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1987,7 +2058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1999,11 +2070,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2018,11 +2089,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2033,36 +2104,25 @@
           <http://model.geneontology.org/CHEBI_37565_GDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2070,11 +2130,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2085,14 +2145,14 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2100,11 +2160,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2115,9 +2175,6 @@
           <http://model.geneontology.org/reaction_AIRS-RXN_location_lociGO_0005829>
 ] .
 
-<http://identifiers.org/sgd/S000003293>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/CHEBI_30616_RXN0-745>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2127,7 +2184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2144,7 +2201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2156,11 +2213,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2171,26 +2228,18 @@
           <http://model.geneontology.org/reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000003293>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2201,59 +2250,15 @@
           <http://model.geneontology.org/CHEBI_456216_ADENYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002413_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'AMP + ATP &harr; 2 ADP' 'null' 'dADP + an oxidized thioredoxin + H<sub>2</sub>O &larr; ADP + a reduced thioredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2264,6 +2269,28 @@
           <http://model.geneontology.org/ADPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/GART-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004644> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2273,9 +2300,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> , <http://model.geneontology.org/d13bd257-caf0-4de2-b110-222c558dde75_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> , <http://model.geneontology.org/490f3c85-f8e3-4291-a71b-b6bee759f6bc_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/228e6828-796c-473b-8218-938cb845a030_GART-RXN> , <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/f6bb3135-3f7e-43e9-91ac-8243cd646d2d_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2283,7 +2310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2298,11 +2325,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2313,17 +2340,6 @@
           <http://model.geneontology.org/CHEBI_29985_FGAMSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001259> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2331,24 +2347,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYProtein57803> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004727> ;
@@ -2357,7 +2362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2365,40 +2370,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_f6bb3135-3f7e-43e9-91ac-8243cd646d2d_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58681>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2409,25 +2414,14 @@
           <http://model.geneontology.org/CHEBI_58443_SAICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2440,7 +2434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2451,6 +2445,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_43474_GLYRIBONUCSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2460,24 +2465,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57591> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29806_AICARSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29806> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2488,7 +2482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2505,7 +2499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2517,11 +2511,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2541,13 +2535,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57378> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YLR359W-MONOMER_AICARSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000004351> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2556,7 +2561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2568,11 +2573,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2586,14 +2591,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2606,7 +2611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2621,11 +2626,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2636,15 +2641,26 @@
           <http://model.geneontology.org/reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2655,51 +2671,18 @@
           <http://model.geneontology.org/CHEBI_456215_AMPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
-] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Provides Input For Rule. The relation '5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole &harr; fumarate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide' 'null' 'a 10-formyltetrahydrofolate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide &harr; a tetrahydrofolate + 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2710,6 +2693,39 @@
           <http://model.geneontology.org/AICARTRANSFORM-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58681> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2719,7 +2735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2732,7 +2748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2741,7 +2757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2749,11 +2765,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2764,15 +2780,26 @@
           <http://model.geneontology.org/CHEBI_29985_PRPPAMIDOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2783,26 +2810,15 @@
           <http://model.geneontology.org/CHEBI_57667_ADPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' 'null' 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2825,7 +2841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2840,7 +2856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2848,17 +2864,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2866,11 +2904,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2881,17 +2919,6 @@
           <http://model.geneontology.org/CHEBI_30616_ADENYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_IMP-DEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2901,7 +2928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2909,14 +2936,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2927,7 +2965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2940,7 +2978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2953,7 +2991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2961,14 +2999,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002413_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2976,11 +3025,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3010,7 +3059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3018,27 +3067,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57567>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_30616_SAICARSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3049,7 +3090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3057,15 +3098,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57567>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3078,7 +3127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3105,7 +3154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3113,15 +3162,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3136,11 +3196,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3151,14 +3211,25 @@
           <http://model.geneontology.org/CHEBI_16526_AIRCARBOXY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3169,7 +3240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3177,14 +3248,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3192,11 +3263,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3211,11 +3282,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3230,11 +3301,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3250,7 +3321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3258,11 +3329,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3273,26 +3344,15 @@
           <http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Provides Input For Rule. The relation 'ATP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine &rarr; ADP + 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + phosphate + H<SUP>+</SUP>' 'null' '5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + 2 H<SUP>+</SUP> &harr; 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002413_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002413_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3312,7 +3372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3320,25 +3380,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3346,11 +3395,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3361,26 +3410,15 @@
           <http://model.geneontology.org/YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3390,17 +3428,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_AICARSYN-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SAICARSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004639> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3421,7 +3448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3432,67 +3459,45 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004639>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000003412>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3501,18 +3506,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3525,7 +3530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3533,14 +3538,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3553,13 +3558,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57335> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_FGAMSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3570,7 +3586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3590,7 +3606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3608,11 +3624,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3623,26 +3639,15 @@
           <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3657,11 +3662,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3676,11 +3681,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3700,7 +3705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3715,7 +3720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3727,11 +3732,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3745,15 +3750,29 @@
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58467>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3764,18 +3783,37 @@
           <http://model.geneontology.org/YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58467>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3805,7 +3843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3813,15 +3851,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Provides Input For Rule. The relation 'GDP + ATP &rarr; GTP + ADP' 'null' 'formate + GTP + H<SUP>+</SUP> &rarr; dGTP + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3836,11 +3896,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3851,25 +3911,58 @@
           <http://model.geneontology.org/CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_490f3c85-f8e3-4291-a71b-b6bee759f6bc_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3877,11 +3970,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3892,36 +3985,25 @@
           <http://model.geneontology.org/CHEBI_15377_RXN0-746>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3933,18 +4015,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3952,11 +4034,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3976,7 +4058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3988,11 +4070,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4003,35 +4085,26 @@
           <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
 ] .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/CHEBI_15377_FGAMSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57378> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4042,29 +4115,49 @@
           <http://model.geneontology.org/CHEBI_15377_IMP-DEHYDROG-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_37565>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/CHEBI_15377_FGAMSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57378> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_37565>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4075,25 +4168,14 @@
           <http://model.geneontology.org/CHEBI_30616_AIRS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_228e6828-796c-473b-8218-938cb845a030_GART-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4101,11 +4183,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4120,11 +4202,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4144,7 +4226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4161,32 +4243,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57591> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58053_IMPCYCLOHYDROLASE-RXN>
-] .
 
 <http://model.geneontology.org/DGDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004550> ;
@@ -4205,7 +4268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4213,12 +4276,42 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58053_IMPCYCLOHYDROLASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4226,11 +4319,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4239,25 +4332,6 @@
           <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_FGAMSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN>
@@ -4269,13 +4343,65 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57575> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456216_FGAMSYN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58595> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4286,7 +4412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4297,14 +4423,25 @@
 <http://purl.obolibrary.org/obo/GO_0006164>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4315,7 +4452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4326,6 +4463,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_58595>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000002634>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -4333,11 +4481,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4357,24 +4505,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57744> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_GMP-SYN-GLUT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4385,7 +4522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4397,11 +4534,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4419,11 +4556,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Provides Input For Rule. The relation 'adenylo-succinate &harr; fumarate + AMP' 'null' 'AMP + ATP &harr; 2 ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4442,7 +4579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4450,11 +4587,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4465,15 +4602,26 @@
           <http://model.geneontology.org/CHEBI_58359_GMP-SYN-GLUT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4484,26 +4632,15 @@
           <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4518,11 +4655,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4537,11 +4674,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4552,29 +4689,29 @@
           <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://identifiers.org/sgd/S000005654>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000005654>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4588,15 +4725,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_58475>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4610,14 +4758,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_58443>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4625,11 +4773,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4640,28 +4788,6 @@
           <http://model.geneontology.org/CHEBI_456216_ADENYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57567> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4671,7 +4797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4682,51 +4808,29 @@
 <http://purl.obolibrary.org/obo/GO_0004642>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4746,7 +4850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4763,7 +4867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4790,7 +4894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4798,19 +4902,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/AIRCARBOXY-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0043727> ;
@@ -4831,13 +4935,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYBiochemicalReaction57806> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005164> ;
@@ -4846,7 +4961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4854,26 +4969,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4888,11 +4992,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4912,7 +5016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4924,11 +5028,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4948,7 +5052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4956,14 +5060,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4971,11 +5075,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4986,15 +5090,26 @@
           <http://model.geneontology.org/YML056C-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5014,7 +5129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5026,11 +5141,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5046,7 +5161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5054,11 +5169,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5069,15 +5184,26 @@
           <http://model.geneontology.org/CHEBI_29806_AICARSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5088,28 +5214,6 @@
           <http://model.geneontology.org/CHEBI_58426_GART-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_61404_RXN0-745>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_61404> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5119,7 +5223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5134,7 +5238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5142,30 +5246,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_29991>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -5173,47 +5255,58 @@
 <http://purl.obolibrary.org/obo/CHEBI_58115>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_157f2b12-7d24-41a7-9c89-c2404e9eac4c_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_8c46835b-50a2-4f68-a701-369ace424509_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5221,11 +5314,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5236,25 +5329,47 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5262,11 +5377,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5281,11 +5396,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5300,11 +5415,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5315,6 +5430,39 @@
           <http://model.geneontology.org/CHEBI_15378_GART-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -5322,11 +5470,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5337,17 +5485,6 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_RXN0-745>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5357,7 +5494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5369,11 +5506,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5384,37 +5521,15 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5434,7 +5549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5446,11 +5561,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5465,11 +5580,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5479,28 +5594,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58053_IMPCYCLOHYDROLASE-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005164>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5527,7 +5620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5544,13 +5637,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57713> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456215_AMPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456215> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5561,7 +5665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5572,62 +5676,51 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_ADENYL-KIN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5636,23 +5729,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000070>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57464> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5663,7 +5756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5671,32 +5764,54 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_29806>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/CHEBI_29806>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/GO_0004018>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5711,11 +5826,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5726,14 +5841,14 @@
           <http://model.geneontology.org/CHEBI_15378_AIRS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5741,11 +5856,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5760,11 +5875,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5779,11 +5894,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5798,11 +5913,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5817,11 +5932,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Provides Input For Rule. The relation 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' 'null' 'ATP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine &rarr; ADP + 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5832,15 +5947,26 @@
           <http://model.geneontology.org/AIRS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5856,18 +5982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5875,11 +5990,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5897,7 +6012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5924,7 +6039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5935,69 +6050,91 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_d13bd257-caf0-4de2-b110-222c558dde75_GART-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6005,11 +6142,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6020,14 +6157,36 @@
           <http://model.geneontology.org/CHEBI_15378_RXN0-746>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6038,7 +6197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6058,7 +6217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6073,11 +6232,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6088,26 +6247,15 @@
           <http://model.geneontology.org/CHEBI_29888_GMP-SYN-GLUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_02fe330b-a3eb-4ceb-97a7-b2abe3506898_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_8c46835b-50a2-4f68-a701-369ace424509_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6115,18 +6263,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/02fe330b-a3eb-4ceb-97a7-b2abe3506898_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/8c46835b-50a2-4f68-a701-369ace424509_AICARTRANSFORM-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6137,26 +6285,15 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6167,17 +6304,6 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6187,7 +6313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6199,11 +6325,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6214,26 +6340,15 @@
           <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'dGDP + an oxidized thioredoxin + H<sub>2</sub>O &larr; GDP + a reduced thioredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6244,15 +6359,26 @@
           <http://model.geneontology.org/GDPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6266,15 +6392,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6289,11 +6426,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6304,15 +6441,26 @@
           <http://model.geneontology.org/reaction_ADPREDUCT-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6332,7 +6480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6340,74 +6488,47 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/aa6e4ae1-dfd2-447e-a1a3-7731e0e852c4_AICARTRANSFORM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57894> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004644>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN0-746>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
@@ -6424,13 +6545,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYBiochemicalReaction57648> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15740>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6439,11 +6582,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6454,36 +6597,36 @@
           <http://model.geneontology.org/CHEBI_456216_SAICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6496,7 +6639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6507,25 +6650,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_61429>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6536,11 +6668,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6551,15 +6683,26 @@
           <http://model.geneontology.org/CHEBI_15377_RXN0-745>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6575,7 +6718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6583,11 +6726,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6602,11 +6745,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6617,15 +6760,26 @@
           <http://model.geneontology.org/CHEBI_29806_AMPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6640,11 +6794,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6664,7 +6818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6681,7 +6835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6689,15 +6843,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6715,11 +6880,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6730,15 +6895,18 @@
           <http://model.geneontology.org/CHEBI_30616_DADPKIN-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_58426>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6749,8 +6917,27 @@
           <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58426>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0043727>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6764,7 +6951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6781,7 +6968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of purine nucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -6793,11 +6980,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6814,14 +7001,14 @@
 <http://identifiers.org/sgd/S000001550>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6834,7 +7021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6842,26 +7029,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6877,7 +7053,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6885,11 +7072,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6900,14 +7087,14 @@
           <http://model.geneontology.org/CHEBI_58359_PRPPAMIDOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6915,11 +7102,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6933,14 +7120,14 @@
 <http://identifiers.org/sgd/S000003563>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6948,11 +7135,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6967,11 +7154,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6987,7 +7174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6996,32 +7183,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7035,26 +7203,34 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7072,7 +7248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7080,26 +7256,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7110,14 +7275,14 @@
           <http://model.geneontology.org/CHEBI_57945_IMP-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7125,11 +7290,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7140,17 +7305,6 @@
           <http://model.geneontology.org/YGL234W-MONOMER_AIRS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58457> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7160,7 +7314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7168,16 +7322,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/8c46835b-50a2-4f68-a701-369ace424509_AICARTRANSFORM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57872> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller>
         a       <http://identifiers.org/sgd/S000002816> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7186,7 +7346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7205,18 +7365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7225,7 +7374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7236,7 +7385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7244,36 +7393,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7281,11 +7419,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7300,11 +7438,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'dADP + an oxidized thioredoxin + H<sub>2</sub>O &larr; ADP + a reduced thioredoxin' 'null' 'dADP + ATP &rarr; dATP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7324,7 +7462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7336,11 +7474,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'IMP + H<sub>2</sub>O &harr; 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' 'null' 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7370,7 +7508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7382,11 +7520,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7404,11 +7542,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7424,18 +7562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7444,7 +7571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7452,11 +7579,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7471,11 +7598,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7486,14 +7613,14 @@
           <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7504,11 +7631,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7519,26 +7646,15 @@
           <http://model.geneontology.org/YKL067W-MONOMER_GDPKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7558,7 +7674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7579,46 +7695,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYProtein57978> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15740_RXN0-746>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15740> ;
@@ -7629,24 +7712,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57305> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YAR015W-MONOMER_SAICARSYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000070> ;
@@ -7655,7 +7727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7663,14 +7735,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7683,7 +7755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7695,11 +7767,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7710,6 +7782,17 @@
           <http://model.geneontology.org/CHEBI_37565_GDPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58359_PRPPAMIDOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58359> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7719,28 +7802,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57713> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/157f2b12-7d24-41a7-9c89-c2404e9eac4c_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57894> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -7749,18 +7815,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7768,11 +7834,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ATP + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + L-aspartate &rarr; ADP + 5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole + phosphate + H<SUP>+</SUP>' 'null' '5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole &harr; fumarate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7783,14 +7849,47 @@
           <http://model.geneontology.org/AICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7798,11 +7897,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7818,7 +7917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7826,11 +7925,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7845,11 +7944,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7867,7 +7966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -7884,7 +7983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7901,7 +8000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7918,7 +8017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7930,11 +8029,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7945,14 +8044,14 @@
           <http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7960,11 +8059,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7975,17 +8074,6 @@
           <http://model.geneontology.org/CHEBI_18413_FGAMSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_FGAMSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7995,7 +8083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8003,37 +8091,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8044,37 +8110,15 @@
           <http://model.geneontology.org/CHEBI_30616_GLYRIBONUCSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8085,26 +8129,15 @@
           <http://model.geneontology.org/Red-Thioredoxin_ADPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8124,7 +8157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8136,11 +8169,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8151,17 +8184,6 @@
           <http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_ADENYL-KIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8171,24 +8193,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57322> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -8202,7 +8213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8210,14 +8221,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8233,13 +8266,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57411> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/AICARTRANSFORM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004643> ;
@@ -8250,9 +8286,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/02fe330b-a3eb-4ceb-97a7-b2abe3506898_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
+                <http://model.geneontology.org/8c46835b-50a2-4f68-a701-369ace424509_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/157f2b12-7d24-41a7-9c89-c2404e9eac4c_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/aa6e4ae1-dfd2-447e-a1a3-7731e0e852c4_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -8260,16 +8296,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYBiochemicalReaction57867> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/DADPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004550> ;
@@ -8288,13 +8321,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYBiochemicalReaction57382> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GMP-SYN-GLUT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003922> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -8315,7 +8359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8323,26 +8367,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8353,25 +8386,25 @@
           <http://model.geneontology.org/CHEBI_61404_RXN0-745>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8380,33 +8413,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8417,15 +8439,26 @@
           <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8439,14 +8472,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8454,11 +8487,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8473,11 +8506,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8488,15 +8521,26 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8511,11 +8555,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8530,11 +8574,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8545,26 +8589,15 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8579,11 +8612,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8603,7 +8636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8611,25 +8644,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8640,7 +8662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8648,14 +8670,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8663,11 +8685,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8678,17 +8700,6 @@
           <http://model.geneontology.org/CHEBI_456215_AMPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58115_GMP-SYN-GLUT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58115> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8698,7 +8709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8706,14 +8717,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8736,7 +8747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8744,19 +8755,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/GO_0004641>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004641>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -8765,11 +8787,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8780,33 +8802,22 @@
           <http://model.geneontology.org/CHEBI_58564_AIRCARBOXY-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000004351>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_137981_AIRS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_137981> ;
@@ -8817,7 +8828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8825,32 +8836,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/d13bd257-caf0-4de2-b110-222c558dde75_GART-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57872> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8861,15 +8866,26 @@
           <http://model.geneontology.org/CHEBI_456216_GUANYL-KIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8880,29 +8896,29 @@
           <http://model.geneontology.org/CHEBI_15378_AIRCARBOXY-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8917,11 +8933,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8932,26 +8948,15 @@
           <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8966,11 +8971,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8985,11 +8990,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9000,6 +9005,23 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY>
 ] .
 
+<http://model.geneontology.org/490f3c85-f8e3-4291-a71b-b6bee759f6bc_GART-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57872> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_456216_AIRS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9009,7 +9031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9021,11 +9043,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ATP + 5-phospho-&beta;-D-ribosylamine + glycine &rarr; ADP + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + phosphate + H<SUP>+</SUP>' 'null' 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9040,11 +9062,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9055,14 +9077,14 @@
           <http://model.geneontology.org/CHEBI_58443_SAICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9075,13 +9097,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57322> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GUANYL-KIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004385> ;
@@ -9102,7 +9135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9129,7 +9162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9146,7 +9179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9169,7 +9202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9177,25 +9210,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9203,11 +9225,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9221,28 +9243,28 @@
 <http://identifiers.org/sgd/S000002816>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000002862>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000002862>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_aa6e4ae1-dfd2-447e-a1a3-7731e0e852c4_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9250,11 +9272,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9269,11 +9291,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9288,11 +9310,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_d13bd257-caf0-4de2-b110-222c558dde75_GART-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_490f3c85-f8e3-4291-a71b-b6bee759f6bc_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9300,18 +9322,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d13bd257-caf0-4de2-b110-222c558dde75_GART-RXN>
+          <http://model.geneontology.org/490f3c85-f8e3-4291-a71b-b6bee759f6bc_GART-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9322,26 +9344,15 @@
           <http://model.geneontology.org/GUANYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" , "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide &harr; a tetrahydrofolate + 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' 'null' 'IMP + H<sub>2</sub>O &harr; 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9352,14 +9363,25 @@
           <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9367,11 +9389,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9382,15 +9404,26 @@
           <http://model.geneontology.org/CHEBI_61429_DGDPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9405,11 +9438,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9427,7 +9460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9435,19 +9468,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/GO_0003937>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0003937>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
         a       <http://identifiers.org/sgd/S000001550> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -9456,7 +9489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9464,25 +9497,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9490,11 +9512,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9505,36 +9527,25 @@
           <http://model.geneontology.org/CHEBI_16526_RXN0-746>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY_SGD_YeastPathways_DENOVOPURINE2-PWY>
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9543,7 +9554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9556,7 +9567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9564,26 +9575,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9598,11 +9598,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9622,7 +9622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9638,7 +9638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9649,11 +9649,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9668,11 +9668,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9682,6 +9682,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_137981_AIRS-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ADENYL-KIN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004017> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -9702,7 +9713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9722,7 +9733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9730,26 +9741,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9760,15 +9760,37 @@
           <http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9779,26 +9801,15 @@
           <http://model.geneontology.org/CHEBI_57667_ADPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9813,11 +9824,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9832,11 +9843,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9846,14 +9857,3 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YGR061C-MONOMER_FGAMSYN-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_DENOVOPURINE3-PWY.ttl
+++ b/models/YeastPathways_DENOVOPURINE3-PWY.ttl
@@ -3,18 +3,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -35,14 +35,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -80,52 +80,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_28938_GMP-SYN-NH3-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004385>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/AIRS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004641> ;
@@ -146,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -158,11 +125,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -172,6 +139,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58564>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -183,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -191,15 +180,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,11 +214,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -229,17 +229,6 @@
           <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004044>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -247,11 +236,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'IMP + H<sub>2</sub>O &harr; 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' 'null' 'L-aspartate + IMP + GTP &rarr; adenylo-succinate + GDP + phosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -262,14 +251,14 @@
           <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -277,11 +266,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -313,11 +302,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,26 +317,15 @@
           <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_456215_GMP-SYN-NH3-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_456215_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -367,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -379,11 +357,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + 2 H<SUP>+</SUP> &harr; 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + CO<SUB>2</SUB>' 'null' 'ATP + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + L-aspartate &rarr; ADP + 5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -401,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -418,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -430,11 +408,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" , "Provides Input For Rule. The relation 'dGDP + an oxidized thioredoxin + H<sub>2</sub>O &larr; GDP + a reduced thioredoxin' 'null' 'dGDP + ATP &rarr; dGTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -445,17 +423,6 @@
           <http://model.geneontology.org/DGDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -465,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -477,11 +444,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -492,26 +459,15 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_30616_GMP-SYN-NH3-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,6 +478,17 @@
           <http://model.geneontology.org/YDR226W-MONOMER_ADENYL-KIN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58467> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -531,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -546,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -563,24 +530,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45692> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_15378_GMP-SYN-NH3-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_PRPPAMIDOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -591,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -604,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -628,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -636,18 +592,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_a647f8a7-3220-4e56-9034-6443c683dc6e_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -658,14 +647,36 @@
           <http://model.geneontology.org/CHEBI_15378_RXN0-746>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -673,11 +684,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -697,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -705,48 +716,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -761,11 +739,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -780,11 +758,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-aspartate + IMP + GTP &rarr; adenylo-succinate + GDP + phosphate + 2 H<SUP>+</SUP>' 'null' 'adenylo-succinate &harr; fumarate + AMP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -804,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -812,26 +790,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -846,11 +813,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -861,14 +828,36 @@
           <http://model.geneontology.org/CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -876,11 +865,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -898,11 +887,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -913,25 +902,14 @@
           <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_c2fbfcb2-28e0-4f85-9a77-d4053f83caed_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -939,11 +917,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_705c0407-5907-45b0-8aad-402702ad943e_GART-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_938e1ee6-3674-4173-821f-fd45075cf301_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -951,7 +929,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/705c0407-5907-45b0-8aad-402702ad943e_GART-RXN>
+          <http://model.geneontology.org/938e1ee6-3674-4173-821f-fd45075cf301_GART-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
@@ -963,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -971,62 +949,73 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_0c0e0b2c-31c0-46ea-805c-cbb02d0b2e56_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57464>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1036,6 +1025,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/IMP-DEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003938> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1056,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1064,50 +1064,50 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_29888_GMP-SYN-NH3-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1115,11 +1115,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1130,22 +1130,16 @@
           <http://model.geneontology.org/CHEBI_16526_RXN0-745>
 ] .
 
-<http://model.geneontology.org/CHEBI_61429_RXN0-746>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_61429> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "dGTP" ;
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45558> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/AICARSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004018> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1166,7 +1160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1174,37 +1168,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_61429_RXN0-746>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_61429> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "dGTP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45558> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1215,26 +1215,15 @@
           <http://model.geneontology.org/reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1254,7 +1243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1269,11 +1258,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000066_reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000066_reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1293,7 +1282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1305,11 +1294,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1329,7 +1318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1341,11 +1330,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1360,11 +1349,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1379,11 +1368,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1394,6 +1383,58 @@
           <http://model.geneontology.org/CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YDR226W-MONOMER_ADENYL-KIN-RXN_controller>
         a       <http://identifiers.org/sgd/S000002634> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1401,7 +1442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1413,41 +1454,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANYL-KIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1458,50 +1469,55 @@
           <http://model.geneontology.org/CHEBI_456216_AIRS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/d9037ac0-4af2-451b-83a9-59277b195fe8_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45960> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004637>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_456215_GMP-SYN-NH3-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_AIRS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1512,7 +1528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1520,14 +1536,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1535,11 +1551,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1550,6 +1566,17 @@
           <http://model.geneontology.org/CHEBI_29991_SAICARSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1559,7 +1586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1567,14 +1594,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1587,7 +1614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1595,40 +1622,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://purl.obolibrary.org/obo/GO_0004019>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004019>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1639,14 +1655,14 @@
           <http://model.geneontology.org/CHEBI_456216_GUANYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1654,11 +1670,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1669,40 +1685,51 @@
           <http://model.geneontology.org/CHEBI_43474_AIRS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_61404>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1713,26 +1740,15 @@
           <http://model.geneontology.org/CHEBI_43474_GLYRIBONUCSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1747,11 +1763,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1766,11 +1782,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1785,11 +1801,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1800,14 +1816,25 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1815,11 +1842,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1834,11 +1861,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_17506184-179d-40a3-8eeb-a67bf524c758_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_a647f8a7-3220-4e56-9034-6443c683dc6e_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1846,17 +1873,39 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/17506184-179d-40a3-8eeb-a67bf524c758_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/a647f8a7-3220-4e56-9034-6443c683dc6e_AICARTRANSFORM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1869,13 +1918,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45460> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -1886,7 +1946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1894,47 +1954,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1947,7 +1996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1955,26 +2004,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1985,17 +2023,72 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_30616>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_30616>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2003,11 +2096,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2018,28 +2111,28 @@
           <http://model.geneontology.org/CHEBI_15377_RXN0-746>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2047,11 +2140,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2062,17 +2155,6 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_ADPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2082,7 +2164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2094,11 +2176,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2113,11 +2195,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2132,11 +2214,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" , "Provides Input For Rule. The relation 'XMP + ammonium + ATP &rarr; GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2147,26 +2229,15 @@
           <http://model.geneontology.org/GUANYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2177,6 +2248,39 @@
           <http://model.geneontology.org/reaction_AIRS-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_RXN0-745>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2186,7 +2290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2203,7 +2307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2215,11 +2319,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2237,11 +2341,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2252,26 +2356,15 @@
           <http://model.geneontology.org/CHEBI_456216_ADENYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'AMP + ATP &harr; 2 ADP' 'null' 'dADP + an oxidized thioredoxin + H<sub>2</sub>O &larr; ADP + a reduced thioredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2282,17 +2375,6 @@
           <http://model.geneontology.org/ADPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/GART-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004644> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2302,9 +2384,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> , <http://model.geneontology.org/059104df-5fc2-415a-9543-2f02776339b2_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> , <http://model.geneontology.org/c2fbfcb2-28e0-4f85-9a77-d4053f83caed_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> , <http://model.geneontology.org/705c0407-5907-45b0-8aad-402702ad943e_GART-RXN> ;
+                <http://model.geneontology.org/938e1ee6-3674-4173-821f-fd45075cf301_GART-RXN> , <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2312,7 +2394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2327,11 +2409,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2349,13 +2431,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYProtein45830> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004727> ;
@@ -2364,7 +2468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2375,14 +2479,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_58681>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2390,11 +2494,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2405,17 +2509,6 @@
           <http://model.geneontology.org/CHEBI_37565_GDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58443_SAICARSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58443> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2425,7 +2518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2436,17 +2529,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_43474_GLYRIBONUCSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2456,7 +2538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2464,15 +2546,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" , "Provides Input For Rule. The relation 'ATP + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + L-aspartate &rarr; ADP + 5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole + phosphate + H<SUP>+</SUP>' 'null' '5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole &harr; fumarate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2483,14 +2576,14 @@
           <http://model.geneontology.org/AICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2503,7 +2596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2520,7 +2613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2532,11 +2625,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2547,17 +2640,6 @@
           <http://model.geneontology.org/CHEBI_29888_PRPPAMIDOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_IMPCYCLOHYDROLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2567,7 +2649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2582,7 +2664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2594,11 +2676,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2612,6 +2694,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2621,7 +2725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2636,11 +2740,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2655,11 +2759,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2670,61 +2774,28 @@
           <http://model.geneontology.org/CHEBI_456215_AMPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2735,11 +2806,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2754,11 +2825,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" , "Provides Input For Rule. The relation '5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole &harr; fumarate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide' 'null' 'a 10-formyltetrahydrofolate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide &harr; a tetrahydrofolate + 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2778,7 +2849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2791,7 +2862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2800,7 +2871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2808,11 +2879,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2823,15 +2894,26 @@
           <http://model.geneontology.org/CHEBI_58053_IMPCYCLOHYDROLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2842,15 +2924,26 @@
           <http://model.geneontology.org/CHEBI_57667_ADPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" , "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' 'null' 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2861,30 +2954,19 @@
           <http://model.geneontology.org/FGAMSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004424>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29991_SAICARSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29991> ;
@@ -2895,7 +2977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2910,7 +2992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2925,11 +3007,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2949,13 +3031,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45593> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YOR128C-MONOMER_AIRCARBOXY-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005654> ;
@@ -2964,7 +3057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2977,7 +3070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2990,7 +3083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2998,64 +3091,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/059104df-5fc2-415a-9543-2f02776339b2_GART-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45960> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3063,11 +3106,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002411_DADPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002411_DADPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3097,7 +3140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3105,47 +3148,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002413_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3158,7 +3168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3174,7 +3184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3187,7 +3197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3214,7 +3224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3226,11 +3236,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_30616_GMP-SYN-NH3-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_30616_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3245,11 +3255,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3260,6 +3270,17 @@
           <http://model.geneontology.org/CHEBI_16526_AIRCARBOXY-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
         a       <http://identifiers.org/sgd/S000002862> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3267,7 +3288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3275,26 +3296,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3305,26 +3315,15 @@
           <http://model.geneontology.org/CHEBI_15377_FGAMSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3339,11 +3338,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3359,7 +3358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3367,11 +3366,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" , "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'GDP + ATP &rarr; GTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3382,37 +3381,15 @@
           <http://model.geneontology.org/GDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ATP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine &rarr; ADP + 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + phosphate + H<SUP>+</SUP>' 'null' '5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + 2 H<SUP>+</SUP> &harr; 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002413_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002413_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3423,6 +3400,17 @@
           <http://model.geneontology.org/AIRCARBOXY-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_18413_FGAMSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_18413> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3432,7 +3420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3440,14 +3428,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3455,11 +3465,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3474,11 +3484,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3508,7 +3518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3522,50 +3532,61 @@
 <http://purl.obolibrary.org/obo/GO_0004639>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_d9037ac0-4af2-451b-83a9-59277b195fe8_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000066_reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003412>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_30616_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3576,11 +3597,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3596,7 +3617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3609,24 +3630,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45393> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_AIRCARBOXY-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -3637,7 +3647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3654,7 +3664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3674,7 +3684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3685,6 +3695,39 @@
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000004520>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3692,11 +3735,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3711,11 +3754,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3726,15 +3769,37 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" , "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3745,37 +3810,15 @@
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3795,7 +3838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3810,7 +3853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3822,11 +3865,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3837,18 +3880,46 @@
           <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
 ] .
 
+<http://model.geneontology.org/a647f8a7-3220-4e56-9034-6443c683dc6e_AICARTRANSFORM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45982> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002413_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3862,26 +3933,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_58467>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3911,7 +3971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3923,11 +3983,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'GDP + ATP &rarr; GTP + ADP' 'null' 'formate + GTP + H<SUP>+</SUP> &rarr; dGTP + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3942,11 +4002,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3957,80 +4017,80 @@
           <http://model.geneontology.org/CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_29888_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4038,11 +4098,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4053,40 +4113,40 @@
           <http://model.geneontology.org/CHEBI_15378_RXN0-745>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4102,51 +4162,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4154,11 +4192,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4178,7 +4216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4190,11 +4228,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4205,17 +4243,6 @@
           <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_FGAMSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4225,7 +4252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4237,11 +4264,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4262,11 +4289,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4281,11 +4308,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4300,11 +4327,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4324,7 +4351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4341,7 +4368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4349,16 +4376,35 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
+] .
 
 <http://model.geneontology.org/DGDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004550> ;
@@ -4377,7 +4423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4385,42 +4431,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4428,11 +4444,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4447,11 +4463,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4471,7 +4487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4479,14 +4495,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4499,7 +4526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4510,28 +4537,6 @@
 <http://purl.obolibrary.org/obo/GO_0006164>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004424> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4539,13 +4544,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYProtein45824> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58595>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4557,11 +4584,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4581,7 +4608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4589,14 +4616,69 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_456215_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4609,7 +4691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4626,7 +4708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4638,11 +4720,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4653,17 +4735,6 @@
           <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004748>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -4671,11 +4742,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'adenylo-succinate &harr; fumarate + AMP' 'null' 'AMP + ATP &harr; 2 ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4686,6 +4757,17 @@
           <http://model.geneontology.org/ADENYL-KIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -4694,7 +4776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4702,11 +4784,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4721,11 +4803,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4736,15 +4818,26 @@
           <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4755,15 +4848,26 @@
           <http://model.geneontology.org/YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4774,26 +4878,15 @@
           <http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4811,11 +4904,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_29888_GMP-SYN-NH3-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_29888_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4826,17 +4919,6 @@
           <http://model.geneontology.org/CHEBI_29888_GMP-SYN-NH3-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58475>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -4844,11 +4926,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4859,25 +4941,36 @@
           <http://model.geneontology.org/YOR128C-MONOMER_AIRCARBOXY-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4888,11 +4981,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4903,47 +4996,14 @@
           <http://model.geneontology.org/CHEBI_456216_ADENYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4956,7 +5016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4964,43 +5024,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0004642>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-NH3-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://purl.obolibrary.org/obo/GO_0004642>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5011,17 +5071,6 @@
           <http://model.geneontology.org/reaction_RXN0-746_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_28938_GMP-SYN-NH3-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_28938> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5031,7 +5080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5048,7 +5097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5065,7 +5114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5092,7 +5141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5100,15 +5149,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5141,7 +5212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5156,13 +5227,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYProtein45925> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456215_GMP-SYN-NH3-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456215> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5173,7 +5255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5185,11 +5267,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5204,11 +5286,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5228,7 +5310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5240,11 +5322,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5255,17 +5337,6 @@
           <http://model.geneontology.org/YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16526_RXN0-745>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5275,7 +5346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5287,11 +5358,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5302,26 +5373,15 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5332,6 +5392,17 @@
           <http://model.geneontology.org/reaction_AMPSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57945_IMP-DEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5341,7 +5412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5353,11 +5424,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5368,12 +5439,23 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_AIRS-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5381,11 +5463,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5396,15 +5478,32 @@
           <http://model.geneontology.org/CHEBI_29806_AICARSYN-RXN>
 ] .
 
+<http://model.geneontology.org/c2fbfcb2-28e0-4f85-9a77-d4053f83caed_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45960> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5424,24 +5523,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45526> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002411_DADPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YKL067W-MONOMER_GDPKIN-RXN_controller>
         a       <http://identifiers.org/sgd/S000001550> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5450,13 +5538,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYProtein45433> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29991>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5474,11 +5573,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5489,15 +5588,59 @@
           <http://model.geneontology.org/CHEBI_43474_SAICARSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5508,14 +5651,14 @@
           <http://model.geneontology.org/CHEBI_15377_RXN0-745>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5536,7 +5679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5548,11 +5691,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5563,26 +5706,15 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5597,11 +5729,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5612,6 +5744,17 @@
           <http://model.geneontology.org/CHEBI_15378_GART-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -5619,11 +5762,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5643,7 +5786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5651,26 +5794,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5683,13 +5815,32 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GDPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5709,7 +5860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5717,34 +5868,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPREDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
-] .
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5755,22 +5898,33 @@
           <http://model.geneontology.org/CHEBI_58053_IMPCYCLOHYDROLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000005164>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0003938>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_15378_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004550> ;
@@ -5791,7 +5945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5808,7 +5962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5825,7 +5979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5833,65 +5987,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_ADENYL-KIN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5900,7 +6021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5908,11 +6029,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5926,6 +6047,17 @@
 <http://identifiers.org/sgd/S000000070>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57464> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5935,7 +6067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5946,17 +6078,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_29806>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004018>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -5964,11 +6085,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5983,11 +6104,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5998,26 +6119,15 @@
           <http://model.geneontology.org/CHEBI_15378_AIRS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6028,26 +6138,15 @@
           <http://model.geneontology.org/CHEBI_15378_GLYRIBONUCSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6062,11 +6161,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6081,11 +6180,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6100,11 +6199,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' 'null' 'ATP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine &rarr; ADP + 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6119,11 +6218,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6139,7 +6238,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6147,11 +6257,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6169,7 +6279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6196,7 +6306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6204,50 +6314,94 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_705c0407-5907-45b0-8aad-402702ad943e_GART-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6255,11 +6409,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" , "Provides Input For Rule. The relation '5-phospho-&beta;-D-ribosylamine + L-glutamate + diphosphate &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + L-glutamine + H<sub>2</sub>O' 'null' 'ATP + 5-phospho-&beta;-D-ribosylamine + glycine &rarr; ADP + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6270,23 +6424,23 @@
           <http://model.geneontology.org/GLYRIBONUCSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6297,7 +6451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6317,35 +6471,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45512> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6354,11 +6486,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6373,11 +6505,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_d9037ac0-4af2-451b-83a9-59277b195fe8_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_0c0e0b2c-31c0-46ea-805c-cbb02d0b2e56_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6385,17 +6517,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d9037ac0-4af2-451b-83a9-59277b195fe8_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/0c0e0b2c-31c0-46ea-805c-cbb02d0b2e56_AICARTRANSFORM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6403,11 +6535,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" , "Provides Input For Rule. The relation 'IMP + H<sub>2</sub>O &harr; 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' 'null' 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6416,25 +6548,6 @@
           <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DGDPKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN>
@@ -6446,7 +6559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6458,11 +6571,30 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DGDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6473,15 +6605,26 @@
           <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6492,15 +6635,26 @@
           <http://model.geneontology.org/CHEBI_58115_GMP-SYN-NH3-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6511,28 +6665,17 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6540,11 +6683,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6559,11 +6702,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6574,26 +6717,15 @@
           <http://model.geneontology.org/reaction_ADPREDUCT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6613,7 +6745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6621,67 +6753,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/17506184-179d-40a3-8eeb-a67bf524c758_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45982> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.obolibrary.org/obo/GO_0004644>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_17506184-179d-40a3-8eeb-a67bf524c758_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004644>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6700,7 +6793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6711,25 +6804,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_15740>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6737,11 +6819,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6752,27 +6834,35 @@
           <http://model.geneontology.org/CHEBI_15740_RXN0-746>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YAR015W-MONOMER_SAICARSYN-RXN_controller>
+] .
 
 <http://model.geneontology.org/CHEBI_29806_AMPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29806> ;
@@ -6783,7 +6873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6791,24 +6881,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YAR015W-MONOMER_SAICARSYN-RXN_controller>
-] .
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_61429>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6822,35 +6904,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45723> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000972>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6859,11 +6919,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6878,11 +6938,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6898,18 +6958,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6917,11 +6977,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6932,15 +6992,37 @@
           <http://model.geneontology.org/CHEBI_15377_IMP-DEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6955,11 +7037,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6974,11 +7056,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6989,14 +7071,14 @@
           <http://model.geneontology.org/CHEBI_15377_GMP-SYN-GLUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_059104df-5fc2-415a-9543-2f02776339b2_GART-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7009,7 +7091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7026,7 +7108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7038,11 +7120,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7060,11 +7142,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7075,18 +7157,15 @@
           <http://model.geneontology.org/CHEBI_30616_DADPKIN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58426>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7097,25 +7176,17 @@
           <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_58426>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7131,7 +7202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7139,15 +7210,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7158,70 +7240,20 @@
           <http://model.geneontology.org/reaction_ADENYL-KIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000001259>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000001550>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/705c0407-5907-45b0-8aad-402702ad943e_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45982> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7234,46 +7266,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45781> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -7287,7 +7286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7299,11 +7298,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7314,12 +7313,45 @@
           <http://model.geneontology.org/CHEBI_61404_RXN0-745>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_AICARSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7327,11 +7359,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7342,26 +7374,15 @@
           <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7372,51 +7393,18 @@
           <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000003563>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_28938_GMP-SYN-NH3-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_28938_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7427,15 +7415,37 @@
           <http://model.geneontology.org/CHEBI_28938_GMP-SYN-NH3-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000066_reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7451,33 +7461,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001328>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7495,11 +7505,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7510,15 +7520,26 @@
           <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7529,14 +7550,14 @@
           <http://model.geneontology.org/CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7547,7 +7568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7559,11 +7580,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7574,26 +7595,15 @@
           <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7604,6 +7614,50 @@
           <http://model.geneontology.org/YGL234W-MONOMER_AIRS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002411_DADPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58457> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7613,7 +7667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7621,36 +7675,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7661,7 +7704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7680,18 +7723,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7700,7 +7743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7708,11 +7751,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7730,7 +7773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7738,15 +7781,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7766,7 +7842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "de novo biosynthesis of purine nucleotides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -7778,11 +7854,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'dADP + an oxidized thioredoxin + H<sub>2</sub>O &larr; ADP + a reduced thioredoxin' 'null' 'dADP + ATP &rarr; dATP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7802,7 +7878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7814,11 +7890,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7848,7 +7924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7856,26 +7932,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7893,11 +7958,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7913,18 +7978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7933,7 +7987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7941,11 +7995,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7960,11 +8014,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7978,26 +8032,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_18413>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8012,11 +8055,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8036,7 +8079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8057,7 +8100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8065,36 +8108,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8107,7 +8139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8122,13 +8154,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYProtein46013> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_ADENYL-KIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -8139,7 +8193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8151,11 +8205,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8166,17 +8220,6 @@
           <http://model.geneontology.org/reaction_RXN0-745_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58359_PRPPAMIDOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58359> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8186,7 +8229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8199,7 +8242,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8207,11 +8261,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8222,37 +8276,15 @@
           <http://model.geneontology.org/CHEBI_16526_RXN0-746>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8268,18 +8300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8287,11 +8308,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8306,11 +8327,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8330,7 +8351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8347,7 +8368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8364,7 +8385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8376,11 +8397,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8395,11 +8416,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8419,7 +8440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8431,11 +8452,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8450,11 +8471,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8465,37 +8486,15 @@
           <http://model.geneontology.org/Red-Thioredoxin_ADPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8515,7 +8514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8527,11 +8526,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8542,28 +8541,6 @@
           <http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_ADENYL-KIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8573,7 +8550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8584,6 +8561,17 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_43474_SAICARSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8593,7 +8581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8601,10 +8589,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_58359>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
+<http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_456216_GLYRIBONUCSYN-RXN>
@@ -8616,7 +8612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8624,16 +8620,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/AICARTRANSFORM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004643> ;
@@ -8644,9 +8632,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/d9037ac0-4af2-451b-83a9-59277b195fe8_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
+                <http://model.geneontology.org/0c0e0b2c-31c0-46ea-805c-cbb02d0b2e56_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/17506184-179d-40a3-8eeb-a67bf524c758_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/a647f8a7-3220-4e56-9034-6443c683dc6e_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -8654,13 +8642,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYBiochemicalReaction45955> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/DADPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004550> ;
@@ -8679,7 +8678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8687,25 +8686,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8728,7 +8716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8736,15 +8724,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8755,23 +8754,29 @@
           <http://model.geneontology.org/CHEBI_29985_PRPPAMIDOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/0c0e0b2c-31c0-46ea-805c-cbb02d0b2e56_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45960> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8782,11 +8787,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8797,26 +8802,15 @@
           <http://model.geneontology.org/CHEBI_58053_IMPCYCLOHYDROLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8827,6 +8821,17 @@
           <http://model.geneontology.org/YLR359W-MONOMER_AMPSYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -8834,11 +8839,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8853,11 +8858,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8868,26 +8873,15 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8898,26 +8892,15 @@
           <http://model.geneontology.org/YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8932,11 +8915,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8947,14 +8930,14 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8962,11 +8945,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_15378_GMP-SYN-NH3-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_15378_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8981,11 +8964,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9005,7 +8988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9020,7 +9003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9028,26 +9011,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9058,14 +9030,47 @@
           <http://model.geneontology.org/CHEBI_456215_AMPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9078,13 +9083,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45654> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/AMPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004018> ;
@@ -9105,7 +9121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9113,42 +9129,42 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://purl.obolibrary.org/obo/GO_0004641>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0004641>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9156,11 +9172,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9174,17 +9190,6 @@
 <http://identifiers.org/sgd/S000004351>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0006164> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9194,7 +9199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -9202,30 +9207,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_137981_AIRS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_137981> ;
@@ -9236,7 +9230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9244,26 +9238,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9278,11 +9261,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9300,11 +9283,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9315,15 +9298,26 @@
           <http://model.geneontology.org/CHEBI_30616_FGAMSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9334,26 +9328,15 @@
           <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9364,15 +9347,26 @@
           <http://model.geneontology.org/CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'dGDP + an oxidized thioredoxin + H<sub>2</sub>O &larr; GDP + a reduced thioredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9387,11 +9381,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9402,17 +9396,6 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_AIRS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9422,7 +9405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9434,11 +9417,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ATP + 5-phospho-&beta;-D-ribosylamine + glycine &rarr; ADP + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + phosphate + H<SUP>+</SUP>' 'null' 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9453,11 +9436,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9468,47 +9451,36 @@
           <http://model.geneontology.org/CHEBI_58443_SAICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9521,7 +9493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9529,14 +9501,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9544,11 +9538,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9578,13 +9572,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYBiochemicalReaction45640> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PRPPAMIDOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004044> ;
@@ -9605,7 +9610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9622,7 +9627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9645,7 +9650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9653,25 +9658,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_938e1ee6-3674-4173-821f-fd45075cf301_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9679,11 +9695,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9694,42 +9710,31 @@
           <http://model.geneontology.org/CHEBI_30616_RXN0-745>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000002816>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000002862>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_28938_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9737,11 +9742,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + ammonium + ATP &rarr; GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-NH3-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9756,11 +9761,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9775,11 +9780,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_059104df-5fc2-415a-9543-2f02776339b2_GART-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_c2fbfcb2-28e0-4f85-9a77-d4053f83caed_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9787,17 +9792,28 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/059104df-5fc2-415a-9543-2f02776339b2_GART-RXN>
+          <http://model.geneontology.org/c2fbfcb2-28e0-4f85-9a77-d4053f83caed_GART-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9805,11 +9821,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9824,11 +9840,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide &harr; a tetrahydrofolate + 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' 'null' 'IMP + H<sub>2</sub>O &harr; 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9839,26 +9855,15 @@
           <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9873,11 +9878,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9892,11 +9897,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9914,7 +9919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9922,30 +9927,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0003937>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
         a       <http://identifiers.org/sgd/S000001550> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -9954,7 +9948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9962,15 +9956,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9981,59 +9997,15 @@
           <http://model.geneontology.org/CHEBI_15740_RXN0-745>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10049,7 +10021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10062,7 +10034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10070,14 +10042,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10085,11 +10057,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10104,11 +10076,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10119,8 +10091,16 @@
           <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58053>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29888_PRPPAMIDOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -10131,7 +10111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10139,7 +10119,7 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0004017>
+<http://purl.obolibrary.org/obo/CHEBI_58053>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829>
@@ -10147,30 +10127,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004017>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10181,26 +10153,15 @@
           <http://model.geneontology.org/CHEBI_30616_GUANYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10230,7 +10191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10250,7 +10211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10262,11 +10223,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10277,14 +10238,14 @@
           <http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10292,11 +10253,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10307,15 +10268,32 @@
           <http://model.geneontology.org/CHEBI_57667_ADPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/938e1ee6-3674-4173-821f-fd45075cf301_GART-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45982> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10326,15 +10304,37 @@
           <http://model.geneontology.org/CHEBI_57945_IMP-DEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10349,11 +10349,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_DETOX1-PWY.ttl
+++ b/models/YeastPathways_DETOX1-PWY.ttl
@@ -1,22 +1,11 @@
-<http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002333_YDR256C-MONOMER_CATAL-RXN_controller_SGD_YeastPathways_DETOX1-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002413_CATAL-RXN_SGD_PWY_YeastPathways_DETOX1-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DETOX1-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002234_CHEBI_15379_SUPEROX-DISMUT-RXN_SGD_YeastPathways_DETOX1-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DETOX1-PWY" ;
+                "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -27,7 +16,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -35,26 +24,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002413_CATAL-RXN_SGD_YeastPathways_DETOX1-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DETOX1-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002333_MONOMER3O-1642_SUPEROX-DISMUT-RXN_controller_SGD_YeastPathways_DETOX1-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002333_MONOMER3O-1642_SUPEROX-DISMUT-RXN_controller_SGD_PWY_YeastPathways_DETOX1-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -91,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -103,11 +81,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002234_CHEBI_15379_CATAL-RXN_SGD_YeastPathways_DETOX1-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002234_CHEBI_15379_CATAL-RXN_SGD_PWY_YeastPathways_DETOX1-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -124,14 +102,25 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_BFO_0000066_reaction_SUPEROX-DISMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_DETOX1-PWY>
+<http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_BFO_0000066_reaction_SUPEROX-DISMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DETOX1-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DETOX1-PWY" ;
+                "SGD_PWY:DETOX1-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002234_CHEBI_16240_SUPEROX-DISMUT-RXN_SGD_PWY_YeastPathways_DETOX1-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -156,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -164,25 +153,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002333_YGR088W-MONOMER_CATAL-RXN_controller_SGD_YeastPathways_DETOX1-PWY>
+<http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002234_CHEBI_15379_SUPEROX-DISMUT-RXN_SGD_PWY_YeastPathways_DETOX1-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DETOX1-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_BFO_0000050_YeastPathways_DETOX1-PWY/YeastPathways_DETOX1-PWY_SGD_YeastPathways_DETOX1-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DETOX1-PWY" ;
+                "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -201,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -213,11 +191,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002333_MONOMER3O-1629_SUPEROX-DISMUT-RXN_controller_SGD_YeastPathways_DETOX1-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002333_MONOMER3O-1629_SUPEROX-DISMUT-RXN_controller_SGD_PWY_YeastPathways_DETOX1-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,11 +210,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002234_CHEBI_15377_CATAL-RXN_SGD_YeastPathways_DETOX1-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002234_CHEBI_15377_CATAL-RXN_SGD_PWY_YeastPathways_DETOX1-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -256,24 +234,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DETOX1-PWYSmallMolecule28324> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002234_CHEBI_15377_CATAL-RXN_SGD_YeastPathways_DETOX1-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DETOX1-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGR088W-MONOMER_CATAL-RXN_controller>
         a       <http://identifiers.org/sgd/S000003320> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -282,7 +249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -299,14 +266,14 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002233_CHEBI_16240_SUPEROX-DISMUT-RXN_SGD_YeastPathways_DETOX1-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_BFO_0000050_YeastPathways_DETOX1-PWY/YeastPathways_DETOX1-PWY_SGD_PWY_YeastPathways_DETOX1-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DETOX1-PWY" ;
+                "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -320,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -331,6 +298,17 @@
 <http://identifiers.org/sgd/S000003865>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002234_CHEBI_15377_CATAL-RXN_SGD_PWY_YeastPathways_DETOX1-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DETOX1-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER3O-1629_SUPEROX-DISMUT-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003865> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -338,24 +316,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DETOX1-PWYProtein28379> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_CATAL-RXN_BFO_0000066_reaction_CATAL-RXN_location_lociGO_0005829_SGD_YeastPathways_DETOX1-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DETOX1-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CATAL-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004096> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -374,13 +341,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DETOX1-PWYBiochemicalReaction28279> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_CATAL-RXN_BFO_0000066_reaction_CATAL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DETOX1-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DETOX1-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -394,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -406,11 +384,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_BFO_0000066_reaction_SUPEROX-DISMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_DETOX1-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_BFO_0000066_reaction_SUPEROX-DISMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DETOX1-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -428,11 +406,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002234_CHEBI_16240_SUPEROX-DISMUT-RXN_SGD_YeastPathways_DETOX1-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002234_CHEBI_16240_SUPEROX-DISMUT-RXN_SGD_PWY_YeastPathways_DETOX1-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -447,11 +425,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002233_CHEBI_16240_SUPEROX-DISMUT-RXN_SGD_YeastPathways_DETOX1-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002233_CHEBI_16240_SUPEROX-DISMUT-RXN_SGD_PWY_YeastPathways_DETOX1-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -467,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -490,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -507,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superoxide radicals degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -524,15 +502,26 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002234_CHEBI_15379_CATAL-RXN_SGD_PWY_YeastPathways_DETOX1-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DETOX1-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_BFO_0000050_YeastPathways_DETOX1-PWY/YeastPathways_DETOX1-PWY_SGD_YeastPathways_DETOX1-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_BFO_0000050_YeastPathways_DETOX1-PWY/YeastPathways_DETOX1-PWY_SGD_PWY_YeastPathways_DETOX1-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -543,14 +532,14 @@
           <http://model.geneontology.org/YeastPathways_DETOX1-PWY/YeastPathways_DETOX1-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002233_CHEBI_15378_SUPEROX-DISMUT-RXN_SGD_YeastPathways_DETOX1-PWY>
+<http://model.geneontology.org/ev_w_id_CATAL-RXN_BFO_0000050_YeastPathways_DETOX1-PWY/YeastPathways_DETOX1-PWY_SGD_PWY_YeastPathways_DETOX1-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DETOX1-PWY" ;
+                "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -561,11 +550,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002234_CHEBI_15379_SUPEROX-DISMUT-RXN_SGD_YeastPathways_DETOX1-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002234_CHEBI_15379_SUPEROX-DISMUT-RXN_SGD_PWY_YeastPathways_DETOX1-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -581,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -589,11 +578,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CATAL-RXN_BFO_0000066_reaction_CATAL-RXN_location_lociGO_0005829_SGD_YeastPathways_DETOX1-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CATAL-RXN_BFO_0000066_reaction_CATAL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DETOX1-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,14 +593,25 @@
           <http://model.geneontology.org/reaction_CATAL-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CATAL-RXN_BFO_0000050_YeastPathways_DETOX1-PWY/YeastPathways_DETOX1-PWY_SGD_YeastPathways_DETOX1-PWY>
+<http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002233_CHEBI_18421_SUPEROX-DISMUT-RXN_SGD_PWY_YeastPathways_DETOX1-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:DETOX1-PWY" ;
+                "SGD_PWY:DETOX1-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002333_YGR088W-MONOMER_CATAL-RXN_controller_SGD_PWY_YeastPathways_DETOX1-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -628,11 +628,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002333_YGR088W-MONOMER_CATAL-RXN_controller_SGD_YeastPathways_DETOX1-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002333_YGR088W-MONOMER_CATAL-RXN_controller_SGD_PWY_YeastPathways_DETOX1-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -656,11 +656,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002233_CHEBI_18421_SUPEROX-DISMUT-RXN_SGD_YeastPathways_DETOX1-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002233_CHEBI_18421_SUPEROX-DISMUT-RXN_SGD_PWY_YeastPathways_DETOX1-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,26 +671,15 @@
           <http://model.geneontology.org/CHEBI_18421_SUPEROX-DISMUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002333_MONOMER3O-1642_SUPEROX-DISMUT-RXN_controller_SGD_YeastPathways_DETOX1-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DETOX1-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CATAL-RXN_BFO_0000050_YeastPathways_DETOX1-PWY/YeastPathways_DETOX1-PWY_SGD_YeastPathways_DETOX1-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CATAL-RXN_BFO_0000050_YeastPathways_DETOX1-PWY/YeastPathways_DETOX1-PWY_SGD_PWY_YeastPathways_DETOX1-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -704,6 +693,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_16240>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002233_CHEBI_15378_SUPEROX-DISMUT-RXN_SGD_PWY_YeastPathways_DETOX1-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DETOX1-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -714,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -722,44 +722,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002233_CHEBI_16240_SUPEROX-DISMUT-RXN_SGD_PWY_YeastPathways_DETOX1-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DETOX1-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002234_CHEBI_15379_CATAL-RXN_SGD_YeastPathways_DETOX1-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DETOX1-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002234_CHEBI_16240_SUPEROX-DISMUT-RXN_SGD_YeastPathways_DETOX1-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DETOX1-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002233_CHEBI_18421_SUPEROX-DISMUT-RXN_SGD_YeastPathways_DETOX1-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DETOX1-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -768,11 +746,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 superoxide + 2 H<SUP>+</SUP> &rarr; hydrogen peroxide + oxygen' 'null' '2 hydrogen peroxide &rarr; 2 H<sub>2</sub>O + oxygen' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002413_CATAL-RXN_SGD_YeastPathways_DETOX1-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002413_CATAL-RXN_SGD_PWY_YeastPathways_DETOX1-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -783,26 +761,15 @@
           <http://model.geneontology.org/CATAL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002333_MONOMER3O-1629_SUPEROX-DISMUT-RXN_controller_SGD_YeastPathways_DETOX1-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DETOX1-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002333_YDR256C-MONOMER_CATAL-RXN_controller_SGD_YeastPathways_DETOX1-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002333_YDR256C-MONOMER_CATAL-RXN_controller_SGD_PWY_YeastPathways_DETOX1-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -816,15 +783,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002333_MONOMER3O-1642_SUPEROX-DISMUT-RXN_controller_SGD_PWY_YeastPathways_DETOX1-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DETOX1-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002233_CHEBI_15378_SUPEROX-DISMUT-RXN_SGD_YeastPathways_DETOX1-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002233_CHEBI_15378_SUPEROX-DISMUT-RXN_SGD_PWY_YeastPathways_DETOX1-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -837,3 +815,25 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002333_YDR256C-MONOMER_CATAL-RXN_controller_SGD_PWY_YeastPathways_DETOX1-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DETOX1-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SUPEROX-DISMUT-RXN_RO_0002333_MONOMER3O-1629_SUPEROX-DISMUT-RXN_controller_SGD_PWY_YeastPathways_DETOX1-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DETOX1-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_ERGOSTEROL-SYN-PWY-1.ttl
+++ b/models/YeastPathways_ERGOSTEROL-SYN-PWY-1.ttl
@@ -7,24 +7,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule59020> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002413_RXN3O-9820_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003407>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -38,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -46,14 +35,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15339_RXN3O-9816_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -64,7 +53,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -79,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -96,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -104,48 +93,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_16526_RXN66-313_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_17499_RXN3O-9816_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_15378_1.3.1.71-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_15378_1.3.1.71-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -156,14 +112,14 @@
           <http://model.geneontology.org/CHEBI_15378_1.3.1.71-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_13390_RXN3O-9823_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -171,11 +127,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Provides Input For Rule. The relation '4&alpha;-methyl-zymosterol + NADP<sup>+</sup> &larr; 3-dehydro-4-methylzymosterol + NADPH + H<SUP>+</SUP>' 'null' '4&alpha;-methyl-zymosterol + NAD(P)H + oxygen &rarr; 4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002413_RXN3O-9824_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002413_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -186,46 +142,51 @@
           <http://model.geneontology.org/RXN3O-9824>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002413_MEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002413_RXN66-313_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002333_YHR190W-MONOMER_RXN-12263_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002413_1.3.1.71-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17813>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/3f0937e3-8481-4225-880e-b21c39cbe539_RXN3O-9826>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58948> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_57310_RXN-12263_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_57310_RXN-12263_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -240,11 +201,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_57783_RXN66-319_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_57783_RXN66-319_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -255,12 +216,45 @@
           <http://model.geneontology.org/CHEBI_57783_RXN66-319>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002413_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_15379_RXN3O-9827_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_1.1.1.34-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -279,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -296,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -312,7 +306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -335,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -347,11 +341,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,25 +356,14 @@
           <http://model.geneontology.org/YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002333_YGR060W-MONOMER_RXN3O-9823_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_65cc70bc-fd73-4e92-9622-ed63b43c2ae5_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -388,11 +371,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,6 +386,17 @@
           <http://model.geneontology.org/CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_15377_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15379_RXN3O-9826>
         a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -412,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -424,11 +418,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_57783_RXN3O-9828_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_57783_RXN3O-9828_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -448,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -461,7 +455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -469,11 +463,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_59789_RXN3O-178_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_59789_RXN3O-178_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,11 +482,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002333_YHR007C-MONOMER_RXN3O-9820_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002333_YHR007C-MONOMER_RXN3O-9820_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,15 +497,29 @@
           <http://model.geneontology.org/YHR007C-MONOMER_RXN3O-9820_controller>
 ] .
 
+<http://model.geneontology.org/416e20df-e661-4cb0-8052-7ae908c232fa_RXN3O-9826>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002411_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_3cac9700-8f1d-4bf6-a1b1-f14d98d5a7fe_RXN3O-9824_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_531a4b6f-c29b-4d85-a97f-81db11cd50a5_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -519,18 +527,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3cac9700-8f1d-4bf6-a1b1-f14d98d5a7fe_RXN3O-9824>
+          <http://model.geneontology.org/531a4b6f-c29b-4d85-a97f-81db11cd50a5_RXN3O-9824>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000066_reaction_LANOSTEROL-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000066_reaction_LANOSTEROL-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -563,7 +571,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_29888_RXN66-281_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -576,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -584,25 +603,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002233_CHEBI_17038_RXN3O-178_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_64925_RXN3O-9823_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_15378_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -610,11 +618,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_13392_RXN3O-9822_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_13392_RXN3O-9822_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -629,11 +637,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -653,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -661,14 +669,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_29888_RXN66-281_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_87287_RXN3O-9822_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -677,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -685,11 +693,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002333_YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002333_YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,14 +708,25 @@
           <http://model.geneontology.org/YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_13390_RXN3O-9823_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_13392_RXN3O-9823_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -720,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -737,7 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -745,14 +764,47 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000066_reaction_1.3.1.71-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002413_RXN3O-9828_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -765,7 +817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -773,15 +825,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_15378_RXN66-314_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_52386_RXN66-318_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_52386_RXN66-318_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -792,36 +855,14 @@
           <http://model.geneontology.org/CHEBI_52386_RXN66-318>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_57783_1.1.1.34-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_50586_RXN3O-203_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_58349_RXN66-319_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -829,11 +870,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002333_YNL280C-MONOMER_RXN66-306_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002333_YNL280C-MONOMER_RXN66-306_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -848,11 +889,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YLR450W-MONOMER_1.1.1.34-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YLR450W-MONOMER_1.1.1.34-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,7 +913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -880,14 +921,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002413_RXN66-318_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -895,11 +936,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_15378_RXN66-314_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_15378_RXN66-314_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -910,39 +951,6 @@
           <http://model.geneontology.org/CHEBI_15378_RXN66-314>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_58349_1.1.1.34-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002413_RXN3O-178_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YMR220W-MONOMER_PHOSPHOMEVALONATE-KINASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004833> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -950,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -967,9 +975,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9825_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13392_RXN3O-9825> , <http://model.geneontology.org/3cac9700-8f1d-4bf6-a1b1-f14d98d5a7fe_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_13392_RXN3O-9825> , <http://model.geneontology.org/531a4b6f-c29b-4d85-a97f-81db11cd50a5_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_RXN3O-9825> , <http://model.geneontology.org/738a50ee-9d28-4118-adf7-395d7df26a78_RXN3O-9825> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN3O-9825> , <http://model.geneontology.org/1eb2327c-9441-4117-b261-e6841c206dce_RXN3O-9825> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9825_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -977,7 +985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -989,11 +997,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9816_BFO_0000066_reaction_RXN3O-9816_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9816_BFO_0000066_reaction_RXN3O-9816_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1011,11 +1019,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_BFO_0000066_reaction_RXN3O-9822_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_BFO_0000066_reaction_RXN3O-9822_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1031,7 +1039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1039,11 +1047,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1058,11 +1066,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_3f0937e3-8481-4225-880e-b21c39cbe539_RXN3O-9826_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_da7fd5aa-4c92-4733-9e59-1484c64553a6_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,18 +1078,29 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3f0937e3-8481-4225-880e-b21c39cbe539_RXN3O-9826>
+          <http://model.geneontology.org/da7fd5aa-4c92-4733-9e59-1484c64553a6_RXN3O-9826>
 ] .
+
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>R</i>)-mevalonate + ATP &harr; (<i>R</i>)-mevalonate 5-phosphate + ADP + H<SUP>+</SUP>' 'null' '(<i>R</i>)-mevalonate 5-phosphate + ATP &harr; (R)-mevalonate diphosphate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002413_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002413_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1092,48 +1111,15 @@
           <http://model.geneontology.org/PHOSPHOMEVALONATE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_16526_RXN66-318_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_15377_RXN3O-9824_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_13390_RXN3O-9823_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_13390_RXN3O-9823_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1148,11 +1134,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1172,7 +1158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1187,7 +1173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1195,25 +1181,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_1949_RXN66-314_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_BFO_0000066_reaction_RXN3O-9822_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_57783_1.3.1.71-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1221,11 +1196,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_57783_RXN3O-9820_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_57783_RXN3O-9820_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1236,47 +1211,25 @@
           <http://model.geneontology.org/CHEBI_57783_RXN3O-9820>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000066_reaction_RXN3O-203_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_57783_RXN3O-9828_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002413_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002333_YGR060W-MONOMER_RXN3O-9825_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_BFO_0000066_reaction_RXN3O-9827_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1285,7 +1238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1296,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1313,13 +1266,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58680> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002413_GPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_136486_RXN66-313>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_136486> ;
@@ -1330,7 +1294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1338,14 +1302,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_13390_RXN3O-9822_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_15377_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_15379_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1353,11 +1339,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1368,17 +1354,6 @@
           <http://model.geneontology.org/YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_58349_1.3.1.71-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_MEVALONATE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1388,7 +1363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1396,14 +1371,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_57783_RXN3O-9820_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1412,7 +1387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1425,7 +1400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1436,15 +1411,26 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_58349_1.3.1.71-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002333_YGL001C-MONOMER_RXN66-318_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002333_YGL001C-MONOMER_RXN66-318_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1458,6 +1444,23 @@
 <http://purl.obolibrary.org/obo/GO_0003838>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/1eb2327c-9441-4117-b261-e6841c206dce_RXN3O-9825>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58941> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_57856_RXN3O-178>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57856> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1467,7 +1470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1482,7 +1485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1490,26 +1493,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15377_RXN3O-9816_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_15378_RXN66-306_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_15378_RXN66-306_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1520,50 +1512,28 @@
           <http://model.geneontology.org/CHEBI_15378_RXN66-306>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000066_reaction_PHOSPHOMEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0000246>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002413_RXN66-319_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_52386_RXN66-318_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002333_YGL001C-MONOMER_RXN66-313_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002413_RXN3O-9827_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1571,11 +1541,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Provides Input For Rule. The relation 'episterol + NADPH + oxygen + H<SUP>+</SUP> &rarr; ergosta-5,7,24(28)-trien-3&beta;-ol + NADP<sup>+</sup> + 2 H<sub>2</sub>O' 'null' 'ergosta-5,7,24(28)-trien-3&beta;-ol + NADPH + oxygen + H<SUP>+</SUP> &rarr; ergosta-5,7,22,24(28)-tetraen-3-&beta;-ol + NADP<sup>+</sup> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002413_RXN3O-9828_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002413_RXN3O-9828_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1586,6 +1556,17 @@
           <http://model.geneontology.org/RXN3O-9828>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002413_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15339_RXN3O-9816>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1595,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1603,26 +1584,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002411_RXN3O-9826_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_57310_RXN-12263_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_57310_RXN-12263_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1633,15 +1603,26 @@
           <http://model.geneontology.org/CHEBI_57310_RXN-12263>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_64925_RXN3O-9823_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002333_YGR060W-MONOMER_RXN3O-9824_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002333_YGR060W-MONOMER_RXN3O-9824_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1656,11 +1637,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000066_reaction_IPPISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000066_reaction_IPPISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1671,15 +1652,18 @@
           <http://model.geneontology.org/reaction_IPPISOM-RXN_location_lociGO_0005829>
 ] .
 
+<http://identifiers.org/sgd/S000004467>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002233_CHEBI_17038_RXN3O-178_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002233_CHEBI_17038_RXN3O-178_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1689,34 +1673,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_17038_RXN3O-178>
 ] .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000004467>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_57288>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_f9530e00-adbe-450f-bdcd-9ace56781c6d_RXN3O-9826_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-9820>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008398> ;
@@ -1737,7 +1693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1745,25 +1701,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_36464_1.1.1.34-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57288>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_57783_RXN66-314_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_57310_RXN-12263_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1771,11 +1719,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_15377_RXN3O-9821_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_15377_RXN3O-9821_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1790,11 +1738,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1814,7 +1762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1826,11 +1774,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_13392_RXN3O-9826_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_13392_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1845,11 +1793,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_36464_1.1.1.34-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_36464_1.1.1.34-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1869,7 +1817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1886,13 +1834,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58879> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_GPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_57310_RXN-12263_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1903,7 +1873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1933,7 +1903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1941,14 +1911,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000066_reaction_RXN66-281_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1958,36 +1928,14 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002413_GPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15441_RXN3O-9816_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_36464_1.1.1.34-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1996,7 +1944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2004,11 +1952,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_15378_1.1.1.34-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_15378_1.1.1.34-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2019,36 +1967,14 @@
           <http://model.geneontology.org/CHEBI_15378_1.1.1.34-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002413_RXN3O-9816_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002413_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_6f54693a-c945-454d-b8f1-cebecd196d9d_RXN3O-9824_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2056,11 +1982,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_16526_RXN66-313_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_16526_RXN66-313_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2071,14 +1997,14 @@
           <http://model.geneontology.org/CHEBI_16526_RXN66-313>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_15378_RXN66-314_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_136486_RXN66-313_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2086,11 +2012,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_16933_1.3.1.71-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_16933_1.3.1.71-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2101,17 +2027,6 @@
           <http://model.geneontology.org/CHEBI_16933_1.3.1.71-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002333_YGR175C-MONOMER_RXN3O-9816_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_13392_RXN66-281>
         a       <http://purl.obolibrary.org/obo/CHEBI_13392> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2121,13 +2036,57 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58879> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_15379_RXN3O-9823_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_59789_RXN3O-178_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0006696> ;
@@ -2138,7 +2097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2150,11 +2109,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000066_reaction_RXN3O-9826_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000066_reaction_RXN3O-9826_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2172,11 +2131,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_MEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2187,14 +2146,25 @@
           <http://model.geneontology.org/CHEBI_30616_MEVALONATE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002333_YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_57287_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_3eea751e-7ad3-46fc-9ae9-7e02d091de67_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2202,11 +2172,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)H + oxygen &rarr; 4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + 2 H<sub>2</sub>O' 'null' '4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)H + oxygen &rarr; 4&alpha;-carboxy-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002413_RXN3O-9823_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002413_RXN3O-9823_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2217,14 +2187,14 @@
           <http://model.geneontology.org/RXN3O-9823>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_15377_RXN3O-9823_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_15377_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2232,11 +2202,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2251,11 +2221,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_57783_RXN3O-9827_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_57783_RXN3O-9827_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2271,7 +2241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2279,11 +2249,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Provides Input For Rule. The relation '(<i>R</i>)-mevalonate 5-phosphate + ATP &harr; (R)-mevalonate diphosphate + ADP' 'null' '(R)-mevalonate diphosphate + ATP &rarr; CO<SUB>2</SUB> + isopentenyl diphosphate + ADP + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002413_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002413_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2298,11 +2268,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'squalene + a reduced electron acceptor + oxygen &rarr; (3<i>S</i>)-2,3-epoxy-2,3-dihydrosqualene + an oxidized electron acceptor + H<sub>2</sub>O' 'null' '(3<i>S</i>)-2,3-epoxy-2,3-dihydrosqualene &rarr; lanosterol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002413_LANOSTEROL-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002413_LANOSTEROL-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2317,11 +2287,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_15379_RXN3O-9824_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_15379_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2332,15 +2302,26 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-9824>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_36464_1.1.1.34-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2351,6 +2332,17 @@
           <http://model.geneontology.org/CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_18364_RXN66-306_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9816>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2360,7 +2352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2368,34 +2360,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002333_YGL001C-MONOMER_RXN66-313_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-9820_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_57783_1.3.1.71-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2404,18 +2385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2428,7 +2398,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> , <http://model.geneontology.org/f9530e00-adbe-450f-bdcd-9ace56781c6d_RXN3O-9826> ;
+                <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> , <http://model.geneontology.org/416e20df-e661-4cb0-8052-7ae908c232fa_RXN3O-9826> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16526_RXN66-318> , <http://model.geneontology.org/CHEBI_13392_RXN66-318> , <http://model.geneontology.org/CHEBI_52386_RXN66-318> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -2438,24 +2408,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1BiochemicalReaction59130> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_13390_RXN3O-9821_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0050046>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2469,7 +2428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2477,25 +2436,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002333_YML126C-MONOMER_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_17813_RXN3O-9820_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_18252_RXN66-319_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_58349_RXN66-319_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2508,7 +2478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2521,7 +2491,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000066_reaction_RXN-12263_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2529,11 +2510,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000066_reaction_RXN66-318_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000066_reaction_RXN66-318_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2548,11 +2529,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_15440_RXN66-281_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_15440_RXN66-281_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2573,11 +2554,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_58349_RXN66-319_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_58349_RXN66-319_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2592,11 +2573,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000066_reaction_RXN66-313_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000066_reaction_RXN66-313_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2610,14 +2591,36 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_87289_RXN3O-9821_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002413_RXN3O-9827_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_13392_RXN66-313_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2633,7 +2636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2645,11 +2648,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_18249_RXN3O-9828_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_18249_RXN3O-9828_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2660,17 +2663,6 @@
           <http://model.geneontology.org/CHEBI_18249_RXN3O-9828>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_59789_RXN3O-178_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_RXN-12263>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2680,7 +2672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2692,11 +2684,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_17038_RXN3O-178_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_17038_RXN3O-178_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2714,11 +2706,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2733,11 +2725,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_15377_RXN3O-9825_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_15377_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2755,11 +2747,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002234_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002234_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2770,26 +2762,15 @@
           <http://model.geneontology.org/CHEBI_16521_LANOSTEROL-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_BFO_0000066_reaction_RXN3O-9820_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_87289_RXN3O-9821_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_87289_RXN3O-9821_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2804,11 +2785,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2823,11 +2804,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2838,14 +2819,25 @@
           <http://model.geneontology.org/YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_52972_RXN3O-9827_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2853,11 +2845,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_17499_RXN3O-9816_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_17499_RXN3O-9816_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2868,23 +2860,45 @@
           <http://model.geneontology.org/CHEBI_17499_RXN3O-9816>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_13392_RXN66-313_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_GPPSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_15377_RXN3O-9822_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002413_RXN3O-9822_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_15379_RXN3O-9822_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2897,46 +2911,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58464> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_15378_RXN3O-9828_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_15440_RXN66-281_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN66-313>
         a       <http://purl.obolibrary.org/obo/GO_0103067> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2957,7 +2938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2970,7 +2951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2978,11 +2959,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2998,33 +2979,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_17813_RXN3O-9820_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>R</i>)-mevalonate + coenzyme A + 2 NADP<sup>+</sup> &harr; (<i>S</i>)-3-hydroxy-3-methylglutaryl-CoA + 2 NADPH + 2 H<SUP>+</SUP>' 'null' '(<i>R</i>)-mevalonate + ATP &harr; (<i>R</i>)-mevalonate 5-phosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002413_MEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002413_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3045,11 +3015,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_1949_RXN66-314_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_1949_RXN66-314_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3060,12 +3030,23 @@
           <http://model.geneontology.org/CHEBI_1949_RXN66-314>
 ] .
 
+<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002333_YHR072W-MONOMER_LANOSTEROL-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-9821_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3076,11 +3057,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000066_reaction_RXN66-281_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000066_reaction_RXN66-281_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3103,7 +3084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3130,7 +3111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3142,11 +3123,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15440_RXN66-281_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15440_RXN66-281_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3157,25 +3138,14 @@
           <http://model.geneontology.org/CHEBI_15440_RXN66-281>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_15377_RXN3O-9822_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_13392_RXN3O-9823_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3183,11 +3153,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Provides Input For Rule. The relation '4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)H + oxygen &rarr; 4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + H<sub>2</sub>O' 'null' '4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> &rarr; zymosterone + CO<SUB>2</SUB> + NAD(P)H' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002413_RXN66-318_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002413_RXN66-318_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3198,14 +3168,14 @@
           <http://model.geneontology.org/RXN66-318>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_1949_RXN66-314_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_57783_RXN3O-9828_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3213,11 +3183,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000066_reaction_PHOSPHOMEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000066_reaction_PHOSPHOMEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3240,7 +3210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3252,11 +3222,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_64925_RXN3O-9823_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_64925_RXN3O-9823_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3274,7 +3244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3286,11 +3256,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3310,7 +3280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3318,26 +3288,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_52972_RXN3O-9827_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_15378_RXN3O-9828_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_15378_RXN3O-9828_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3352,11 +3311,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3371,11 +3330,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_15740_RXN3O-9820_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_15740_RXN3O-9820_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3386,14 +3345,25 @@
           <http://model.geneontology.org/CHEBI_15740_RXN3O-9820>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_17813_RXN3O-9820_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3406,24 +3376,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58680> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002413_RXN3O-203_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57287_1.1.1.34-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57287> ;
@@ -3434,24 +3393,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58607> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000066_reaction_MEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -3460,11 +3408,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3474,28 +3422,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_18252_RXN66-319_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_15378_RXN66-281_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_18364>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3509,7 +3435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3520,26 +3446,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_13390>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000066_reaction_RXN-12263_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3559,7 +3474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3570,28 +3485,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57623>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002333_YGL001C-MONOMER_RXN66-318_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58349_1.3.1.71-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3601,7 +3494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3613,11 +3506,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_57783_RXN66-306_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_57783_RXN66-306_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3633,18 +3526,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002333_YGL012W-MONOMER_1.3.1.71-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_531a4b6f-c29b-4d85-a97f-81db11cd50a5_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3652,11 +3556,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_36464_1.1.1.34-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_36464_1.1.1.34-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3670,15 +3574,26 @@
 <http://purl.obolibrary.org/obo/GO_0004506>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_15377_RXN3O-9821_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3689,15 +3604,37 @@
           <http://model.geneontology.org/YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_15379_RXN3O-9821_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002233_CHEBI_15441_RXN3O-9816_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002234_CHEBI_57623_IPPISOM-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002234_CHEBI_57623_IPPISOM-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3708,14 +3645,14 @@
           <http://model.geneontology.org/CHEBI_57623_IPPISOM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002333_YNL280C-MONOMER_RXN66-306_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3738,7 +3675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3750,11 +3687,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002333_YMR202W-MONOMER_RXN3O-203_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002333_YMR202W-MONOMER_RXN3O-203_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3770,7 +3707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3778,11 +3715,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002333_YGR060W-MONOMER_RXN3O-9821_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002333_YGR060W-MONOMER_RXN3O-9821_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3793,17 +3730,6 @@
           <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9821_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000066_reaction_RXN66-306_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0103067>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3811,11 +3737,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002333_YNR043W-MONOMER_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002333_YNR043W-MONOMER_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3831,7 +3757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3839,11 +3765,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_6c292b8d-35d3-4464-aa45-6427249f04f6_RXN3O-9825_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_3eea751e-7ad3-46fc-9ae9-7e02d091de67_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3851,29 +3777,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6c292b8d-35d3-4464-aa45-6427249f04f6_RXN3O-9825>
+          <http://model.geneontology.org/3eea751e-7ad3-46fc-9ae9-7e02d091de67_RXN3O-9825>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_MEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3883,23 +3798,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_456216_MEVALONATE-KINASE-RXN>
 ] .
-
-<http://model.geneontology.org/738a50ee-9d28-4118-adf7-395d7df26a78_RXN3O-9825>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58941> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0004496>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3911,11 +3809,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_13392_RXN3O-9823_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_13392_RXN3O-9823_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3926,15 +3824,24 @@
           <http://model.geneontology.org/CHEBI_13392_RXN3O-9823>
 ] .
 
+<http://model.geneontology.org/reaction_RXN66-313_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_IPPISOM-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_IPPISOM-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3945,65 +3852,45 @@
           <http://model.geneontology.org/CHEBI_57623_IPPISOM-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_RXN66-313_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_6c292b8d-35d3-4464-aa45-6427249f04f6_RXN3O-9825_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_15377_RXN3O-9828_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_15378_RXN3O-9827_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-9822_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_136486_RXN66-313_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_15378_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000066_reaction_RXN66-318_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4016,7 +3903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4024,62 +3911,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002234_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000066_reaction_RXN66-281_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_175763>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000066_reaction_RXN3O-9824_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_15379_RXN3O-9824_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_57783_1.1.1.34-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_57783_1.1.1.34-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4093,18 +3936,40 @@
 <http://identifiers.org/sgd/S000004815>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_15378_RXN3O-9828_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_57783_RXN3O-9827_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Provides Input For Rule. The relation '4&alpha;-carboxy-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> &rarr; 3-dehydro-4-methylzymosterol + CO<SUB>2</SUB> + NAD(P)H' 'null' '4&alpha;-methyl-zymosterol + NADP<sup>+</sup> &larr; 3-dehydro-4-methylzymosterol + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002413_RXN66-314_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002413_RXN66-314_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4115,14 +3980,25 @@
           <http://model.geneontology.org/RXN66-314>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_13390_RXN3O-9826_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002333_YPL117C-MONOMER_IPPISOM-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4133,11 +4009,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002333_YGL012W-MONOMER_1.3.1.71-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002333_YGL012W-MONOMER_1.3.1.71-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4148,37 +4024,15 @@
           <http://model.geneontology.org/YGL012W-MONOMER_1.3.1.71-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_13390_RXN66-281_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_57310_RXN-12263_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_13392_RXN66-318_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_13392_RXN66-318_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4189,25 +4043,14 @@
           <http://model.geneontology.org/CHEBI_13392_RXN66-318>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_58349_RXN3O-9828_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_13392_RXN3O-9822_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4217,36 +4060,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_15440>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000066_reaction_RXN66-313_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_57856_RXN3O-178_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_15377_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002333_YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4259,13 +4080,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58680> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000066_reaction_RXN3O-9823_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9823> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-9823_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004421> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4286,7 +4126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4296,32 +4136,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000066_reaction_RXN3O-9823_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9823> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-9823_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4332,14 +4153,14 @@
           <http://model.geneontology.org/CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002413_1.1.1.34-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000066_reaction_1.1.1.34-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4347,11 +4168,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_52972_RXN3O-9827_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_52972_RXN3O-9827_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4366,11 +4187,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000066_reaction_RXN-12263_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000066_reaction_RXN-12263_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4385,11 +4206,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_BFO_0000066_reaction_RXN3O-9820_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_BFO_0000066_reaction_RXN3O-9820_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4404,11 +4225,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_13390_RXN3O-9824_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_13390_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4419,6 +4240,17 @@
           <http://model.geneontology.org/CHEBI_13390_RXN3O-9824>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_87289_RXN3O-9821_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_1.3.1.71-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4428,7 +4260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4443,11 +4275,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002333_YML126C-MONOMER_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002333_YML126C-MONOMER_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4465,16 +4297,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein58901> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/3cac9700-8f1d-4bf6-a1b1-f14d98d5a7fe_RXN3O-9824>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/YJL167W-MONOMER_FPPSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000003703> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4483,7 +4312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4495,11 +4324,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_15379_RXN3O-9821_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_15379_RXN3O-9821_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4514,11 +4343,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4538,13 +4367,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58886> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_18252_RXN66-319_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17499_RXN3O-9816>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
@@ -4555,7 +4395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4572,7 +4412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4580,14 +4420,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002333_MONOMER3O-188_RXN3O-178_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002413_RXN66-319_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4610,7 +4450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4618,50 +4458,61 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57288_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15339_RXN3O-9816_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002333_YLR100W-MONOMER_RXN66-319_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_15740_RXN3O-9820_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_64925>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_57783_RXN66-306_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_52386_RXN66-318_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_16933_1.3.1.71-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_15440_RXN66-281_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4674,7 +4525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4686,11 +4537,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002333_YHR190W-MONOMER_RXN66-281_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002333_YHR190W-MONOMER_RXN66-281_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4705,11 +4556,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Provides Input For Rule. The relation 'zymosterol + NADP<sup>+</sup> &larr; zymosterone + NADPH + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + zymosterol &rarr; <i>S</i>-adenosyl-L-homocysteine + fecosterol + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002413_RXN3O-178_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002413_RXN3O-178_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4720,15 +4571,37 @@
           <http://model.geneontology.org/RXN3O-178>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_15378_RXN66-319_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002333_MONOMER3O-188_RXN3O-178_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN66-314_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4736,11 +4609,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_64925_RXN3O-9823_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_64925_RXN3O-9823_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4751,26 +4624,15 @@
           <http://model.geneontology.org/CHEBI_64925_RXN3O-9823>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002413_LANOSTEROL-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002333_MONOMER3O-232_RXN3O-9828_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002333_MONOMER3O-232_RXN3O-9828_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4800,7 +4662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4812,11 +4674,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002333_MONOMER3O-188_RXN3O-178_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002333_MONOMER3O-188_RXN3O-178_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4827,29 +4689,15 @@
           <http://model.geneontology.org/MONOMER3O-188_RXN3O-178_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_BFO_0000066_reaction_RXN3O-9825_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002333_YGR060W-MONOMER_RXN3O-9825_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002333_YGR060W-MONOMER_RXN3O-9825_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4860,37 +4708,18 @@
           <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9825_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_15378_1.3.1.71-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_15378_RXN66-306_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(3<i>S</i>)-2,3-epoxy-2,3-dihydrosqualene &rarr; lanosterol' 'null' 'lanosterol + 3 NADPH + 3 oxygen + 3 H<SUP>+</SUP> &rarr; 4,4-dimethyl-cholesta-8,14,24-trienol + formate + 3 NADP<sup>+</sup> + 4 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002413_RXN3O-9820_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002413_RXN3O-9820_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4901,29 +4730,29 @@
           <http://model.geneontology.org/RXN3O-9820>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002413_RXN66-314_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://purl.obolibrary.org/obo/CHEBI_18252>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_15378_RXN3O-178_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_18252>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_15377_RXN3O-9822_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_15377_RXN3O-9822_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4934,15 +4763,26 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-9822>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_15378_RXN3O-9827_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4953,37 +4793,15 @@
           <http://model.geneontology.org/CHEBI_29888_FPPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000066_reaction_1.3.1.71-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_15377_RXN3O-9827_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_15378_RXN3O-9827_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_15378_RXN3O-9827_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4998,11 +4816,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5022,7 +4840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5034,11 +4852,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15377_RXN3O-9816_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15377_RXN3O-9816_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5048,6 +4866,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_RXN3O-9816>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_13390_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_13392_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/1.3.1.71-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000246> ;
@@ -5066,7 +4906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5083,7 +4923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5098,24 +4938,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein58955> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_15379_RXN3O-9823_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9825_controller>
         a       <http://identifiers.org/sgd/S000003292> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5124,7 +4953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5151,13 +4980,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1BiochemicalReaction58420> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002413_RXN66-314_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9826_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003292> ;
@@ -5166,7 +5006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5174,14 +5014,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_456216_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5194,7 +5034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5206,11 +5046,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000066_reaction_1.3.1.71-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000066_reaction_1.3.1.71-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5221,39 +5061,17 @@
           <http://model.geneontology.org/reaction_1.3.1.71-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002413_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000066_reaction_1.1.1.34-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004163>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000066_reaction_IPPISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5264,7 +5082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5272,15 +5090,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_16933_1.3.1.71-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002333_YLR100W-MONOMER_RXN66-314_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002333_YLR100W-MONOMER_RXN66-314_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5294,25 +5123,14 @@
 <http://identifiers.org/sgd/S000005949>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002413_RXN3O-9828_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_52386_RXN66-318_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_13392_RXN3O-9821_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5320,11 +5138,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_15378_RXN66-281_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_15378_RXN66-281_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5335,17 +5153,6 @@
           <http://model.geneontology.org/CHEBI_15378_RXN66-281>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_BFO_0000066_reaction_RXN3O-9828_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43074> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5355,7 +5162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5367,11 +5174,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_BFO_0000066_reaction_RXN3O-9827_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_BFO_0000066_reaction_RXN3O-9827_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5386,11 +5193,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5404,6 +5211,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16526_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5413,7 +5231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5425,11 +5243,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Provides Input For Rule. The relation '4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)H + oxygen &rarr; 4&alpha;-carboxy-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + H<sub>2</sub>O' 'null' '4&alpha;-carboxy-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> &rarr; 3-dehydro-4-methylzymosterol + CO<SUB>2</SUB> + NAD(P)H' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002413_RXN66-313_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002413_RXN66-313_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5442,25 +5260,6 @@
 
 <http://purl.obolibrary.org/obo/GO_0008398>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_15377_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
-] .
 
 <http://model.geneontology.org/IPPISOM-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004452> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5481,13 +5280,43 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1BiochemicalReaction58716> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_15377_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002333_YGR060W-MONOMER_RXN3O-9822_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15379_RXN3O-9825>
         a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5498,7 +5327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5510,11 +5339,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_52972_RXN3O-9827_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_52972_RXN3O-9827_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5529,11 +5358,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_18252_RXN66-319_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_18252_RXN66-319_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5544,26 +5373,15 @@
           <http://model.geneontology.org/CHEBI_18252_RXN66-319>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_57856_RXN3O-178_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_58349_RXN3O-9820_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_58349_RXN3O-9820_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5593,7 +5411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5610,7 +5428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5618,15 +5436,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000066_reaction_RXN66-314_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_15379_RXN3O-9825_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_15379_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5641,11 +5470,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5665,7 +5494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5673,15 +5502,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002234_CHEBI_50586_RXN3O-203_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_87287_RXN3O-9822_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_58349_RXN66-306_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5692,6 +5554,17 @@
           <http://model.geneontology.org/CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_1949_RXN66-314_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_1.1.1.34-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5701,13 +5574,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58567> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004421>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5719,11 +5603,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_15378_RXN66-319_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_15378_RXN66-319_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5743,7 +5627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5754,26 +5638,15 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_64925_RXN3O-9823_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_58349_RXN66-306_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_58349_RXN66-306_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5788,11 +5661,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_58349_1.1.1.34-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_58349_1.1.1.34-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5803,6 +5676,17 @@
           <http://model.geneontology.org/CHEBI_58349_1.1.1.34-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57287> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5812,7 +5696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5820,15 +5704,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_136486_RXN66-313_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_136486_RXN66-313_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5842,12 +5737,34 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002333_MONOMER3O-232_RXN3O-9828_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_13390_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-203_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5862,7 +5779,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_1949_RXN66-314> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9824> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_13390_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9824> , <http://model.geneontology.org/6f54693a-c945-454d-b8f1-cebecd196d9d_RXN3O-9824> ;
+                <http://model.geneontology.org/CHEBI_13390_RXN3O-9824> , <http://model.geneontology.org/65cc70bc-fd73-4e92-9622-ed63b43c2ae5_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9824> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9824_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -5870,7 +5787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5882,11 +5799,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9816_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9816_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5901,11 +5818,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5920,11 +5837,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(R)-mevalonate diphosphate + ATP &rarr; CO<SUB>2</SUB> + isopentenyl diphosphate + ADP + phosphate' 'null' 'isopentenyl diphosphate &harr; dimethylallyl diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_IPPISOM-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_IPPISOM-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5935,26 +5852,15 @@
           <http://model.geneontology.org/IPPISOM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002413_RXN66-281_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_15377_RXN3O-9826_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_15377_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5969,11 +5875,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002333_YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002333_YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5988,11 +5894,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_87287_RXN3O-9822_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_87287_RXN3O-9822_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6007,11 +5913,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6031,7 +5937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6042,15 +5948,26 @@
 <http://identifiers.org/sgd/S000002969>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6061,25 +5978,14 @@
           <http://model.geneontology.org/CHEBI_16521_LANOSTEROL-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_15379_RXN3O-9822_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000066_reaction_RXN66-319_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002333_YGR060W-MONOMER_RXN3O-9822_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6092,7 +5998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6100,19 +6006,38 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002333_YLR056W-MONOMER_RXN3O-9827_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://identifiers.org/sgd/S000005326>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002233_CHEBI_175763_FPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9821>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6123,7 +6048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6136,18 +6061,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://identifiers.org/sgd/S000005326>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_18252_RXN66-319_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6163,13 +6091,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58567> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002413_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YNR043W-MONOMER_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000005326> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6178,24 +6117,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein58516> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -6204,11 +6132,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000066_reaction_RXN66-314_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000066_reaction_RXN66-314_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6219,19 +6147,19 @@
           <http://model.geneontology.org/reaction_RXN66-314_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://purl.obolibrary.org/obo/CHEBI_87289>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000066_reaction_RXN3O-203_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_87289>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/1.1.1.34-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004420> ;
@@ -6252,7 +6180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6260,14 +6188,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_BFO_0000066_reaction_RXN3O-9816_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002234_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6275,11 +6203,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_52386_RXN66-318_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_52386_RXN66-318_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6299,7 +6227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of ergosterol biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -6307,37 +6235,15 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002333_MONOMER3O-232_RXN3O-9828_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002233_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000066_reaction_RXN66-306_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000066_reaction_RXN66-306_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6347,6 +6253,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN66-306_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002411_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN66-281>
         a       <http://purl.obolibrary.org/obo/GO_0004310> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6367,7 +6295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6375,15 +6303,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_15378_1.1.1.34-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002333_YLR056W-MONOMER_RXN3O-9827_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002333_YLR056W-MONOMER_RXN3O-9827_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6398,11 +6337,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_29888_RXN-12263_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_29888_RXN-12263_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6413,15 +6352,26 @@
           <http://model.geneontology.org/CHEBI_29888_RXN-12263>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_15377_RXN3O-9828_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_15379_RXN3O-9820_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_15379_RXN3O-9820_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6432,15 +6382,26 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-9820>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_15379_RXN3O-9828_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_6f54693a-c945-454d-b8f1-cebecd196d9d_RXN3O-9824_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_65cc70bc-fd73-4e92-9622-ed63b43c2ae5_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6448,7 +6409,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9824> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6f54693a-c945-454d-b8f1-cebecd196d9d_RXN3O-9824>
+          <http://model.geneontology.org/65cc70bc-fd73-4e92-9622-ed63b43c2ae5_RXN3O-9824>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
@@ -6458,11 +6419,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6473,51 +6434,40 @@
           <http://model.geneontology.org/YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_MEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_16526_RXN66-313_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YLR450W-MONOMER_1.1.1.34-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000066_reaction_RXN3O-203_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000066_reaction_RXN3O-203_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6528,15 +6478,26 @@
           <http://model.geneontology.org/reaction_RXN3O-203_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_13390_RXN3O-9822_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_13390_RXN3O-9821_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_13390_RXN3O-9821_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6551,11 +6512,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6566,6 +6527,17 @@
           <http://model.geneontology.org/CHEBI_16526_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_13392_RXN3O-9822_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_13390_RXN3O-9824>
         a       <http://purl.obolibrary.org/obo/CHEBI_13390> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6575,7 +6547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6583,14 +6555,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000066_reaction_RXN66-318_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_52386_RXN66-318_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_57783_RXN66-314_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6603,7 +6586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6611,19 +6594,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001049>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_13392_RXN66-281_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGL001C-MONOMER_RXN66-313_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002969> ;
@@ -6632,7 +6626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6643,14 +6637,14 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_18364_RXN66-306_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6663,30 +6657,37 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller>
-        a       <http://identifiers.org/sgd/S000005949> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoacetyl CoA thiolase" ;
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YLR450W-MONOMER_1.1.1.34-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein58713> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_57783_RXN66-306_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000066_reaction_1.1.1.34-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000066_reaction_1.1.1.34-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6697,22 +6698,20 @@
           <http://model.geneontology.org/reaction_1.1.1.34-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/CHEBI_17813_RXN3O-9820>
-        a       <http://purl.obolibrary.org/obo/CHEBI_17813> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
+<http://model.geneontology.org/YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller>
+        a       <http://identifiers.org/sgd/S000005949> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "4,4-dimethyl-cholesta-8,14,24-trienol" ;
+                "acetoacetyl CoA thiolase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule59055> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein58713> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_456216_PHOSPHOMEVALONATE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6723,7 +6722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6731,27 +6730,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002333_YGR060W-MONOMER_RXN3O-9824_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_17813_RXN3O-9820>
+        a       <http://purl.obolibrary.org/obo/CHEBI_17813> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4,4-dimethyl-cholesta-8,14,24-trienol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_15379_RXN3O-9828_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule59055> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN66-314>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6762,7 +6756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6770,14 +6764,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_50586_RXN3O-203_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6785,11 +6790,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_136486_RXN66-313_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_136486_RXN66-313_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6807,7 +6812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6815,37 +6820,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_738a50ee-9d28-4118-adf7-395d7df26a78_RXN3O-9825_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_58349_RXN66-314_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_57783_1.3.1.71-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_57783_1.3.1.71-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6856,14 +6839,58 @@
           <http://model.geneontology.org/CHEBI_57783_1.3.1.71-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002413_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_18364_RXN66-306_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_15378_RXN66-281_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_57287_1.1.1.34-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6871,11 +6898,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6890,11 +6917,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000066_reaction_MEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000066_reaction_MEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6905,17 +6932,6 @@
           <http://model.geneontology.org/reaction_MEVALONATE-KINASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_13392_RXN3O-9826_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_GPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6925,7 +6941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6937,11 +6953,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002333_YGR060W-MONOMER_RXN3O-9822_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002333_YGR060W-MONOMER_RXN3O-9822_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6956,11 +6972,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Provides Input For Rule. The relation 'geranyl diphosphate + isopentenyl diphosphate &rarr; (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate + diphosphate' 'null' '2 (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate &rarr; presqualene diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002413_RXN-12263_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002413_RXN-12263_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6975,11 +6991,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_50586_RXN3O-203_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_50586_RXN3O-203_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6994,11 +7010,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002333_YMR220W-MONOMER_PHOSPHOMEVALONATE-KINASE-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002333_YMR220W-MONOMER_PHOSPHOMEVALONATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7013,11 +7029,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002333_YGR175C-MONOMER_RXN3O-9816_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002333_YGR175C-MONOMER_RXN3O-9816_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7035,35 +7051,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein59151> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_13390_RXN3O-9823_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_15379_RXN3O-9821_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0006696>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -7072,11 +7066,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_13392_RXN3O-9824_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_13392_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7087,15 +7081,26 @@
           <http://model.geneontology.org/CHEBI_13392_RXN3O-9824>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002413_RXN3O-203_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_15378_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_15378_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7105,28 +7110,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_58349_RXN3O-9828_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15440_RXN66-281_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_43074>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -7140,7 +7123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7148,28 +7131,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_87287_RXN3O-9822_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_15379_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/6c292b8d-35d3-4464-aa45-6427249f04f6_RXN3O-9825>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_57783_RXN3O-9827_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_15378_RXN3O-9820_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7177,11 +7157,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_18249_RXN3O-9828_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_18249_RXN3O-9828_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7201,7 +7181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7209,40 +7189,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://purl.obolibrary.org/obo/GO_0004631>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_15377_RXN3O-9827_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002413_RXN3O-9821_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004631>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7260,7 +7229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7268,28 +7237,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_3cac9700-8f1d-4bf6-a1b1-f14d98d5a7fe_RXN3O-9824_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_58349_RXN3O-9820_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002333_YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001233>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_136486_RXN66-313_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7297,11 +7277,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_13390_RXN66-281_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_13390_RXN66-281_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7312,14 +7292,14 @@
           <http://model.geneontology.org/CHEBI_13390_RXN66-281>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002233_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7332,7 +7312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7340,15 +7320,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_13390_RXN3O-9821_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_18252_RXN66-319_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_18252_RXN66-319_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7359,14 +7350,14 @@
           <http://model.geneontology.org/CHEBI_18252_RXN66-319>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002333_YGR060W-MONOMER_RXN3O-9826_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_13392_RXN3O-9821_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7374,11 +7365,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000066_reaction_RXN3O-9824_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000066_reaction_RXN3O-9824_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7389,37 +7380,15 @@
           <http://model.geneontology.org/reaction_RXN3O-9824_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002333_YLR056W-MONOMER_RXN3O-9827_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002333_YHR072W-MONOMER_LANOSTEROL-SYNTHASE-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57288_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57288_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7430,14 +7399,14 @@
           <http://model.geneontology.org/CHEBI_57288_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_57783_RXN66-319_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7450,7 +7419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7458,14 +7427,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_57783_RXN3O-9820_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_BFO_0000066_reaction_RXN3O-9821_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7473,11 +7442,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_15377_RXN3O-9828_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_15377_RXN3O-9828_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7492,11 +7461,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_15378_RXN3O-178_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_15378_RXN3O-178_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7511,11 +7480,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'lanosterol + 3 NADPH + 3 oxygen + 3 H<SUP>+</SUP> &rarr; 4,4-dimethyl-cholesta-8,14,24-trienol + formate + 3 NADP<sup>+</sup> + 4 H<sub>2</sub>O' 'null' '4,4-dimethylzymosterol + NADP<sup>+</sup> &larr; 4,4-dimethyl-cholesta-8,14,24-trienol + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002413_RXN66-306_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002413_RXN66-306_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7526,25 +7495,14 @@
           <http://model.geneontology.org/RXN66-306>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_17813_RXN3O-9820_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000066_reaction_RXN3O-9826_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7552,11 +7510,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_13390_RXN3O-9825_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_13390_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7567,15 +7525,26 @@
           <http://model.geneontology.org/CHEBI_13390_RXN3O-9825>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002233_CHEBI_15441_RXN3O-9816_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002233_CHEBI_15441_RXN3O-9816_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7586,14 +7555,14 @@
           <http://model.geneontology.org/CHEBI_15441_RXN3O-9816>
 ] .
 
-<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7606,7 +7575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7623,7 +7592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7631,15 +7600,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002333_YGR060W-MONOMER_RXN3O-9825_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_13390_RXN66-281_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_15379_RXN3O-9822_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_15379_RXN3O-9822_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7657,11 +7648,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7675,26 +7666,15 @@
 <http://identifiers.org/sgd/S000004442>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 acetyl-CoA &harr; acetoacetyl-CoA + coenzyme A' 'null' 'acetoacetyl-CoA + acetyl-CoA + H<sub>2</sub>O &harr; (<i>S</i>)-3-hydroxy-3-methylglutaryl-CoA + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002413_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002413_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7708,50 +7688,72 @@
 <http://identifiers.org/sgd/S000004617>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_15378_RXN66-319_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_13390_RXN3O-9823_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_15379_RXN3O-9827_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_36464_1.1.1.34-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_17038_RXN3O-178_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_15378_RXN66-306_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15740>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002333_YMR202W-MONOMER_RXN3O-203_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7759,11 +7761,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Provides Input For Rule. The relation '4,4-dimethylzymosterol + NADP<sup>+</sup> &larr; 4,4-dimethyl-cholesta-8,14,24-trienol + NADPH + H<SUP>+</SUP>' 'null' '4,4-dimethylzymosterol + NAD(P)H + oxygen &rarr; 4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002413_RXN3O-9821_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002413_RXN3O-9821_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7774,37 +7776,15 @@
           <http://model.geneontology.org/RXN3O-9821>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_IPPISOM-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002233_CHEBI_175763_FPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YML075C-MONOMER_1.1.1.34-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YML075C-MONOMER_1.1.1.34-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7824,7 +7804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7836,11 +7816,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_57783_RXN66-314_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_57783_RXN66-314_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7851,26 +7831,76 @@
           <http://model.geneontology.org/CHEBI_57783_RXN66-314>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_18249_RXN3O-9828_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002413_RXN3O-9816_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15377_RXN3O-9816_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15379_RXN3O-9816_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/da7fd5aa-4c92-4733-9e59-1484c64553a6_RXN3O-9826>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58948> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7881,25 +7911,25 @@
           <http://model.geneontology.org/YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_13392_RXN3O-9825_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002411_RXN3O-9825_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_15377_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_15379_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7912,9 +7942,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9826_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13392_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9826> , <http://model.geneontology.org/6c292b8d-35d3-4464-aa45-6427249f04f6_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_13392_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9826> , <http://model.geneontology.org/3eea751e-7ad3-46fc-9ae9-7e02d091de67_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/3f0937e3-8481-4225-880e-b21c39cbe539_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> ;
+                <http://model.geneontology.org/da7fd5aa-4c92-4733-9e59-1484c64553a6_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9826_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -7922,7 +7952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7934,11 +7964,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15379_RXN3O-9816_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15379_RXN3O-9816_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7949,15 +7979,26 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-9816>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002333_YNR043W-MONOMER_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002333_YGR060W-MONOMER_RXN3O-9826_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002333_YGR060W-MONOMER_RXN3O-9826_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7972,11 +8013,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7994,7 +8035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8002,26 +8043,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_15379_RXN3O-9820_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_15377_RXN3O-9823_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_15377_RXN3O-9823_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8036,11 +8066,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Provides Input For Rule. The relation 'dimethylallyl diphosphate + isopentenyl diphosphate &rarr; geranyl diphosphate + diphosphate' 'null' 'geranyl diphosphate + isopentenyl diphosphate &rarr; (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8051,14 +8081,14 @@
           <http://model.geneontology.org/FPPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_58349_RXN3O-9827_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8071,7 +8101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8083,11 +8113,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_BFO_0000066_reaction_RXN3O-9828_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_BFO_0000066_reaction_RXN3O-9828_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8098,15 +8128,26 @@
           <http://model.geneontology.org/reaction_RXN3O-9828_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002333_YHR190W-MONOMER_RXN66-281_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate &rarr; presqualene diphosphate + diphosphate' 'null' 'presqualene diphosphate + NAD(P)H + H<SUP>+</SUP> &rarr; squalene + NAD(P)<sup>+</sup> + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002413_RXN66-281_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002413_RXN66-281_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8117,15 +8158,26 @@
           <http://model.geneontology.org/RXN66-281>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_15377_RXN3O-9820_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_15377_RXN3O-9820_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8145,24 +8197,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58531> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9823>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -8173,7 +8214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8181,47 +8222,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_416e20df-e661-4cb0-8052-7ae908c232fa_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000066_reaction_LANOSTEROL-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8229,11 +8248,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8244,17 +8263,6 @@
           <http://model.geneontology.org/reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002333_YHR190W-MONOMER_RXN66-281_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57783_RXN3O-9820>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8264,13 +8272,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58623> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000066_reaction_RXN66-313_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_da7fd5aa-4c92-4733-9e59-1484c64553a6_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004833>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -8284,7 +8314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8311,7 +8341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8319,37 +8349,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002333_YLR100W-MONOMER_RXN66-314_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Provides Input For Rule. The relation '4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> &rarr; zymosterone + CO<SUB>2</SUB> + NAD(P)H' 'null' 'zymosterol + NADP<sup>+</sup> &larr; zymosterone + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002413_RXN66-319_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002413_RXN66-319_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8360,33 +8368,33 @@
           <http://model.geneontology.org/RXN66-319>
 ] .
 
+<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002333_YGR060W-MONOMER_RXN3O-9823_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_1949>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_58349_RXN3O-9820_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_64925_RXN3O-9823>
         a       <http://purl.obolibrary.org/obo/CHEBI_64925> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -8397,7 +8405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8405,15 +8413,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_17813_RXN3O-9820_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_17813_RXN3O-9820_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8424,14 +8443,14 @@
           <http://model.geneontology.org/CHEBI_17813_RXN3O-9820>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_BFO_0000066_reaction_RXN3O-9821_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8439,11 +8458,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8458,11 +8477,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002333_YHR190W-MONOMER_RXN-12263_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002333_YHR190W-MONOMER_RXN-12263_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8473,26 +8492,15 @@
           <http://model.geneontology.org/YHR190W-MONOMER_RXN-12263_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002411_RXN3O-9825_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002411_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8507,11 +8515,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002233_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002233_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8522,21 +8530,6 @@
           <http://model.geneontology.org/CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/YGL001C-MONOMER_RXN66-318_controller>
-        a       <http://identifiers.org/sgd/S000002969> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "C-3 sterol dehydrogenase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein59137> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://model.geneontology.org/CHEBI_18252_RXN66-319>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_18252> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8546,7 +8539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8573,7 +8566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8581,30 +8574,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004821> ;
+<http://model.geneontology.org/YGL001C-MONOMER_RXN66-318_controller>
+        a       <http://identifiers.org/sgd/S000002969> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "mevalonate kinase" ;
+                "C-3 sterol dehydrogenase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein58574> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein59137> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_1eb2327c-9441-4117-b261-e6841c206dce_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002234_CHEBI_50586_RXN3O-203_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002234_CHEBI_50586_RXN3O-203_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8615,6 +8619,32 @@
           <http://model.geneontology.org/CHEBI_50586_RXN3O-203>
 ] .
 
+<http://model.geneontology.org/YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004821> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "mevalonate kinase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein58574> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_BFO_0000066_reaction_RXN3O-9816_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -8622,11 +8652,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_87289_RXN3O-9821_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_87289_RXN3O-9821_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8637,26 +8667,15 @@
           <http://model.geneontology.org/CHEBI_87289_RXN3O-9821>
 ] .
 
-<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002233_CHEBI_15441_RXN3O-9816_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_456216_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_456216_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8676,7 +8695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8684,26 +8703,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_13392_RXN66-318_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_15379_RXN3O-9826_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_15379_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8714,12 +8722,31 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-9826>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_15378_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/MEVALONATE-KINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_MEVALONATE-KINASE-RXN>
+] .
+
 <http://model.geneontology.org/reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8732,7 +8759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8740,66 +8767,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_15378_MEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MEVALONATE-KINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_MEVALONATE-KINASE-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000066_reaction_RXN3O-178_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000066_reaction_RXN66-306_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002234_CHEBI_50586_RXN3O-203_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_GPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002413_1.3.1.71-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8812,57 +8787,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58449> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000066_reaction_IPPISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_57287_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_15379_RXN3O-9826_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_13390_RXN3O-9826_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN66-306>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0050613> ;
@@ -8883,7 +8814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8891,29 +8822,62 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002413_RXN3O-9824_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_15377_RXN3O-9823_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002980>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002413_LANOSTEROL-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_BFO_0000066_reaction_RXN3O-9820_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8924,33 +8888,16 @@
           <http://model.geneontology.org/CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_17038_RXN3O-178_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_456216_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/6f54693a-c945-454d-b8f1-cebecd196d9d_RXN3O-9824>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58965> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_17038_RXN3O-178>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17038> ;
@@ -8961,7 +8908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8969,14 +8916,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_18249_RXN3O-9828_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_BFO_0000066_reaction_RXN3O-9825_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57288_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8984,11 +8942,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002333_YGL001C-MONOMER_RXN66-313_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002333_YGL001C-MONOMER_RXN66-313_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8999,6 +8957,28 @@
           <http://model.geneontology.org/YGL001C-MONOMER_RXN66-313_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_136486_RXN66-313_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002413_RXN3O-9823_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57856>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -9006,11 +8986,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_58349_1.3.1.71-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_58349_1.3.1.71-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9021,14 +9001,25 @@
           <http://model.geneontology.org/CHEBI_58349_1.3.1.71-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002234_CHEBI_57623_IPPISOM-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002333_YNL280C-MONOMER_RXN66-306_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9039,7 +9030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9047,26 +9038,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_13392_RXN3O-9824_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_f9530e00-adbe-450f-bdcd-9ace56781c6d_RXN3O-9826_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_416e20df-e661-4cb0-8052-7ae908c232fa_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9074,18 +9054,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-318> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f9530e00-adbe-450f-bdcd-9ace56781c6d_RXN3O-9826>
+          <http://model.geneontology.org/416e20df-e661-4cb0-8052-7ae908c232fa_RXN3O-9826>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9105,7 +9085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9117,11 +9097,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9132,17 +9112,6 @@
           <http://model.geneontology.org/reaction_GPPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_IPPISOM-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15379_RXN3O-9816>
         a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9152,7 +9121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9164,11 +9133,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_15377_RXN3O-9827_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_15377_RXN3O-9827_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9183,11 +9152,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9198,26 +9167,32 @@
           <http://model.geneontology.org/YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_15377_RXN3O-9821_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/65cc70bc-fd73-4e92-9622-ed63b43c2ae5_RXN3O-9824>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58965> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9228,14 +9203,25 @@
           <http://model.geneontology.org/YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_15378_RXN3O-9820_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000066_reaction_PHOSPHOMEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000066_reaction_MEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9243,11 +9229,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_1949_RXN66-314_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_1949_RXN66-314_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9258,15 +9244,26 @@
           <http://model.geneontology.org/CHEBI_1949_RXN66-314>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002333_YGR060W-MONOMER_RXN3O-9821_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_57287_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_57287_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9286,7 +9283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9298,11 +9295,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_13392_RXN3O-9821_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_13392_RXN3O-9821_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9322,32 +9319,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58554> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_13390_RXN3O-9821>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_13390> ;
@@ -9358,7 +9336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9366,14 +9344,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_BFO_0000066_reaction_RXN3O-9822_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_15378_1.3.1.71-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9396,24 +9393,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1BiochemicalReaction59104> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002413_RXN66-306_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_13392_RXN3O-9821>
         a       <http://purl.obolibrary.org/obo/CHEBI_13392> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -9424,7 +9410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9432,15 +9418,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_13390_RXN3O-9826_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_13390_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9451,6 +9448,17 @@
           <http://model.geneontology.org/CHEBI_13390_RXN3O-9826>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_50586_RXN3O-203>
         a       <http://purl.obolibrary.org/obo/CHEBI_50586> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9460,7 +9468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9468,36 +9476,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000066_reaction_RXN66-314_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_18249_RXN3O-9828_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_15378_1.1.1.34-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9505,11 +9491,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_29888_RXN66-281_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_29888_RXN66-281_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9520,17 +9506,6 @@
           <http://model.geneontology.org/CHEBI_29888_RXN66-281>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002333_YMR220W-MONOMER_PHOSPHOMEVALONATE-KINASE-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_18249_RXN3O-9828>
         a       <http://purl.obolibrary.org/obo/CHEBI_18249> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9540,7 +9515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9552,11 +9527,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002333_YLR100W-MONOMER_RXN66-319_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002333_YLR100W-MONOMER_RXN66-319_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9586,7 +9561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9594,14 +9569,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002333_YPL117C-MONOMER_IPPISOM-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002413_RXN-12263_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9609,11 +9584,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_13390_RXN3O-9823_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_13390_RXN3O-9823_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9624,14 +9599,47 @@
           <http://model.geneontology.org/CHEBI_13390_RXN3O-9823>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002413_RXN3O-9822_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_15377_RXN3O-9820_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_15379_RXN3O-9820_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002333_YMR202W-MONOMER_RXN3O-203_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9640,18 +9648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002333_YNR043W-MONOMER_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9662,7 +9659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9674,11 +9671,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_58349_RXN3O-9828_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_58349_RXN3O-9828_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9693,11 +9690,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_57856_RXN3O-178_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_57856_RXN3O-178_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9708,26 +9705,15 @@
           <http://model.geneontology.org/CHEBI_57856_RXN3O-178>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_BFO_0000066_reaction_RXN3O-9821_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_BFO_0000066_reaction_RXN3O-9821_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9738,28 +9724,6 @@
           <http://model.geneontology.org/reaction_RXN3O-9821_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002333_YLR100W-MONOMER_RXN66-319_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_MEVALONATE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9769,7 +9733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9781,11 +9745,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_738a50ee-9d28-4118-adf7-395d7df26a78_RXN3O-9825_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_1eb2327c-9441-4117-b261-e6841c206dce_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9793,29 +9757,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/738a50ee-9d28-4118-adf7-395d7df26a78_RXN3O-9825>
+          <http://model.geneontology.org/1eb2327c-9441-4117-b261-e6841c206dce_RXN3O-9825>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002333_YHR190W-MONOMER_RXN-12263_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002333_YHR072W-MONOMER_LANOSTEROL-SYNTHASE-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002333_YHR072W-MONOMER_LANOSTEROL-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9826,17 +9779,6 @@
           <http://model.geneontology.org/YHR072W-MONOMER_LANOSTEROL-SYNTHASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002413_RXN66-318_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58349_RXN66-319>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9846,7 +9788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9854,37 +9796,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_58349_RXN66-306_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_13390_RXN3O-9822_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_13390_RXN3O-9822_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9899,11 +9819,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9914,14 +9834,14 @@
           <http://model.geneontology.org/CHEBI_175763_FPPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_15740_RXN3O-9820_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9934,7 +9854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9951,7 +9871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9963,11 +9883,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000066_reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000066_reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9978,19 +9898,19 @@
           <http://model.geneontology.org/reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_50586>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_57287_1.1.1.34-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_52972_RXN3O-9827_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_50586>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57783_RXN3O-9827>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
@@ -10001,7 +9921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10013,11 +9933,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15339_RXN3O-9816_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15339_RXN3O-9816_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10031,30 +9951,63 @@
 <http://purl.obolibrary.org/obo/CHEBI_128769>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_15379_RXN3O-9825_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_18249_RXN3O-9828_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002413_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002413_RXN3O-178_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_IPPISOM-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_1949_RXN66-314_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN66-314>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0102176> ;
@@ -10075,7 +10028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10102,7 +10055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10113,16 +10066,8 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002413_RXN3O-9823_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/531a4b6f-c29b-4d85-a97f-81db11cd50a5_RXN3O-9824>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9821_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003292> ;
@@ -10131,7 +10076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10139,26 +10084,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_57310_RXN-12263_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10176,7 +10110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10184,14 +10118,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YML075C-MONOMER_1.1.1.34-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002233_CHEBI_17038_RXN3O-178_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10202,7 +10136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10210,40 +10144,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_15378_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004337>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_58349_RXN3O-9827_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_58349_RXN66-314_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_58349_RXN66-314_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10261,7 +10184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10269,37 +10192,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_13390_RXN3O-9825_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000066_reaction_RXN3O-9823_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_13392_RXN66-281_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_13392_RXN66-281_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10329,35 +10230,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1BiochemicalReaction59154> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -10371,7 +10250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10383,11 +10262,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10402,11 +10281,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10417,17 +10296,6 @@
           <http://model.geneontology.org/CHEBI_30616_PHOSPHOMEVALONATE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_15377_RXN3O-9820_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -10435,11 +10303,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002333_YGR060W-MONOMER_RXN3O-9823_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002333_YGR060W-MONOMER_RXN3O-9823_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10453,15 +10321,26 @@
 <http://purl.obolibrary.org/obo/GO_0000250>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002413_1.1.1.34-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10481,7 +10360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10493,11 +10372,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_15379_RXN3O-9828_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_15379_RXN3O-9828_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10508,26 +10387,15 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-9828>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_15378_RXN3O-178_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000066_reaction_RXN3O-178_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000066_reaction_RXN3O-178_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10538,15 +10406,26 @@
           <http://model.geneontology.org/reaction_RXN3O-178_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000066_reaction_RXN3O-9824_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_17813_RXN3O-9820_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_17813_RXN3O-9820_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10562,7 +10441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10570,11 +10449,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_13392_RXN3O-9825_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_13392_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10589,11 +10468,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'isopentenyl diphosphate &harr; dimethylallyl diphosphate' 'null' 'dimethylallyl diphosphate + isopentenyl diphosphate &rarr; geranyl diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002413_GPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002413_GPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10623,7 +10502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10640,7 +10519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10657,7 +10536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10665,17 +10544,47 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0004452>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_3f0937e3-8481-4225-880e-b21c39cbe539_RXN3O-9826_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_58349_RXN66-314_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_58349_1.1.1.34-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000066_reaction_LANOSTEROL-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_16526_RXN66-318_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10688,7 +10597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10700,11 +10609,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10715,43 +10624,82 @@
           <http://model.geneontology.org/CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://purl.obolibrary.org/obo/GO_0004452>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YML075C-MONOMER_1.1.1.34-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/3eea751e-7ad3-46fc-9ae9-7e02d091de67_RXN3O-9825>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_57783_RXN66-319_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004420>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_59789>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_59789>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000066_reaction_RXN66-319_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000066_reaction_RXN66-319_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10771,7 +10719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10782,28 +10730,17 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_36464>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000066_reaction_RXN3O-9826_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_IPPISOM-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10811,11 +10748,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_18364_RXN66-306_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_18364_RXN66-306_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10826,37 +10763,15 @@
           <http://model.geneontology.org/CHEBI_18364_RXN66-306>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_15378_MEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_57287_1.1.1.34-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_57287_1.1.1.34-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10867,68 +10782,35 @@
           <http://model.geneontology.org/CHEBI_57287_1.1.1.34-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_87287_RXN3O-9822_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002333_YGR060W-MONOMER_RXN3O-9826_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_13392_RXN66-281_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005224>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000004540>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002413_RXN66-313_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_BFO_0000066_reaction_RXN3O-9825_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_BFO_0000066_reaction_RXN3O-9825_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10946,7 +10828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10958,11 +10840,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002333_YPL117C-MONOMER_IPPISOM-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002333_YPL117C-MONOMER_IPPISOM-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10973,19 +10855,30 @@
           <http://model.geneontology.org/YPL117C-MONOMER_IPPISOM-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_MEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_29888_RXN-12263_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002333_YGL012W-MONOMER_1.3.1.71-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-9823>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000254> ;
@@ -11006,7 +10899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11018,11 +10911,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Provides Input For Rule. The relation 'fecosterol &rarr; episterol' 'null' 'episterol + NADPH + oxygen + H<SUP>+</SUP> &rarr; ergosta-5,7,24(28)-trien-3&beta;-ol + NADP<sup>+</sup> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002413_RXN3O-9827_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002413_RXN3O-9827_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11037,11 +10930,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '4,4-dimethylzymosterol + NAD(P)H + oxygen &rarr; 4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + H<sub>2</sub>O' 'null' '4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)H + oxygen &rarr; 4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002413_RXN3O-9822_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002413_RXN3O-9822_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11056,11 +10949,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(R)-mevalonate diphosphate + ATP &rarr; CO<SUB>2</SUB> + isopentenyl diphosphate + ADP + phosphate' 'null' 'dimethylallyl diphosphate + isopentenyl diphosphate &rarr; geranyl diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_GPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_GPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11075,11 +10968,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_13390_RXN3O-9826_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_13390_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11090,15 +10983,26 @@
           <http://model.geneontology.org/CHEBI_13390_RXN3O-9826>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002234_CHEBI_57623_IPPISOM-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11109,14 +11013,36 @@
           <http://model.geneontology.org/CHEBI_58146_MEVALONATE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000066_reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15441_RXN3O-9816_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_13392_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002333_YGR175C-MONOMER_RXN3O-9816_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11129,7 +11055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11141,11 +11067,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_15379_RXN3O-9823_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_15379_RXN3O-9823_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11160,11 +11086,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11175,41 +11101,8 @@
           <http://model.geneontology.org/CHEBI_29888_GPPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_18364_RXN66-306_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_52972>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_15377_RXN3O-9826_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57286> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -11220,7 +11113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11228,8 +11121,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/f9530e00-adbe-450f-bdcd-9ace56781c6d_RXN3O-9826>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002413_RXN3O-9820_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9820>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -11240,13 +11141,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58680> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002333_YML126C-MONOMER_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGL012W-MONOMER_1.3.1.71-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002980> ;
@@ -11255,7 +11167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11272,7 +11184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11283,14 +11195,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_58146>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_87289_RXN3O-9821_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11303,7 +11215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11315,11 +11227,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11330,65 +11242,32 @@
           <http://model.geneontology.org/YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_13390_RXN3O-9824_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002413_RXN-12263_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_52386>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_16526_RXN66-318_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_16526_RXN66-318_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11418,7 +11297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11435,7 +11314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11450,11 +11329,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11468,14 +11347,14 @@
 <http://purl.obolibrary.org/obo/GO_0102176>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15379_RXN3O-9816_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_57783_1.1.1.34-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11483,11 +11362,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_58349_RXN3O-9827_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_58349_RXN3O-9827_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11502,11 +11381,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002233_CHEBI_175763_FPPSYN-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002233_CHEBI_175763_FPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11521,11 +11400,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_15378_RXN3O-9820_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_15378_RXN3O-9820_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11539,15 +11418,59 @@
 <http://purl.obolibrary.org/obo/CHEBI_57310>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_64925_RXN3O-9823_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_87289_RXN3O-9821_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002413_RXN3O-9821_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15440_RXN66-281_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_15377_RXN3O-9824_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_15377_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11558,15 +11481,37 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-9824>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002333_YLR100W-MONOMER_RXN66-314_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'acetoacetyl-CoA + acetyl-CoA + H<sub>2</sub>O &harr; (<i>S</i>)-3-hydroxy-3-methylglutaryl-CoA + coenzyme A + H<SUP>+</SUP>' 'null' '(<i>R</i>)-mevalonate + coenzyme A + 2 NADP<sup>+</sup> &harr; (<i>S</i>)-3-hydroxy-3-methylglutaryl-CoA + 2 NADPH + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002413_1.1.1.34-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002413_1.1.1.34-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11577,17 +11522,6 @@
           <http://model.geneontology.org/1.1.1.34-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_BFO_0000066_reaction_RXN3O-9827_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57286>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -11595,11 +11529,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11610,14 +11544,14 @@
           <http://model.geneontology.org/YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000066_reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11625,11 +11559,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_18364_RXN66-306_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_18364_RXN66-306_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11647,11 +11581,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11671,7 +11605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11688,7 +11622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11696,15 +11630,103 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000066_reaction_RXN3O-178_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002333_YGR060W-MONOMER_RXN3O-9824_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_136486>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_13392_RXN66-318_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002413_RXN66-306_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002333_YGL001C-MONOMER_RXN66-318_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002333_YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_17499_RXN3O-9816_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN3O-9823_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11712,11 +11734,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'presqualene diphosphate + NAD(P)H + H<SUP>+</SUP> &rarr; squalene + NAD(P)<sup>+</sup> + diphosphate' 'null' 'squalene + a reduced electron acceptor + oxygen &rarr; (3<i>S</i>)-2,3-epoxy-2,3-dihydrosqualene + an oxidized electron acceptor + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002413_RXN3O-9816_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002413_RXN3O-9816_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11732,7 +11754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11740,11 +11762,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11758,47 +11780,36 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000066_reaction_RXN3O-9823_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002333_YGR060W-MONOMER_RXN3O-9821_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_13390_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_29888_RXN-12263_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_13392_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_52972_RXN3O-9827_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11811,7 +11822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11823,11 +11834,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_13392_RXN66-313_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_13392_RXN66-313_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11838,14 +11849,25 @@
           <http://model.geneontology.org/CHEBI_13392_RXN66-313>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_BFO_0000066_reaction_RXN3O-9828_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002333_YMR220W-MONOMER_PHOSPHOMEVALONATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11853,11 +11875,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ergosta-5,7,24(28)-trien-3&beta;-ol + NADPH + oxygen + H<SUP>+</SUP> &rarr; ergosta-5,7,22,24(28)-tetraen-3-&beta;-ol + NADP<sup>+</sup> + 2 H<sub>2</sub>O' 'null' 'ergosterol + NADP<sup>+</sup> &larr; ergosta-5,7,22,24(28)-tetraen-3-&beta;-ol + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002413_1.3.1.71-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002413_1.3.1.71-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11868,14 +11890,14 @@
           <http://model.geneontology.org/1.3.1.71-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000066_reaction_RXN66-319_location_lociGO_0005829_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002333_YHR007C-MONOMER_RXN3O-9820_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11883,11 +11905,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + zymosterol &rarr; <i>S</i>-adenosyl-L-homocysteine + fecosterol + H<SUP>+</SUP>' 'null' 'fecosterol &rarr; episterol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002413_RXN3O-203_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002413_RXN3O-203_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11907,7 +11929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11919,11 +11941,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002411_RXN3O-9826_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002411_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11943,7 +11965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11955,11 +11977,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11977,7 +11999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11992,11 +12014,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_87287_RXN3O-9822_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_87287_RXN3O-9822_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12007,14 +12029,14 @@
           <http://model.geneontology.org/CHEBI_87287_RXN3O-9822>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002413_RXN66-281_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12022,11 +12044,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12046,7 +12068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12054,26 +12076,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002333_YHR007C-MONOMER_RXN3O-9820_controller_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_15379_RXN3O-9827_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_15379_RXN3O-9827_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12084,26 +12095,15 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-9827>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12114,15 +12114,26 @@
           <http://model.geneontology.org/CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_13390_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15441_RXN3O-9816_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15441_RXN3O-9816_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12132,14 +12143,3 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15441_RXN3O-9816>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_15377_RXN3O-9825_SGD_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_FASYN-ELONG2-PWY.ttl
+++ b/models/YeastPathways_FASYN-ELONG2-PWY.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,15 +17,26 @@
           <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002233_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002233_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,37 +47,15 @@
           <http://model.geneontology.org/OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -86,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -94,14 +83,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -114,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,31 +111,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002411_RXN3O-9780_SGD_YeastPathways_FASYN-ELONG2-PWY>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002413_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -154,11 +143,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -173,11 +162,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,19 +177,19 @@
           <http://model.geneontology.org/CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_7896>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_7896>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -208,14 +197,47 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -223,11 +245,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -245,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -257,11 +279,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,17 +294,6 @@
           <http://model.geneontology.org/CHEBI_57379_RXN3O-9780>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -290,11 +301,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000066_reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000066_reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -305,29 +316,40 @@
           <http://model.geneontology.org/reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002333_YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" , "Provides Input For Rule. The relation 'a 2,3,4-saturated fatty acyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; acyl-carrier protein + a 3-oxoacyl-[acp] + CO<SUB>2</SUB>' 'null' 'a (3<i>R</i>)-3-hydroxyacyl-[acyl-carrier protein] + NADP<sup>+</sup> &larr; a 3-oxoacyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002413_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002413_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,26 +360,15 @@
           <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN3O-9780_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002333_YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002333_YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,76 +379,54 @@
           <http://model.geneontology.org/YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004316>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002233_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000863>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000066_reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -455,11 +444,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -482,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -490,25 +479,80 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -516,11 +560,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -535,11 +579,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -553,26 +597,15 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -586,17 +619,6 @@
 <http://identifiers.org/sgd/S000001538>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57379>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -607,11 +629,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -626,11 +648,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -641,6 +663,28 @@
           <http://model.geneontology.org/CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -650,7 +694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -661,62 +705,51 @@
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_YeastPathways_FASYN-ELONG2-PWY>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_YeastPathways_FASYN-ELONG2-PWY>
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002333_YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002413_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002333_YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxyacyl-[acyl-carrier protein] + NADP<sup>+</sup> &larr; a 3-oxoacyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (3<i>R</i>)-3-hydroxyacyl-[acyl-carrier protein] &rarr; a <i>trans</i>-2-enoyl-[acyl-carrier protein] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002413_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002413_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -727,26 +760,15 @@
           <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN3O-9780_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN3O-9780_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,6 +778,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/Palmitoyl-ACPs_RXN3O-9780>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -772,7 +805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -791,18 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -810,11 +832,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -829,11 +851,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -844,26 +866,15 @@
           <http://model.geneontology.org/CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002333_YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002333_YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -873,6 +884,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0030497>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -896,7 +918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -904,30 +926,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -938,7 +938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -946,15 +946,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,11 +980,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1002,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1010,28 +1021,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000066_reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1039,11 +1039,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1054,26 +1054,15 @@
           <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1087,25 +1076,14 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002333_YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller_SGD_YeastPathways_FASYN-ELONG2-PWY>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1113,11 +1091,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1128,17 +1106,6 @@
           <http://model.geneontology.org/CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1148,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1169,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1181,11 +1148,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxyacyl-[acyl-carrier protein] &rarr; a <i>trans</i>-2-enoyl-[acyl-carrier protein] + H<sub>2</sub>O' 'null' 'a 2,3,4-saturated fatty acyl-[acp] + NADP<sup>+</sup> &larr; a <i>trans</i>-2-enoyl-[acyl-carrier protein] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002413_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002413_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1203,11 +1170,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1218,14 +1185,14 @@
           <http://model.geneontology.org/YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1238,7 +1205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1258,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fatty acid elongation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1266,25 +1233,14 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000066_reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_FASYN-ELONG2-PWY>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1292,11 +1248,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1311,11 +1267,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1326,25 +1282,25 @@
           <http://model.geneontology.org/reaction_RXN3O-9780_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_SGD_YeastPathways_FASYN-ELONG2-PWY>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002413_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1357,7 +1313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1365,14 +1321,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002413_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002411_RXN3O-9780_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1395,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1407,11 +1363,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1426,11 +1382,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000066_reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000066_reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1448,7 +1404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1465,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1477,11 +1433,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1491,28 +1447,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/ACP_ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1536,24 +1470,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FASYN-ELONG2-PWYBiochemicalReaction21260> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1563,7 +1486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1576,7 +1499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1584,15 +1507,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1607,11 +1541,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1622,17 +1556,6 @@
           <http://model.geneontology.org/CHEBI_57379_RXN3O-9780>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000066_reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0030497> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1642,7 +1565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1662,13 +1585,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FASYN-ELONG2-PWYSmallMolecule21219> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN3O-9780_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1689,7 +1623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1701,11 +1635,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1720,11 +1654,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1742,24 +1676,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FASYN-ELONG2-PWYProtein21105> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1770,7 +1693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1778,15 +1701,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002233_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1797,14 +1731,25 @@
           <http://model.geneontology.org/YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002413_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1813,7 +1758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1821,11 +1766,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1844,7 +1789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1852,11 +1797,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1876,7 +1821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1888,11 +1833,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002411_RXN3O-9780_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002411_RXN3O-9780_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1906,23 +1851,12 @@
 <http://purl.obolibrary.org/obo/GO_0004315>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-9780_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1935,7 +1869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1950,7 +1884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1967,13 +1901,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FASYN-ELONG2-PWYSmallMolecule21122> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-9780>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1994,7 +1939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2006,11 +1951,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2021,15 +1966,18 @@
           <http://model.geneontology.org/CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2040,8 +1988,16 @@
           <http://model.geneontology.org/CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -2056,7 +2012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2073,7 +2029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2085,11 +2041,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2100,6 +2056,17 @@
           <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002413_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2109,7 +2076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2121,11 +2088,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a palmitoyl-[acp] + coenzyme A &rarr; palmitoyl-CoA + acyl-carrier protein' 'null' 'palmitoyl-CoA + H<sub>2</sub>O &rarr; palmitate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2136,26 +2103,15 @@
           <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2166,6 +2122,17 @@
           <http://model.geneontology.org/CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57287> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2175,7 +2142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2186,15 +2153,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2210,7 +2188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2218,11 +2196,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2242,7 +2220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2250,14 +2228,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2265,11 +2265,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2289,7 +2289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2306,7 +2306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2318,11 +2318,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_YeastPathways_FASYN-ELONG2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2333,25 +2333,14 @@
           <http://model.geneontology.org/CHEBI_57287_RXN3O-9780>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000050_YeastPathways_FASYN-ELONG2-PWY/YeastPathways_FASYN-ELONG2-PWY_SGD_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FASYN-ELONG2-PWY" ;
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2362,10 +2351,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FASYN-ELONG2-PWYProtein21257> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_FOLSYN-PWY-1.ttl
+++ b/models/YeastPathways_FOLSYN-PWY-1.ttl
@@ -1,23 +1,12 @@
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_2e23746e-617f-41a1-afa5-c92072427778_GLYOHMETRANS-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_491cb219-ea5d-416b-b431-71d4450af4a5_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,11 +14,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2e23746e-617f-41a1-afa5-c92072427778_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/491cb219-ea5d-416b-b431-71d4450af4a5_GLYOHMETRANS-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0046820>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_491cb219-ea5d-416b-b431-71d4450af4a5_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003093>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -58,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -66,26 +63,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_9ba92fb1-5065-4070-9e56-88db36709397_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0046820>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -100,11 +89,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -118,17 +107,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -138,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -146,37 +124,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YPL023C-MONOMER_RXN3O-9789_controller_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -187,26 +143,15 @@
           <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_1.5.1.15-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -217,32 +162,43 @@
           <http://model.geneontology.org/1.5.1.15-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_17071>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -253,25 +209,25 @@
           <http://model.geneontology.org/YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -279,11 +235,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Provides Input For Rule. The relation 'GTP + H<sub>2</sub>O &rarr; formate + 7,8-dihydroneopterin 3'-triphosphate + H<SUP>+</SUP>' 'null' '7,8-dihydroneopterin 3'-triphosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin 3'-phosphate + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -294,32 +250,40 @@
           <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
-<http://model.geneontology.org/569e793c-d90c-4f1e-ac08-e637bca24a7a_GCVMULTI-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -339,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -347,42 +311,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/f1a80e3d-2b57-4c5f-8cd3-a46f6f8f3db7_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_2665d435-44fb-457b-a7de-f7489637eaad_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -390,11 +337,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GCVMULTI-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -405,15 +352,59 @@
           <http://model.geneontology.org/GCVMULTI-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_15378_RXN3O-9789_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_15378_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -424,19 +415,38 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-9789>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_6db40862-b841-40f3-b224-6767737c0932_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -445,11 +455,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -464,11 +474,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -479,23 +489,15 @@
           <http://model.geneontology.org/CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -503,11 +505,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,18 +525,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -547,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -555,37 +557,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -596,15 +576,26 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_84b4901d-cbec-433e-a320-2a22b55005ec_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_6db40862-b841-40f3-b224-6767737c0932_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,7 +603,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/84b4901d-cbec-433e-a320-2a22b55005ec_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/6db40862-b841-40f3-b224-6767737c0932_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
@@ -634,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -645,37 +636,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Provides Input For Rule. The relation 'L-glutamate + 7,8-dihydropteroate + ATP &rarr; ADP + 7,8-dihydrofolate monoglutamate + phosphate + H<SUP>+</SUP>' 'null' 'a tetrahydrofolate + NADP<sup>+</sup> &larr; a 7,8-dihydrofolate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -690,11 +659,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -714,13 +683,38 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60240> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_29985>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_44841_H2NEOPTERINALDOL-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_44841> ;
@@ -731,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -742,40 +736,51 @@
 <http://identifiers.org/sgd/S000004801>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_29985>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/5772f0df-4884-4529-ba7b-be7ed151deb9_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -790,11 +795,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -805,14 +810,39 @@
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000066_reaction_RXN3O-9789_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/f98d555b-3e4b-4c8e-ad68-e63e1b6f0a13_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -825,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -833,14 +863,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_b6bd7f91-be90-4c69-ad89-3a075c88df8e_FORMATETHFLIG-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -848,30 +878,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_9a5d93c2-7c03-4692-a63e-a85bb9e89456_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_ad112016-44eb-44fa-ae01-9409044476fe_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9a5d93c2-7c03-4692-a63e-a85bb9e89456_DIHYDROFOLATEREDUCT-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_2665d435-44fb-457b-a7de-f7489637eaad_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -879,8 +890,49 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2665d435-44fb-457b-a7de-f7489637eaad_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/ad112016-44eb-44fa-ae01-9409044476fe_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_59bf992c-078c-439b-a224-ed559c39e8f9_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/59bf992c-078c-439b-a224-ed559c39e8f9_DIHYDROFOLATEREDUCT-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_7065e207-6a9a-4413-8e46-d2716a2bc5cb_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_c4a18306-80f9-453b-a3ce-8d7ebc00438d_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -889,11 +941,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -908,11 +960,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -923,78 +975,45 @@
           <http://model.geneontology.org/CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_569e793c-d90c-4f1e-ac08-e637bca24a7a_GCVMULTI-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_4b2dd6eb-c348-4609-ae78-88f3f2ef9958_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1003,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1011,11 +1030,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1026,14 +1045,14 @@
           <http://model.geneontology.org/YNR033W-MONOMER_PABASYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_15378_RXN3O-9789_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1044,7 +1063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1060,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1068,11 +1087,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1087,11 +1106,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '7,8-dihydroneopterin &rarr; glycolaldehyde + 6-(hydroxymethyl)-7,8-dihydropterin' 'null' '6-(hydroxymethyl)-7,8-dihydropterin + ATP &rarr; (7,8-dihydropterin-6-yl)methyl diphosphate + AMP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1102,26 +1121,21 @@
           <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/97afffad-9d24-4bd3-a96c-b05cacb31aff_1.5.1.15-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://purl.obolibrary.org/obo/CHEBI_33384>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1132,45 +1146,17 @@
           <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_33384>
+<http://purl.obolibrary.org/obo/GO_0004150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004487>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/d41a57ec-bd13-42ba-ae83-d88e3555272d_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+<http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005600> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/aabcf0a8-1a54-434d-b0dd-342a0fa9f989_THYMIDYLATESYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60073> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
         a       <http://identifiers.org/sgd/S000003436> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1179,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1191,11 +1177,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1206,95 +1192,15 @@
           <http://model.geneontology.org/MONOMER3O-131_ADCLY-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002426> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/9a5d93c2-7c03-4692-a63e-a85bb9e89456_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATESYNTH-RXN>
-] .
-
-<http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000288> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "mitochondrial C1-tetrahydrofolate synthase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1Protein59867> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://purl.obolibrary.org/obo/CHEBI_456215>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005600> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1305,8 +1211,98 @@
           <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004150>
+<http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002426> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004487>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000288> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "mitochondrial C1-tetrahydrofolate synthase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1Protein59867> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATESYNTH-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_456215>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ADCLY-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0008696> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1327,7 +1323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1335,22 +1331,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/80eb82c9-4c40-40a3-a71e-8b206a5db537_RXN3O-9789>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59802> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003848>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1358,15 +1348,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_57451>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1386,7 +1387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1394,17 +1395,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/b6bd7f91-be90-4c69-ad89-3a075c88df8e_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YGL125W-MONOMER_RXN3O-9789_controller_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1417,7 +1426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1425,14 +1434,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1440,11 +1449,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1455,35 +1464,29 @@
           <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/0a2b3403-33d2-42cc-9735-d734d04cfdd2_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_ad112016-44eb-44fa-ae01-9409044476fe_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001876>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_246422>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '7,8-dihydroneopterin 3'-phosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin + phosphate' 'null' '7,8-dihydroneopterin &rarr; glycolaldehyde + 6-(hydroxymethyl)-7,8-dihydropterin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1494,26 +1497,29 @@
           <http://model.geneontology.org/H2NEOPTERINALDOL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_246422>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_d68f3af6-c14b-4007-be19-82f34ca02c61_1.5.1.15-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_3d2808a2-08b9-4969-b371-d65d0a89aafc_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1521,17 +1527,56 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d68f3af6-c14b-4007-be19-82f34ca02c61_1.5.1.15-RXN>
+          <http://model.geneontology.org/3d2808a2-08b9-4969-b371-d65d0a89aafc_1.5.1.15-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_f1a80e3d-2b57-4c5f-8cd3-a46f6f8f3db7_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_aae9d28f-7ecf-4636-a8d3-822e4228b3b8_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ef4708c7-4d57-4442-b22a-7fda458335e8_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60091> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1539,11 +1584,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1558,11 +1603,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1573,31 +1618,31 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15377>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/efdb1e9e-4a74-421f-8790-e8362eeeeda7_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59839> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1610,9 +1655,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/9a5d93c2-7c03-4692-a63e-a85bb9e89456_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/59bf992c-078c-439b-a224-ed559c39e8f9_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/d3713987-8a2c-4fd3-a2bc-6e571b453a21_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/ef4708c7-4d57-4442-b22a-7fda458335e8_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1620,7 +1665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1628,27 +1673,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_d41a57ec-bd13-42ba-ae83-d88e3555272d_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1659,7 +1688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1667,26 +1696,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '6-(hydroxymethyl)-7,8-dihydropterin + ATP &rarr; (7,8-dihydropterin-6-yl)methyl diphosphate + AMP + H<SUP>+</SUP>' 'null' '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1701,11 +1719,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1716,29 +1734,40 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1749,6 +1778,28 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1758,7 +1809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1775,7 +1826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1792,7 +1843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1807,11 +1858,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1822,44 +1873,22 @@
           <http://model.geneontology.org/GLYOHMETRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15740>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1868,11 +1897,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1887,11 +1916,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1902,14 +1931,14 @@
           <http://model.geneontology.org/reaction_ADCLY-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1917,11 +1946,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1936,11 +1965,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_CHEBI_13390_RXN3O-9789_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_CHEBI_13390_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1950,17 +1979,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_13390_RXN3O-9789>
 ] .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1974,9 +1992,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/834653ac-38bb-4431-bc56-dd6faec2dff9_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/97afffad-9d24-4bd3-a96c-b05cacb31aff_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/2665d435-44fb-457b-a7de-f7489637eaad_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/ad112016-44eb-44fa-ae01-9409044476fe_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1984,7 +2002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1992,34 +2010,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_b6bd7f91-be90-4c69-ad89-3a075c88df8e_FORMATETHFLIG-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b6bd7f91-be90-4c69-ad89-3a075c88df8e_FORMATETHFLIG-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2030,12 +2040,31 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_1776eea8-97af-49ae-98bb-eea567ad1b25_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/1776eea8-97af-49ae-98bb-eea567ad1b25_FORMATETHFLIG-RXN>
+] .
+
 <http://model.geneontology.org/reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2048,9 +2077,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/008504b8-e26b-4a35-9b11-a1cc68e5a5f4_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/054c3b0b-0214-4a55-b5ae-d35b60071dc1_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/aabcf0a8-1a54-434d-b0dd-342a0fa9f989_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/221ee795-ae83-42fe-a1ba-2adea78dec40_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2058,7 +2087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2069,17 +2098,6 @@
 <http://purl.obolibrary.org/obo/GO_0004156>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2089,7 +2107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2119,7 +2137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2127,49 +2145,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glu" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60190> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2180,15 +2178,52 @@
           <http://model.geneontology.org/CHEBI_37565_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "glu" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60190> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/3d2808a2-08b9-4969-b371-d65d0a89aafc_1.5.1.15-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59839> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2199,14 +2234,25 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YGL125W-MONOMER_RXN3O-9789_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2219,7 +2265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2227,19 +2273,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2248,11 +2305,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2263,26 +2320,15 @@
           <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2302,7 +2348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2310,25 +2356,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_ADCLY-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_d3713987-8a2c-4fd3-a2bc-6e571b453a21_FORMATETHFLIG-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2336,11 +2371,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_885ace2c-0200-45c3-b15b-e268c7c08790_THYMIDYLATESYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_c4a18306-80f9-453b-a3ce-8d7ebc00438d_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2348,18 +2383,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/885ace2c-0200-45c3-b15b-e268c7c08790_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/c4a18306-80f9-453b-a3ce-8d7ebc00438d_THYMIDYLATESYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2374,11 +2409,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2389,15 +2424,26 @@
           <http://model.geneontology.org/CHEBI_15378_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_221ee795-ae83-42fe-a1ba-2adea78dec40_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2411,12 +2457,23 @@
 <http://purl.obolibrary.org/obo/GO_0008696>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_CHEBI_13390_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2437,7 +2494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2445,14 +2502,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_efdb1e9e-4a74-421f-8790-e8362eeeeda7_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2465,7 +2522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2477,11 +2534,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2496,11 +2553,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Provides Input For Rule. The relation 'L-glutamine + chorismate &harr; 4-amino-4-deoxychorismate + L-glutamate' 'null' '4-amino-4-deoxychorismate &rarr; 4-aminobenzoate + pyruvate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2511,14 +2568,14 @@
           <http://model.geneontology.org/ADCLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2531,7 +2588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2539,14 +2596,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_1776eea8-97af-49ae-98bb-eea567ad1b25_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2554,11 +2611,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2573,11 +2630,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2597,9 +2654,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/b6bd7f91-be90-4c69-ad89-3a075c88df8e_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/1776eea8-97af-49ae-98bb-eea567ad1b25_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/387e76b0-0668-4e8e-ae27-2c1ac6122582_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/efdb1e9e-4a74-421f-8790-e8362eeeeda7_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2607,7 +2664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2615,54 +2672,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/2665d435-44fb-457b-a7de-f7489637eaad_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2673,26 +2691,15 @@
           <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Provides Input For Rule. The relation '4-amino-4-deoxychorismate &rarr; 4-aminobenzoate + pyruvate + H<SUP>+</SUP>' 'null' '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2703,14 +2710,25 @@
           <http://model.geneontology.org/H2PTEROATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2719,22 +2737,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2749,11 +2778,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2776,7 +2805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2784,25 +2813,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_885ace2c-0200-45c3-b15b-e268c7c08790_THYMIDYLATESYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2810,11 +2839,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2825,17 +2854,36 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/9ba92fb1-5065-4070-9e56-88db36709397_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2843,11 +2891,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2858,25 +2906,14 @@
           <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2887,11 +2924,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2902,25 +2939,14 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2928,11 +2954,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2943,35 +2969,29 @@
           <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller>
 ] .
 
-<http://model.geneontology.org/2e23746e-617f-41a1-afa5-c92072427778_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
+<http://purl.obolibrary.org/obo/CHEBI_17001>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_17001>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2986,11 +3006,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3010,7 +3030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3030,7 +3050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3044,26 +3064,32 @@
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/4b2dd6eb-c348-4609-ae78-88f3f2ef9958_RXN3O-9789>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59802> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3078,11 +3104,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3097,11 +3123,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3112,28 +3138,39 @@
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000003499>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003499>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_15378_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3141,11 +3178,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3160,11 +3197,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3179,11 +3216,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3198,11 +3235,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3213,22 +3250,27 @@
           <http://model.geneontology.org/reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/d3713987-8a2c-4fd3-a2bc-6e571b453a21_FORMATETHFLIG-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60091> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004048>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3248,7 +3290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3260,11 +3302,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3279,11 +3321,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3297,6 +3339,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_17839>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_5772f0df-4884-4529-ba7b-be7ed151deb9_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
         a       <http://identifiers.org/sgd/S000005762> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3304,7 +3357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3312,26 +3365,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3342,26 +3384,15 @@
           <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_80eb82c9-4c40-40a3-a71e-8b206a5db537_RXN3O-9789_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_4b2dd6eb-c348-4609-ae78-88f3f2ef9958_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3369,40 +3400,71 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/80eb82c9-4c40-40a3-a71e-8b206a5db537_RXN3O-9789>
+          <http://model.geneontology.org/4b2dd6eb-c348-4609-ae78-88f3f2ef9958_RXN3O-9789>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_aabcf0a8-1a54-434d-b0dd-342a0fa9f989_THYMIDYLATESYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/221ee795-ae83-42fe-a1ba-2adea78dec40_THYMIDYLATESYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60073> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/c4a18306-80f9-453b-a3ce-8d7ebc00438d_THYMIDYLATESYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3417,11 +3479,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3441,13 +3503,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60376> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3458,89 +3531,12 @@
 <http://purl.obolibrary.org/obo/GO_0035999>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3548,11 +3544,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3563,25 +3559,36 @@
           <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_d24d3c1a-6946-4abc-af85-0badb5e65b66_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3589,11 +3596,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3604,6 +3611,20 @@
           <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
 ] .
 
+<http://model.geneontology.org/59bf992c-078c-439b-a224-ed559c39e8f9_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller>
         a       <http://identifiers.org/sgd/S000004719> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3611,7 +3632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3628,7 +3649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3640,11 +3661,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3655,15 +3676,26 @@
           <http://model.geneontology.org/CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3681,7 +3713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3698,7 +3730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3706,37 +3738,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_d3713987-8a2c-4fd3-a2bc-6e571b453a21_FORMATETHFLIG-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_ef4708c7-4d57-4442-b22a-7fda458335e8_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3744,28 +3754,39 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d3713987-8a2c-4fd3-a2bc-6e571b453a21_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/ef4708c7-4d57-4442-b22a-7fda458335e8_FORMATETHFLIG-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000005762>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004477>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_3d2808a2-08b9-4969-b371-d65d0a89aafc_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_44841>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3774,11 +3795,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_d41a57ec-bd13-42ba-ae83-d88e3555272d_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_d24d3c1a-6946-4abc-af85-0badb5e65b66_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3786,18 +3807,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d41a57ec-bd13-42ba-ae83-d88e3555272d_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/d24d3c1a-6946-4abc-af85-0badb5e65b66_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3808,44 +3829,6 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004372> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/f1a80e3d-2b57-4c5f-8cd3-a46f6f8f3db7_DIHYDROFOLATEREDUCT-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/2e23746e-617f-41a1-afa5-c92072427778_GLYOHMETRANS-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
-                <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1BiochemicalReaction59994> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
 <http://model.geneontology.org/CHEBI_17071_H2NEOPTERINALDOL-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17071> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3855,7 +3838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3868,7 +3851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3876,11 +3859,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002411_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002411_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3895,11 +3878,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3910,16 +3893,32 @@
           <http://model.geneontology.org/reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004372> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/f98d555b-3e4b-4c8e-ad68-e63e1b6f0a13_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/491cb219-ea5d-416b-b431-71d4450af4a5_GLYOHMETRANS-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002411>
+                <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1BiochemicalReaction59994> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3930,7 +3929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3938,15 +3937,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_569e793c-d90c-4f1e-ac08-e637bca24a7a_GCVMULTI-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_aae9d28f-7ecf-4636-a8d3-822e4228b3b8_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3954,28 +3964,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/569e793c-d90c-4f1e-ac08-e637bca24a7a_GCVMULTI-RXN>
+          <http://model.geneontology.org/aae9d28f-7ecf-4636-a8d3-822e4228b3b8_GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3983,11 +3982,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4005,11 +4004,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4024,11 +4023,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_008504b8-e26b-4a35-9b11-a1cc68e5a5f4_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_054c3b0b-0214-4a55-b5ae-d35b60071dc1_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4036,7 +4035,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/008504b8-e26b-4a35-9b11-a1cc68e5a5f4_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/054c3b0b-0214-4a55-b5ae-d35b60071dc1_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
@@ -4048,7 +4047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4059,39 +4058,28 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_ef4708c7-4d57-4442-b22a-7fda458335e8_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_387e76b0-0668-4e8e-ae27-2c1ac6122582_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_834653ac-38bb-4431-bc56-dd6faec2dff9_1.5.1.15-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4099,11 +4087,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4114,6 +4102,28 @@
           <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER3O-131_ADCLY-RXN_controller>
         a       <http://identifiers.org/sgd/S000004902> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4121,7 +4131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4129,14 +4139,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4144,11 +4154,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4159,15 +4169,37 @@
           <http://model.geneontology.org/THYMIDYLATESYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4178,30 +4210,8 @@
           <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58762>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_008504b8-e26b-4a35-9b11-a1cc68e5a5f4_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_DIHYDROFOLATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -4212,7 +4222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4224,11 +4234,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4248,7 +4258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4259,37 +4269,15 @@
 <http://identifiers.org/sgd/S000005600>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4309,13 +4297,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59966> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58406>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4324,11 +4323,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4343,11 +4342,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4358,6 +4357,20 @@
           <http://model.geneontology.org/CHEBI_58359_PABASYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002411_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000467>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller>
         a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4365,7 +4378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4373,26 +4386,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://identifiers.org/sgd/S000000467>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/054c3b0b-0214-4a55-b5ae-d35b60071dc1_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4400,11 +4413,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4419,11 +4432,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_ADCLY-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_ADCLY-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4437,34 +4450,12 @@
 <http://purl.obolibrary.org/obo/GO_0004146>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4477,7 +4468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of tetrahydrofolate biosynthesis and salvage - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -4494,9 +4485,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/0a2b3403-33d2-42cc-9735-d734d04cfdd2_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/7065e207-6a9a-4413-8e46-d2716a2bc5cb_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/d68f3af6-c14b-4007-be19-82f34ca02c61_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/3d2808a2-08b9-4969-b371-d65d0a89aafc_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -4504,7 +4495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4519,11 +4510,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Provides Input For Rule. The relation '7,8-dihydroneopterin 3'-triphosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin 3'-phosphate + diphosphate + H<SUP>+</SUP>' 'null' '7,8-dihydroneopterin 3'-phosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4534,15 +4525,26 @@
           <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4553,14 +4555,25 @@
           <http://model.geneontology.org/CHEBI_15361_ADCLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4569,7 +4582,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4577,11 +4599,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_f1a80e3d-2b57-4c5f-8cd3-a46f6f8f3db7_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_f98d555b-3e4b-4c8e-ad68-e63e1b6f0a13_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4589,38 +4611,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f1a80e3d-2b57-4c5f-8cd3-a46f6f8f3db7_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/f98d555b-3e4b-4c8e-ad68-e63e1b6f0a13_DIHYDROFOLATEREDUCT-RXN>
 ] .
-
-<http://model.geneontology.org/reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YGL125W-MONOMER_RXN3O-9789_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YGL125W-MONOMER_RXN3O-9789_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4650,35 +4652,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1BiochemicalReaction60446> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_13390>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4692,7 +4672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4700,15 +4680,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4723,11 +4714,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_387e76b0-0668-4e8e-ae27-2c1ac6122582_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_efdb1e9e-4a74-421f-8790-e8362eeeeda7_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4735,49 +4726,21 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/387e76b0-0668-4e8e-ae27-2c1ac6122582_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/efdb1e9e-4a74-421f-8790-e8362eeeeda7_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004719>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_37565_GTP-CYCLOHYDRO-I-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_37565> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "GTP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60460> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4788,6 +4751,17 @@
           <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004048> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4795,7 +4769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4803,27 +4777,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_0a2b3403-33d2-42cc-9735-d734d04cfdd2_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_37565_GTP-CYCLOHYDRO-I-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_37565> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "GTP" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60460> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17001> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4834,7 +4803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4847,7 +4816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4860,7 +4829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4874,6 +4843,17 @@
 <http://identifiers.org/sgd/S000001788>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/RXN3O-9789>
         a       <http://purl.obolibrary.org/obo/GO_0004489> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4883,15 +4863,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9789_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9789> , <http://model.geneontology.org/84b4901d-cbec-433e-a320-2a22b55005ec_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9789> , <http://model.geneontology.org/6db40862-b841-40f3-b224-6767737c0932_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_13390_RXN3O-9789> , <http://model.geneontology.org/80eb82c9-4c40-40a3-a71e-8b206a5db537_RXN3O-9789> ;
+                <http://model.geneontology.org/CHEBI_13390_RXN3O-9789> , <http://model.geneontology.org/4b2dd6eb-c348-4609-ae78-88f3f2ef9958_RXN3O-9789> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL125W-MONOMER_RXN3O-9789_controller> , <http://model.geneontology.org/YPL023C-MONOMER_RXN3O-9789_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4903,11 +4883,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4918,15 +4898,26 @@
           <http://model.geneontology.org/CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4941,11 +4932,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4956,15 +4947,26 @@
           <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_RXN3O-9789_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4975,16 +4977,36 @@
           <http://model.geneontology.org/RXN3O-9789>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/aae9d28f-7ecf-4636-a8d3-822e4228b3b8_GCVMULTI-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/7065e207-6a9a-4413-8e46-d2716a2bc5cb_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57305> ;
@@ -4995,7 +5017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5003,15 +5025,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5026,11 +5059,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5044,27 +5077,8 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/1776eea8-97af-49ae-98bb-eea567ad1b25_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -5073,11 +5087,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5091,11 +5105,33 @@
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_37565>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005944>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_37565>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5106,7 +5142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5123,7 +5159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5135,11 +5171,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5150,15 +5186,26 @@
           <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_97afffad-9d24-4bd3-a96c-b05cacb31aff_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000066_reaction_RXN3O-9789_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000066_reaction_RXN3O-9789_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5169,47 +5216,36 @@
           <http://model.geneontology.org/reaction_RXN3O-9789_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_2e23746e-617f-41a1-afa5-c92072427778_GLYOHMETRANS-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_f98d555b-3e4b-4c8e-ad68-e63e1b6f0a13_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5222,7 +5258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5232,32 +5268,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Provides Input For Rule. The relation '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' 'null' 'L-glutamate + 7,8-dihydropteroate + ATP &rarr; ADP + 7,8-dihydrofolate monoglutamate + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5268,28 +5285,47 @@
           <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_13392_RXN3O-9789_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5302,7 +5338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5310,14 +5346,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5325,11 +5361,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5340,36 +5376,42 @@
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/491cb219-ea5d-416b-b431-71d4450af4a5_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5377,11 +5419,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5396,11 +5438,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5411,19 +5453,41 @@
           <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0019177>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_59bf992c-078c-439b-a224-ed559c39e8f9_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YNR033W-MONOMER_PABASYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005316> ;
@@ -5432,7 +5496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5440,15 +5504,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5459,39 +5534,17 @@
           <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_CHEBI_13390_RXN3O-9789_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5500,39 +5553,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
-] .
 
 <http://model.geneontology.org/YGL125W-MONOMER_RXN3O-9789_controller>
         a       <http://identifiers.org/sgd/S000003093> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5541,7 +5564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5553,11 +5576,41 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_aabcf0a8-1a54-434d-b0dd-342a0fa9f989_THYMIDYLATESYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
+] .
+
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_221ee795-ae83-42fe-a1ba-2adea78dec40_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5565,7 +5618,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/aabcf0a8-1a54-434d-b0dd-342a0fa9f989_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/221ee795-ae83-42fe-a1ba-2adea78dec40_THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_17839_H2PTEROATESYNTH-RXN>
@@ -5577,7 +5630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5590,7 +5643,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5598,11 +5662,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5617,11 +5681,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_834653ac-38bb-4431-bc56-dd6faec2dff9_1.5.1.15-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_97afffad-9d24-4bd3-a96c-b05cacb31aff_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5629,7 +5693,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/834653ac-38bb-4431-bc56-dd6faec2dff9_1.5.1.15-RXN>
+          <http://model.geneontology.org/97afffad-9d24-4bd3-a96c-b05cacb31aff_1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
@@ -5639,7 +5703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5666,7 +5730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5674,25 +5738,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5700,11 +5753,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5719,11 +5772,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5734,53 +5787,25 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/885ace2c-0200-45c3-b15b-e268c7c08790_THYMIDYLATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/84b4901d-cbec-433e-a320-2a22b55005ec_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_RXN3O-9789_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5788,11 +5813,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5803,17 +5828,6 @@
           <http://model.geneontology.org/CHEBI_17071_H2NEOPTERINALDOL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58762> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5823,7 +5837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5831,15 +5845,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5850,26 +5886,15 @@
           <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5884,11 +5909,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5903,11 +5928,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5918,33 +5943,16 @@
           <http://model.geneontology.org/CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002411_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/d68f3af6-c14b-4007-be19-82f34ca02c61_1.5.1.15-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59839> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_29888_H2PTEROATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
@@ -5955,13 +5963,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60265> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_PABASYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5972,7 +5991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5980,15 +5999,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_13392_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5999,6 +6029,17 @@
           <http://model.geneontology.org/CHEBI_15378_ADCLY-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -6006,11 +6047,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YPL023C-MONOMER_RXN3O-9789_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YPL023C-MONOMER_RXN3O-9789_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6021,17 +6062,6 @@
           <http://model.geneontology.org/YPL023C-MONOMER_RXN3O-9789_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6041,7 +6071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6058,7 +6088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6075,7 +6105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6087,11 +6117,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6102,6 +6132,28 @@
           <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0035999> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6111,7 +6163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -6131,9 +6183,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/9ba92fb1-5065-4070-9e56-88db36709397_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/5772f0df-4884-4529-ba7b-be7ed151deb9_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/569e793c-d90c-4f1e-ac08-e637bca24a7a_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> , <http://model.geneontology.org/aae9d28f-7ecf-4636-a8d3-822e4228b3b8_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -6141,7 +6193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6153,11 +6205,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6175,7 +6227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6190,7 +6242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6198,15 +6250,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6224,11 +6298,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_0a2b3403-33d2-42cc-9735-d734d04cfdd2_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_7065e207-6a9a-4413-8e46-d2716a2bc5cb_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6236,46 +6310,46 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0a2b3403-33d2-42cc-9735-d734d04cfdd2_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/7065e207-6a9a-4413-8e46-d2716a2bc5cb_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_80eb82c9-4c40-40a3-a71e-8b206a5db537_RXN3O-9789_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58462>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_58462>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6295,9 +6369,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/885ace2c-0200-45c3-b15b-e268c7c08790_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/c4a18306-80f9-453b-a3ce-8d7ebc00438d_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/d41a57ec-bd13-42ba-ae83-d88e3555272d_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/d24d3c1a-6946-4abc-af85-0badb5e65b66_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -6305,7 +6379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6317,11 +6391,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6332,6 +6406,17 @@
           <http://model.geneontology.org/THYMIDYLATESYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58406_PABASYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58406> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6341,7 +6426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6358,7 +6443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6366,40 +6451,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000004902>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GCVMULTI-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://identifiers.org/sgd/S000004902>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6414,11 +6499,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6429,27 +6514,38 @@
           <http://model.geneontology.org/YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YPL023C-MONOMER_RXN3O-9789_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_PABASYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6460,58 +6556,25 @@
           <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6519,11 +6582,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6538,11 +6601,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_13392_RXN3O-9789_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_13392_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6570,7 +6633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6578,59 +6641,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_9a5d93c2-7c03-4692-a63e-a85bb9e89456_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003436>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-9789_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6638,30 +6668,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58462_GTP-CYCLOHYDRO-I-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6672,39 +6683,47 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58462_GTP-CYCLOHYDRO-I-RXN>
+] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_58359>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001876> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_58359>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_ADCLY-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17836>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6713,11 +6732,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6728,17 +6747,6 @@
           <http://model.geneontology.org/THYMIDYLATESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003436> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -6746,7 +6754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6761,7 +6769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6778,7 +6786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6795,7 +6803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6812,7 +6820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6824,11 +6832,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6839,25 +6847,28 @@
           <http://model.geneontology.org/YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6866,43 +6877,34 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/387e76b0-0668-4e8e-ae27-2c1ac6122582_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59839> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_DIHYDROFOLATESYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6913,13 +6915,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60143> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004799>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6933,7 +6946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6945,11 +6958,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6964,11 +6977,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6979,40 +6992,18 @@
           <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_BFO_0000066_reaction_RXN3O-9789_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_d68f3af6-c14b-4007-be19-82f34ca02c61_1.5.1.15-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7027,11 +7018,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7061,7 +7052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7078,7 +7069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7090,11 +7081,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7109,11 +7100,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7124,25 +7115,31 @@
           <http://model.geneontology.org/reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/d24d3c1a-6946-4abc-af85-0badb5e65b66_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7150,11 +7147,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7165,14 +7162,14 @@
           <http://model.geneontology.org/CHEBI_44841_H2NEOPTERINALDOL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7185,7 +7182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7202,7 +7199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7217,11 +7214,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_9ba92fb1-5065-4070-9e56-88db36709397_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_5772f0df-4884-4529-ba7b-be7ed151deb9_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7229,18 +7226,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9ba92fb1-5065-4070-9e56-88db36709397_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/5772f0df-4884-4529-ba7b-be7ed151deb9_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7251,15 +7248,37 @@
           <http://model.geneontology.org/CHEBI_58406_PABASYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7274,11 +7293,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7293,11 +7312,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7317,7 +7336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7325,39 +7344,49 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/834653ac-38bb-4431-bc56-dd6faec2dff9_1.5.1.15-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ad112016-44eb-44fa-ae01-9409044476fe_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0004329>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller>
-        a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase [multifunctional]" ;
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1Protein60272> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/6db40862-b841-40f3-b224-6767737c0932_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7377,7 +7406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7385,16 +7414,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_84b4901d-cbec-433e-a320-2a22b55005ec_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -7405,7 +7426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7417,11 +7438,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7432,14 +7453,29 @@
           <http://model.geneontology.org/CHEBI_17836_ADCLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller>
+        a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1Protein60272> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7452,7 +7488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7460,25 +7496,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7489,7 +7514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7501,11 +7526,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7516,26 +7541,15 @@
           <http://model.geneontology.org/CHEBI_30616_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7546,9 +7560,6 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/008504b8-e26b-4a35-9b11-a1cc68e5a5f4_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://purl.obolibrary.org/obo/CHEBI_13392>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -7557,18 +7568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7576,11 +7576,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7591,17 +7591,6 @@
           <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_1.5.1.15-RXN_SGD_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33384> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7611,10 +7600,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60007> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_054c3b0b-0214-4a55-b5ae-d35b60071dc1_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_GLNSYN-PWY.ttl
+++ b/models/YeastPathways_GLNSYN-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-glutamine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -53,11 +53,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_30616_GLUTAMINESYN-RXN_SGD_YeastPathways_GLNSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_30616_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_GLNSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,36 +74,14 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_BFO_0000066_reaction_GLUTAMINESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLNSYN-PWY>
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_28938_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_GLNSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLNSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_BFO_0000050_YeastPathways_GLNSYN-PWY/YeastPathways_GLNSYN-PWY_SGD_YeastPathways_GLNSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLNSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_58359_GLUTAMINESYN-RXN_SGD_YeastPathways_GLNSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLNSYN-PWY" ;
+                "SGD_PWY:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -122,24 +100,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLNSYN-PWYSmallMolecule21545> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002333_YPR035W-MONOMER_GLUTAMINESYN-RXN_controller_SGD_YeastPathways_GLNSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLNSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_GLUTAMINESYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -150,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -162,11 +129,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_29985_GLUTAMINESYN-RXN_SGD_YeastPathways_GLNSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_29985_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_GLNSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -177,17 +144,6 @@
           <http://model.geneontology.org/CHEBI_29985_GLUTAMINESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_28938_GLUTAMINESYN-RXN_SGD_YeastPathways_GLNSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLNSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_28938_GLUTAMINESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_28938> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -197,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -214,6 +170,17 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_BFO_0000050_YeastPathways_GLNSYN-PWY/YeastPathways_GLNSYN-PWY_SGD_PWY_YeastPathways_GLNSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLNSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -221,11 +188,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_58359_GLUTAMINESYN-RXN_SGD_YeastPathways_GLNSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_58359_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_GLNSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -243,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -274,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -286,11 +253,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_28938_GLUTAMINESYN-RXN_SGD_YeastPathways_GLNSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_28938_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_GLNSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,24 +278,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLNSYN-PWYProtein21583> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_43474_GLUTAMINESYN-RXN_SGD_YeastPathways_GLNSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLNSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -339,15 +295,26 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_58359_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_GLNSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLNSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_456216_GLUTAMINESYN-RXN_SGD_YeastPathways_GLNSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_456216_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_GLNSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -370,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,11 +352,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_BFO_0000066_reaction_GLUTAMINESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLNSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_BFO_0000066_reaction_GLUTAMINESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLNSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,6 +370,28 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_BFO_0000066_reaction_GLUTAMINESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLNSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLNSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_456216_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_GLNSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLNSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -410,11 +399,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_43474_GLUTAMINESYN-RXN_SGD_YeastPathways_GLNSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_43474_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_GLNSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,7 +426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -453,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -461,11 +450,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_BFO_0000050_YeastPathways_GLNSYN-PWY/YeastPathways_GLNSYN-PWY_SGD_YeastPathways_GLNSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_BFO_0000050_YeastPathways_GLNSYN-PWY/YeastPathways_GLNSYN-PWY_SGD_PWY_YeastPathways_GLNSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -476,22 +465,22 @@
           <http://model.geneontology.org/YeastPathways_GLNSYN-PWY/YeastPathways_GLNSYN-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002333_YPR035W-MONOMER_GLUTAMINESYN-RXN_controller_SGD_PWY_YeastPathways_GLNSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLNSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_15378_GLUTAMINESYN-RXN_SGD_YeastPathways_GLNSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLNSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -499,21 +488,54 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_43474_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_GLNSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLNSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000006239>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_15378_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_GLNSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLNSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_30616_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_GLNSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLNSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_15378_GLUTAMINESYN-RXN_SGD_YeastPathways_GLNSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_15378_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_GLNSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -524,25 +546,14 @@
           <http://model.geneontology.org/CHEBI_15378_GLUTAMINESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_29985_GLUTAMINESYN-RXN_SGD_YeastPathways_GLNSYN-PWY>
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_29985_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_GLNSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLNSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_30616_GLUTAMINESYN-RXN_SGD_YeastPathways_GLNSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLNSYN-PWY" ;
+                "SGD_PWY:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -550,11 +561,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002333_YPR035W-MONOMER_GLUTAMINESYN-RXN_controller_SGD_YeastPathways_GLNSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002333_YPR035W-MONOMER_GLUTAMINESYN-RXN_controller_SGD_PWY_YeastPathways_GLNSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -570,14 +581,3 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_456216_GLUTAMINESYN-RXN_SGD_YeastPathways_GLNSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLNSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_GLUCFERMEN-PWY.ttl
+++ b/models/YeastPathways_GLUCFERMEN-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -19,11 +19,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -34,15 +34,37 @@
           <http://model.geneontology.org/CHEBI_58702_2PGADEHYDRAT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002233_CHEBI_17478_ALDHDEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_57634_F16BDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_57634_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,37 +75,15 @@
           <http://model.geneontology.org/CHEBI_57634_F16BDEPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YOL086C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YOL086C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,11 +98,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -116,53 +116,53 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002411_ALDHDEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_15377_F16BDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002333_YKL152C-MONOMER_3PGAREARR-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002333_YLR377C-MONOMER_F16BDEPHOS-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004034>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://identifiers.org/sgd/S000004818>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_59776_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://identifiers.org/sgd/S000004818>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002413_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -170,11 +170,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,26 +185,15 @@
           <http://model.geneontology.org/CPLX3O-67_RXN-6161_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -222,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,15 +219,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR083W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_15343_RXN-6161_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -256,11 +278,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN-6161_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN-6161_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,15 +293,26 @@
           <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-274_BFO_0000066_reaction_RXN3O-274_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" , "Provides Input For Rule. The relation 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' 'null' '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16ALDOLASE-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -290,14 +323,14 @@
           <http://model.geneontology.org/F16ALDOLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002413_PGLUCISOM-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15378_RXN-6161_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -306,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -319,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -334,11 +367,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002333_YER073W-MONOMER_RXN3O-274_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002333_YER073W-MONOMER_RXN3O-274_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,11 +386,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002234_CHEBI_58289_RXN-15513_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002234_CHEBI_58289_RXN-15513_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,11 +411,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -393,36 +426,32 @@
           <http://model.geneontology.org/YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0003872>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0004396>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller>
-        a       <http://identifiers.org/sgd/S000003486> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "enolase I" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37456> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YGL253W-MONOMER_GLUCOKIN-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YGL253W-MONOMER_GLUCOKIN-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -433,15 +462,41 @@
           <http://model.geneontology.org/YGL253W-MONOMER_GLUCOKIN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller>
+        a       <http://identifiers.org/sgd/S000003486> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "enolase I" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37456> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' 'null' '&beta;-D-fructose 1,6-bisphosphate + H<sub>2</sub>O &rarr; &beta;-D-fructofuranose 6-phosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16BDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -488,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -505,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -513,15 +568,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_57945_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_29067_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' 'null' 'D-glyceraldehyde 3-phosphate &harr; glycerone phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_TRIOSEPISOMERIZATION-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_TRIOSEPISOMERIZATION-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -536,11 +613,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002333_YOR374W-MONOMER_RXN3O-274_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002333_YOR374W-MONOMER_RXN3O-274_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,14 +628,14 @@
           <http://model.geneontology.org/YOR374W-MONOMER_RXN3O-274_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000066_reaction_PEPDEPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002413_PGLUCISOM-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -571,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -579,14 +656,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_15377_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_15378_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -597,11 +696,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -621,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -629,14 +728,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_57642_F16ALDOLASE-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-274_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000004818_CPLX3O-77_component_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -649,7 +759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -661,11 +771,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57540_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57540_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -680,11 +790,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -704,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -721,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -736,11 +846,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002234_CHEBI_15378_ALDHDEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002234_CHEBI_15378_ALDHDEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -755,11 +865,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15378_RXN-6161_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15378_RXN-6161_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -773,17 +883,6 @@
 <http://identifiers.org/sgd/S000000036>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_4167_GLUCOKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_4167> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -793,7 +892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -801,14 +900,58 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_29067_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR303C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_16236_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-274_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_30616_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -817,56 +960,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003588>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_RXN-15513_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/F16ALDOLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004332> ;
@@ -887,13 +986,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYBiochemicalReaction37326> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002233_CHEBI_57540_ALDHDEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003769>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -902,11 +1012,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_57634_PGLUCISOM-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_57634_PGLUCISOM-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -916,6 +1026,39 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57634_PGLUCISOM-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002234_CHEBI_13392_RXN3O-274_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002413_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_57642_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -927,7 +1070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -939,11 +1082,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_13390_RXN3O-274_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_13390_RXN3O-274_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -958,11 +1101,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '3-phospho-D-glycerate + ATP &harr; 3-phospho-D-glyceroyl-phosphate + ADP' 'null' '2-phospho-D-glycerate &harr; 3-phospho-D-glycerate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_RXN-15513_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_RXN-15513_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -992,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1003,28 +1146,6 @@
 <http://purl.obolibrary.org/obo/GO_0004807>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002234_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57642_F16ALDOLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57642> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1034,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1046,11 +1167,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_15378_GLUCOKIN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_15378_GLUCOKIN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,15 +1199,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_57540_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_57540_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1097,14 +1229,14 @@
           <http://model.geneontology.org/CHEBI_57540_ALCOHOL-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_57634_PGLUCISOM-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1112,11 +1244,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1131,11 +1263,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_15378_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_15378_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1146,14 +1278,14 @@
           <http://model.geneontology.org/CHEBI_15378_ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_15343_RXN-6161_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002234_CHEBI_58289_RXN-15513_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1165,29 +1297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_43474_F16BDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1195,11 +1305,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" , "Provides Input For Rule. The relation 'D-glyceraldehyde 3-phosphate &harr; glycerone phosphate' 'null' 'D-glyceraldehyde 3-phosphate + NAD<sup>+</sup> + phosphate &harr; 3-phospho-D-glyceroyl-phosphate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1210,47 +1320,25 @@
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000066_reaction_RXN-6161_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_15378_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000066_reaction_PGLUCISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1258,11 +1346,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_15361_PEPDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_15361_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1284,7 +1372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1292,11 +1380,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002333_YLR377C-MONOMER_F16BDEPHOS-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002333_YLR377C-MONOMER_F16BDEPHOS-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1307,36 +1395,14 @@
           <http://model.geneontology.org/YLR377C-MONOMER_F16BDEPHOS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000066_reaction_3PGAREARR-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002234_CHEBI_30089_RXN3O-274_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1344,11 +1410,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1366,11 +1432,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002234_CHEBI_58289_3PGAREARR-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002234_CHEBI_58289_3PGAREARR-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1388,13 +1454,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37200> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_58289_RXN-15513_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YBR196C-MONOMER_PGLUCISOM-RXN_controller>
         a       <http://identifiers.org/sgd/S000000400> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1403,7 +1480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1418,7 +1495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1429,15 +1506,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002333_CPLX3O-77_6PFRUCTPHOS-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002411_ALDHDEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002411_ALDHDEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1452,11 +1540,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1473,14 +1561,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000066_reaction_ALCOHOL-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_15378_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1488,11 +1587,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1503,6 +1602,17 @@
           <http://model.geneontology.org/YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YMR083W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller>
         a       <http://identifiers.org/sgd/S000004688> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1510,7 +1620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1518,14 +1628,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YGL253W-MONOMER_GLUCOKIN-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_RXN-15513_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1533,11 +1643,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN-6161_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN-6161_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1548,21 +1658,32 @@
           <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
 ] .
 
-<http://model.geneontology.org/reaction_RXN-15513_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
         a       <http://identifiers.org/sgd/S000004034> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_15378_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_RXN-15513_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1575,7 +1696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1589,14 +1710,25 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000066_reaction_PEPDEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_4167_GLUCOKIN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1604,11 +1736,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1628,7 +1760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1640,11 +1772,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000066_reaction_ALCOHOL-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000066_reaction_ALCOHOL-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1655,14 +1787,14 @@
           <http://model.geneontology.org/reaction_ALCOHOL-DEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002413_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002413_RXN-6161_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1675,7 +1807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1683,14 +1815,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YPL061W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1698,11 +1830,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-glucopyranose + ATP &rarr; D-glucopyranose 6-phosphate + ADP + H<SUP>+</SUP>' 'null' 'D-glucopyranose 6-phosphate &harr; &beta;-D-fructofuranose 6-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002413_PGLUCISOM-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002413_PGLUCISOM-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1717,11 +1849,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1735,6 +1867,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002333_YER073W-MONOMER_RXN3O-274_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57540_ALDHDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1744,7 +1887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1756,11 +1899,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1775,11 +1918,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1793,6 +1936,17 @@
 <http://purl.obolibrary.org/obo/GO_0004030>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YCL040W-MONOMER_GLUCOKIN-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1802,13 +1956,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of glucose fermentation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002333_YOR374W-MONOMER_ALDHDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/TRIOSEPISOMERIZATION-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004807> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1829,7 +2005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1844,7 +2020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1859,7 +2035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1876,7 +2052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1894,11 +2070,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000066_reaction_PGLUCISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000066_reaction_PGLUCISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1912,17 +2088,6 @@
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YOL086C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57634_PGLUCISOM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57634> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1932,7 +2097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1949,7 +2114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1961,11 +2126,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1980,11 +2145,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2004,7 +2169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2015,23 +2180,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_58289>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-274_BFO_0000066_reaction_RXN3O-274_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000003472_CPLX3O-77_component>
         a       <http://identifiers.org/sgd/S000003472> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2039,11 +2193,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002234_CHEBI_29067_ALDHDEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002234_CHEBI_29067_ALDHDEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2054,26 +2208,15 @@
           <http://model.geneontology.org/CHEBI_29067_ALDHDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2088,11 +2231,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002233_CHEBI_4170_GLUCOKIN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002233_CHEBI_4170_GLUCOKIN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2102,6 +2245,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_4170_GLUCOKIN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GAPOXNPHOSPHN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004365> ;
@@ -2122,32 +2276,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYBiochemicalReaction37375> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_15378_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GAPOXNPHOSPHN-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-6161>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2158,7 +2293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2166,12 +2301,64 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_15378_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_GAPOXNPHOSPHN-RXN>
+] .
+
 <http://model.geneontology.org/reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_456216_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2179,11 +2366,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002234_CHEBI_57945_ALDHDEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002234_CHEBI_57945_ALDHDEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2198,11 +2385,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_15378_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_15378_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2213,14 +2400,14 @@
           <http://model.geneontology.org/CHEBI_15378_6PFRUCTPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2229,36 +2416,6 @@
 
 <http://identifiers.org/sgd/S000003222>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YCL040W-MONOMER_GLUCOKIN-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_15343_RXN-6161_SGD_YeastPathways_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-274> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15343_RXN-6161>
-] .
 
 <http://model.geneontology.org/CHEBI_15378_PEPDEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2269,7 +2426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2279,13 +2436,32 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '3-phospho-D-glycerate + ATP &harr; 3-phospho-D-glyceroyl-phosphate + ADP' 'null' '2-phospho-D-glycerate &harr; 3-phospho-D-glycerate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_3PGAREARR-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_15343_RXN-6161_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-274> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15343_RXN-6161>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '3-phospho-D-glycerate + ATP &harr; 3-phospho-D-glyceroyl-phosphate + ADP' 'null' '2-phospho-D-glycerate &harr; 3-phospho-D-glycerate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_3PGAREARR-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2295,17 +2471,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/3PGAREARR-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_30616_PEPDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000400>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2319,7 +2484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2336,7 +2501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2344,26 +2509,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002234_CHEBI_15378_ALDHDEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_4170_GLUCOKIN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_4170_GLUCOKIN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2374,15 +2528,26 @@
           <http://model.geneontology.org/CHEBI_4170_GLUCOKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YBR145W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YBR145W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2393,6 +2558,28 @@
           <http://model.geneontology.org/YBR145W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_BFO_0000066_reaction_ALDHDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2400,11 +2587,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_57642_F16ALDOLASE-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_57642_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2419,11 +2606,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_29067_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_29067_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2443,7 +2630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2451,25 +2638,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000004818_CPLX3O-77_component_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002233_CHEBI_17478_ALDHDEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2479,15 +2655,26 @@
 <http://purl.obolibrary.org/obo/GO_0004332>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002411_ALDHDEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2498,15 +2685,48 @@
           <http://model.geneontology.org/YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002413_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YGL253W-MONOMER_GLUCOKIN-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_43474_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_30616_PEPDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_30616_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2517,25 +2737,14 @@
           <http://model.geneontology.org/CHEBI_30616_PEPDEPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000066_reaction_GLUCOKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YOR374W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2543,11 +2752,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" , "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate + H<sub>2</sub>O &rarr; &beta;-D-fructofuranose 6-phosphate + phosphate' 'null' 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002413_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002413_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2565,7 +2774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2578,40 +2787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_456216_PEPDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_57634_F16BDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2619,11 +2795,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_BFO_0000066_reaction_ALDHDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_BFO_0000066_reaction_ALDHDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2638,11 +2814,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002333_YKL152C-MONOMER_3PGAREARR-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002333_YKL152C-MONOMER_3PGAREARR-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2653,54 +2829,32 @@
           <http://model.geneontology.org/YKL152C-MONOMER_3PGAREARR-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_13390_RXN3O-274_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002233_CHEBI_57540_ALDHDEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000000605>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_PEPDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN-6161_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000605>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002411_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002411_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2711,15 +2865,26 @@
           <http://model.geneontology.org/ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2732,17 +2897,6 @@
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/6PFRUCTPHOS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003872> ;
@@ -2763,7 +2917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2771,12 +2925,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000066_reaction_3PGAREARR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2784,11 +2960,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" , "Provides Input For Rule. The relation 'D-glyceraldehyde 3-phosphate + NAD<sup>+</sup> + phosphate &harr; 3-phospho-D-glyceroyl-phosphate + NADH + H<SUP>+</SUP>' 'null' '3-phospho-D-glycerate + ATP &harr; 3-phospho-D-glyceroyl-phosphate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002413_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002413_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2803,11 +2979,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" , "Provides Input For Rule. The relation '2-phospho-D-glycerate &harr; 3-phospho-D-glycerate' 'null' '2-phospho-D-glycerate &harr; phospho<i>enol</i>pyruvate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002413_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002413_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2818,15 +2994,81 @@
           <http://model.geneontology.org/2PGADEHYDRAT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_57634_PGLUCISOM-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_3PGAREARR-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN-6161_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2841,11 +3083,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" , "Provides Input For Rule. The relation 'pyruvate + H<SUP>+</SUP> &rarr; acetaldehyde + CO<SUB>2</SUB>' 'null' 'ethanol + NAD<sup>+</sup> &harr; acetaldehyde + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2865,7 +3107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2873,14 +3115,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_30616_GLUCOKIN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_15377_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2893,7 +3146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2901,39 +3154,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_15378_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-274_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2941,11 +3183,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2-phospho-D-glycerate &harr; 3-phospho-D-glycerate' 'null' '2-phospho-D-glycerate &harr; phospho<i>enol</i>pyruvate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002413_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002413_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2960,11 +3202,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_15343_RXN-6161_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_15343_RXN-6161_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2974,6 +3216,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15343_RXN-6161>
 ] .
+
+<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/3PGAREARR-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -2994,7 +3247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3002,15 +3255,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3028,7 +3292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3040,11 +3304,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3055,6 +3319,39 @@
           <http://model.geneontology.org/reaction_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002234_CHEBI_30089_RXN3O-274_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_16526_RXN-6161_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_15378_GLUCOKIN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_PEPDEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3064,7 +3361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3079,11 +3376,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3098,11 +3395,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000066_reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000066_reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3112,6 +3409,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_43474_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002413_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3141,7 +3460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3149,36 +3468,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_15361_PEPDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_15378_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002333_YKL060C-MONOMER_F16ALDOLASE-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3186,11 +3494,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2-phospho-D-glycerate &harr; phospho<i>enol</i>pyruvate + H<sub>2</sub>O' 'null' 'pyruvate + ATP &larr; phospho<i>enol</i>pyruvate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002413_PEPDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002413_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3207,17 +3515,6 @@
 <http://identifiers.org/sgd/S000005901>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YKL060C-MONOMER_F16ALDOLASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000001543> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3225,7 +3522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3242,7 +3539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3254,11 +3551,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_16526_RXN-6161_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_16526_RXN-6161_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3269,37 +3566,15 @@
           <http://model.geneontology.org/CHEBI_16526_RXN-6161>
 ] .
 
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002333_CPLX3O-77_6PFRUCTPHOS-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_57634_PGLUCISOM-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_57634_PGLUCISOM-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3309,17 +3584,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57634_PGLUCISOM-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_16526_RXN-6161_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PGLUCISOM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004347> ;
@@ -3340,7 +3604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3358,7 +3622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3370,11 +3634,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3385,25 +3649,14 @@
           <http://model.geneontology.org/CHEBI_57604_GAPOXNPHOSPHN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000066_reaction_GLUCOKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3414,7 +3667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3429,11 +3682,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002333_YER073W-MONOMER_ALDHDEHYDROG-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002333_YER073W-MONOMER_ALDHDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3448,11 +3701,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3463,14 +3716,14 @@
           <http://model.geneontology.org/CHEBI_32966_6PFRUCTPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_59776_F16ALDOLASE-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3481,7 +3734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3510,7 +3763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3522,11 +3775,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_15377_RXN3O-274_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_15377_RXN3O-274_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3541,11 +3794,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3556,40 +3809,40 @@
           <http://model.geneontology.org/YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000066_reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_15377_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002413_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003319>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_456216_GLUCOKIN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_456216_GLUCOKIN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_456216_GLUCOKIN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3600,29 +3853,44 @@
           <http://model.geneontology.org/CHEBI_456216_GLUCOKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002333_YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004688>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller>
+        a       <http://identifiers.org/sgd/S000001217> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "enolase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37450> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YGL256W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YGL256W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3633,21 +3901,6 @@
           <http://model.geneontology.org/YGL256W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller>
-        a       <http://identifiers.org/sgd/S000001217> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "enolase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37450> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://model.geneontology.org/YKL152C-MONOMER_3PGAREARR-RXN_controller>
         a       <http://identifiers.org/sgd/S000001635> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3655,7 +3908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3667,11 +3920,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_59776_F16ALDOLASE-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_59776_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3691,7 +3944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3708,7 +3961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3720,11 +3973,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3734,17 +3987,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57783_ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3756,11 +3998,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3774,26 +4016,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_57634>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002333_YER073W-MONOMER_RXN3O-274_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YAL038W-MONOMER_PEPDEPHOS-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YAL038W-MONOMER_PEPDEPHOS-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3804,14 +4035,14 @@
           <http://model.geneontology.org/YAL038W-MONOMER_PEPDEPHOS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR083W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57540_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3825,7 +4056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3833,29 +4064,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_57540_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/GO_0033721>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0033721>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3875,7 +4106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3888,7 +4119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3901,7 +4132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3918,16 +4149,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37178> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/GO_0004737>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000002457>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3939,7 +4167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3947,16 +4175,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002413_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004737>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_17478_ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17478> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3967,7 +4187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3979,11 +4199,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002233_CHEBI_15377_ALDHDEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002233_CHEBI_15377_ALDHDEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3994,68 +4214,38 @@
           <http://model.geneontology.org/CHEBI_15377_ALDHDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000003472_CPLX3O-77_component_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_15378_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YAL038W-MONOMER_PEPDEPHOS-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002333_YOR374W-MONOMER_ALDHDEHYDROG-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000066_reaction_6PFRUCTPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_16236_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YGL256W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57604_GAPOXNPHOSPHN-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_30616_PHOSGLYPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4066,7 +4256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4074,17 +4264,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57604_GAPOXNPHOSPHN-RXN>
+] .
+
 <http://purl.obolibrary.org/obo/CHEBI_58702>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000066_reaction_F16ALDOLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002413_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4093,7 +4302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4101,11 +4310,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4120,11 +4329,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4135,14 +4344,36 @@
           <http://model.geneontology.org/YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YOR374W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_57634_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4150,11 +4381,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000003472_CPLX3O-77_component_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000003472_CPLX3O-77_component_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4169,11 +4400,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" , "Provides Input For Rule. The relation 'pyruvate + H<SUP>+</SUP> &rarr; acetaldehyde + CO<SUB>2</SUB>' 'null' 'acetaldehyde + NAD(P)<sup>+</sup> + H<sub>2</sub>O &rarr; acetate + NAD(P)H' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-274_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-274_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4184,31 +4415,53 @@
           <http://model.geneontology.org/RXN3O-274>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_17478_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000004918>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_17478>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002413_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_57540_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_TRIOSEPISOMERIZATION-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_15377_RXN3O-274_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000003472_CPLX3O-77_component_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4221,7 +4474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4233,11 +4486,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4248,26 +4501,15 @@
           <http://model.geneontology.org/YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000066_reaction_RXN-6161_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_15378_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_15378_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4278,39 +4520,17 @@
           <http://model.geneontology.org/CHEBI_15378_ALCOHOL-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16236>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_57945_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4318,11 +4538,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000066_reaction_PEPDEPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000066_reaction_PEPDEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4337,11 +4557,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_15377_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_15377_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4352,25 +4572,14 @@
           <http://model.geneontology.org/CHEBI_15377_ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YOL086C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4379,7 +4588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4395,7 +4604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4407,11 +4616,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_15377_F16BDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_15377_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4426,11 +4635,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002233_CHEBI_57642_F16ALDOLASE-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002233_CHEBI_57642_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4441,36 +4650,14 @@
           <http://model.geneontology.org/CHEBI_57642_F16ALDOLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_456216_GLUCOKIN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4478,11 +4665,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_15378_PEPDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_15378_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4501,7 +4688,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000066_reaction_PGLUCISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4525,7 +4723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4537,11 +4735,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4557,18 +4755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_15377_RXN3O-274_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4581,24 +4768,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_GLUCFERMEN-PWY" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YOL086C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller>
         a       <http://identifiers.org/sgd/S000005446> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4607,13 +4783,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein36918> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_59776_TRIOSEPISOMERIZATION-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_59776> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4624,7 +4811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4632,26 +4819,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR083W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR083W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4669,11 +4845,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4684,14 +4860,14 @@
           <http://model.geneontology.org/YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_BFO_0000066_reaction_ALDHDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_30616_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4704,7 +4880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4729,7 +4905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4737,26 +4913,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4771,11 +4936,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4789,51 +4954,29 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-274_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_456216_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN-6161_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YFR053C-MONOMER_GLUCOKIN-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4854,11 +4997,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002333_YMR170C-MONOMER_ALDHDEHYDROG-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002333_YMR170C-MONOMER_ALDHDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4869,14 +5012,14 @@
           <http://model.geneontology.org/YMR170C-MONOMER_ALDHDEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YPL061W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4884,11 +5027,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_456216_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_456216_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4904,7 +5047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4927,7 +5070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4935,12 +5078,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002333_YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000066_reaction_F16ALDOLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_PGLUCISOM-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4948,11 +5113,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002234_CHEBI_13392_RXN3O-274_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002234_CHEBI_13392_RXN3O-274_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4967,11 +5132,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4982,17 +5147,6 @@
           <http://model.geneontology.org/reaction_RXN-15513_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_30616_GLUCOKIN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -5001,18 +5155,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_4167_GLUCOKIN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5023,7 +5177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5031,15 +5185,35 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002234_CHEBI_15378_ALDHDEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_PEPDEPHOS-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YCL040W-MONOMER_GLUCOKIN-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YCL040W-MONOMER_GLUCOKIN-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5050,24 +5224,15 @@
           <http://model.geneontology.org/YCL040W-MONOMER_GLUCOKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/reaction_PEPDEPHOS-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002333_YKL060C-MONOMER_F16ALDOLASE-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002333_YKL060C-MONOMER_F16ALDOLASE-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5078,26 +5243,15 @@
           <http://model.geneontology.org/YKL060C-MONOMER_F16ALDOLASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002413_PEPDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YER073W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YER073W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5108,15 +5262,26 @@
           <http://model.geneontology.org/YER073W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YER073W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_58289_RXN-15513_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_58289_RXN-15513_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5127,17 +5292,6 @@
           <http://model.geneontology.org/CHEBI_58289_RXN-15513>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_ALCOHOL-DEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5147,24 +5301,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule36910> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002234_CHEBI_58289_3PGAREARR-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15361_PEPDEPHOS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
@@ -5175,24 +5318,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37027> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002234_CHEBI_58289_RXN-15513_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-118_RXN-6161_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5203,7 +5335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5215,11 +5347,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YOR347C-MONOMER_PEPDEPHOS-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YOR347C-MONOMER_PEPDEPHOS-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5234,11 +5366,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YOR374W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YOR374W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5248,28 +5380,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YOR374W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_15378_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ALDHDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004030> ;
@@ -5288,7 +5398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5300,11 +5410,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5315,14 +5425,14 @@
           <http://model.geneontology.org/CHEBI_15377_2PGADEHYDRAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002413_RXN-6161_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002333_YER073W-MONOMER_ALDHDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5330,11 +5440,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5345,19 +5455,52 @@
           <http://model.geneontology.org/reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002233_CHEBI_57642_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0042132>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002234_CHEBI_57945_ALDHDEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-67_RXN-6161_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -5368,13 +5511,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYComplex37057> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
+
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YER073W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller>
         a       <http://identifiers.org/sgd/S000000875> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5383,7 +5537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5395,11 +5549,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002233_CHEBI_17478_ALDHDEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002233_CHEBI_17478_ALDHDEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5429,7 +5583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5441,11 +5595,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000066_reaction_RXN-6161_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000066_reaction_RXN-6161_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5456,14 +5610,25 @@
           <http://model.geneontology.org/reaction_RXN-6161_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002233_CHEBI_4170_GLUCOKIN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5471,11 +5636,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5486,14 +5651,25 @@
           <http://model.geneontology.org/CHEBI_30616_PHOSGLYPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002333_YLR377C-MONOMER_F16BDEPHOS-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002234_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5506,7 +5682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5518,30 +5694,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000066_reaction_GLUCOKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000066_reaction_6PFRUCTPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUCOKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GLUCOKIN-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000066_reaction_6PFRUCTPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5552,6 +5709,36 @@
           <http://model.geneontology.org/reaction_6PFRUCTPHOS-RXN_location_lociGO_0005829>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000066_reaction_GLUCOKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLUCOKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_GLUCOKIN-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_TRIOSEPISOMERIZATION-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57634_F16BDEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57634> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5561,7 +5748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5569,29 +5756,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_59776>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002333_YMR170C-MONOMER_ALDHDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_59776>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000004818_CPLX3O-77_component_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000004818_CPLX3O-77_component_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5606,11 +5793,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-274_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-274_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5621,14 +5808,14 @@
           <http://model.geneontology.org/YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN-6161_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YOR347C-MONOMER_PEPDEPHOS-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5641,7 +5828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5649,37 +5836,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002333_YER073W-MONOMER_ALDHDEHYDROG-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_57945_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_57945_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5699,7 +5864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5707,19 +5872,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000003472>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002234_CHEBI_57945_ALDHDEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YBR145W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003472>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -5728,11 +5893,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_17478_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_17478_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5750,7 +5915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5758,56 +5923,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YOR347C-MONOMER_PEPDEPHOS-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002411_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002413_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002333_YKL152C-MONOMER_3PGAREARR-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000066_reaction_ALCOHOL-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5815,11 +5947,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002234_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002234_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5829,17 +5961,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_59776_TRIOSEPISOMERIZATION-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002234_CHEBI_13392_RXN3O-274_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -5851,7 +5972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5868,7 +5989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5880,11 +6001,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_456216_PEPDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_456216_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5902,11 +6023,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_43474_F16BDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_43474_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5917,25 +6038,36 @@
           <http://model.geneontology.org/CHEBI_43474_F16BDEPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YGL256W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_456216_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5946,11 +6078,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR303C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR303C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5961,26 +6093,15 @@
           <http://model.geneontology.org/YMR303C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YBR145W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000066_reaction_3PGAREARR-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000066_reaction_3PGAREARR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6000,13 +6121,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37103> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003424>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6017,14 +6149,14 @@
 <http://purl.obolibrary.org/obo/GO_0004618>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_57634_PGLUCISOM-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6035,7 +6167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6043,14 +6175,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_17478_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6058,11 +6190,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6077,11 +6209,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-glucopyranose 6-phosphate &harr; &beta;-D-fructofuranose 6-phosphate' 'null' 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002413_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002413_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6092,6 +6224,17 @@
           <http://model.geneontology.org/6PFRUCTPHOS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YFR053C-MONOMER_GLUCOKIN-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -6099,11 +6242,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6119,62 +6262,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_15378_GLUCOKIN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YAL038W-MONOMER_PEPDEPHOS-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15378_RXN-6161_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57540_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002333_YKL060C-MONOMER_F16ALDOLASE-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6182,11 +6292,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002333_YOR374W-MONOMER_ALDHDEHYDROG-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002333_YOR374W-MONOMER_ALDHDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6197,14 +6307,14 @@
           <http://model.geneontology.org/YOR374W-MONOMER_ALDHDEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6212,11 +6322,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002333_CPLX3O-77_6PFRUCTPHOS-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002333_CPLX3O-77_6PFRUCTPHOS-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6227,14 +6337,14 @@
           <http://model.geneontology.org/CPLX3O-77_6PFRUCTPHOS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_13390_RXN3O-274_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6245,11 +6355,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002234_CHEBI_30089_RXN3O-274_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002234_CHEBI_30089_RXN3O-274_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6260,26 +6370,15 @@
           <http://model.geneontology.org/CHEBI_30089_RXN3O-274>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_4170_GLUCOKIN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6290,14 +6389,14 @@
           <http://model.geneontology.org/CHEBI_58272_PHOSGLYPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002333_YOR374W-MONOMER_RXN3O-274_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002233_CHEBI_15377_ALDHDEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6310,7 +6409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6327,7 +6426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6335,14 +6434,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000066_reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6355,7 +6454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6367,11 +6466,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YFR053C-MONOMER_GLUCOKIN-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YFR053C-MONOMER_GLUCOKIN-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6385,14 +6484,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_30089>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YER073W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002333_YOR374W-MONOMER_RXN3O-274_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002413_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6405,7 +6515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6416,26 +6526,15 @@
 <http://purl.obolibrary.org/obo/GO_0004365>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_3PGAREARR-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" , "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' 'null' 'D-glyceraldehyde 3-phosphate + NAD<sup>+</sup> + phosphate &harr; 3-phospho-D-glyceroyl-phosphate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6446,23 +6545,6 @@
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_456216_GLUCOKIN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ADP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule36989> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_43474_GAPOXNPHOSPHN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6472,7 +6554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6480,42 +6562,70 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002233_CHEBI_57642_F16ALDOLASE-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_456216_GLUCOKIN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ADP" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule36989> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000066_reaction_6PFRUCTPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002233_CHEBI_4170_GLUCOKIN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002234_CHEBI_58289_3PGAREARR-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_15378_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6523,11 +6633,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" , "Provides Input For Rule. The relation 'pyruvate + ATP &larr; phospho<i>enol</i>pyruvate + ADP + H<SUP>+</SUP>' 'null' 'pyruvate + H<SUP>+</SUP> &rarr; acetaldehyde + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002413_RXN-6161_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002413_RXN-6161_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6542,11 +6652,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YPL061W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YPL061W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6557,17 +6667,6 @@
           <http://model.geneontology.org/YPL061W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_RXN3O-274>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6577,7 +6676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6588,14 +6687,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002233_CHEBI_15377_ALDHDEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002411_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6603,11 +6702,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_43474_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_43474_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6622,11 +6721,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6637,30 +6736,19 @@
           <http://model.geneontology.org/CHEBI_58702_2PGADEHYDRAT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002234_CHEBI_29067_ALDHDEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000001543>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_43474_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58289_RXN-15513>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58289> ;
@@ -6671,7 +6759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6689,7 +6777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6701,11 +6789,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002233_CHEBI_57540_ALDHDEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002233_CHEBI_57540_ALDHDEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6720,11 +6808,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_PEPDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6738,25 +6826,14 @@
 <http://identifiers.org/sgd/S000004124>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_58289_RXN-15513_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6767,11 +6844,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6782,51 +6859,18 @@
           <http://model.geneontology.org/CHEBI_58272_PHOSGLYPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002333_YMR170C-MONOMER_ALDHDEHYDROG-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_29067>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_30616_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_30616_GLUCOKIN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_30616_GLUCOKIN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6841,11 +6885,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_30616_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_30616_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6863,43 +6907,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37123> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002234_CHEBI_29067_ALDHDEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller>
-] .
 
 <http://model.geneontology.org/CHEBI_57540_ALCOHOL-DEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6910,7 +6924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6925,7 +6939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6937,11 +6951,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6959,7 +6973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6971,11 +6985,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-274_BFO_0000066_reaction_RXN3O-274_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-274_BFO_0000066_reaction_RXN3O-274_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6986,41 +7000,27 @@
           <http://model.geneontology.org/reaction_RXN3O-274_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16BDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PHOSGLYPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller>
+] .
 
 <http://purl.obolibrary.org/obo/GO_0004022>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16ALDOLASE-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005982>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -7029,11 +7029,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_4167_GLUCOKIN-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_4167_GLUCOKIN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7051,11 +7051,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_16236_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_16236_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7066,23 +7066,23 @@
           <http://model.geneontology.org/CHEBI_16236_ALCOHOL-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_15378_PEPDEPHOS-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_3PGAREARR-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_15361_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7090,11 +7090,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000066_reaction_F16ALDOLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000066_reaction_F16ALDOLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7109,11 +7109,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7124,28 +7124,17 @@
           <http://model.geneontology.org/CHEBI_58349_ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_15343_RXN-6161_SGD_YeastPathways_GLUCFERMEN-PWY>
+<http://purl.obolibrary.org/obo/CHEBI_13392>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000050_YeastPathways_GLUCFERMEN-PWY/YeastPathways_GLUCFERMEN-PWY_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_13392>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7166,7 +7155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7174,26 +7163,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR303C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002333_YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller_SGD_YeastPathways_GLUCFERMEN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002333_YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller_SGD_PWY_YeastPathways_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7204,14 +7182,36 @@
           <http://model.geneontology.org/YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_57634_PGLUCISOM-RXN_SGD_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_4170_GLUCOKIN-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_15343_RXN-6161_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7234,7 +7234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7249,7 +7249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_GLUCONEO-PWY-1.ttl
+++ b/models/YeastPathways_GLUCONEO-PWY-1.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,36 +17,36 @@
           <http://model.geneontology.org/CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
+<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_BFO_0000066_reaction_1.1.1.39-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1>
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -54,11 +54,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -86,14 +86,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_BFO_0000066_reaction_1.1.1.39-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002233_CHEBI_58289_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -101,11 +101,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -126,11 +126,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_BFO_0000066_reaction_1.1.1.39-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_BFO_0000066_reaction_1.1.1.39-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -141,17 +141,6 @@
           <http://model.geneontology.org/reaction_1.1.1.39-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57540_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YKL152C-MONOMER_RXN-15513_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001635> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -159,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -167,15 +156,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_4170_PGLUCISOM-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_4170_PGLUCISOM-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -186,8 +186,30 @@
           <http://model.geneontology.org/CHEBI_4170_PGLUCISOM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002413_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PEPCARBOXYKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004612> ;
@@ -208,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -220,11 +242,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_43474_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_43474_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -244,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -252,12 +274,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002233_CHEBI_16452_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_1.1.1.39-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -265,11 +298,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_58702_PEPCARBOXYKIN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_58702_PEPCARBOXYKIN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -287,11 +320,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -324,11 +357,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_1.1.1.39-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_1.1.1.39-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,6 +371,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15361_1.1.1.39-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/2PGADEHYDRAT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004634> ;
@@ -358,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -366,15 +410,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,17 +439,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002333_YKL060C-MONOMER_F16ALDOLASE-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008948>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -406,24 +450,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_GLUCONEO-PWY-1" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002333_YKL029C-MONOMER_1.1.1.39-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58702_PEPCARBOXYKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58702> ;
@@ -434,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -446,11 +479,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,6 +494,17 @@
           <http://model.geneontology.org/reaction_RXN-15513_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_PEPCARBOXYKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -470,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -478,26 +522,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002234_CHEBI_58702_PEPCARBOXYKIN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002234_CHEBI_58702_PEPCARBOXYKIN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,11 +548,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate + H<sub>2</sub>O &rarr; &beta;-D-fructofuranose 6-phosphate + phosphate' 'null' 'D-glucopyranose 6-phosphate &harr; &beta;-D-fructofuranose 6-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002413_PGLUCISOM-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002413_PGLUCISOM-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -530,23 +563,23 @@
           <http://model.geneontology.org/PGLUCISOM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_PEPCARBOXYKIN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -559,7 +592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -567,25 +600,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002234_CHEBI_456216_PEPCARBOXYKIN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1>
+<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002233_CHEBI_15589_1.1.1.39-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -596,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -606,31 +639,6 @@
 
 <http://identifiers.org/sgd/S000003588>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://identifiers.org/sgd/S000003769>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/F16ALDOLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004332> ;
@@ -651,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -668,7 +676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -676,25 +684,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000003769>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_43474_F16BDEPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -707,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -725,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -737,11 +737,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002411_MALATE-DEH-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002411_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,11 +756,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_57604_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_57604_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -771,17 +771,6 @@
           <http://model.geneontology.org/CHEBI_57604_PHOSGLYPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002234_CHEBI_57945_1.1.1.39-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57642_F16ALDOLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57642> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -791,7 +780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -799,14 +788,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -819,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -831,11 +820,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_59776_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_59776_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -846,15 +835,26 @@
           <http://model.geneontology.org/CHEBI_59776_GAPOXNPHOSPHN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002333_YKR097W-MONOMER_PEPCARBOXYKIN-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -865,30 +865,8 @@
           <http://model.geneontology.org/YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002413_F16ALDOLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000001568>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57945_MALATE-DEH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
@@ -899,7 +877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -907,12 +885,67 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002234_CHEBI_57945_1.1.1.39-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002413_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_F16BDEPHOS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_32966_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -920,11 +953,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -942,11 +975,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_BFO_0000066_reaction_PEPCARBOXYKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_BFO_0000066_reaction_PEPCARBOXYKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -961,11 +994,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_15377_F16BDEPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_15377_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -986,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1001,11 +1034,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002233_CHEBI_15589_1.1.1.39-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002233_CHEBI_15589_1.1.1.39-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1019,15 +1052,26 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_58272_RXN-15513_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1038,25 +1082,25 @@
           <http://model.geneontology.org/YBR196C-MONOMER_PGLUCISOM-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002234_CHEBI_15361_1.1.1.39-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_15378_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1064,11 +1108,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57540_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57540_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1079,25 +1123,14 @@
           <http://model.geneontology.org/CHEBI_57540_GAPOXNPHOSPHN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1106,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1119,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1137,11 +1170,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58289_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58289_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1152,17 +1185,6 @@
           <http://model.geneontology.org/CHEBI_58289_2PGADEHYDRAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_15377_F16BDEPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57945_GAPOXNPHOSPHN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1172,7 +1194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1184,11 +1206,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1199,37 +1221,15 @@
           <http://model.geneontology.org/SGD_S000001568_CPLX3O-85_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1240,15 +1240,26 @@
           <http://model.geneontology.org/CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002413_PGLUCISOM-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1259,25 +1270,25 @@
           <http://model.geneontology.org/CHEBI_57945_MALATE-DEH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57604_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002413_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002233_CHEBI_15589_1.1.1.39-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1288,7 +1299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1300,11 +1311,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002233_CHEBI_58289_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002233_CHEBI_58289_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1326,29 +1337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002413_PGLUCISOM-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58289_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1357,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1373,7 +1362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1385,11 +1374,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002333_YKR097W-MONOMER_PEPCARBOXYKIN-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002333_YKR097W-MONOMER_PEPCARBOXYKIN-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1403,15 +1392,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_58289>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_57642_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1426,11 +1426,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002234_CHEBI_58272_RXN-15513_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002234_CHEBI_58272_RXN-15513_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1446,7 +1446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1469,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1480,15 +1480,26 @@
 <http://purl.obolibrary.org/obo/GO_0030060>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" , "Provides Input For Rule. The relation 'oxaloacetate + ATP &rarr; CO<SUB>2</SUB> + phospho<i>enol</i>pyruvate + ADP' 'null' '2-phospho-D-glycerate &harr; phospho<i>enol</i>pyruvate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002413_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002413_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1499,34 +1510,12 @@
           <http://model.geneontology.org/2PGADEHYDRAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002413_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002413_RXN-15513_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1534,11 +1523,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1549,14 +1538,25 @@
           <http://model.geneontology.org/reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58289_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002234_CHEBI_58272_RXN-15513_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1569,7 +1569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1581,11 +1581,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" , "Provides Input For Rule. The relation '(<i>S</i>)-malate + NAD<sup>+</sup> &rarr; CO<SUB>2</SUB> + pyruvate + NADH' 'null' 'hydrogencarbonate + pyruvate + ATP &rarr; oxaloacetate + ADP + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002413_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002413_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1608,7 +1608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1625,7 +1625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1633,26 +1633,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002234_CHEBI_58702_PEPCARBOXYKIN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1667,11 +1656,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_32966_F16ALDOLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_32966_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1682,28 +1671,6 @@
           <http://model.geneontology.org/CHEBI_32966_F16ALDOLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_43474_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_57642_F16ALDOLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1711,11 +1678,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1732,20 +1699,20 @@
 <http://purl.obolibrary.org/obo/GO_0004332>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000001805>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/CHEBI_16452>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://identifiers.org/sgd/S000001805>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_1.1.1.39-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1753,11 +1720,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1768,15 +1735,48 @@
           <http://model.geneontology.org/YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57604_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002233_CHEBI_30616_PEPCARBOXYKIN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_4170_PGLUCISOM-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002233_CHEBI_16452_MALATE-DEH-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002233_CHEBI_16452_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1787,58 +1787,28 @@
           <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002333_YKR097W-MONOMER_PEPCARBOXYKIN-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_MALATE-DEH-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004736>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_32966_F16ALDOLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_32966_F16ALDOLASE-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_16526_PEPCARBOXYKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1849,13 +1819,54 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCONEO-PWY-1SmallMolecule30803> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_32966_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/F16BDEPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_32966_F16ALDOLASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_PEPCARBOXYKIN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15589>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1866,26 +1877,15 @@
 <http://identifiers.org/sgd/S000000605>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000066_reaction_PGLUCISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002233_CHEBI_57540_1.1.1.39-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002233_CHEBI_57540_1.1.1.39-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1904,18 +1904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1938,7 +1927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1950,11 +1939,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1969,11 +1958,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_59776_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_59776_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1984,6 +1973,17 @@
           <http://model.geneontology.org/CHEBI_59776_GAPOXNPHOSPHN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_43474_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YKR097W-MONOMER_PEPCARBOXYKIN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001805> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1991,7 +1991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1999,18 +1999,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_59776_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2025,11 +2058,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2040,26 +2073,15 @@
           <http://model.geneontology.org/SGD_S000005486_CPLX3O-88_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2070,14 +2092,14 @@
           <http://model.geneontology.org/CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_32966_F16ALDOLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2085,11 +2107,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2105,17 +2127,6 @@
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_58702_PEPCARBOXYKIN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2139,7 +2150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2156,7 +2167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2171,7 +2182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2191,7 +2202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2202,17 +2213,6 @@
 <http://identifiers.org/sgd/S000003030>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YKL060C-MONOMER_F16ALDOLASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000001543> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2220,7 +2220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2228,15 +2228,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2256,7 +2278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "gluconeogenesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2273,13 +2295,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCONEO-PWY-1SmallMolecule30689> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_32966_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PGLUCISOM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004347> ;
@@ -2298,7 +2331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2313,7 +2346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2321,26 +2354,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2355,11 +2377,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_15378_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_15378_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2379,7 +2401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2394,7 +2416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2402,37 +2424,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002233_CHEBI_57634_F16BDEPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_4170_PGLUCISOM-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2452,7 +2452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2460,15 +2460,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '3-phospho-D-glycerate + ATP &harr; 3-phospho-D-glyceroyl-phosphate + ADP' 'null' 'D-glyceraldehyde 3-phosphate + NAD<sup>+</sup> + phosphate &harr; 3-phospho-D-glyceroyl-phosphate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2483,11 +2494,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002333_YKL060C-MONOMER_F16ALDOLASE-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002333_YKL060C-MONOMER_F16ALDOLASE-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2505,7 +2516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2513,37 +2524,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_MALATE-DEH-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2554,8 +2543,41 @@
           <http://model.geneontology.org/CHEBI_15589_MALATE-DEH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57945_1.1.1.39-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2566,7 +2588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2574,54 +2596,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_58272_RXN-15513_SGD_YeastPathways_GLUCONEO-PWY-1>
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_BFO_0000066_reaction_PEPCARBOXYKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57634>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002411_1.1.1.39-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002411_1.1.1.39-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2641,7 +2652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2656,11 +2667,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002233_CHEBI_30616_PEPCARBOXYKIN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002233_CHEBI_30616_PEPCARBOXYKIN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2671,14 +2682,14 @@
           <http://model.geneontology.org/CHEBI_30616_PEPCARBOXYKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_32966_F16ALDOLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002234_CHEBI_456216_PEPCARBOXYKIN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2686,11 +2697,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_43474_F16BDEPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_43474_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2701,17 +2712,6 @@
           <http://model.geneontology.org/CHEBI_43474_F16BDEPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2721,7 +2721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2729,14 +2729,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_YeastPathways_GLUCONEO-PWY-1>
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002413_RXN-15513_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2749,7 +2771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2761,11 +2783,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002234_CHEBI_15361_1.1.1.39-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002234_CHEBI_15361_1.1.1.39-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2776,17 +2798,28 @@
           <http://model.geneontology.org/CHEBI_15361_1.1.1.39-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58702>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_PEPCARBOXYKIN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58702>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_58702_PEPCARBOXYKIN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2794,11 +2827,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2809,15 +2842,26 @@
           <http://model.geneontology.org/reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2828,14 +2872,14 @@
           <http://model.geneontology.org/YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_57634_F16BDEPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
+<http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_BFO_0000066_reaction_PEPCARBOXYKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2843,11 +2887,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2858,15 +2902,26 @@
           <http://model.geneontology.org/YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002234_CHEBI_58702_PEPCARBOXYKIN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2877,26 +2932,15 @@
           <http://model.geneontology.org/YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2907,28 +2951,6 @@
           <http://model.geneontology.org/CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_59776_GAPOXNPHOSPHN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59776> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2938,35 +2960,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCONEO-PWY-1SmallMolecule30906> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/1.1.1.39-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008948> ;
@@ -2989,7 +2989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3006,7 +3006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3018,11 +3018,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3033,14 +3033,14 @@
           <http://model.geneontology.org/CPLX3O-85_MALATE-DEH-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002234_CHEBI_58272_RXN-15513_SGD_YeastPathways_GLUCONEO-PWY-1>
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_15377_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3048,11 +3048,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3068,7 +3068,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002333_YKL029C-MONOMER_1.1.1.39-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3079,11 +3090,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3094,26 +3105,15 @@
           <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' 'null' '&beta;-D-fructose 1,6-bisphosphate + H<sub>2</sub>O &rarr; &beta;-D-fructofuranose 6-phosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_F16BDEPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3124,28 +3124,17 @@
           <http://model.geneontology.org/F16BDEPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002413_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000004369>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_57604_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3158,7 +3147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3175,7 +3164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3187,11 +3176,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2-phospho-D-glycerate &harr; 3-phospho-D-glycerate' 'null' '3-phospho-D-glycerate + ATP &harr; 3-phospho-D-glyceroyl-phosphate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002413_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002413_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3205,17 +3194,6 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002234_CHEBI_16526_PEPCARBOXYKIN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -3223,11 +3201,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000066_reaction_PGLUCISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000066_reaction_PGLUCISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3237,6 +3215,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_PGLUCISOM-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002333_YKL060C-MONOMER_F16ALDOLASE-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3248,7 +3237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3260,11 +3249,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57604_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57604_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3275,23 +3264,12 @@
           <http://model.geneontology.org/CHEBI_57604_PHOSGLYPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002233_CHEBI_30616_PEPCARBOXYKIN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3300,29 +3278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3330,11 +3286,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3348,37 +3304,15 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002411_MALATE-DEH-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3389,26 +3323,15 @@
           <http://model.geneontology.org/YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3419,14 +3342,14 @@
           <http://model.geneontology.org/CHEBI_57540_MALATE-DEH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_1.1.1.39-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3439,7 +3362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3451,11 +3374,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'hydrogencarbonate + pyruvate + ATP &rarr; oxaloacetate + ADP + phosphate + H<SUP>+</SUP>' 'null' 'oxaloacetate + ATP &rarr; CO<SUB>2</SUB> + phospho<i>enol</i>pyruvate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_PEPCARBOXYKIN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_PEPCARBOXYKIN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3466,14 +3389,14 @@
           <http://model.geneontology.org/PEPCARBOXYKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_F16BDEPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3481,11 +3404,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002234_CHEBI_16526_PEPCARBOXYKIN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002234_CHEBI_16526_PEPCARBOXYKIN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3503,11 +3426,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" , "Provides Input For Rule. The relation '2-phospho-D-glycerate &harr; phospho<i>enol</i>pyruvate + H<sub>2</sub>O' 'null' '2-phospho-D-glycerate &harr; 3-phospho-D-glycerate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002413_RXN-15513_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002413_RXN-15513_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3522,11 +3445,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_57634_F16BDEPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_57634_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3556,7 +3479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3570,15 +3493,26 @@
 <http://identifiers.org/sgd/S000001512>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002234_CHEBI_16526_1.1.1.39-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002234_CHEBI_16526_1.1.1.39-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3589,17 +3523,6 @@
           <http://model.geneontology.org/CHEBI_16526_1.1.1.39-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15589_MALATE-DEH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15589> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3609,7 +3532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3617,14 +3540,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002233_CHEBI_58289_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002233_CHEBI_57540_1.1.1.39-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002411_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3632,11 +3577,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3647,6 +3592,17 @@
           <http://model.geneontology.org/CHEBI_30616_PHOSGLYPHOS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57634_F16BDEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57634> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3656,13 +3612,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCONEO-PWY-1SmallMolecule30700> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_59776>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3671,11 +3638,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3686,15 +3653,59 @@
           <http://model.geneontology.org/YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_43474_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002234_CHEBI_16526_1.1.1.39-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002233_CHEBI_57634_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000066_reaction_F16ALDOLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000066_reaction_F16ALDOLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3704,17 +3715,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_F16ALDOLASE-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000066_reaction_F16ALDOLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3726,7 +3726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3734,14 +3734,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3766,7 +3766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3774,29 +3774,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1>
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_57634_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002234_CHEBI_15361_1.1.1.39-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_PEPCARBOXYKIN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3817,11 +3839,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" , "Provides Input For Rule. The relation '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' 'null' 'oxaloacetate + ATP &rarr; CO<SUB>2</SUB> + phospho<i>enol</i>pyruvate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_PEPCARBOXYKIN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_PEPCARBOXYKIN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3832,6 +3854,17 @@
           <http://model.geneontology.org/PEPCARBOXYKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -3839,11 +3872,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3854,22 +3887,33 @@
           <http://model.geneontology.org/YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000003424>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1>
+<http://purl.obolibrary.org/obo/CHEBI_57642>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002411_1.1.1.39-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57642>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0004618>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3878,11 +3922,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3893,14 +3937,14 @@
           <http://model.geneontology.org/YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3911,11 +3955,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002233_CHEBI_57634_F16BDEPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002233_CHEBI_57634_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3926,6 +3970,28 @@
           <http://model.geneontology.org/CHEBI_57634_F16BDEPHOS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_59776_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000066_reaction_PGLUCISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0006094>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3933,11 +3999,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3948,36 +4014,25 @@
           <http://model.geneontology.org/CHEBI_57945_GAPOXNPHOSPHN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002234_CHEBI_16526_1.1.1.39-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_15378_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002233_CHEBI_57540_1.1.1.39-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3985,11 +4040,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4009,7 +4064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4026,7 +4081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4034,26 +4089,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4064,17 +4108,6 @@
           <http://model.geneontology.org/reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004365>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -4082,11 +4115,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4097,17 +4130,6 @@
           <http://model.geneontology.org/CHEBI_15378_MALATE-DEH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_59776_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_43474_GAPOXNPHOSPHN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4117,7 +4139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4125,11 +4147,44 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002413_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000066_reaction_F16ALDOLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000002236>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002234_CHEBI_16526_PEPCARBOXYKIN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4138,11 +4193,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4160,11 +4215,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002234_CHEBI_456216_PEPCARBOXYKIN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002234_CHEBI_456216_PEPCARBOXYKIN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4181,26 +4236,15 @@
 <http://purl.obolibrary.org/obo/GO_0004347>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002333_YLR377C-MONOMER_F16BDEPHOS-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002333_YLR377C-MONOMER_F16BDEPHOS-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4220,24 +4264,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCONEO-PWY-1SmallMolecule30634> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001217>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4251,7 +4284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4263,11 +4296,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002234_CHEBI_57945_1.1.1.39-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002234_CHEBI_57945_1.1.1.39-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4278,14 +4311,14 @@
           <http://model.geneontology.org/CHEBI_57945_1.1.1.39-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_RO_0002233_CHEBI_16452_MALATE-DEH-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4298,7 +4331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4306,26 +4339,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_PEPCARBOXYKIN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_58272_RXN-15513_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_58272_RXN-15513_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4336,47 +4358,14 @@
           <http://model.geneontology.org/CHEBI_58272_RXN-15513>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002413_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1>
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PEPCARBOXYKIN-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4384,11 +4373,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4399,15 +4388,26 @@
           <http://model.geneontology.org/YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57540_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002333_YKL029C-MONOMER_1.1.1.39-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.39-RXN_RO_0002333_YKL029C-MONOMER_1.1.1.39-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4418,17 +4418,6 @@
           <http://model.geneontology.org/YKL029C-MONOMER_1.1.1.39-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002411_1.1.1.39-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_32966_F16ALDOLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_32966> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4438,7 +4427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4450,11 +4439,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4472,11 +4461,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_57642_F16ALDOLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_57642_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4492,18 +4481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002333_YLR377C-MONOMER_F16BDEPHOS-RXN_controller_SGD_YeastPathways_GLUCONEO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4511,11 +4489,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" , "Provides Input For Rule. The relation 'D-glyceraldehyde 3-phosphate + NAD<sup>+</sup> + phosphate &harr; 3-phospho-D-glyceroyl-phosphate + NADH + H<SUP>+</SUP>' 'null' '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002413_F16ALDOLASE-RXN_SGD_YeastPathways_GLUCONEO-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002413_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4526,14 +4504,36 @@
           <http://model.geneontology.org/F16ALDOLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_59776_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLUCONEO-PWY-1>
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_57604_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCONEO-PWY-1" ;
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000050_YeastPathways_GLUCONEO-PWY-1/YeastPathways_GLUCONEO-PWY-1_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002333_YLR377C-MONOMER_F16BDEPHOS-RXN_controller_SGD_PWY_YeastPathways_GLUCONEO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4556,7 +4556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL.ttl
+++ b/models/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_91939d60-e940-4a8d-8b6e-29fdba074eb5_RXN3O-413_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_8da13775-d9df-4ab8-a12a-a7c945a3e8d4_RXN3O-413_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14,40 +14,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-413> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/91939d60-e940-4a8d-8b6e-29fdba074eb5_RXN3O-413>
+          <http://model.geneontology.org/8da13775-d9df-4ab8-a12a-a7c945a3e8d4_RXN3O-413>
 ] .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_CHEBI_58189_2.4.1.132-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_bd57b36e-de2d-41f8-b752-0c8c4486f469_RXN3O-3_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002411_RXN3O-379_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002411_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,19 +36,30 @@
           <http://model.geneontology.org/RXN3O-379>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002413_RXN3O-9818_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://purl.obolibrary.org/obo/CHEBI_12427>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-378_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_12427>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002234_CHEBI_18278_2.7.8.15-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YOR067C-MONOMER_RXN3O-412_controller>
         a       <http://identifiers.org/sgd/S000005593> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -79,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -87,15 +76,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/2e5dfe1e-d8a3-4d8b-bc58-ad19a4ed26d2_RXN3O-9818>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_BFO_0000066_reaction_RXN3O-259_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_BFO_0000066_reaction_RXN3O-259_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -114,32 +106,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_CHEBI_57527_2.4.1.131-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.4.1.131-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57527_2.4.1.131-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" , "Provides Input For Rule. The relation '<i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + UDP-<i>N</i>-acetyl-&alpha;-D-glucosamine &rarr; <i>N</i>-acetyl-&beta;-D-glucosaminyl-(1&rarr;4)-<i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + UDP + H<SUP>+</SUP>' 'null' '<i>N</i>-acetyl-&beta;-D-glucosaminyl-(1&rarr;4)-<i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + GDP-&alpha;-D-mannose &rarr; Man(1)GlcNAc(2)-PP-Dol + GDP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002413_RXN3O-9818_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002413_RXN3O-9818_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -150,36 +123,33 @@
           <http://model.geneontology.org/RXN3O-9818>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-24_2.4.1.141-RXN_controller_BFO_0000051_SGD_S000003015_CPLX3O-24_component_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_CHEBI_57527_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.4.1.131-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57527_2.4.1.131-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002333_MONOMER3O-36_RXN3O-379_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002333_YOR002W-MONOMER_RXN3O-411_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -187,11 +157,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_b67ad06a-95fc-46fb-a757-7e4629aff2f2_RXN3O-259_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_92ed5ae5-4551-40b6-8f8b-f6b7ccc355c0_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -199,7 +169,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-411> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b67ad06a-95fc-46fb-a757-7e4629aff2f2_RXN3O-259>
+          <http://model.geneontology.org/92ed5ae5-4551-40b6-8f8b-f6b7ccc355c0_RXN3O-259>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -214,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -226,11 +196,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_b50744c1-a9f4-4a0c-97d2-ed4ba187d66b_RXN3O-291_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_f8cd9545-5855-4fbf-8914-6358840b0e2c_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -238,21 +208,54 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-291> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b50744c1-a9f4-4a0c-97d2-ed4ba187d66b_RXN3O-291>
+          <http://model.geneontology.org/f8cd9545-5855-4fbf-8914-6358840b0e2c_RXN3O-291>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002411_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002411_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005313>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_2e5dfe1e-d8a3-4d8b-bc58-ad19a4ed26d2_RXN3O-9818_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_1d3dc9df-017f-43ea-864b-975b15686f61_2.4.1.132-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_57ff4c1d-26a1-4a83-ad75-414834cac731_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -260,18 +263,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.132-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1d3dc9df-017f-43ea-864b-975b15686f61_2.4.1.132-RXN>
+          <http://model.geneontology.org/57ff4c1d-26a1-4a83-ad75-414834cac731_2.4.1.132-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-24_2.4.1.141-RXN_controller_BFO_0000051_SGD_S000000274_CPLX3O-24_component_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-24_2.4.1.141-RXN_controller_BFO_0000051_SGD_S000000274_CPLX3O-24_component_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -297,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -305,16 +308,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002333_YGL065C-MONOMER_RXN3O-378_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/df7aad3c-370b-4788-ad36-cae95dc92f2c_RXN3O-11>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(8)GlcNAc(2)-PP-Dol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28226> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57527_2.4.1.132-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57527> ;
@@ -325,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -337,11 +346,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002411_RXN3O-413_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002411_RXN3O-413_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -358,29 +367,26 @@
 <http://purl.obolibrary.org/obo/GO_0004577>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_360e52b4-accc-48f3-95be-771e53d945e5_RXN3O-379_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-413_BFO_0000066_reaction_RXN3O-413_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/17a2f53d-e700-4974-bedd-7b647be7fbd4_2.4.1.132-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_BFO_0000066_reaction_RXN3O-378_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_BFO_0000066_reaction_RXN3O-378_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,28 +397,61 @@
           <http://model.geneontology.org/reaction_RXN3O-378_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_CHEBI_16214_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-378_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_CHEBI_58189_RXN3O-379_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0052925>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002333_YNL219C-MONOMER_RXN3O-259_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-259_BFO_0000066_reaction_RXN3O-259_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_bd41d81e-c35a-4ede-adec-1b7ddd2468c2_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58189_RXN3O-379>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58189> ;
@@ -423,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -431,14 +470,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_CHEBI_16214_RXN3O-412_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002333_YOR067C-MONOMER_RXN3O-412_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -446,11 +485,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_CHEBI_58189_RXN3O-9818_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_CHEBI_58189_RXN3O-9818_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,17 +500,6 @@
           <http://model.geneontology.org/CHEBI_58189_RXN3O-9818>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-412_BFO_0000066_reaction_RXN3O-412_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_2.4.1.141-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -481,13 +509,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28036> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002234_CHEBI_12427_2.4.1.141-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/GO_0006488> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -498,7 +537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -513,11 +552,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_d922f291-7d3c-4cd4-8c08-fc561c6ed489_RXN3O-379_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_1ee9c7f0-7825-4911-bfb2-79bd9d6c8759_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -525,54 +564,35 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-379> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d922f291-7d3c-4cd4-8c08-fc561c6ed489_RXN3O-379>
+          <http://model.geneontology.org/1ee9c7f0-7825-4911-bfb2-79bd9d6c8759_RXN3O-379>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_40052bbe-5f6b-478f-a096-7d97d5e21b9e_RXN3O-291_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/f259a394-e6b4-4366-98d0-511206579371_RXN3O-3>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(7)GlcNAc(2)-PP-Dol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-11_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_CHEBI_16214_RXN3O-291_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/4b047a20-8bff-4cd3-b34c-c147d08ed40b_2.4.1.131-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28240> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002411_RXN3O-411_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002411_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -587,11 +607,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002233_CHEBI_57705_2.4.1.141-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002233_CHEBI_57705_2.4.1.141-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -602,33 +622,33 @@
           <http://model.geneontology.org/CHEBI_57705_2.4.1.141-RXN>
 ] .
 
-<http://model.geneontology.org/572dcc70-98b8-4f61-a4c3-354c92584101_2.4.1.131-RXN>
+<http://model.geneontology.org/ev_w_id_RXN3O-412_BFO_0000066_reaction_RXN3O-412_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/bd41d81e-c35a-4ede-adec-1b7ddd2468c2_RXN3O-291>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(5)GlcNAc(2)-PP-Dol" ;
+                "a dolichyl &beta;-D-mannosyl phosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28207> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002233_CHEBI_16214_2.7.8.15-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16214_RXN3O-413>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16214> ;
@@ -639,13 +659,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28079> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_CHEBI_57527_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-36_RXN3O-379_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004993> ;
@@ -654,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -662,25 +693,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002233_CHEBI_12427_2.4.1.141-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_CHEBI_16214_RXN3O-259_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_CHEBI_57527_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_CHEBI_57525_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/76caf99b-7c44-416f-9c15-1b759ef4f7c2_RXN3O-11>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_CHEBI_58189_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -693,9 +738,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.4.1.131-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57527_2.4.1.131-RXN> , <http://model.geneontology.org/360e52b4-accc-48f3-95be-771e53d945e5_RXN3O-379> ;
+                <http://model.geneontology.org/7ae87e1c-9314-4357-a81d-86dcd42498d6_RXN3O-379> , <http://model.geneontology.org/CHEBI_57527_2.4.1.131-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58189_2.4.1.131-RXN> , <http://model.geneontology.org/572dcc70-98b8-4f61-a4c3-354c92584101_2.4.1.131-RXN> ;
+                <http://model.geneontology.org/847718e9-db40-4695-a692-a04b9160265a_2.4.1.131-RXN> , <http://model.geneontology.org/CHEBI_58189_2.4.1.131-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-36_2.4.1.131-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -703,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -711,18 +756,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/0433c00d-c6aa-453f-ab8d-df4648461eee_RXN3O-3>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002333_YBR243C-MONOMER_2.7.8.15-RXN_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002333_YBR243C-MONOMER_2.7.8.15-RXN_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -737,11 +779,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_BFO_0000066_reaction_2.4.1.132-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_BFO_0000066_reaction_2.4.1.132-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -767,11 +809,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/4050a249-f7fe-40bf-bc93-5c6cb09af629_RXN3O-378>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 <http://identifiers.org/sgd/S000000314>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/b216b294-cfd3-49df-a526-06432804f0d0_RXN3O-9818>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/RXN3O-3>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -782,9 +824,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-3_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/9fb45b97-7c01-47d5-b64a-5464b4b98e18_RXN3O-3> , <http://model.geneontology.org/40052bbe-5f6b-478f-a096-7d97d5e21b9e_RXN3O-291> ;
+                <http://model.geneontology.org/d08d5f38-dde9-48fc-8cd1-7ad512636d89_RXN3O-291> , <http://model.geneontology.org/fca9712b-d55a-42bf-9cfa-dae08a75ca65_RXN3O-3> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/bd57b36e-de2d-41f8-b752-0c8c4486f469_RXN3O-3> , <http://model.geneontology.org/CHEBI_16214_RXN3O-3> ;
+                <http://model.geneontology.org/f259a394-e6b4-4366-98d0-511206579371_RXN3O-3> , <http://model.geneontology.org/CHEBI_16214_RXN3O-3> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YNL219C-MONOMER_RXN3O-3_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -792,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -805,18 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002333_CPLX3O-24_2.4.1.141-RXN_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -824,11 +855,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_CHEBI_57525_RXN3O-412_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_CHEBI_57525_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -843,11 +874,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_CHEBI_16214_RXN3O-11_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_CHEBI_16214_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -858,15 +889,26 @@
           <http://model.geneontology.org/CHEBI_16214_RXN3O-11>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002234_CHEBI_57865_2.7.8.15-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_CHEBI_16214_RXN3O-3_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_CHEBI_16214_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -877,27 +919,8 @@
           <http://model.geneontology.org/CHEBI_16214_RXN3O-3>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002333_YBR110W-MONOMER_RXN3O-9818_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/7ac670b3-263f-4508-92ae-468bb59034b3_RXN3O-3>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/CHEBI_16214_2.7.8.15-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16214> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -908,7 +931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -916,15 +939,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/c39a4d48-72b5-4e3f-8db2-46f9b7a0c239_RXN3O-9818>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(1)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule27974> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_df58bf29-4a78-4024-a457-02168ed2cf74_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002333_YGR227W-MONOMER_RXN3O-413_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002333_YGR227W-MONOMER_RXN3O-413_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -935,40 +986,32 @@
           <http://model.geneontology.org/YGR227W-MONOMER_RXN3O-413_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0003975>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_CHEBI_58189_RXN3O-378_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_CHEBI_58189_RXN3O-9818_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/f4a6dbdc-6bdc-491c-8f9f-7784a34e5f65_2.4.1.131-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -979,23 +1022,12 @@
           <http://model.geneontology.org/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_CHEBI_16214_RXN3O-411_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-411_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1003,11 +1035,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_5294f3b2-d3cd-4435-968e-1c8d048fa71c_RXN3O-259_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_5f9d87b1-c58f-4732-b512-c7fe9bda0df7_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,7 +1047,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-259> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5294f3b2-d3cd-4435-968e-1c8d048fa71c_RXN3O-259>
+          <http://model.geneontology.org/5f9d87b1-c58f-4732-b512-c7fe9bda0df7_RXN3O-259>
 ] .
 
 <http://model.geneontology.org/reaction_2.4.1.132-RXN_location_lociGO_0005829>
@@ -1023,7 +1055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1034,7 +1066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1042,26 +1074,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-411_BFO_0000066_reaction_RXN3O-411_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1072,26 +1093,15 @@
           <http://model.geneontology.org/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-411_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_360e52b4-accc-48f3-95be-771e53d945e5_RXN3O-379_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_7ae87e1c-9314-4357-a81d-86dcd42498d6_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1099,35 +1109,35 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.131-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/360e52b4-accc-48f3-95be-771e53d945e5_RXN3O-379>
+          <http://model.geneontology.org/7ae87e1c-9314-4357-a81d-86dcd42498d6_RXN3O-379>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_b216b294-cfd3-49df-a526-06432804f0d0_RXN3O-9818_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/CHEBI_58223>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002333_YGL065C-MONOMER_RXN3O-378_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58223>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_CHEBI_16214_RXN3O-411_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_CHEBI_16214_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1150,7 +1160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1161,14 +1171,14 @@
 <http://identifiers.org/sgd/S000005163>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_d922f291-7d3c-4cd4-8c08-fc561c6ed489_RXN3O-379_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-24_2.4.1.141-RXN_controller_BFO_0000051_SGD_S000003015_CPLX3O-24_component_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1176,11 +1186,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002333_YBL082C-MONOMER_RXN3O-291_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002333_YBL082C-MONOMER_RXN3O-291_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1196,7 +1206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1209,9 +1219,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-11_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/0433c00d-c6aa-453f-ab8d-df4648461eee_RXN3O-3> , <http://model.geneontology.org/1e9a2a78-c02e-4507-8d42-6e38768b3831_RXN3O-11> ;
+                <http://model.geneontology.org/a845ab77-9fd0-4bff-8437-af0f9cf4bea1_RXN3O-11> , <http://model.geneontology.org/7ac670b3-263f-4508-92ae-468bb59034b3_RXN3O-3> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16214_RXN3O-11> , <http://model.geneontology.org/e2f43d20-b877-4352-968b-3667ed7cce4e_RXN3O-11> ;
+                <http://model.geneontology.org/CHEBI_16214_RXN3O-11> , <http://model.geneontology.org/df7aad3c-370b-4788-ad36-cae95dc92f2c_RXN3O-11> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-256_RXN3O-11_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1219,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1230,8 +1240,38 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002333_YGL065C-MONOMER_2.4.1.132-RXN_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.4.1.132-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGL065C-MONOMER_2.4.1.132-RXN_controller>
+] .
 
 <http://model.geneontology.org/YGR227W-MONOMER_RXN3O-413_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003459> ;
@@ -1240,7 +1280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1252,30 +1292,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002333_YGL065C-MONOMER_2.4.1.132-RXN_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-24_2.4.1.141-RXN_controller_BFO_0000051_SGD_S000003015_CPLX3O-24_component_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.4.1.132-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL065C-MONOMER_2.4.1.132-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-24_2.4.1.141-RXN_controller_BFO_0000051_SGD_S000003015_CPLX3O-24_component_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1290,11 +1311,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-413_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-413_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1312,11 +1333,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_CHEBI_57527_RXN3O-378_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_CHEBI_57527_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1326,6 +1347,23 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57527_RXN3O-378>
 ] .
+
+<http://model.geneontology.org/fca9712b-d55a-42bf-9cfa-dae08a75ca65_RXN3O-3>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a dolichyl &beta;-D-mannosyl phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000000447>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1339,7 +1377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1347,32 +1385,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002411_RXN3O-11_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_18278>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/360e52b4-accc-48f3-95be-771e53d945e5_RXN3O-379>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002233_CHEBI_57705_2.7.8.15-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_fe511d01-7180-4197-a8fd-b396fcde1049_RXN3O-9818_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_c39a4d48-72b5-4e3f-8db2-46f9b7a0c239_RXN3O-9818_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1380,7 +1415,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9818> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fe511d01-7180-4197-a8fd-b396fcde1049_RXN3O-9818>
+          <http://model.geneontology.org/c39a4d48-72b5-4e3f-8db2-46f9b7a0c239_RXN3O-9818>
 ] .
 
 <http://purl.org/pav/providedBy>
@@ -1389,57 +1424,51 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_6b1c0bd9-9bc3-4df4-bca0-41a604e432fc_RXN3O-11_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_be6a93ca-16d7-4293-9125-f02046823c50_RXN3O-259_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002411_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/bd57b36e-de2d-41f8-b752-0c8c4486f469_RXN3O-3>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(7)GlcNAc(2)-PP-Dol" ;
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-259_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28240> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002233_CHEBI_16214_2.7.8.15-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002333_MONOMER3O-36_RXN3O-379_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002333_MONOMER3O-36_RXN3O-379_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1450,6 +1479,17 @@
           <http://model.geneontology.org/MONOMER3O-36_RXN3O-379_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_ba7af82c-24c6-4cdc-8a0c-83afd7cd4b25_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58223_2.4.1.141-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58223> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1459,7 +1499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1467,14 +1507,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_b50744c1-a9f4-4a0c-97d2-ed4ba187d66b_RXN3O-291_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_BFO_0000066_reaction_2.4.1.131-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1487,9 +1527,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-378_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/17a2f53d-e700-4974-bedd-7b647be7fbd4_2.4.1.132-RXN> , <http://model.geneontology.org/CHEBI_57527_RXN3O-378> ;
+                <http://model.geneontology.org/163cbe7f-335a-421b-a7a1-50b782606d2f_2.4.1.132-RXN> , <http://model.geneontology.org/CHEBI_57527_RXN3O-378> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/bf6bcb6d-4e6e-44b5-9df2-9a973af57334_RXN3O-378> , <http://model.geneontology.org/CHEBI_58189_RXN3O-378> ;
+                <http://model.geneontology.org/CHEBI_58189_RXN3O-378> , <http://model.geneontology.org/f56e7bde-caf9-44e3-b77a-62655be32ae0_RXN3O-378> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL065C-MONOMER_RXN3O-378_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1497,7 +1537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1505,14 +1545,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_17a2f53d-e700-4974-bedd-7b647be7fbd4_2.4.1.132-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002333_YBR110W-MONOMER_RXN3O-9818_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1520,11 +1560,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1535,26 +1575,15 @@
           <http://model.geneontology.org/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002411_RXN3O-413_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002234_CHEBI_12427_2.4.1.141-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002234_CHEBI_12427_2.4.1.141-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1569,11 +1598,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002333_YBR110W-MONOMER_RXN3O-9818_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002333_YBR110W-MONOMER_RXN3O-9818_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1584,29 +1613,15 @@
           <http://model.geneontology.org/YBR110W-MONOMER_RXN3O-9818_controller>
 ] .
 
-<http://model.geneontology.org/6b1c0bd9-9bc3-4df4-bca0-41a604e432fc_RXN3O-11>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_1d3dc9df-017f-43ea-864b-975b15686f61_2.4.1.132-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002411_2.4.1.131-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002411_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1617,37 +1632,65 @@
           <http://model.geneontology.org/2.4.1.131-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002333_YBR243C-MONOMER_2.7.8.15-RXN_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_BFO_0000066_reaction_2.7.8.15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_CHEBI_58189_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002413_RXN3O-9818_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57705>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/1ee9c7f0-7825-4911-bfb2-79bd9d6c8759_RXN3O-379>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(4)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28183> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/reaction_RXN3O-412_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_572dcc70-98b8-4f61-a4c3-354c92584101_2.4.1.131-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1655,11 +1698,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_BFO_0000066_reaction_RXN3O-291_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_BFO_0000066_reaction_RXN3O-291_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1677,7 +1720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1685,23 +1728,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_b67ad06a-95fc-46fb-a757-7e4629aff2f2_RXN3O-259_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ba7af82c-24c6-4cdc-8a0c-83afd7cd4b25_RXN3O-411>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Glc(1)Man(9)GlcNAc(2)-PP-Dol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28122> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/reaction_RXN3O-11_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1709,11 +1758,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" , "Provides Input For Rule. The relation 'a dolichyl phosphate + UDP-<i>N</i>-acetyl-&alpha;-D-glucosamine &rarr; <i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + UMP' 'null' '<i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + UDP-<i>N</i>-acetyl-&alpha;-D-glucosamine &rarr; <i>N</i>-acetyl-&beta;-D-glucosaminyl-(1&rarr;4)-<i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + UDP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002413_2.4.1.141-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002413_2.4.1.141-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1728,11 +1777,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_CHEBI_57527_2.4.1.132-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_CHEBI_57527_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1743,32 +1792,15 @@
           <http://model.geneontology.org/CHEBI_57527_2.4.1.132-RXN>
 ] .
 
-<http://model.geneontology.org/d922f291-7d3c-4cd4-8c08-fc561c6ed489_RXN3O-379>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(4)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28183> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_4cee55a2-aeb1-4352-ac5f-6542d7953d99_RXN3O-411_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_854001f4-bd40-4746-9c77-b37d0d411124_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1776,18 +1808,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-412> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4cee55a2-aeb1-4352-ac5f-6542d7953d99_RXN3O-411>
+          <http://model.geneontology.org/854001f4-bd40-4746-9c77-b37d0d411124_RXN3O-411>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_e2f43d20-b877-4352-968b-3667ed7cce4e_RXN3O-11_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_df7aad3c-370b-4788-ad36-cae95dc92f2c_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1795,26 +1827,15 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-11> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e2f43d20-b877-4352-968b-3667ed7cce4e_RXN3O-11>
+          <http://model.geneontology.org/df7aad3c-370b-4788-ad36-cae95dc92f2c_RXN3O-11>
 ] .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002411_RXN3O-291_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN3O-9818_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1822,11 +1843,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_bd57b36e-de2d-41f8-b752-0c8c4486f469_RXN3O-3_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_f259a394-e6b4-4366-98d0-511206579371_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1834,8 +1855,25 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-3> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bd57b36e-de2d-41f8-b752-0c8c4486f469_RXN3O-3>
+          <http://model.geneontology.org/f259a394-e6b4-4366-98d0-511206579371_RXN3O-3>
 ] .
+
+<http://model.geneontology.org/f8cd9545-5855-4fbf-8914-6358840b0e2c_RXN3O-291>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(6)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28254> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_12427_2.4.1.141-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_12427> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1846,7 +1884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1854,25 +1892,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_5294f3b2-d3cd-4435-968e-1c8d048fa71c_RXN3O-259_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002411_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002234_CHEBI_58223_2.4.1.141-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1880,11 +1907,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9818_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9818_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1895,14 +1922,14 @@
           <http://model.geneontology.org/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_CHEBI_57527_2.4.1.132-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_CHEBI_16214_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1910,11 +1937,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_BFO_0000066_reaction_RXN3O-379_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_BFO_0000066_reaction_RXN3O-379_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1925,43 +1952,26 @@
           <http://model.geneontology.org/reaction_RXN3O-379_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_BFO_0000066_reaction_2.4.1.132-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_BFO_0000066_reaction_2.4.1.141-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/43d28393-db18-4b43-91a8-ec4aa25e3520_RXN3O-412>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Glc(2)Man(9)GlcNac(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28136> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_6b1c0bd9-9bc3-4df4-bca0-41a604e432fc_RXN3O-11_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_76caf99b-7c44-416f-9c15-1b759ef4f7c2_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1969,30 +1979,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-259> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6b1c0bd9-9bc3-4df4-bca0-41a604e432fc_RXN3O-11>
+          <http://model.geneontology.org/76caf99b-7c44-416f-9c15-1b759ef4f7c2_RXN3O-11>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_CHEBI_57525_RXN3O-413_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-259_BFO_0000066_reaction_RXN3O-259_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-9818>
         a       <http://purl.obolibrary.org/obo/GO_0004578> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2005,7 +1993,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_12427_2.4.1.141-RXN> , <http://model.geneontology.org/CHEBI_57527_RXN3O-9818> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/fe511d01-7180-4197-a8fd-b396fcde1049_RXN3O-9818> , <http://model.geneontology.org/CHEBI_58189_RXN3O-9818> ;
+                <http://model.geneontology.org/c39a4d48-72b5-4e3f-8db2-46f9b7a0c239_RXN3O-9818> , <http://model.geneontology.org/CHEBI_58189_RXN3O-9818> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YBR110W-MONOMER_RXN3O-9818_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2013,7 +2001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2024,29 +2012,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/BFO_0000051>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002333_MONOMER3O-256_RXN3O-11_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_BFO_0000066_reaction_2.7.8.15-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_BFO_0000066_reaction_2.7.8.15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2061,11 +2035,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_CHEBI_58189_2.4.1.131-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_CHEBI_58189_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2076,50 +2050,17 @@
           <http://model.geneontology.org/CHEBI_58189_2.4.1.131-RXN>
 ] .
 
-<http://model.geneontology.org/5294f3b2-d3cd-4435-968e-1c8d048fa71c_RXN3O-259>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl &beta;-D-mannosyl phosphate" ;
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002233_CHEBI_57705_2.4.1.141-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_f367eebe-b2a7-40a8-bd22-3e51600fa06a_RXN3O-411_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-411> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f367eebe-b2a7-40a8-bd22-3e51600fa06a_RXN3O-411>
-] .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_CHEBI_58189_2.4.1.131-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2127,11 +2068,66 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002411_RXN3O-3_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_ba7af82c-24c6-4cdc-8a0c-83afd7cd4b25_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-411> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ba7af82c-24c6-4cdc-8a0c-83afd7cd4b25_RXN3O-411>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002333_YNL219C-MONOMER_RXN3O-3_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/d08d5f38-dde9-48fc-8cd1-7ad512636d89_RXN3O-291>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_f259a394-e6b4-4366-98d0-511206579371_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002333_MONOMER3O-36_2.4.1.131-RXN_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002411_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2146,11 +2142,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002233_CHEBI_16214_2.7.8.15-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002233_CHEBI_16214_2.7.8.15-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2171,11 +2167,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002411_RXN3O-378_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002411_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2190,11 +2186,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2212,13 +2208,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLProtein28176> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_f8cd9545-5855-4fbf-8914-6358840b0e2c_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-256_RXN3O-11_controller>
         a       <http://identifiers.org/sgd/S000005313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2227,7 +2234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2235,23 +2242,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_1e9a2a78-c02e-4507-8d42-6e38768b3831_RXN3O-11_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-413_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2259,11 +2255,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-413_BFO_0000066_reaction_RXN3O-413_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-413_BFO_0000066_reaction_RXN3O-413_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2274,25 +2270,42 @@
           <http://model.geneontology.org/reaction_RXN3O-413_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002233_CHEBI_57705_2.4.1.141-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002411_RXN3O-378_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002333_YBL082C-MONOMER_RXN3O-291_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/f56e7bde-caf9-44e3-b77a-62655be32ae0_RXN3O-378>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(3)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28169> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_f4a6dbdc-6bdc-491c-8f9f-7784a34e5f65_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2300,11 +2313,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_17a2f53d-e700-4974-bedd-7b647be7fbd4_2.4.1.132-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_163cbe7f-335a-421b-a7a1-50b782606d2f_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2312,60 +2325,51 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-378> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/17a2f53d-e700-4974-bedd-7b647be7fbd4_2.4.1.132-RXN>
+          <http://model.geneontology.org/163cbe7f-335a-421b-a7a1-50b782606d2f_2.4.1.132-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002234_CHEBI_12427_2.4.1.141-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002333_YBL082C-MONOMER_RXN3O-291_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/847718e9-db40-4695-a692-a04b9160265a_2.4.1.131-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(5)GlcNAc(2)-PP-Dol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28207> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/7ae87e1c-9314-4357-a81d-86dcd42498d6_RXN3O-379>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/reaction_RXN3O-291_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/YBR110W-MONOMER_RXN3O-9818_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000314> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Dol-PP-GlcNAc2:Man transferase" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_CHEBI_16214_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLProtein27997> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://purl.obolibrary.org/obo/GO_0042281>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/2.4.1.141-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004577> ;
@@ -2386,7 +2390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2394,16 +2398,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002333_YNL219C-MONOMER_RXN3O-259_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/GO_0042281>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/YBR110W-MONOMER_RXN3O-9818_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000314> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Dol-PP-GlcNAc2:Man transferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLProtein27997> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_57527_2.4.1.131-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57527> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2414,7 +2425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2422,27 +2433,55 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002411_2.4.1.131-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_91939d60-e940-4a8d-8b6e-29fdba074eb5_RXN3O-413_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_163cbe7f-335a-421b-a7a1-50b782606d2f_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_5f9d87b1-c58f-4732-b512-c7fe9bda0df7_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_76caf99b-7c44-416f-9c15-1b759ef4f7c2_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/57ff4c1d-26a1-4a83-ad75-414834cac731_2.4.1.132-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a lipid-linked &alpha;(1->3)-D-mannosyl-D-mannose-oligosaccharide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28197> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN3O-379>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -2453,9 +2492,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-379_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57527_RXN3O-379> , <http://model.geneontology.org/adcf732f-a97e-4507-9fa4-a7e736d37abf_RXN3O-378> ;
+                <http://model.geneontology.org/4050a249-f7fe-40bf-bc93-5c6cb09af629_RXN3O-378> , <http://model.geneontology.org/CHEBI_57527_RXN3O-379> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58189_RXN3O-379> , <http://model.geneontology.org/d922f291-7d3c-4cd4-8c08-fc561c6ed489_RXN3O-379> ;
+                <http://model.geneontology.org/CHEBI_58189_RXN3O-379> , <http://model.geneontology.org/1ee9c7f0-7825-4911-bfb2-79bd9d6c8759_RXN3O-379> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-36_RXN3O-379_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2463,7 +2502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2475,11 +2514,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002234_CHEBI_15378_2.4.1.141-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002234_CHEBI_15378_2.4.1.141-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2494,11 +2533,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002411_2.4.1.132-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002411_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2509,45 +2548,17 @@
           <http://model.geneontology.org/2.4.1.132-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_CHEBI_16214_RXN3O-3_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/be6a93ca-16d7-4293-9125-f02046823c50_RXN3O-259>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(9)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28117> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57525>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_CHEBI_57525_RXN3O-412_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002233_CHEBI_57527_RXN3O-9818_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2555,11 +2566,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2570,37 +2581,15 @@
           <http://model.geneontology.org/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002333_YOR067C-MONOMER_RXN3O-412_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_43d28393-db18-4b43-91a8-ec4aa25e3520_RXN3O-412_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_4b047a20-8bff-4cd3-b34c-c147d08ed40b_2.4.1.131-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_bd41d81e-c35a-4ede-adec-1b7ddd2468c2_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2608,39 +2597,42 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-291> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4b047a20-8bff-4cd3-b34c-c147d08ed40b_2.4.1.131-RXN>
+          <http://model.geneontology.org/bd41d81e-c35a-4ede-adec-1b7ddd2468c2_RXN3O-291>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002411_RXN3O-3_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002333_YGL065C-MONOMER_2.4.1.132-RXN_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_aa8f68b9-8158-4ab6-8bcd-4958a375b23b_RXN3O-412_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/92ed5ae5-4551-40b6-8f8b-f6b7ccc355c0_RXN3O-259>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002333_YGR227W-MONOMER_RXN3O-413_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9818_BFO_0000066_reaction_RXN3O-9818_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002233_CHEBI_57527_RXN3O-9818_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2648,11 +2640,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_b216b294-cfd3-49df-a526-06432804f0d0_RXN3O-9818_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_2e5dfe1e-d8a3-4d8b-bc58-ad19a4ed26d2_RXN3O-9818_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2660,17 +2652,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.132-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b216b294-cfd3-49df-a526-06432804f0d0_RXN3O-9818>
+          <http://model.geneontology.org/2e5dfe1e-d8a3-4d8b-bc58-ad19a4ed26d2_RXN3O-9818>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-412_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_CHEBI_58189_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2681,11 +2673,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_CHEBI_16214_RXN3O-412_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_CHEBI_16214_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2705,7 +2697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2717,11 +2709,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002333_MONOMER3O-256_RXN3O-11_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002333_MONOMER3O-256_RXN3O-11_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2732,43 +2724,15 @@
           <http://model.geneontology.org/MONOMER3O-256_RXN3O-11_controller>
 ] .
 
-<http://model.geneontology.org/f367eebe-b2a7-40a8-bd22-3e51600fa06a_RXN3O-411>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Glc(1)Man(9)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28122> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_570a8676-592d-4ae7-8b69-565c78fb915a_RXN3O-291_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002333_YNL219C-MONOMER_RXN3O-3_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002333_YNL219C-MONOMER_RXN3O-3_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2782,32 +2746,35 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/adcf732f-a97e-4507-9fa4-a7e736d37abf_RXN3O-378>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9818_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/a845ab77-9fd0-4bff-8437-af0f9cf4bea1_RXN3O-11>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a dolichyl &beta;-D-mannosyl phosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9818_BFO_0000066_reaction_RXN3O-9818_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9818_BFO_0000066_reaction_RXN3O-9818_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2818,28 +2785,6 @@
           <http://model.geneontology.org/reaction_RXN3O-9818_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9818_BFO_0000066_reaction_RXN3O-9818_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-11_BFO_0000066_reaction_RXN3O-11_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000000274>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2847,11 +2792,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_CHEBI_57527_RXN3O-379_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_CHEBI_57527_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2862,34 +2807,29 @@
           <http://model.geneontology.org/CHEBI_57527_RXN3O-379>
 ] .
 
+<http://model.geneontology.org/8da13775-d9df-4ab8-a12a-a7c945a3e8d4_RXN3O-413>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Glc(3)Man(9)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28150> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/reaction_2.7.8.15-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_BFO_0000066_reaction_2.4.1.141-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-291_BFO_0000066_reaction_RXN3O-291_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2897,11 +2837,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_CHEBI_16214_RXN3O-259_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_CHEBI_16214_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2912,17 +2852,6 @@
           <http://model.geneontology.org/CHEBI_16214_RXN3O-259>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_9fb45b97-7c01-47d5-b64a-5464b4b98e18_RXN3O-3_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/RXN3O-259>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2932,9 +2861,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-259_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/5294f3b2-d3cd-4435-968e-1c8d048fa71c_RXN3O-259> , <http://model.geneontology.org/6b1c0bd9-9bc3-4df4-bca0-41a604e432fc_RXN3O-11> ;
+                <http://model.geneontology.org/76caf99b-7c44-416f-9c15-1b759ef4f7c2_RXN3O-11> , <http://model.geneontology.org/5f9d87b1-c58f-4732-b512-c7fe9bda0df7_RXN3O-259> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/be6a93ca-16d7-4293-9125-f02046823c50_RXN3O-259> , <http://model.geneontology.org/CHEBI_16214_RXN3O-259> ;
+                <http://model.geneontology.org/5395ffe3-c478-46e5-891d-bbd008f6296e_RXN3O-259> , <http://model.geneontology.org/CHEBI_16214_RXN3O-259> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YNL219C-MONOMER_RXN3O-259_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2942,7 +2871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2954,11 +2883,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_572dcc70-98b8-4f61-a4c3-354c92584101_2.4.1.131-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_847718e9-db40-4695-a692-a04b9160265a_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2966,7 +2895,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.131-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/572dcc70-98b8-4f61-a4c3-354c92584101_2.4.1.131-RXN>
+          <http://model.geneontology.org/847718e9-db40-4695-a692-a04b9160265a_2.4.1.131-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57705_2.7.8.15-RXN>
@@ -2978,7 +2907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2986,35 +2915,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/aa8f68b9-8158-4ab6-8bcd-4958a375b23b_RXN3O-412>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/91939d60-e940-4a8d-8b6e-29fdba074eb5_RXN3O-413>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Glc(3)Man(9)GlcNAc(2)-PP-Dol" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_a845ab77-9fd0-4bff-8437-af0f9cf4bea1_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28150> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002411_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002333_YOR002W-MONOMER_RXN3O-411_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002333_YOR002W-MONOMER_RXN3O-411_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3025,14 +2967,47 @@
           <http://model.geneontology.org/YOR002W-MONOMER_RXN3O-411_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002234_CHEBI_18278_2.7.8.15-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_7ae87e1c-9314-4357-a81d-86dcd42498d6_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-3_BFO_0000066_reaction_RXN3O-3_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_CHEBI_57525_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-378_BFO_0000066_reaction_RXN3O-378_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3040,30 +3015,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002233_CHEBI_57705_2.7.8.15-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.7.8.15-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57705_2.7.8.15-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3074,34 +3030,53 @@
           <http://model.geneontology.org/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_CHEBI_57525_RXN3O-411_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002333_MONOMER3O-36_2.4.1.131-RXN_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002233_CHEBI_57705_2.7.8.15-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.7.8.15-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57705_2.7.8.15-RXN>
+] .
 
 <http://model.geneontology.org/SGD_S000000274_CPLX3O-24_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000274> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-291_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3109,11 +3084,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3133,9 +3108,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-411_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/b67ad06a-95fc-46fb-a757-7e4629aff2f2_RXN3O-259> , <http://model.geneontology.org/CHEBI_57525_RXN3O-411> ;
+                <http://model.geneontology.org/92ed5ae5-4551-40b6-8f8b-f6b7ccc355c0_RXN3O-259> , <http://model.geneontology.org/CHEBI_57525_RXN3O-411> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/f367eebe-b2a7-40a8-bd22-3e51600fa06a_RXN3O-411> , <http://model.geneontology.org/CHEBI_16214_RXN3O-411> ;
+                <http://model.geneontology.org/ba7af82c-24c6-4cdc-8a0c-83afd7cd4b25_RXN3O-411> , <http://model.geneontology.org/CHEBI_16214_RXN3O-411> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR002W-MONOMER_RXN3O-411_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3143,7 +3118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3160,7 +3135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3172,11 +3147,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_BFO_0000066_reaction_RXN3O-11_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_BFO_0000066_reaction_RXN3O-11_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3191,11 +3166,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_CHEBI_57525_RXN3O-413_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_CHEBI_57525_RXN3O-413_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3206,37 +3181,32 @@
           <http://model.geneontology.org/CHEBI_57525_RXN3O-413>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_fe511d01-7180-4197-a8fd-b396fcde1049_RXN3O-9818_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/5395ffe3-c478-46e5-891d-bbd008f6296e_RXN3O-259>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(9)GlcNAc(2)-PP-Dol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002411_2.4.1.132-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28117> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_CHEBI_58189_RXN3O-378_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_CHEBI_58189_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3247,26 +3217,15 @@
           <http://model.geneontology.org/CHEBI_58189_RXN3O-378>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002411_RXN3O-411_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_aa8f68b9-8158-4ab6-8bcd-4958a375b23b_RXN3O-412_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_1686f98c-06ea-4fdc-bc0a-18b834d48772_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3274,19 +3233,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-413> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/aa8f68b9-8158-4ab6-8bcd-4958a375b23b_RXN3O-412>
+          <http://model.geneontology.org/1686f98c-06ea-4fdc-bc0a-18b834d48772_RXN3O-412>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-259_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -3297,24 +3245,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "lipid-linked oligosaccharide biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-378_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16214_RXN3O-11>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16214> ;
@@ -3325,7 +3262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3340,11 +3277,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_bf6bcb6d-4e6e-44b5-9df2-9a973af57334_RXN3O-378_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_f56e7bde-caf9-44e3-b77a-62655be32ae0_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3352,18 +3289,29 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-378> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bf6bcb6d-4e6e-44b5-9df2-9a973af57334_RXN3O-378>
+          <http://model.geneontology.org/f56e7bde-caf9-44e3-b77a-62655be32ae0_RXN3O-378>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_8da13775-d9df-4ab8-a12a-a7c945a3e8d4_RXN3O-413_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002411_RXN3O-259_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002411_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3374,6 +3322,17 @@
           <http://model.geneontology.org/RXN3O-259>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_92ed5ae5-4551-40b6-8f8b-f6b7ccc355c0_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-24_2.4.1.141-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3383,7 +3342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3391,15 +3350,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002233_CHEBI_12427_2.4.1.141-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002234_CHEBI_15378_2.4.1.141-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002234_CHEBI_58223_2.4.1.141-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002234_CHEBI_58223_2.4.1.141-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3410,15 +3391,26 @@
           <http://model.geneontology.org/CHEBI_58223_2.4.1.141-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002411_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3432,47 +3424,47 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_CHEBI_57527_RXN3O-379_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002333_YNL219C-MONOMER_RXN3O-3_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002333_YGR227W-MONOMER_RXN3O-413_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_4cee55a2-aeb1-4352-ac5f-6542d7953d99_RXN3O-411_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002234_CHEBI_58223_2.4.1.141-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_847718e9-db40-4695-a692-a04b9160265a_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_1686f98c-06ea-4fdc-bc0a-18b834d48772_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3483,11 +3475,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_BFO_0000066_reaction_RXN3O-411_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_BFO_0000066_reaction_RXN3O-411_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3498,25 +3490,14 @@
           <http://model.geneontology.org/reaction_RXN3O-411_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-291_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002233_CHEBI_18278_2.7.8.15-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_CHEBI_57527_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3524,11 +3505,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_570a8676-592d-4ae7-8b69-565c78fb915a_RXN3O-291_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_f4a6dbdc-6bdc-491c-8f9f-7784a34e5f65_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3536,18 +3517,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-291> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/570a8676-592d-4ae7-8b69-565c78fb915a_RXN3O-291>
+          <http://model.geneontology.org/f4a6dbdc-6bdc-491c-8f9f-7784a34e5f65_2.4.1.131-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_CHEBI_58189_2.4.1.132-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_CHEBI_58189_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3561,32 +3542,15 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/1d3dc9df-017f-43ea-864b-975b15686f61_2.4.1.132-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a lipid-linked &alpha;(1->3)-D-mannosyl-D-mannose-oligosaccharide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28197> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_43d28393-db18-4b43-91a8-ec4aa25e3520_RXN3O-412_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_df58bf29-4a78-4024-a457-02168ed2cf74_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3594,35 +3558,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-412> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/43d28393-db18-4b43-91a8-ec4aa25e3520_RXN3O-412>
+          <http://model.geneontology.org/df58bf29-4a78-4024-a457-02168ed2cf74_RXN3O-412>
 ] .
-
-<http://model.geneontology.org/e2f43d20-b877-4352-968b-3667ed7cce4e_RXN3O-11>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(8)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28226> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002411_RXN3O-11_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002411_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3636,14 +3583,14 @@
 <http://identifiers.org/sgd/S000000178>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-24_2.4.1.141-RXN_controller_BFO_0000051_SGD_S000000274_CPLX3O-24_component_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_BFO_0000066_reaction_2.4.1.132-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3655,7 +3602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3668,7 +3615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3676,15 +3623,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_4050a249-f7fe-40bf-bc93-5c6cb09af629_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-11_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002233_CHEBI_12427_2.4.1.141-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002233_CHEBI_12427_2.4.1.141-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3695,40 +3664,12 @@
           <http://model.geneontology.org/CHEBI_12427_2.4.1.141-RXN>
 ] .
 
-<http://model.geneontology.org/570a8676-592d-4ae7-8b69-565c78fb915a_RXN3O-291>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl &beta;-D-mannosyl phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_adcf732f-a97e-4507-9fa4-a7e736d37abf_RXN3O-378_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-259_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3736,11 +3677,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_adcf732f-a97e-4507-9fa4-a7e736d37abf_RXN3O-378_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_4050a249-f7fe-40bf-bc93-5c6cb09af629_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3748,19 +3689,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-379> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/adcf732f-a97e-4507-9fa4-a7e736d37abf_RXN3O-378>
+          <http://model.geneontology.org/4050a249-f7fe-40bf-bc93-5c6cb09af629_RXN3O-378>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-3_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57527_RXN3O-378>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57527> ;
@@ -3771,7 +3701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3782,9 +3712,6 @@
 <http://identifiers.org/sgd/S000003459>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/40052bbe-5f6b-478f-a096-7d97d5e21b9e_RXN3O-291>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/CHEBI_57705_2.4.1.141-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57705> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3794,7 +3721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3806,11 +3733,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_be6a93ca-16d7-4293-9125-f02046823c50_RXN3O-259_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_5395ffe3-c478-46e5-891d-bbd008f6296e_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3818,18 +3745,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-259> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/be6a93ca-16d7-4293-9125-f02046823c50_RXN3O-259>
+          <http://model.geneontology.org/5395ffe3-c478-46e5-891d-bbd008f6296e_RXN3O-259>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_BFO_0000066_reaction_2.4.1.141-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_BFO_0000066_reaction_2.4.1.141-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3840,6 +3767,17 @@
           <http://model.geneontology.org/reaction_2.4.1.141-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002411_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16214_RXN3O-411>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16214> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3849,7 +3787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3861,11 +3799,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002333_MONOMER3O-36_2.4.1.131-RXN_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002333_MONOMER3O-36_2.4.1.131-RXN_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3876,24 +3814,27 @@
           <http://model.geneontology.org/MONOMER3O-36_2.4.1.131-RXN_controller>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002411_RXN3O-412_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-411> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-412>
-] .
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_57ff4c1d-26a1-4a83-ad75-414834cac731_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_c39a4d48-72b5-4e3f-8db2-46f9b7a0c239_RXN3O-9818_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-291>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0052925> ;
@@ -3904,9 +3845,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-291_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/4b047a20-8bff-4cd3-b34c-c147d08ed40b_2.4.1.131-RXN> , <http://model.geneontology.org/570a8676-592d-4ae7-8b69-565c78fb915a_RXN3O-291> ;
+                <http://model.geneontology.org/f4a6dbdc-6bdc-491c-8f9f-7784a34e5f65_2.4.1.131-RXN> , <http://model.geneontology.org/bd41d81e-c35a-4ede-adec-1b7ddd2468c2_RXN3O-291> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/b50744c1-a9f4-4a0c-97d2-ed4ba187d66b_RXN3O-291> , <http://model.geneontology.org/CHEBI_16214_RXN3O-291> ;
+                <http://model.geneontology.org/CHEBI_16214_RXN3O-291> , <http://model.geneontology.org/f8cd9545-5855-4fbf-8914-6358840b0e2c_RXN3O-291> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YBL082C-MONOMER_RXN3O-291_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3914,7 +3855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3922,36 +3863,44 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-379_BFO_0000066_reaction_RXN3O-379_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002411_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-411> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-412>
+] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_CHEBI_57527_RXN3O-378_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-9818_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_CHEBI_57527_2.4.1.131-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-24_2.4.1.141-RXN_controller_BFO_0000051_SGD_S000000274_CPLX3O-24_component_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3959,11 +3908,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_BFO_0000066_reaction_RXN3O-3_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_BFO_0000066_reaction_RXN3O-3_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3978,11 +3927,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002234_CHEBI_18278_2.7.8.15-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002234_CHEBI_18278_2.7.8.15-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3993,28 +3942,45 @@
           <http://model.geneontology.org/CHEBI_18278_2.7.8.15-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000005528>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-3_BFO_0000066_reaction_RXN3O-3_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002333_CPLX3O-24_2.4.1.141-RXN_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002234_CHEBI_57865_2.7.8.15-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/5f9d87b1-c58f-4732-b512-c7fe9bda0df7_RXN3O-259>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a dolichyl &beta;-D-mannosyl phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000005528>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-379_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4027,9 +3993,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-412_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57525_RXN3O-412> , <http://model.geneontology.org/4cee55a2-aeb1-4352-ac5f-6542d7953d99_RXN3O-411> ;
+                <http://model.geneontology.org/CHEBI_57525_RXN3O-412> , <http://model.geneontology.org/854001f4-bd40-4746-9c77-b37d0d411124_RXN3O-411> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16214_RXN3O-412> , <http://model.geneontology.org/43d28393-db18-4b43-91a8-ec4aa25e3520_RXN3O-412> ;
+                <http://model.geneontology.org/df58bf29-4a78-4024-a457-02168ed2cf74_RXN3O-412> , <http://model.geneontology.org/CHEBI_16214_RXN3O-412> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR067C-MONOMER_RXN3O-412_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -4037,7 +4003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4049,11 +4015,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_0433c00d-c6aa-453f-ab8d-df4648461eee_RXN3O-3_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_a845ab77-9fd0-4bff-8437-af0f9cf4bea1_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4061,19 +4027,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-11> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0433c00d-c6aa-453f-ab8d-df4648461eee_RXN3O-3>
+          <http://model.geneontology.org/a845ab77-9fd0-4bff-8437-af0f9cf4bea1_RXN3O-11>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_0433c00d-c6aa-453f-ab8d-df4648461eee_RXN3O-3_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58189_2.4.1.132-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58189> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4084,7 +4039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4092,53 +4047,47 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/c6baceb7-253d-4fa2-b80d-7b1f8c794050_2.4.1.132-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(2)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28164> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/1e9a2a78-c02e-4507-8d42-6e38768b3831_RXN3O-11>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl &beta;-D-mannosyl phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_4b047a20-8bff-4cd3-b34c-c147d08ed40b_2.4.1.131-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002411_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-379_BFO_0000066_reaction_RXN3O-379_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/df58bf29-4a78-4024-a457-02168ed2cf74_RXN3O-412>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Glc(2)Man(9)GlcNac(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28136> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YOR002W-MONOMER_RXN3O-411_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005528> ;
@@ -4147,7 +4096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4155,29 +4104,46 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-413_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_CHEBI_16214_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/d018c7da-1515-4b95-b5cd-e915969b26d8_2.4.1.132-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(2)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28164> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_CHEBI_16214_RXN3O-413_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_CHEBI_16214_RXN3O-413_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4191,14 +4157,25 @@
 <http://purl.obolibrary.org/obo/GO_0042283>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_CHEBI_16214_RXN3O-11_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_df7aad3c-370b-4788-ad36-cae95dc92f2c_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_CHEBI_16214_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4206,11 +4183,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002333_YGL065C-MONOMER_RXN3O-378_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002333_YGL065C-MONOMER_RXN3O-378_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4221,6 +4198,17 @@
           <http://model.geneontology.org/YGL065C-MONOMER_RXN3O-378_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_7ac670b3-263f-4508-92ae-468bb59034b3_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER3O-36_2.4.1.131-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004993> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4228,7 +4216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4239,15 +4227,26 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_fca9712b-d55a-42bf-9cfa-dae08a75ca65_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4258,26 +4257,15 @@
           <http://model.geneontology.org/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_BFO_0000066_reaction_2.4.1.131-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002333_CPLX3O-24_2.4.1.141-RXN_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002333_CPLX3O-24_2.4.1.141-RXN_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4292,11 +4280,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_BFO_0000066_reaction_2.4.1.131-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_BFO_0000066_reaction_2.4.1.131-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4307,14 +4295,14 @@
           <http://model.geneontology.org/reaction_2.4.1.131-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002233_CHEBI_57705_2.7.8.15-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002411_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4329,7 +4317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4337,11 +4325,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_CHEBI_57525_RXN3O-411_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_CHEBI_57525_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4352,6 +4340,17 @@
           <http://model.geneontology.org/CHEBI_57525_RXN3O-411>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_d018c7da-1515-4b95-b5cd-e915969b26d8_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YNL219C-MONOMER_RXN3O-259_controller>
         a       <http://identifiers.org/sgd/S000005163> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4359,13 +4358,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLProtein28233> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002233_CHEBI_18278_2.7.8.15-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57525_RXN3O-411>
         a       <http://purl.obolibrary.org/obo/CHEBI_57525> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4376,7 +4386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4384,14 +4394,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_bf6bcb6d-4e6e-44b5-9df2-9a973af57334_RXN3O-378_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_d08d5f38-dde9-48fc-8cd1-7ad512636d89_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4399,11 +4409,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_CHEBI_16214_RXN3O-291_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_CHEBI_16214_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4414,19 +4424,30 @@
           <http://model.geneontology.org/CHEBI_16214_RXN3O-291>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_CHEBI_58189_RXN3O-9818_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://purl.obolibrary.org/obo/CHEBI_57865>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_CHEBI_16214_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57865>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002411_RXN3O-413_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YBL082C-MONOMER_RXN3O-291_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000178> ;
@@ -4435,7 +4456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4443,32 +4464,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/b50744c1-a9f4-4a0c-97d2-ed4ba187d66b_RXN3O-291>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(6)GlcNAc(2)-PP-Dol" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-3_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28254> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_c6baceb7-253d-4fa2-b80d-7b1f8c794050_2.4.1.132-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_d018c7da-1515-4b95-b5cd-e915969b26d8_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4476,39 +4491,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.132-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c6baceb7-253d-4fa2-b80d-7b1f8c794050_2.4.1.132-RXN>
+          <http://model.geneontology.org/d018c7da-1515-4b95-b5cd-e915969b26d8_2.4.1.132-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_e2f43d20-b877-4352-968b-3667ed7cce4e_RXN3O-11_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002333_YOR002W-MONOMER_RXN3O-411_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-378_BFO_0000066_reaction_RXN3O-378_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_c6baceb7-253d-4fa2-b80d-7b1f8c794050_2.4.1.132-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4516,11 +4509,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002333_YOR067C-MONOMER_RXN3O-412_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002333_YOR067C-MONOMER_RXN3O-412_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4531,25 +4524,17 @@
           <http://model.geneontology.org/YOR067C-MONOMER_RXN3O-412_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002234_CHEBI_15378_2.4.1.141-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/163cbe7f-335a-421b-a7a1-50b782606d2f_2.4.1.132-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002333_MONOMER3O-256_RXN3O-11_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4557,11 +4542,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4572,22 +4557,60 @@
           <http://model.geneontology.org/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
-<http://model.geneontology.org/9fb45b97-7c01-47d5-b64a-5464b4b98e18_RXN3O-3>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl &beta;-D-mannosyl phosphate" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-291_BFO_0000066_reaction_RXN3O-291_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_5395ffe3-c478-46e5-891d-bbd008f6296e_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002413_2.4.1.141-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-411_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-11_BFO_0000066_reaction_RXN3O-11_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58189_RXN3O-9818>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58189> ;
@@ -4598,24 +4621,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule27989> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002333_MONOMER3O-36_RXN3O-379_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58189_RXN3O-378>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58189> ;
@@ -4626,7 +4638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4634,46 +4646,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_f367eebe-b2a7-40a8-bd22-3e51600fa06a_RXN3O-411_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_1ee9c7f0-7825-4911-bfb2-79bd9d6c8759_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_16214_RXN3O-291>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16214> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl phosphate" ;
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-411_BFO_0000066_reaction_RXN3O-411_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28079> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/854001f4-bd40-4746-9c77-b37d0d411124_RXN3O-411>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002233_CHEBI_57527_RXN3O-9818_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002233_CHEBI_57527_RXN3O-9818_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4684,25 +4693,42 @@
           <http://model.geneontology.org/CHEBI_57527_RXN3O-9818>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002411_RXN3O-379_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/CHEBI_16214_RXN3O-291>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16214> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a dolichyl phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28079> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_CHEBI_16214_RXN3O-413_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002333_YGL065C-MONOMER_2.4.1.132-RXN_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-412_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4713,11 +4739,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_CHEBI_58189_RXN3O-379_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_CHEBI_58189_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4737,7 +4763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4745,18 +4771,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/4cee55a2-aeb1-4352-ac5f-6542d7953d99_RXN3O-411>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_CHEBI_57525_RXN3O-413_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002333_YNL219C-MONOMER_RXN3O-259_controller_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002333_YNL219C-MONOMER_RXN3O-259_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4771,11 +4805,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002233_CHEBI_18278_2.7.8.15-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002233_CHEBI_18278_2.7.8.15-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4786,17 +4820,6 @@
           <http://model.geneontology.org/CHEBI_18278_2.7.8.15-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-379_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58189_2.4.1.131-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58189> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4806,7 +4829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4814,22 +4837,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/bf6bcb6d-4e6e-44b5-9df2-9a973af57334_RXN3O-378>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(3)GlcNAc(2)-PP-Dol" ;
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_CHEBI_57527_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28169> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16214_RXN3O-412>
         a       <http://purl.obolibrary.org/obo/CHEBI_16214> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4840,7 +4857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4848,32 +4865,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/fe511d01-7180-4197-a8fd-b396fcde1049_RXN3O-9818>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(1)GlcNAc(2)-PP-Dol" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-413_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule27974> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002411_RXN3O-291_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002411_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4884,12 +4895,34 @@
           <http://model.geneontology.org/RXN3O-291>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_f56e7bde-caf9-44e3-b77a-62655be32ae0_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-379_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_CHEBI_58189_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4897,11 +4930,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4912,26 +4945,18 @@
           <http://model.geneontology.org/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002413_2.4.1.141-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/1686f98c-06ea-4fdc-bc0a-18b834d48772_RXN3O-412>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_40052bbe-5f6b-478f-a096-7d97d5e21b9e_RXN3O-291_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_d08d5f38-dde9-48fc-8cd1-7ad512636d89_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4939,18 +4964,29 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-3> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/40052bbe-5f6b-478f-a096-7d97d5e21b9e_RXN3O-291>
+          <http://model.geneontology.org/d08d5f38-dde9-48fc-8cd1-7ad512636d89_RXN3O-291>
 ] .
+
+<http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002333_YBR243C-MONOMER_2.7.8.15-RXN_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002234_CHEBI_57865_2.7.8.15-RXN_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002234_CHEBI_57865_2.7.8.15-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4965,11 +5001,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4999,7 +5035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5011,11 +5047,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_BFO_0000066_reaction_RXN3O-412_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_BFO_0000066_reaction_RXN3O-412_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5038,15 +5074,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-413_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/aa8f68b9-8158-4ab6-8bcd-4958a375b23b_RXN3O-412> , <http://model.geneontology.org/CHEBI_57525_RXN3O-413> ;
+                <http://model.geneontology.org/CHEBI_57525_RXN3O-413> , <http://model.geneontology.org/1686f98c-06ea-4fdc-bc0a-18b834d48772_RXN3O-412> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/91939d60-e940-4a8d-8b6e-29fdba074eb5_RXN3O-413> , <http://model.geneontology.org/CHEBI_16214_RXN3O-413> ;
+                <http://model.geneontology.org/8da13775-d9df-4ab8-a12a-a7c945a3e8d4_RXN3O-413> , <http://model.geneontology.org/CHEBI_16214_RXN3O-413> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR227W-MONOMER_RXN3O-413_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5058,11 +5094,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_1e9a2a78-c02e-4507-8d42-6e38768b3831_RXN3O-11_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_7ac670b3-263f-4508-92ae-468bb59034b3_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5070,29 +5106,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-11> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1e9a2a78-c02e-4507-8d42-6e38768b3831_RXN3O-11>
+          <http://model.geneontology.org/7ac670b3-263f-4508-92ae-468bb59034b3_RXN3O-3>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002411_RXN3O-259_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_9fb45b97-7c01-47d5-b64a-5464b4b98e18_RXN3O-3_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_fca9712b-d55a-42bf-9cfa-dae08a75ca65_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5100,53 +5125,28 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-3> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9fb45b97-7c01-47d5-b64a-5464b4b98e18_RXN3O-3>
+          <http://model.geneontology.org/fca9712b-d55a-42bf-9cfa-dae08a75ca65_RXN3O-3>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_CHEBI_16214_RXN3O-413_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002411_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-413_BFO_0000066_reaction_RXN3O-413_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_854001f4-bd40-4746-9c77-b37d0d411124_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002411_RXN3O-412_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/b67ad06a-95fc-46fb-a757-7e4629aff2f2_RXN3O-259>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_BFO_0000066_reaction_2.7.8.15-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5162,9 +5162,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.4.1.132-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57527_2.4.1.132-RXN> , <http://model.geneontology.org/b216b294-cfd3-49df-a526-06432804f0d0_RXN3O-9818> ;
+                <http://model.geneontology.org/CHEBI_57527_2.4.1.132-RXN> , <http://model.geneontology.org/2e5dfe1e-d8a3-4d8b-bc58-ad19a4ed26d2_RXN3O-9818> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/1d3dc9df-017f-43ea-864b-975b15686f61_2.4.1.132-RXN> , <http://model.geneontology.org/c6baceb7-253d-4fa2-b80d-7b1f8c794050_2.4.1.132-RXN> , <http://model.geneontology.org/CHEBI_58189_2.4.1.132-RXN> ;
+                <http://model.geneontology.org/57ff4c1d-26a1-4a83-ad75-414834cac731_2.4.1.132-RXN> , <http://model.geneontology.org/d018c7da-1515-4b95-b5cd-e915969b26d8_2.4.1.132-RXN> , <http://model.geneontology.org/CHEBI_58189_2.4.1.132-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL065C-MONOMER_2.4.1.132-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -5172,7 +5172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_GLUDEG-I-PWY-1.ttl
+++ b/models/YeastPathways_GLUDEG-I-PWY-1.ttl
@@ -3,7 +3,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002234_CHEBI_59888_GLUTDECARBOX-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,15 +38,37 @@
 <http://identifiers.org/sgd/S000000210>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002413_RXN0-5293_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_15377_RXN0-5293_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002333_YMR250W-MONOMER_GLUTDECARBOX-RXN_controller_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002333_YMR250W-MONOMER_GLUTDECARBOX-RXN_controller_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -67,11 +100,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002234_CHEBI_29985_GABATRANSAM-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002234_CHEBI_29985_GABATRANSAM-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -91,28 +124,6 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002234_CHEBI_16526_GLUTDECARBOX-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002234_CHEBI_29985_GABATRANSAM-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29985_GLUTDECARBOX-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -122,24 +133,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUDEG-I-PWY-1SmallMolecule51066> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002413_GABATRANSAM-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN0-5293>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -163,7 +163,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002234_CHEBI_16526_GLUTDECARBOX-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -171,11 +182,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_13392_RXN0-5293_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_13392_RXN0-5293_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -186,37 +197,48 @@
           <http://model.geneontology.org/CHEBI_13392_RXN0-5293>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_13390_RXN0-5293_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002333_YBR006W-MONOMER_RXN0-5293_controller_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://purl.obolibrary.org/obo/GO_0034386>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/GO_0004351>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0034386>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002333_YMR250W-MONOMER_GLUTDECARBOX-RXN_controller_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_BFO_0000066_reaction_GLUTDECARBOX-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002233_CHEBI_16810_GABATRANSAM-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -224,11 +246,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002234_CHEBI_59888_GLUTDECARBOX-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002234_CHEBI_59888_GLUTDECARBOX-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,26 +261,15 @@
           <http://model.geneontology.org/CHEBI_59888_GLUTDECARBOX-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002333_YMR250W-MONOMER_GLUTDECARBOX-RXN_controller_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002233_CHEBI_59888_GLUTDECARBOX-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002233_CHEBI_59888_GLUTDECARBOX-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -269,6 +280,17 @@
           <http://model.geneontology.org/CHEBI_59888_GLUTDECARBOX-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002233_CHEBI_29985_GLUTDECARBOX-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_13390_RXN0-5293>
         a       <http://purl.obolibrary.org/obo/CHEBI_13390> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -278,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,6 +310,28 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_15378_RXN0-5293_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002333_YGR019W-MONOMER_GABATRANSAM-RXN_controller_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -301,13 +345,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUDEG-I-PWY-1SmallMolecule50980> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002233_CHEBI_59888_GLUTDECARBOX-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -329,13 +384,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUDEG-I-PWY-1BiochemicalReaction50963> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_BFO_0000066_reaction_GABATRANSAM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -344,11 +410,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_57706_GABATRANSAM-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_57706_GABATRANSAM-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -371,7 +437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -379,26 +445,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002233_CHEBI_59888_GLUTDECARBOX-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_13390_RXN0-5293_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_13390_RXN0-5293_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -416,11 +471,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_BFO_0000050_YeastPathways_GLUDEG-I-PWY-1/YeastPathways_GLUDEG-I-PWY-1_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_BFO_0000050_YeastPathways_GLUDEG-I-PWY-1/YeastPathways_GLUDEG-I-PWY-1_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,6 +486,17 @@
           <http://model.geneontology.org/YeastPathways_GLUDEG-I-PWY-1/YeastPathways_GLUDEG-I-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002233_CHEBI_15378_GLUTDECARBOX-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -438,11 +504,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002234_CHEBI_16526_GLUTDECARBOX-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002234_CHEBI_16526_GLUTDECARBOX-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -453,37 +519,15 @@
           <http://model.geneontology.org/CHEBI_16526_GLUTDECARBOX-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_57706_GABATRANSAM-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002233_CHEBI_15378_GLUTDECARBOX-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002233_CHEBI_16810_GABATRANSAM-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002233_CHEBI_16810_GABATRANSAM-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,36 +538,47 @@
           <http://model.geneontology.org/CHEBI_16810_GABATRANSAM-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0009013>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-5293_BFO_0000066_reaction_RXN0-5293_location_lociGO_0005829_SGD_YeastPathways_GLUDEG-I-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_30031_RXN0-5293_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0009013>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_BFO_0000066_reaction_GLUTDECARBOX-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_13392>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_BFO_0000066_reaction_GABATRANSAM-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUDEG-I-PWY-1>
+<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002234_CHEBI_29985_GABATRANSAM-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_13392>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_16526_GLUTDECARBOX-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -534,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -549,11 +604,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_15377_RXN0-5293_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_15377_RXN0-5293_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -563,17 +618,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_RXN0-5293>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002234_CHEBI_57706_GABATRANSAM-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0036242>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -585,24 +629,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUDEG-I-PWY-1Protein51128> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002333_YBR006W-MONOMER_RXN0-5293_controller_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -626,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -637,26 +670,15 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002233_CHEBI_16810_GABATRANSAM-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5293_BFO_0000066_reaction_RXN0-5293_location_lociGO_0005829_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5293_BFO_0000066_reaction_RXN0-5293_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,11 +693,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2-oxoglutarate + 4-aminobutanoate &harr; L-glutamate + succinate semialdehyde' 'null' 'succinate semialdehyde + NAD(P)<sup>+</sup> + H<sub>2</sub>O &rarr; succinate + NAD(P)H + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002413_RXN0-5293_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002413_RXN0-5293_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -686,14 +708,14 @@
           <http://model.geneontology.org/RXN0-5293>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_BFO_0000050_YeastPathways_GLUDEG-I-PWY-1/YeastPathways_GLUDEG-I-PWY-1_SGD_YeastPathways_GLUDEG-I-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN0-5293_BFO_0000066_reaction_RXN0-5293_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -706,13 +728,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutamate degradation I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-5293_BFO_0000050_YeastPathways_GLUDEG-I-PWY-1/YeastPathways_GLUDEG-I-PWY-1_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -721,11 +754,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002233_CHEBI_29985_GLUTDECARBOX-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002233_CHEBI_29985_GLUTDECARBOX-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -740,11 +773,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_BFO_0000066_reaction_GABATRANSAM-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_BFO_0000066_reaction_GABATRANSAM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -755,17 +788,6 @@
           <http://model.geneontology.org/reaction_GABATRANSAM-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_15378_RXN0-5293_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29985_GABATRANSAM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -775,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -787,11 +809,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002333_YBR006W-MONOMER_RXN0-5293_controller_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002333_YBR006W-MONOMER_RXN0-5293_controller_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -807,45 +829,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_30031_RXN0-5293_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-5293_BFO_0000050_YeastPathways_GLUDEG-I-PWY-1/YeastPathways_GLUDEG-I-PWY-1_SGD_YeastPathways_GLUDEG-I-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_13390_RXN0-5293_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002233_CHEBI_29985_GLUTDECARBOX-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30031>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -859,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -877,11 +877,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5293_BFO_0000050_YeastPathways_GLUDEG-I-PWY-1/YeastPathways_GLUDEG-I-PWY-1_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5293_BFO_0000050_YeastPathways_GLUDEG-I-PWY-1/YeastPathways_GLUDEG-I-PWY-1_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -892,26 +892,15 @@
           <http://model.geneontology.org/YeastPathways_GLUDEG-I-PWY-1/YeastPathways_GLUDEG-I-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_BFO_0000050_YeastPathways_GLUDEG-I-PWY-1/YeastPathways_GLUDEG-I-PWY-1_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002333_YGR019W-MONOMER_GABATRANSAM-RXN_controller_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002333_YGR019W-MONOMER_GABATRANSAM-RXN_controller_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -932,7 +921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -946,26 +935,15 @@
 <http://identifiers.org/sgd/S000004862>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002234_CHEBI_59888_GLUTDECARBOX-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002233_CHEBI_15378_GLUTDECARBOX-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002233_CHEBI_15378_GLUTDECARBOX-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -980,11 +958,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_BFO_0000050_YeastPathways_GLUDEG-I-PWY-1/YeastPathways_GLUDEG-I-PWY-1_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_BFO_0000050_YeastPathways_GLUDEG-I-PWY-1/YeastPathways_GLUDEG-I-PWY-1_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -999,11 +977,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_30031_RXN0-5293_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_30031_RXN0-5293_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1024,7 +1002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1034,17 +1012,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_13390>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002333_YGR019W-MONOMER_GABATRANSAM-RXN_controller_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1058,7 +1025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,13 +1045,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUDEG-I-PWY-1SmallMolecule51026> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_57706_GABATRANSAM-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1098,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1106,14 +1084,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_15377_RXN0-5293_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002413_GABATRANSAM-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1121,11 +1099,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-glutamate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + 4-aminobutanoate' 'null' '2-oxoglutarate + 4-aminobutanoate &harr; L-glutamate + succinate semialdehyde' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002413_GABATRANSAM-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_RO_0002413_GABATRANSAM-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1136,15 +1114,26 @@
           <http://model.geneontology.org/GABATRANSAM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_BFO_0000050_YeastPathways_GLUDEG-I-PWY-1/YeastPathways_GLUDEG-I-PWY-1_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002234_CHEBI_57706_GABATRANSAM-RXN_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002234_CHEBI_57706_GABATRANSAM-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1154,6 +1143,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57706_GABATRANSAM-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_13392_RXN0-5293_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GABATRANSAM-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0034386> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1174,7 +1174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1185,15 +1185,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_BFO_0000050_YeastPathways_GLUDEG-I-PWY-1/YeastPathways_GLUDEG-I-PWY-1_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_BFO_0000066_reaction_GLUTDECARBOX-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDECARBOX-RXN_BFO_0000066_reaction_GLUTDECARBOX-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1211,11 +1222,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_15378_RXN0-5293_SGD_YeastPathways_GLUDEG-I-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_15378_RXN0-5293_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1226,24 +1237,13 @@
           <http://model.geneontology.org/CHEBI_15378_RXN0-5293>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002413_RXN0-5293_SGD_YeastPathways_GLUDEG-I-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_13392_RXN0-5293_SGD_YeastPathways_GLUDEG-I-PWY-1>
+<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002234_CHEBI_57706_GABATRANSAM-RXN_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUDEG-I-PWY-1" ;
+                "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_GLUGLNSYN-PWY.ttl
+++ b/models/YeastPathways_GLUGLNSYN-PWY.ttl
@@ -15,7 +15,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,14 +23,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_16810_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_GLUGLNSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_BFO_0000066_reaction_GLUTAMATE-SYNTHASE-NADH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUGLNSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUGLNSYN-PWY" ;
+                "SGD_PWY:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -38,11 +38,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_57945_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_GLUGLNSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_57945_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_GLUGLNSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -52,6 +52,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57945_GLUTAMATE-SYNTHASE-NADH-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_15378_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_GLUGLNSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUGLNSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -68,24 +79,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_GLUGLNSYN-PWY" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_57945_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_GLUGLNSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUGLNSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57945_GLUTAMATE-SYNTHASE-NADH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -131,11 +131,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_16810_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_GLUGLNSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_16810_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_GLUGLNSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -146,33 +146,33 @@
           <http://model.geneontology.org/CHEBI_16810_GLUTAMATE-SYNTHASE-NADH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_58359_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_GLUGLNSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_58359_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_GLUGLNSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUGLNSYN-PWY" ;
+                "SGD_PWY:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_BFO_0000066_reaction_GLUTAMATE-SYNTHASE-NADH-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUGLNSYN-PWY>
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002234_CHEBI_57540_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_GLUGLNSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUGLNSYN-PWY" ;
+                "SGD_PWY:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -181,11 +181,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002333_YDL171C-MONOMER_GLUTAMATE-SYNTHASE-NADH-RXN_controller_SGD_YeastPathways_GLUGLNSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002333_YDL171C-MONOMER_GLUTAMATE-SYNTHASE-NADH-RXN_controller_SGD_PWY_YeastPathways_GLUGLNSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -196,17 +196,6 @@
           <http://model.geneontology.org/YDL171C-MONOMER_GLUTAMATE-SYNTHASE-NADH-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002234_CHEBI_57540_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_GLUGLNSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUGLNSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -214,11 +203,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_15378_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_GLUGLNSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_15378_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_GLUGLNSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -252,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -266,11 +255,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002234_CHEBI_57540_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_GLUGLNSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002234_CHEBI_57540_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_GLUGLNSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -291,11 +280,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_BFO_0000066_reaction_GLUTAMATE-SYNTHASE-NADH-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUGLNSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_BFO_0000066_reaction_GLUTAMATE-SYNTHASE-NADH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUGLNSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,8 +298,41 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_16810_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_GLUGLNSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUGLNSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002234_CHEBI_29985_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_GLUGLNSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUGLNSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_57945_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_GLUGLNSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUGLNSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -324,24 +346,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-glutamate biosynthesis IV - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002333_YDL171C-MONOMER_GLUTAMATE-SYNTHASE-NADH-RXN_controller_SGD_YeastPathways_GLUGLNSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUGLNSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -350,11 +361,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002234_CHEBI_29985_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_GLUGLNSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002234_CHEBI_29985_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_GLUGLNSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,6 +379,17 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002333_YDL171C-MONOMER_GLUTAMATE-SYNTHASE-NADH-RXN_controller_SGD_PWY_YeastPathways_GLUGLNSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUGLNSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -380,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -397,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -412,11 +434,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_BFO_0000050_YeastPathways_GLUGLNSYN-PWY/YeastPathways_GLUGLNSYN-PWY_SGD_YeastPathways_GLUGLNSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_BFO_0000050_YeastPathways_GLUGLNSYN-PWY/YeastPathways_GLUGLNSYN-PWY_SGD_PWY_YeastPathways_GLUGLNSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -433,14 +455,14 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_BFO_0000050_YeastPathways_GLUGLNSYN-PWY/YeastPathways_GLUGLNSYN-PWY_SGD_YeastPathways_GLUGLNSYN-PWY>
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_BFO_0000050_YeastPathways_GLUGLNSYN-PWY/YeastPathways_GLUGLNSYN-PWY_SGD_PWY_YeastPathways_GLUGLNSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUGLNSYN-PWY" ;
+                "SGD_PWY:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -453,26 +475,15 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002234_CHEBI_29985_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_GLUGLNSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUGLNSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_58359_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_GLUGLNSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_58359_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_GLUGLNSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -492,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -515,21 +526,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUGLNSYN-PWYSmallMolecule22048> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_15378_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_GLUGLNSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUGLNSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_GLUNH3-PWY.ttl
+++ b/models/YeastPathways_GLUNH3-PWY.ttl
@@ -1,11 +1,22 @@
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002333_YOR375C-MONOMER_GLUTDEHYD-RXN_controller_SGD_YeastPathways_GLUNH3-PWY>
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_BFO_0000066_reaction_GLUTDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUNH3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUNH3-PWY" ;
+                "SGD_PWY:GLUNH3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002333_YAL062W-MONOMER_GLUTDEHYD-RXN_controller_SGD_PWY_YeastPathways_GLUNH3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -21,7 +32,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,7 +49,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -46,14 +57,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_BFO_0000050_YeastPathways_GLUNH3-PWY/YeastPathways_GLUNH3-PWY_SGD_YeastPathways_GLUNH3-PWY>
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002333_YOR375C-MONOMER_GLUTDEHYD-RXN_controller_SGD_PWY_YeastPathways_GLUNH3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUNH3-PWY" ;
+                "SGD_PWY:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -61,11 +72,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_28938_GLUTDEHYD-RXN_SGD_YeastPathways_GLUNH3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_28938_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_GLUNH3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -87,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -100,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -114,17 +125,6 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_BFO_0000066_reaction_GLUTDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUNH3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUNH3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29985_GLUTDEHYD-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -145,15 +145,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_16810_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_GLUNH3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUNH3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_16810_GLUTDEHYD-RXN_SGD_YeastPathways_GLUNH3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_16810_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_GLUNH3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -163,6 +174,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16810_GLUTDEHYD-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_57783_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_GLUNH3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUNH3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -183,11 +205,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_58349_GLUTDEHYD-RXN_SGD_YeastPathways_GLUNH3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_58349_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_GLUNH3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,40 +220,18 @@
           <http://model.geneontology.org/CHEBI_58349_GLUTDEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_57783_GLUTDEHYD-RXN_SGD_YeastPathways_GLUNH3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUNH3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002333_YAL062W-MONOMER_GLUTDEHYD-RXN_controller_SGD_YeastPathways_GLUNH3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUNH3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_15378_GLUTDEHYD-RXN_SGD_YeastPathways_GLUNH3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_15378_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_GLUNH3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -241,17 +241,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_GLUTDEHYD-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_15378_GLUTDEHYD-RXN_SGD_YeastPathways_GLUNH3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUNH3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -268,24 +257,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutamate biosynthesis from ammonia - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_28938_GLUTDEHYD-RXN_SGD_YeastPathways_GLUNH3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUNH3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -294,11 +272,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_29985_GLUTDEHYD-RXN_SGD_YeastPathways_GLUNH3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_29985_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_GLUNH3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -318,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -333,11 +311,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_BFO_0000066_reaction_GLUTDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUNH3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_BFO_0000066_reaction_GLUTDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUNH3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -347,17 +325,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_GLUTDEHYD-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_58349_GLUTDEHYD-RXN_SGD_YeastPathways_GLUNH3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUNH3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0097054>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -371,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -382,14 +349,14 @@
 <http://purl.obolibrary.org/obo/GO_0004354>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_16810_GLUTDEHYD-RXN_SGD_YeastPathways_GLUNH3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_29985_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_GLUNH3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUNH3-PWY" ;
+                "SGD_PWY:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -410,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -424,26 +391,15 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_15377_GLUTDEHYD-RXN_SGD_YeastPathways_GLUNH3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUNH3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_15377_GLUTDEHYD-RXN_SGD_YeastPathways_GLUNH3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_15377_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_GLUNH3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -460,6 +416,28 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_28938_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_GLUNH3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUNH3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_58349_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_GLUNH3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUNH3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YAL062W-MONOMER_GLUTDEHYD-RXN_controller>
         a       <http://identifiers.org/sgd/S000000058> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -467,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -479,11 +457,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002333_YOR375C-MONOMER_GLUTDEHYD-RXN_controller_SGD_YeastPathways_GLUNH3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002333_YOR375C-MONOMER_GLUTDEHYD-RXN_controller_SGD_PWY_YeastPathways_GLUNH3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -498,11 +476,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_BFO_0000050_YeastPathways_GLUNH3-PWY/YeastPathways_GLUNH3-PWY_SGD_YeastPathways_GLUNH3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_BFO_0000050_YeastPathways_GLUNH3-PWY/YeastPathways_GLUNH3-PWY_SGD_PWY_YeastPathways_GLUNH3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,6 +491,17 @@
           <http://model.geneontology.org/YeastPathways_GLUNH3-PWY/YeastPathways_GLUNH3-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_BFO_0000050_YeastPathways_GLUNH3-PWY/YeastPathways_GLUNH3-PWY_SGD_PWY_YeastPathways_GLUNH3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUNH3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -521,6 +510,17 @@
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_15377_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_GLUNH3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUNH3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -532,11 +532,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_57783_GLUTDEHYD-RXN_SGD_YeastPathways_GLUNH3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_57783_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_GLUNH3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -574,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -586,11 +586,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002333_YAL062W-MONOMER_GLUTDEHYD-RXN_controller_SGD_YeastPathways_GLUNH3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002333_YAL062W-MONOMER_GLUTDEHYD-RXN_controller_SGD_PWY_YeastPathways_GLUNH3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,6 +604,17 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_15378_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_GLUNH3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUNH3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_GLUTDEHYD-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -613,21 +624,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUNH3-PWYSmallMolecule22189> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_29985_GLUTDEHYD-RXN_SGD_YeastPathways_GLUNH3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUNH3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_GLUT-REDOX2-PWY.ttl
+++ b/models/YeastPathways_GLUT-REDOX2-PWY.ttl
@@ -10,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -18,14 +18,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002333_YLL060C-MONOMER_GSHTRAN-RXN_controller_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_BFO_0000050_YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -33,11 +33,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002411_GLUTATHIONE-PEROXIDASE-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002411_GLUTATHIONE-PEROXIDASE-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -48,18 +48,6 @@
           <http://model.geneontology.org/GLUTATHIONE-PEROXIDASE-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000001476>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/reaction_PRODISULFREDUCT-A-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YIR037W-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001476> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -67,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -75,14 +63,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/reaction_PRODISULFREDUCT-A-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -93,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -105,11 +91,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_58297_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_58297_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -120,16 +106,8 @@
           <http://model.geneontology.org/CHEBI_58297_PRODISULFREDUCT-A-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002234_CHEBI_58297_GLUTATHIONE-PEROXIDASE-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000001476>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YPL091W-MONOMER_GLUTATHIONE-REDUCT-NADPH-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006012> ;
@@ -138,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -150,11 +128,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002234_CHEBI_15377_GLUTATHIONE-PEROXIDASE-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002234_CHEBI_15377_GLUTATHIONE-PEROXIDASE-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -177,9 +155,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GSHTRAN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN> , <http://model.geneontology.org/a620e997-c11d-4540-8192-079a020b01a4_GSHTRAN-RXN> ;
+                <http://model.geneontology.org/CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN> , <http://model.geneontology.org/0ea5b1d4-f73c-4a48-a220-b2e5dc99b423_GSHTRAN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/529ddacd-7918-4581-9baa-30bb00004034_GSHTRAN-RXN> , <http://model.geneontology.org/46d12d9e-dafb-4d3f-80d0-c22d6ec05cfa_GSHTRAN-RXN> ;
+                <http://model.geneontology.org/9903dc9d-e4df-425a-94bb-6536300e6070_GSHTRAN-RXN> , <http://model.geneontology.org/5ea1c58e-5b44-4998-9c4a-50bfe0311e3e_GSHTRAN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YIR038C-MONOMER_GSHTRAN-RXN_controller> , <http://model.geneontology.org/YLL060C-MONOMER_GSHTRAN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -187,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,11 +177,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002333_YIR038C-MONOMER_GSHTRAN-RXN_controller_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002333_YIR038C-MONOMER_GSHTRAN-RXN_controller_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,28 +198,17 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_58297_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0006749>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_5ea1c58e-5b44-4998-9c4a-50bfe0311e3e_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -252,11 +219,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_BFO_0000050_YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_BFO_0000050_YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,40 +234,40 @@
           <http://model.geneontology.org/YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_BFO_0000066_reaction_GLUTATHIONE-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUT-REDOX2-PWY>
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002413_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002234_Red-Glutaredoxins_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004602>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002233_Ox-Glutaredoxins_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002233_Ox-Glutaredoxins_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,28 +281,28 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002333_YIR038C-MONOMER_GSHTRAN-RXN_controller_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_0ea5b1d4-f73c-4a48-a220-b2e5dc99b423_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002413_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -345,28 +312,6 @@
 <http://identifiers.org/sgd/S000000448>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_BFO_0000066_reaction_PRODISULFREDUCT-A-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YKL026C-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001509> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -374,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,26 +330,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_BFO_0000050_YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,11 +353,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002233_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002233_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -434,15 +368,26 @@
           <http://model.geneontology.org/CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002234_CHEBI_58297_GLUTATHIONE-PEROXIDASE-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_529ddacd-7918-4581-9baa-30bb00004034_GSHTRAN-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_9903dc9d-e4df-425a-94bb-6536300e6070_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +395,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GSHTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/529ddacd-7918-4581-9baa-30bb00004034_GSHTRAN-RXN>
+          <http://model.geneontology.org/9903dc9d-e4df-425a-94bb-6536300e6070_GSHTRAN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
@@ -465,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -476,53 +421,48 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002234_CHEBI_15377_GLUTATHIONE-PEROXIDASE-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/5ea1c58e-5b44-4998-9c4a-50bfe0311e3e_GSHTRAN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "HX" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002333_YPL091W-MONOMER_GLUTATHIONE-REDUCT-NADPH-RXN_controller_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60865> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002411_GLUTATHIONE-PEROXIDASE-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
+<http://purl.obolibrary.org/obo/CHEBI_24431>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002413_GLUTATHIONE-PEROXIDASE-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -533,11 +473,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 glutathione + NADP<sup>+</sup> &larr; glutathione disulfide + NADPH + H<SUP>+</SUP>' 'null' '2 glutathione + an oxidized glutaredoxin &rarr; glutathione disulfide + a reduced glutaredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002413_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002413_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -548,14 +488,14 @@
           <http://model.geneontology.org/PRODISULFREDUCT-A-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002413_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_9903dc9d-e4df-425a-94bb-6536300e6070_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -563,11 +503,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002233_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002233_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -585,24 +525,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYProtein60927> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_BFO_0000066_reaction_GSHTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57783_GLUTATHIONE-REDUCT-NADPH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
@@ -613,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -621,15 +550,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_BFO_0000050_YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 glutathione + NADP<sup>+</sup> &larr; glutathione disulfide + NADPH + H<SUP>+</SUP>' 'null' 'hydrogen peroxide + 2 glutathione &rarr; glutathione disulfide + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002413_GLUTATHIONE-PEROXIDASE-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002413_GLUTATHIONE-PEROXIDASE-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,11 +598,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002333_YKL026C-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002333_YKL026C-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -662,25 +613,14 @@
           <http://model.geneontology.org/YKL026C-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002233_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_529ddacd-7918-4581-9baa-30bb00004034_GSHTRAN-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -691,11 +631,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -706,24 +646,15 @@
           <http://model.geneontology.org/CHEBI_15378_GLUTATHIONE-REDUCT-NADPH-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_GSHTRAN-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002233_CHEBI_16240_GLUTATHIONE-PEROXIDASE-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002233_CHEBI_16240_GLUTATHIONE-PEROXIDASE-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,15 +665,35 @@
           <http://model.geneontology.org/CHEBI_16240_GLUTATHIONE-PEROXIDASE-RXN>
 ] .
 
+<http://model.geneontology.org/reaction_GSHTRAN-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002333_YLL060C-MONOMER_GSHTRAN-RXN_controller_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_46d12d9e-dafb-4d3f-80d0-c22d6ec05cfa_GSHTRAN-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_5ea1c58e-5b44-4998-9c4a-50bfe0311e3e_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -750,45 +701,23 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GSHTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/46d12d9e-dafb-4d3f-80d0-c22d6ec05cfa_GSHTRAN-RXN>
+          <http://model.geneontology.org/5ea1c58e-5b44-4998-9c4a-50bfe0311e3e_GSHTRAN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_BFO_0000050_YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002413_GSHTRAN-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002233_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002333_YKL026C-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -796,11 +725,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" , "Provides Input For Rule. The relation '2 glutathione + NADP<sup>+</sup> &larr; glutathione disulfide + NADPH + H<SUP>+</SUP>' 'null' 'glutathione + RX &rarr; a glutathione-<i>S</i>-conjugate + HX' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002413_GSHTRAN-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002413_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -811,32 +740,26 @@
           <http://model.geneontology.org/GSHTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/a620e997-c11d-4540-8192-079a020b01a4_GSHTRAN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "RX" ;
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002333_YPL091W-MONOMER_GLUTATHIONE-REDUCT-NADPH-RXN_controller_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60852> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_BFO_0000066_reaction_PRODISULFREDUCT-A-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_BFO_0000066_reaction_PRODISULFREDUCT-A-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,21 +770,76 @@
           <http://model.geneontology.org/reaction_PRODISULFREDUCT-A-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_BFO_0000066_reaction_PRODISULFREDUCT-A-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57925>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002411_GLUTATHIONE-PEROXIDASE-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002413_GLUTATHIONE-PEROXIDASE-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_BFO_0000066_reaction_GSHTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002333_YPL091W-MONOMER_GLUTATHIONE-REDUCT-NADPH-RXN_controller_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002333_YPL091W-MONOMER_GLUTATHIONE-REDUCT-NADPH-RXN_controller_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -875,26 +853,15 @@
 <http://purl.obolibrary.org/obo/GO_0004362>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002234_Red-Glutaredoxins_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002333_YIR037W-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002333_YIR037W-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -905,23 +872,23 @@
           <http://model.geneontology.org/YIR037W-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_BFO_0000066_reaction_GLUTATHIONE-PEROXIDASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_GLUTATHIONE-PEROXIDASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002233_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -929,11 +896,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_BFO_0000066_reaction_GLUTATHIONE-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_BFO_0000066_reaction_GLUTATHIONE-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,7 +920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutathione-glutaredoxin redox reactions - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -961,37 +928,15 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_46d12d9e-dafb-4d3f-80d0-c22d6ec05cfa_GSHTRAN-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002233_CHEBI_16240_GLUTATHIONE-PEROXIDASE-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_BFO_0000066_reaction_GLUTATHIONE-PEROXIDASE-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_BFO_0000066_reaction_GLUTATHIONE-PEROXIDASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1002,14 +947,14 @@
           <http://model.geneontology.org/reaction_GLUTATHIONE-PEROXIDASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002333_YIR037W-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002413_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1017,11 +962,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_a620e997-c11d-4540-8192-079a020b01a4_GSHTRAN-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_0ea5b1d4-f73c-4a48-a220-b2e5dc99b423_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1029,7 +974,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GSHTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a620e997-c11d-4540-8192-079a020b01a4_GSHTRAN-RXN>
+          <http://model.geneontology.org/0ea5b1d4-f73c-4a48-a220-b2e5dc99b423_GSHTRAN-RXN>
 ] .
 
 <http://model.geneontology.org/YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY>
@@ -1041,24 +986,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_GLUT-REDOX2-PWY" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_GLUTATHIONE-PEROXIDASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -1069,7 +1003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1081,11 +1015,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 glutathione + an oxidized glutaredoxin &rarr; glutathione disulfide + a reduced glutaredoxin' 'null' '2 glutathione + NADP<sup>+</sup> &larr; glutathione disulfide + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002413_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002413_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1108,24 +1042,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYProtein60823> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58349_GLUTATHIONE-REDUCT-NADPH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1136,7 +1059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1144,16 +1067,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_BFO_0000050_YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/0ea5b1d4-f73c-4a48-a220-b2e5dc99b423_GSHTRAN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "RX" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60852> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1165,11 +1094,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_BFO_0000050_YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_BFO_0000050_YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1180,6 +1109,28 @@
           <http://model.geneontology.org/YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002233_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002333_YIR037W-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1187,11 +1138,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1206,11 +1157,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002333_YBR244W-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002333_YBR244W-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1224,11 +1175,33 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002233_Ox-Glutaredoxins_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002333_YBR244W-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003983>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1237,11 +1210,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1257,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1265,11 +1238,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_BFO_0000050_YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_BFO_0000050_YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1287,11 +1260,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1309,11 +1282,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002234_Red-Glutaredoxins_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002234_Red-Glutaredoxins_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1324,30 +1297,19 @@
           <http://model.geneontology.org/Red-Glutaredoxins_PRODISULFREDUCT-A-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002233_Ox-Glutaredoxins_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_BFO_0000050_YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002234_CHEBI_58297_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1356,11 +1318,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002411_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002411_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1371,36 +1333,27 @@
           <http://model.geneontology.org/PRODISULFREDUCT-A-RXN>
 ] .
 
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002411_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_58297_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/529ddacd-7918-4581-9baa-30bb00004034_GSHTRAN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a glutathione-<i>S</i>-conjugate" ;
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002413_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60859> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/Red-Glutaredoxins_PRODISULFREDUCT-A-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -1411,7 +1364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1419,37 +1372,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_a620e997-c11d-4540-8192-079a020b01a4_GSHTRAN-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002333_YBR244W-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1479,7 +1413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1494,11 +1428,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002234_CHEBI_58297_GLUTATHIONE-PEROXIDASE-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002234_CHEBI_58297_GLUTATHIONE-PEROXIDASE-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1509,32 +1443,26 @@
           <http://model.geneontology.org/CHEBI_58297_GLUTATHIONE-PEROXIDASE-RXN>
 ] .
 
-<http://model.geneontology.org/46d12d9e-dafb-4d3f-80d0-c22d6ec05cfa_GSHTRAN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "HX" ;
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002333_YIR038C-MONOMER_GSHTRAN-RXN_controller_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60865> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002333_YLL060C-MONOMER_GSHTRAN-RXN_controller_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002333_YLL060C-MONOMER_GSHTRAN-RXN_controller_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1562,13 +1490,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYBiochemicalReaction60798> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002234_CHEBI_15377_GLUTATHIONE-PEROXIDASE-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58297_PRODISULFREDUCT-A-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58297> ;
@@ -1579,7 +1518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1596,7 +1535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1606,6 +1545,23 @@
 
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/9903dc9d-e4df-425a-94bb-6536300e6070_GSHTRAN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a glutathione-<i>S</i>-conjugate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60859> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/GLUTATHIONE-REDUCT-NADPH-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004362> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1626,7 +1582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1634,14 +1590,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_BFO_0000066_reaction_GLUTATHIONE-PEROXIDASE-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002411_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1652,7 +1608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1664,11 +1620,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" , "Provides Input For Rule. The relation 'hydrogen peroxide + 2 glutathione &rarr; glutathione disulfide + 2 H<sub>2</sub>O' 'null' '2 glutathione + NADP<sup>+</sup> &larr; glutathione disulfide + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002413_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002413_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1682,15 +1638,37 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002333_YKL026C-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002233_CHEBI_16240_GLUTATHIONE-PEROXIDASE-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_BFO_0000066_reaction_GSHTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_BFO_0000066_reaction_GSHTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1710,7 +1688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1718,14 +1696,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002413_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002413_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002234_CHEBI_58297_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_BFO_0000066_reaction_GLUTATHIONE-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1733,11 +1733,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002234_CHEBI_58297_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002234_CHEBI_58297_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_GLUTATHIONESYN-PWY.ttl
+++ b/models/YeastPathways_GLUTATHIONESYN-PWY.ttl
@@ -1,3 +1,14 @@
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_58173_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_GLUTATHIONESYN-PWY/YeastPathways_GLUTATHIONESYN-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0006750> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -20,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -29,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -42,24 +53,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUTATHIONESYN-PWYSmallMolecule59742> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_58173_GLUTCYSLIG-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_GLUTATHIONE-SYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -78,26 +78,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_43474_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_35235_GLUTCYSLIG-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_35235_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -115,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -127,11 +116,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_58173_GLUTCYSLIG-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_58173_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -148,6 +137,17 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_30616_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_GLUTCYSLIG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -177,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -197,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -205,36 +205,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002333_YOL049W-MONOMER_GLUTATHIONE-SYN-RXN_controller_SGD_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/CHEBI_58173_GLUTCYSLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58173> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "&gamma;-L-glutamyl-L-cysteine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUTATHIONESYN-PWYSmallMolecule59626> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_GLUTCYSLIG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -245,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -253,14 +225,42 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_57305_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY>
+<http://model.geneontology.org/CHEBI_58173_GLUTCYSLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58173> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "&gamma;-L-glutamyl-L-cysteine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUTATHIONESYN-PWYSmallMolecule59626> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002333_YOL049W-MONOMER_GLUTATHIONE-SYN-RXN_controller_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -271,11 +271,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_30616_GLUTCYSLIG-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_30616_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -286,15 +286,26 @@
           <http://model.geneontology.org/CHEBI_30616_GLUTCYSLIG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_30616_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_57305_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_57305_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -322,49 +333,60 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_456216_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_29985_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000005409>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_30616_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY>
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_35235_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002413_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" , "Provides Input For Rule. The relation 'L-cysteine + L-glutamate + ATP &rarr; &gamma;-L-glutamyl-L-cysteine + ADP + phosphate + H<SUP>+</SUP>' 'null' 'glycine + &gamma;-L-glutamyl-L-cysteine + ATP &rarr; glutathione + ADP + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002413_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002413_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -392,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -400,15 +422,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_58173_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_58173_GLUTCYSLIG-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_58173_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,11 +462,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -444,14 +477,14 @@
           <http://model.geneontology.org/CHEBI_57925_GLUTATHIONE-SYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_15378_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000050_YeastPathways_GLUTATHIONESYN-PWY/YeastPathways_GLUTATHIONESYN-PWY_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -465,11 +498,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_29985_GLUTCYSLIG-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_29985_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -484,11 +517,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_30616_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_30616_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -508,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -522,37 +555,15 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002333_YJL101C-MONOMER_GLUTCYSLIG-RXN_controller_SGD_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_43474_GLUTCYSLIG-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002333_YJL101C-MONOMER_GLUTCYSLIG-RXN_controller_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002333_YJL101C-MONOMER_GLUTCYSLIG-RXN_controller_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -562,17 +573,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YJL101C-MONOMER_GLUTCYSLIG-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_35235_GLUTCYSLIG-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -587,11 +587,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_456216_GLUTCYSLIG-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_456216_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -611,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -623,11 +623,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_456216_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_456216_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -638,14 +638,25 @@
           <http://model.geneontology.org/CHEBI_456216_GLUTATHIONE-SYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000066_reaction_GLUTATHIONE-SYN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002333_YJL101C-MONOMER_GLUTCYSLIG-RXN_controller_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002413_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -656,11 +667,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000066_reaction_GLUTCYSLIG-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000066_reaction_GLUTCYSLIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -675,11 +686,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000066_reaction_GLUTATHIONE-SYN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000066_reaction_GLUTATHIONE-SYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -693,19 +704,41 @@
 <http://purl.obolibrary.org/obo/CHEBI_35235>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000066_reaction_GLUTCYSLIG-RXN_location_lociGO_0005829_SGD_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_57305>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_15378_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57305>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000066_reaction_GLUTATHIONE-SYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_43474_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_35235_GLUTCYSLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_35235> ;
@@ -716,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -727,6 +760,39 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_43474_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000050_YeastPathways_GLUTATHIONESYN-PWY/YeastPathways_GLUTATHIONESYN-PWY_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000066_reaction_GLUTCYSLIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_GLUTATHIONESYN-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -736,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutathione biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -751,11 +817,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_43474_GLUTCYSLIG-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_43474_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,11 +836,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_43474_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_43474_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,37 +857,15 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_29985_GLUTCYSLIG-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_58173_GLUTCYSLIG-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000050_YeastPathways_GLUTATHIONESYN-PWY/YeastPathways_GLUTATHIONESYN-PWY_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000050_YeastPathways_GLUTATHIONESYN-PWY/YeastPathways_GLUTATHIONESYN-PWY_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -839,11 +883,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000050_YeastPathways_GLUTATHIONESYN-PWY/YeastPathways_GLUTATHIONESYN-PWY_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000050_YeastPathways_GLUTATHIONESYN-PWY/YeastPathways_GLUTATHIONESYN-PWY_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -860,6 +904,28 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_15378_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_57305_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57305_GLUTATHIONE-SYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57305> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -869,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -877,25 +943,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_30616_GLUTCYSLIG-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY>
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_456216_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -906,7 +961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -914,33 +969,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_456216_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000050_YeastPathways_GLUTATHIONESYN-PWY/YeastPathways_GLUTATHIONESYN-PWY_SGD_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GLUTCYSLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004357> ;
@@ -961,24 +994,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUTATHIONESYN-PWYBiochemicalReaction59711> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_456216_GLUTCYSLIG-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -987,11 +1009,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_15378_GLUTCYSLIG-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_15378_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1006,11 +1028,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_15378_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_15378_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1021,29 +1043,15 @@
           <http://model.geneontology.org/CHEBI_15378_GLUTATHIONE-SYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000050_YeastPathways_GLUTATHIONESYN-PWY/YeastPathways_GLUTATHIONESYN-PWY_SGD_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002333_YOL049W-MONOMER_GLUTATHIONE-SYN-RXN_controller_SGD_YeastPathways_GLUTATHIONESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002333_YOL049W-MONOMER_GLUTATHIONE-SYN-RXN_controller_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1054,16 +1062,8 @@
           <http://model.geneontology.org/YOL049W-MONOMER_GLUTATHIONE-SYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_15378_GLUTCYSLIG-RXN_SGD_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUTATHIONESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_15378_GLUTATHIONE-SYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1074,7 +1074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_GLYCLEAV-PWY.ttl
+++ b/models/YeastPathways_GLYCLEAV-PWY.ttl
@@ -1,3 +1,14 @@
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_d1ced68b-7b7c-44e2-a232-c43f7031b473_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_GLYCLEAV-PWY/YeastPathways_GLYCLEAV-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0019464> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -5,13 +16,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_GLYCLEAV-PWY" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_BFO_0000066_reaction_GCVT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YMR189W-MONOMER_GCVP-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004801> ;
@@ -20,7 +42,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -35,13 +57,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYProtein22619> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/e43c2061-ae53-49cc-a136-da83295d3259_GCVT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22635> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57945_RXN-8629>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
@@ -52,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -60,37 +99,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002333_YDR019C-MONOMER_GCVT-RXN_controller_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVP-RXN_BFO_0000050_YeastPathways_GLYCLEAV-PWY/YeastPathways_GLYCLEAV-PWY_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_e1b22a50-5b95-4eec-8c96-6facc69ebe07_GCVT-RXN_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_b8949e9c-3d67-4eb0-b281-a55f734b7e8b_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,7 +115,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e1b22a50-5b95-4eec-8c96-6facc69ebe07_GCVT-RXN>
+          <http://model.geneontology.org/b8949e9c-3d67-4eb0-b281-a55f734b7e8b_GCVT-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-8629_location_lociGO_0005829>
@@ -106,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -114,11 +131,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_b42fb4da-3186-424e-860a-cc20cf36b426_RXN-8629_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_4eecd42f-0ff0-4005-a60a-cf213bac24c5_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -126,7 +143,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b42fb4da-3186-424e-860a-cc20cf36b426_RXN-8629>
+          <http://model.geneontology.org/4eecd42f-0ff0-4005-a60a-cf213bac24c5_RXN-8629>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
@@ -135,43 +152,26 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_3e8fe875-68c8-4de8-b39c-5ff193d71849_GCVT-RXN_SGD_YeastPathways_GLYCLEAV-PWY>
+<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_CHEBI_15378_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
+                "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/5466d80c-ff83-41eb-ac8f-4f0f252b58da_GCVT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22635> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_632e9eb0-8dd0-4b4f-add4-93965455fb7a_GCVT-RXN_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_5aea9989-2ce8-44a4-92ac-daf4a5e6b328_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -179,28 +179,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-8629> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/632e9eb0-8dd0-4b4f-add4-93965455fb7a_GCVT-RXN>
+          <http://model.geneontology.org/5aea9989-2ce8-44a4-92ac-daf4a5e6b328_GCVT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_994dad44-59c9-4d9f-b3fb-d8daa62f49f9_GCVP-RXN_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_BFO_0000050_YeastPathways_GLYCLEAV-PWY/YeastPathways_GLYCLEAV-PWY_SGD_YeastPathways_GLYCLEAV-PWY>
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_CHEBI_28938_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
+                "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -213,9 +202,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_GCVP-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVP-RXN> , <http://model.geneontology.org/b42fb4da-3186-424e-860a-cc20cf36b426_RXN-8629> ;
+                <http://model.geneontology.org/CHEBI_15378_GCVP-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVP-RXN> , <http://model.geneontology.org/4eecd42f-0ff0-4005-a60a-cf213bac24c5_RXN-8629> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16526_GCVP-RXN> , <http://model.geneontology.org/994dad44-59c9-4d9f-b3fb-d8daa62f49f9_GCVP-RXN> ;
+                <http://model.geneontology.org/945ebb2a-2b8e-4c51-b18d-e47dda6ce554_GCVP-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YMR189W-MONOMER_GCVP-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -223,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -246,35 +235,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22655> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_BFO_0000066_reaction_GCVT-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_CHEBI_57305_GCVP-RXN_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002426>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -288,9 +255,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/5466d80c-ff83-41eb-ac8f-4f0f252b58da_GCVT-RXN> , <http://model.geneontology.org/cffe67c6-2640-4f72-9243-8d60356bc022_GCVP-RXN> ;
+                <http://model.geneontology.org/d1ced68b-7b7c-44e2-a232-c43f7031b473_GCVP-RXN> , <http://model.geneontology.org/e43c2061-ae53-49cc-a136-da83295d3259_GCVT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/3e8fe875-68c8-4de8-b39c-5ff193d71849_GCVT-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVT-RXN> , <http://model.geneontology.org/e1b22a50-5b95-4eec-8c96-6facc69ebe07_GCVT-RXN> ;
+                <http://model.geneontology.org/CHEBI_28938_GCVT-RXN> , <http://model.geneontology.org/fd5312ca-65e2-4156-9975-7b862c7d5584_GCVT-RXN> , <http://model.geneontology.org/b8949e9c-3d67-4eb0-b281-a55f734b7e8b_GCVT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR019C-MONOMER_GCVT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -298,7 +265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -310,11 +277,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_CHEBI_28938_GCVT-RXN_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_CHEBI_28938_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,11 +296,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_CHEBI_57305_GCVP-RXN_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_CHEBI_57305_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -344,15 +311,26 @@
           <http://model.geneontology.org/CHEBI_57305_GCVP-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_4eecd42f-0ff0-4005-a60a-cf213bac24c5_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" , "Provides Input For Rule. The relation 'a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine + NAD<sup>+</sup> &harr; a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine + NADH + H<SUP>+</SUP>' 'null' 'glycine + a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine + H<SUP>+</SUP> &harr; CO<SUB>2</SUB> + a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-aminomethyldihydrolipoyl-L-lysine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002413_GCVP-RXN_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002413_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,6 +341,17 @@
           <http://model.geneontology.org/GCVP-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002413_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -372,17 +361,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8629_BFO_0000066_reaction_RXN-8629_location_lociGO_0005829_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -390,11 +368,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_CHEBI_57540_RXN-8629_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_CHEBI_57540_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -405,6 +383,23 @@
           <http://model.geneontology.org/CHEBI_57540_RXN-8629>
 ] .
 
+<http://model.geneontology.org/fd5312ca-65e2-4156-9975-7b862c7d5584_GCVT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22559> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_15378_RXN-8629>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -414,7 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -422,31 +417,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/3e8fe875-68c8-4de8-b39c-5ff193d71849_GCVT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_CHEBI_57945_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22641> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_CHEBI_28938_GCVT-RXN_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
+                "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -455,18 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_CHEBI_16526_GCVP-RXN_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -474,11 +441,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8629_BFO_0000050_YeastPathways_GLYCLEAV-PWY/YeastPathways_GLYCLEAV-PWY_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8629_BFO_0000050_YeastPathways_GLYCLEAV-PWY/YeastPathways_GLYCLEAV-PWY_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -496,11 +463,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002411_GCVT-RXN_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002411_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -511,47 +478,42 @@
           <http://model.geneontology.org/GCVT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_CHEBI_57540_RXN-8629_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_632e9eb0-8dd0-4b4f-add4-93965455fb7a_GCVT-RXN_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_095036ef-9fe6-4eca-90ae-0f82d0d320ae_RXN-8629_SGD_YeastPathways_GLYCLEAV-PWY>
+<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002411_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
+                "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002333_YMR189W-MONOMER_GCVP-RXN_controller_SGD_YeastPathways_GLYCLEAV-PWY>
+<http://model.geneontology.org/b8949e9c-3d67-4eb0-b281-a55f734b7e8b_GCVT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22641> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002333_YFL018C-MONOMER_RXN-8629_controller_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
+                "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -562,11 +524,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_5466d80c-ff83-41eb-ac8f-4f0f252b58da_GCVT-RXN_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_e43c2061-ae53-49cc-a136-da83295d3259_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,18 +536,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5466d80c-ff83-41eb-ac8f-4f0f252b58da_GCVT-RXN>
+          <http://model.geneontology.org/e43c2061-ae53-49cc-a136-da83295d3259_GCVT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_CHEBI_15378_GCVP-RXN_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_CHEBI_15378_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -603,11 +565,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002333_YFL018C-MONOMER_RXN-8629_controller_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002333_YFL018C-MONOMER_RXN-8629_controller_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,66 +580,68 @@
           <http://model.geneontology.org/YFL018C-MONOMER_RXN-8629_controller>
 ] .
 
-<http://model.geneontology.org/b42fb4da-3186-424e-860a-cc20cf36b426_RXN-8629>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.obolibrary.org/obo/GO_0004148>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_e1b22a50-5b95-4eec-8c96-6facc69ebe07_GCVT-RXN_SGD_YeastPathways_GLYCLEAV-PWY>
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_BFO_0000050_YeastPathways_GLYCLEAV-PWY/YeastPathways_GLYCLEAV-PWY_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
+                "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002411_RXN-8629_SGD_YeastPathways_GLYCLEAV-PWY>
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_GCVP-RXN_BFO_0000050_YeastPathways_GLYCLEAV-PWY/YeastPathways_GLYCLEAV-PWY_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004148>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_a7f13410-322a-4c21-915b-f2cad422ddba_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
+                "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/e1b22a50-5b95-4eec-8c96-6facc69ebe07_GCVT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+<http://model.geneontology.org/ev_w_id_RXN-8629_BFO_0000050_YeastPathways_GLYCLEAV-PWY/YeastPathways_GLYCLEAV-PWY_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22559> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8629_BFO_0000066_reaction_RXN-8629_location_lociGO_0005829_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8629_BFO_0000066_reaction_RXN-8629_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -688,62 +652,29 @@
           <http://model.geneontology.org/reaction_RXN-8629_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002333_YFL018C-MONOMER_RXN-8629_controller_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8629_BFO_0000050_YeastPathways_GLYCLEAV-PWY/YeastPathways_GLYCLEAV-PWY_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_cffe67c6-2640-4f72-9243-8d60356bc022_GCVP-RXN_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_GCVP-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_CHEBI_57945_RXN-8629_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_CHEBI_15378_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
+                "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -751,11 +682,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002411_RXN-8629_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002411_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -775,7 +706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -787,11 +718,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002333_YMR189W-MONOMER_GCVP-RXN_controller_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002333_YMR189W-MONOMER_GCVP-RXN_controller_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -802,18 +733,54 @@
           <http://model.geneontology.org/YMR189W-MONOMER_GCVP-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_e43c2061-ae53-49cc-a136-da83295d3259_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/5aea9989-2ce8-44a4-92ac-daf4a5e6b328_GCVT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 <http://purl.obolibrary.org/obo/GO_0004375>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GCVP-RXN_BFO_0000066_reaction_GCVP-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_CHEBI_57305_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_cffe67c6-2640-4f72-9243-8d60356bc022_GCVP-RXN_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_d1ced68b-7b7c-44e2-a232-c43f7031b473_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -821,19 +788,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/cffe67c6-2640-4f72-9243-8d60356bc022_GCVP-RXN>
+          <http://model.geneontology.org/d1ced68b-7b7c-44e2-a232-c43f7031b473_GCVP-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_5466d80c-ff83-41eb-ac8f-4f0f252b58da_GCVT-RXN_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YDR019C-MONOMER_GCVT-RXN_controller>
         a       <http://identifiers.org/sgd/S000002426> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -842,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -854,11 +810,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVP-RXN_BFO_0000066_reaction_GCVP-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVP-RXN_BFO_0000066_reaction_GCVP-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -881,9 +837,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-8629_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/632e9eb0-8dd0-4b4f-add4-93965455fb7a_GCVT-RXN> , <http://model.geneontology.org/CHEBI_57540_RXN-8629> ;
+                <http://model.geneontology.org/5aea9989-2ce8-44a4-92ac-daf4a5e6b328_GCVT-RXN> , <http://model.geneontology.org/CHEBI_57540_RXN-8629> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/095036ef-9fe6-4eca-90ae-0f82d0d320ae_RXN-8629> , <http://model.geneontology.org/CHEBI_15378_RXN-8629> , <http://model.geneontology.org/CHEBI_57945_RXN-8629> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN-8629> , <http://model.geneontology.org/CHEBI_57945_RXN-8629> , <http://model.geneontology.org/a7f13410-322a-4c21-915b-f2cad422ddba_RXN-8629> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YFL018C-MONOMER_RXN-8629_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -891,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -903,11 +859,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_095036ef-9fe6-4eca-90ae-0f82d0d320ae_RXN-8629_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_a7f13410-322a-4c21-915b-f2cad422ddba_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -915,17 +871,28 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-8629> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/095036ef-9fe6-4eca-90ae-0f82d0d320ae_RXN-8629>
+          <http://model.geneontology.org/a7f13410-322a-4c21-915b-f2cad422ddba_RXN-8629>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_CHEBI_15378_RXN-8629_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002333_YDR019C-MONOMER_GCVT-RXN_controller_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_945ebb2a-2b8e-4c51-b18d-e47dda6ce554_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -941,6 +908,20 @@
 <http://identifiers.org/sgd/S000004801>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002411_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/4eecd42f-0ff0-4005-a60a-cf213bac24c5_RXN-8629>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 <http://purl.obolibrary.org/obo/GO_0004047>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -953,18 +934,15 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/632e9eb0-8dd0-4b4f-add4-93965455fb7a_GCVT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002333_YDR019C-MONOMER_GCVT-RXN_controller_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002333_YDR019C-MONOMER_GCVT-RXN_controller_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -979,11 +957,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_994dad44-59c9-4d9f-b3fb-d8daa62f49f9_GCVP-RXN_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_945ebb2a-2b8e-4c51-b18d-e47dda6ce554_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -991,23 +969,45 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/994dad44-59c9-4d9f-b3fb-d8daa62f49f9_GCVP-RXN>
+          <http://model.geneontology.org/945ebb2a-2b8e-4c51-b18d-e47dda6ce554_GCVP-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_b42fb4da-3186-424e-860a-cc20cf36b426_RXN-8629_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_CHEBI_57540_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_5aea9989-2ce8-44a4-92ac-daf4a5e6b328_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_fd5312ca-65e2-4156-9975-7b862c7d5584_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1020,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1032,11 +1032,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_BFO_0000066_reaction_GCVT-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_BFO_0000066_reaction_GCVT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1051,11 +1051,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVP-RXN_BFO_0000050_YeastPathways_GLYCLEAV-PWY/YeastPathways_GLYCLEAV-PWY_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVP-RXN_BFO_0000050_YeastPathways_GLYCLEAV-PWY/YeastPathways_GLYCLEAV-PWY_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,11 +1070,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_CHEBI_57945_RXN-8629_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_CHEBI_57945_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1094,7 +1094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1105,19 +1105,19 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002413_GCVP-RXN_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002333_YMR189W-MONOMER_GCVP-RXN_controller_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
+                "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1131,13 +1131,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycine cleavage - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/a7f13410-322a-4c21-915b-f2cad422ddba_RXN-8629>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22582> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_GCVP-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1148,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1159,15 +1176,26 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_b8949e9c-3d67-4eb0-b281-a55f734b7e8b_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_3e8fe875-68c8-4de8-b39c-5ff193d71849_GCVT-RXN_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_fd5312ca-65e2-4156-9975-7b862c7d5584_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1175,18 +1203,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3e8fe875-68c8-4de8-b39c-5ff193d71849_GCVT-RXN>
+          <http://model.geneontology.org/fd5312ca-65e2-4156-9975-7b862c7d5584_GCVT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_CHEBI_16526_GCVP-RXN_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_CHEBI_16526_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1197,7 +1225,7 @@
           <http://model.geneontology.org/CHEBI_16526_GCVP-RXN>
 ] .
 
-<http://model.geneontology.org/994dad44-59c9-4d9f-b3fb-d8daa62f49f9_GCVP-RXN>
+<http://model.geneontology.org/945ebb2a-2b8e-4c51-b18d-e47dda6ce554_GCVP-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -1206,7 +1234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1214,33 +1242,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GCVP-RXN_BFO_0000066_reaction_GCVP-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCLEAV-PWY>
+<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_CHEBI_16526_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
+                "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/095036ef-9fe6-4eca-90ae-0f82d0d320ae_RXN-8629>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
+<http://model.geneontology.org/ev_w_id_RXN-8629_BFO_0000066_reaction_RXN-8629_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22582> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001876>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1249,11 +1271,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_BFO_0000050_YeastPathways_GLYCLEAV-PWY/YeastPathways_GLYCLEAV-PWY_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_BFO_0000050_YeastPathways_GLYCLEAV-PWY/YeastPathways_GLYCLEAV-PWY_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1271,11 +1293,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_CHEBI_15378_RXN-8629_SGD_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_CHEBI_15378_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1286,27 +1308,5 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-8629>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002411_GCVT-RXN_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_CHEBI_15378_GCVP-RXN_SGD_YeastPathways_GLYCLEAV-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/cffe67c6-2640-4f72-9243-8d60356bc022_GCVP-RXN>
+<http://model.geneontology.org/d1ced68b-7b7c-44e2-a232-c43f7031b473_GCVP-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> .

--- a/models/YeastPathways_GLYCOCAT-YEAST-PWY.ttl
+++ b/models/YeastPathways_GLYCOCAT-YEAST-PWY.ttl
@@ -1,12 +1,23 @@
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" , "Provides Input For Rule. The relation 'a glycogen &rarr; maltotetraose' 'null' 'maltotetraose + D-glucopyranose &harr; maltotriose + maltose' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002413_AMYLOMALT-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002413_AMYLOMALT-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,11 +32,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002234_2993b045-a6a4-4082-93da-9246b422ec73_RXN-9023_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002234_9d1581d0-602c-4255-b6c9-a81e71cab33a_RXN-9023_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -33,17 +44,39 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9023> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2993b045-a6a4-4082-93da-9246b422ec73_RXN-9023>
+          <http://model.geneontology.org/9d1581d0-602c-4255-b6c9-a81e71cab33a_RXN-9023>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_CHEBI_15377_RXN-9024_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002413_RXN-9024_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_BFO_0000066_reaction_GLYCOPHOSPHORYL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002333_YIL099W-MONOMER_RXN-9024_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -54,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -66,11 +99,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002333_YPR184W-MONOMER_AMYLOMALT-RXN_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002333_YPR184W-MONOMER_AMYLOMALT-RXN_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -90,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -98,52 +131,66 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/cd96b8b3-b7b4-4dc6-be00-a79c122e033d_GLYCOPHOSPHORYL-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9023_BFO_0000066_reaction_RXN-9023_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002233_CHEBI_4167_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_3.2.1.3-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_5bc39d1e-7b22-4519-b16c-8c1a9a2beee8_3.2.1.33-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002413_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_CHEBI_58601_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002411_AMYLOMALT-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002411_AMYLOMALT-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,11 +205,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002333_YIL099W-MONOMER_RXN-9024_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002333_YIL099W-MONOMER_RXN-9024_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,11 +227,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_CHEBI_58601_GLYCOPHOSPHORYL-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_CHEBI_58601_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -195,14 +242,14 @@
           <http://model.geneontology.org/CHEBI_58601_GLYCOPHOSPHORYL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002411_RXN-9025_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-9025_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -215,6 +262,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002411_RXN-9023_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YPR184W-MONOMER_3.2.1.33-RXN_controller>
         a       <http://identifiers.org/sgd/S000006388> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -222,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,11 +292,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_5bc39d1e-7b22-4519-b16c-8c1a9a2beee8_3.2.1.33-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_818d6267-d97f-4bef-9b99-719fc902ab9e_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,8 +304,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.2.1.33-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5bc39d1e-7b22-4519-b16c-8c1a9a2beee8_3.2.1.33-RXN>
+          <http://model.geneontology.org/818d6267-d97f-4bef-9b99-719fc902ab9e_3.2.1.33-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_CHEBI_15377_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN-9024>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -258,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -266,26 +335,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_9a6f2328-0099-4ef7-8a45-20e50129d2f9_3.2.1.33-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4038_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4038_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -300,11 +358,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,17 +373,6 @@
           <http://model.geneontology.org/YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -335,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -350,11 +397,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_BFO_0000066_reaction_AMYLOMALT-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_BFO_0000066_reaction_AMYLOMALT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -365,85 +412,62 @@
           <http://model.geneontology.org/reaction_AMYLOMALT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002333_YPR184W-MONOMER_AMYLOMALT-RXN_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002234_CHEBI_24384_3.2.1.3-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002234_CHEBI_4167_RXN-9024_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002234_CHEBI_28460_RXN3O-4038_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_CHEBI_15377_RXN-9024_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/5bc39d1e-7b22-4519-b16c-8c1a9a2beee8_3.2.1.33-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a debranched &alpha;-limit dextrin" ;
+<http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002333_CPLX3O-10513_RXN-9025_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27761> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002333_CPLX3O-10513_RXN-9025_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/2993b045-a6a4-4082-93da-9246b422ec73_RXN-9023>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a &alpha;-limit dextrin with short branches" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27823> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002233_CHEBI_24384_3.2.1.3-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002233_CHEBI_24384_3.2.1.3-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -454,26 +478,15 @@
           <http://model.geneontology.org/CHEBI_24384_3.2.1.3-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4038_BFO_0000066_reaction_RXN3O-4038_location_lociGO_0005829_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9024_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9024_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -484,14 +497,14 @@
           <http://model.geneontology.org/YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002234_CHEBI_15377_3.2.1.3-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9025_BFO_0000066_reaction_RXN-9025_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -502,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -510,25 +523,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_58601_RXN-9025_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9024_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -536,11 +538,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,44 +553,14 @@
           <http://model.geneontology.org/YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002233_CHEBI_24384_3.2.1.3-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_CHEBI_43474_RXN-9025_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9025> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_RXN-9025>
-] .
-
-<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002233_CHEBI_43474_GLYCOPHOSPHORYL-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -599,11 +571,41 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002411_RXN-9023_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_CHEBI_43474_RXN-9025_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9025> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_RXN-9025>
+] .
+
+<http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_BFO_0000066_reaction_AMYLOMALT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002411_RXN-9023_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -614,30 +616,19 @@
           <http://model.geneontology.org/RXN-9023>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002234_2993b045-a6a4-4082-93da-9246b422ec73_RXN-9023_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002234_CHEBI_24384_3.2.1.3-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_4170_PHOSPHOGLUCMUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_4170> ;
@@ -648,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -661,18 +652,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002233_CHEBI_24384_RXN3O-4038_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9023_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -680,11 +682,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002411_RXN-9025_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002411_RXN-9025_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -698,26 +700,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_24384>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002333_YPR184W-MONOMER_3.2.1.33-RXN_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002234_CHEBI_28460_RXN3O-4038_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002234_CHEBI_28460_RXN3O-4038_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -728,26 +719,15 @@
           <http://model.geneontology.org/CHEBI_28460_RXN3O-4038>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002333_CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9023_BFO_0000066_reaction_RXN-9023_location_lociGO_0005829_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9023_BFO_0000066_reaction_RXN-9023_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -758,35 +738,29 @@
           <http://model.geneontology.org/reaction_RXN-9023_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/bbdb328e-1d6a-4dd5-80f4-48801e29db60_GLYCOPHOSPHORYL-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an &alpha;-limit dextrin" ;
+<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002233_CHEBI_24384_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27840> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002234_CHEBI_17306_AMYLOMALT-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002234_CHEBI_17306_AMYLOMALT-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -797,28 +771,6 @@
           <http://model.geneontology.org/CHEBI_17306_AMYLOMALT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002234_CHEBI_28460_RXN3O-4038_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_BFO_0000066_reaction_AMYLOMALT-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/RXN-9024>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004339> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -828,7 +780,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-9024_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/9a6f2328-0099-4ef7-8a45-20e50129d2f9_3.2.1.33-RXN> , <http://model.geneontology.org/CHEBI_15377_RXN-9024> ;
+                <http://model.geneontology.org/ea25a482-01a3-4956-b436-9c17e59d4a25_3.2.1.33-RXN> , <http://model.geneontology.org/CHEBI_15377_RXN-9024> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_4167_RXN-9024> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -836,7 +788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,11 +800,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002234_CHEBI_24384_3.2.1.3-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002234_CHEBI_24384_3.2.1.3-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -870,11 +822,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_9a6f2328-0099-4ef7-8a45-20e50129d2f9_3.2.1.33-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_ea25a482-01a3-4956-b436-9c17e59d4a25_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -882,18 +834,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9024> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9a6f2328-0099-4ef7-8a45-20e50129d2f9_3.2.1.33-RXN>
+          <http://model.geneontology.org/ea25a482-01a3-4956-b436-9c17e59d4a25_3.2.1.33-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002233_CHEBI_24384_GLYCOPHOSPHORYL-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002233_CHEBI_24384_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -906,39 +858,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_58601>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4038_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_CHEBI_43474_RXN-9025_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/AMYLOMALT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -957,7 +876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -972,11 +891,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_b750b905-480d-4ad7-b5d0-bb1960e3251d_RXN-9023_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_1cfe48fe-e981-49ad-b001-2d6b08079fa8_RXN-9023_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -984,7 +903,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.2.1.33-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b750b905-480d-4ad7-b5d0-bb1960e3251d_RXN-9023>
+          <http://model.geneontology.org/1cfe48fe-e981-49ad-b001-2d6b08079fa8_RXN-9023>
 ] .
 
 <http://model.geneontology.org/reaction_GLYCOPHOSPHORYL-RXN_location_lociGO_0005829>
@@ -992,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1000,11 +919,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002333_CPLX3O-10513_RXN-9025_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002333_CPLX3O-10513_RXN-9025_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,14 +934,25 @@
           <http://model.geneontology.org/CPLX3O-10513_RXN-9025_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002233_CHEBI_24384_GLYCOPHOSPHORYL-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002333_YIL099W-MONOMER_3.2.1.3-RXN_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_818d6267-d97f-4bef-9b99-719fc902ab9e_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1030,11 +960,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_58601_RXN-9025_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_58601_RXN-9025_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1056,7 +986,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_24384_GLYCOPHOSPHORYL-RXN> , <http://model.geneontology.org/CHEBI_43474_GLYCOPHOSPHORYL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/bbdb328e-1d6a-4dd5-80f4-48801e29db60_GLYCOPHOSPHORYL-RXN> , <http://model.geneontology.org/CHEBI_58601_GLYCOPHOSPHORYL-RXN> ;
+                <http://model.geneontology.org/CHEBI_58601_GLYCOPHOSPHORYL-RXN> , <http://model.geneontology.org/28654472-3f02-41fd-9809-9cb9573d84a5_GLYCOPHOSPHORYL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1064,7 +994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1081,7 +1011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1089,19 +1019,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
+<http://purl.obolibrary.org/obo/CHEBI_17306>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002234_9d1581d0-602c-4255-b6c9-a81e71cab33a_RXN-9023_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_17306>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_61993_AMYLOMALT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_61993> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1112,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1126,17 +1056,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002413_AMYLOMALT-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000006364>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1149,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1157,26 +1076,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002233_CHEBI_28460_RXN3O-4038_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1196,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1208,11 +1116,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002333_YPR184W-MONOMER_RXN-9023_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002333_YPR184W-MONOMER_RXN-9023_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1228,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1241,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1249,14 +1157,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9023_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002413_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1264,11 +1172,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller_BFO_0000051_SGD_S000006364_CPLX3O-10513_component_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller_BFO_0000051_SGD_S000006364_CPLX3O-10513_component_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1279,25 +1187,36 @@
           <http://model.geneontology.org/SGD_S000006364_CPLX3O-10513_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-10513_RXN-9025_controller_BFO_0000051_SGD_S000006364_CPLX3O-10513_component_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_1cfe48fe-e981-49ad-b001-2d6b08079fa8_RXN-9023_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9023_BFO_0000066_reaction_RXN-9023_location_lociGO_0005829_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002333_YPR184W-MONOMER_AMYLOMALT-RXN_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_ea25a482-01a3-4956-b436-9c17e59d4a25_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1310,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1318,62 +1237,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
+<http://model.geneontology.org/1cfe48fe-e981-49ad-b001-2d6b08079fa8_RXN-9023>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002333_YPR184W-MONOMER_3.2.1.33-RXN_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_BFO_0000066_reaction_3.2.1.33-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_bbdb328e-1d6a-4dd5-80f4-48801e29db60_GLYCOPHOSPHORYL-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002233_CHEBI_4167_AMYLOMALT-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '{6-&alpha;-D-(1,4-&alpha;-D-glucano)-glucan}<sub>n</sub> + H<sub>2</sub>O &rarr; {6-&alpha;-D-(1,4-&alpha;-D-glucano)-glucan}<sub>n-1</sub> + D-glucopyranose' 'null' 'a debranched &alpha;-limit dextrin + n H<sub>2</sub>O &rarr; n D-glucopyranose' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002413_RXN-9024_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002413_RXN-9024_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1393,7 +1282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1405,11 +1294,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9025_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9025_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1424,11 +1313,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_bbdb328e-1d6a-4dd5-80f4-48801e29db60_GLYCOPHOSPHORYL-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_28654472-3f02-41fd-9809-9cb9573d84a5_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1436,28 +1325,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYCOPHOSPHORYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bbdb328e-1d6a-4dd5-80f4-48801e29db60_GLYCOPHOSPHORYL-RXN>
+          <http://model.geneontology.org/28654472-3f02-41fd-9809-9cb9573d84a5_GLYCOPHOSPHORYL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_CHEBI_58601_GLYCOPHOSPHORYL-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002413_AMYLOMALT-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_BFO_0000066_reaction_GLYCOPHOSPHORYL-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1467,14 +1345,25 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002411_RXN-9024_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002413_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002413_3.2.1.3-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1485,11 +1374,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002333_YPR184W-MONOMER_3.2.1.33-RXN_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002333_YPR184W-MONOMER_3.2.1.33-RXN_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1507,11 +1396,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4038_BFO_0000066_reaction_RXN3O-4038_location_lociGO_0005829_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4038_BFO_0000066_reaction_RXN3O-4038_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1522,15 +1411,26 @@
           <http://model.geneontology.org/reaction_RXN3O-4038_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_CHEBI_4167_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1540,17 +1440,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_CHEBI_15377_3.2.1.33-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1562,7 +1451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1570,15 +1459,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002234_CHEBI_4167_RXN-9024_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002233_CHEBI_28460_RXN3O-4038_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002233_CHEBI_28460_RXN3O-4038_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1589,6 +1489,28 @@
           <http://model.geneontology.org/CHEBI_28460_RXN3O-4038>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_465b6759-ca3e-445f-8516-796cf1a222f6_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_4167_AMYLOMALT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_4167> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1598,24 +1520,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27808> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002333_YIL099W-MONOMER_3.2.1.3-RXN_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/3.2.1.3-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004339> ;
@@ -1638,7 +1549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1652,14 +1563,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_61993>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002234_CHEBI_61993_AMYLOMALT-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002233_CHEBI_4167_AMYLOMALT-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1670,7 +1581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1682,11 +1593,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002233_CHEBI_4167_3.2.1.33-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002233_CHEBI_4167_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1697,27 +1608,15 @@
           <http://model.geneontology.org/CHEBI_4167_3.2.1.33-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/reaction_RXN-9023_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9024_BFO_0000066_reaction_RXN-9024_location_lociGO_0005829_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9024_BFO_0000066_reaction_RXN-9024_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1728,14 +1627,15 @@
           <http://model.geneontology.org/reaction_RXN-9024_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002234_CHEBI_58601_RXN-9025_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/reaction_RXN-9023_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1743,11 +1643,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1758,48 +1658,35 @@
           <http://model.geneontology.org/YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002234_CHEBI_17306_AMYLOMALT-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/28654472-3f02-41fd-9809-9cb9573d84a5_GLYCOPHOSPHORYL-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an &alpha;-limit dextrin" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27840> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller_BFO_0000051_SGD_S000006364_CPLX3O-10513_component_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/465b6759-ca3e-445f-8516-796cf1a222f6_3.2.1.33-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_BFO_0000066_reaction_3.2.1.33-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_BFO_0000066_reaction_3.2.1.33-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1810,14 +1697,14 @@
           <http://model.geneontology.org/reaction_3.2.1.33-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-10513_RXN-9025_controller_BFO_0000051_SGD_S000006364_CPLX3O-10513_component_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1825,11 +1712,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_35302bf4-e32f-4a74-b3d3-0e32bd259463_3.2.1.33-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_465b6759-ca3e-445f-8516-796cf1a222f6_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1837,17 +1724,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/35302bf4-e32f-4a74-b3d3-0e32bd259463_3.2.1.33-RXN>
+          <http://model.geneontology.org/465b6759-ca3e-445f-8516-796cf1a222f6_3.2.1.33-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002333_YIL099W-MONOMER_RXN-9024_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller_BFO_0000051_SGD_S000006364_CPLX3O-10513_component_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1855,11 +1742,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1870,25 +1757,36 @@
           <http://model.geneontology.org/YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002233_CHEBI_4167_3.2.1.33-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002333_CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002233_CHEBI_24384_RXN3O-4038_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-9024_BFO_0000066_reaction_RXN-9024_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1897,7 +1795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1908,11 +1806,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a &alpha;-limit dextrin with short branches + n H<sub>2</sub>O &rarr; a debranched &alpha;-limit dextrin + n D-glucopyranose' 'null' '{6-&alpha;-D-(1,4-&alpha;-D-glucano)-glucan}<sub>n</sub> + H<sub>2</sub>O &rarr; {6-&alpha;-D-(1,4-&alpha;-D-glucano)-glucan}<sub>n-1</sub> + D-glucopyranose' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002413_3.2.1.3-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002413_3.2.1.3-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1927,11 +1825,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002333_YPR184W-MONOMER_RXN3O-4038_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002333_YPR184W-MONOMER_RXN3O-4038_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1942,26 +1840,15 @@
           <http://model.geneontology.org/YPR184W-MONOMER_RXN3O-4038_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9025_BFO_0000066_reaction_RXN-9025_location_lociGO_0005829_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002233_e1311b54-04cd-4a02-9375-5630e7164b07_GLYCOPHOSPHORYL-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002233_cd96b8b3-b7b4-4dc6-be00-a79c122e033d_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1969,18 +1856,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9023> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e1311b54-04cd-4a02-9375-5630e7164b07_GLYCOPHOSPHORYL-RXN>
+          <http://model.geneontology.org/cd96b8b3-b7b4-4dc6-be00-a79c122e033d_GLYCOPHOSPHORYL-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002234_CHEBI_61993_AMYLOMALT-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002234_CHEBI_61993_AMYLOMALT-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2006,7 +1893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2023,13 +1910,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27857> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_BFO_0000066_reaction_3.2.1.3-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2043,7 +1941,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-9025_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_43474_RXN-9025> , <http://model.geneontology.org/35302bf4-e32f-4a74-b3d3-0e32bd259463_3.2.1.33-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN-9025> , <http://model.geneontology.org/465b6759-ca3e-445f-8516-796cf1a222f6_3.2.1.33-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_58601_RXN-9025> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -2053,7 +1951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2065,11 +1963,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002333_YIL099W-MONOMER_3.2.1.3-RXN_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002333_YIL099W-MONOMER_3.2.1.3-RXN_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2085,7 +1983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2093,11 +1991,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002234_CHEBI_4167_RXN-9024_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002234_CHEBI_4167_RXN-9024_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2117,7 +2015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2125,15 +2023,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002234_CHEBI_15377_3.2.1.3-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002233_CHEBI_43474_GLYCOPHOSPHORYL-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002233_CHEBI_43474_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2144,51 +2053,18 @@
           <http://model.geneontology.org/CHEBI_43474_GLYCOPHOSPHORYL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002333_YPR184W-MONOMER_RXN-9023_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_b750b905-480d-4ad7-b5d0-bb1960e3251d_RXN-9023_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002411_3.2.1.33-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_CHEBI_4167_3.2.1.33-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_CHEBI_4167_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2199,14 +2075,14 @@
           <http://model.geneontology.org/CHEBI_4167_3.2.1.33-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002413_RXN-9024_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_BFO_0000066_reaction_3.2.1.33-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2214,11 +2090,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a debranched &alpha;-limit dextrin + n phosphate &rarr; n &alpha;-D-glucopyranose 1-phosphate' 'null' '&alpha;-D-glucopyranose 1-phosphate &harr; D-glucopyranose 6-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002413_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002413_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2238,9 +2114,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_3.2.1.33-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_3.2.1.33-RXN> , <http://model.geneontology.org/b750b905-480d-4ad7-b5d0-bb1960e3251d_RXN-9023> ;
+                <http://model.geneontology.org/1cfe48fe-e981-49ad-b001-2d6b08079fa8_RXN-9023> , <http://model.geneontology.org/CHEBI_15377_3.2.1.33-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/5bc39d1e-7b22-4519-b16c-8c1a9a2beee8_3.2.1.33-RXN> , <http://model.geneontology.org/CHEBI_4167_3.2.1.33-RXN> ;
+                <http://model.geneontology.org/818d6267-d97f-4bef-9b99-719fc902ab9e_3.2.1.33-RXN> , <http://model.geneontology.org/CHEBI_4167_3.2.1.33-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YPR184W-MONOMER_3.2.1.33-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2250,7 +2126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2262,11 +2138,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2277,26 +2153,18 @@
           <http://model.geneontology.org/CHEBI_4170_PHOSPHOGLUCMUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002411_AMYLOMALT-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/ea25a482-01a3-4956-b436-9c17e59d4a25_3.2.1.33-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2320,7 +2188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2332,11 +2200,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_BFO_0000066_reaction_3.2.1.3-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_BFO_0000066_reaction_3.2.1.3-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2347,17 +2215,6 @@
           <http://model.geneontology.org/reaction_3.2.1.3-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_CHEBI_4167_3.2.1.33-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0005980>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2365,11 +2222,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002411_3.2.1.33-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002411_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2380,14 +2237,14 @@
           <http://model.geneontology.org/3.2.1.33-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002333_YPR184W-MONOMER_RXN3O-4038_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002233_CHEBI_43474_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2395,11 +2252,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-10513_RXN-9025_controller_BFO_0000051_SGD_S000006364_CPLX3O-10513_component_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-10513_RXN-9025_controller_BFO_0000051_SGD_S000006364_CPLX3O-10513_component_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2410,6 +2267,34 @@
           <http://model.geneontology.org/SGD_S000006364_CPLX3O-10513_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/9d1581d0-602c-4255-b6c9-a81e71cab33a_RXN-9023>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a &alpha;-limit dextrin with short branches" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27823> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_4167_3.2.1.33-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_4167> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2419,7 +2304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2427,14 +2312,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9024_BFO_0000066_reaction_RXN-9024_location_lociGO_0005829_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002234_CHEBI_17306_AMYLOMALT-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002333_YPR184W-MONOMER_RXN3O-4038_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2447,7 +2343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2455,25 +2351,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002413_3.2.1.33-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002234_CHEBI_58601_RXN-9025_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_58601_RXN-9025_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2481,11 +2377,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" , "Provides Input For Rule. The relation '{6-&alpha;-D-(1,4-&alpha;-D-glucano)-glucan}<sub>n</sub> + H<sub>2</sub>O &rarr; {6-&alpha;-D-(1,4-&alpha;-D-glucano)-glucan}<sub>n-1</sub> + D-glucopyranose' 'null' 'a &alpha;-limit dextrin with short branches + n H<sub>2</sub>O &rarr; a debranched &alpha;-limit dextrin + n D-glucopyranose' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002413_3.2.1.33-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002413_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2496,29 +2392,15 @@
           <http://model.geneontology.org/3.2.1.33-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_BFO_0000066_reaction_3.2.1.3-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9025_BFO_0000066_reaction_RXN-9025_location_lociGO_0005829_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9025_BFO_0000066_reaction_RXN-9025_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2534,7 +2416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2542,11 +2424,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002333_CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002333_CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2557,19 +2439,8 @@
           <http://model.geneontology.org/CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_35302bf4-e32f-4a74-b3d3-0e32bd259463_3.2.1.33-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/b750b905-480d-4ad7-b5d0-bb1960e3251d_RXN-9023>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001610> ;
@@ -2578,7 +2449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2586,35 +2457,54 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/35302bf4-e32f-4a74-b3d3-0e32bd259463_3.2.1.33-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002233_CHEBI_24384_3.2.1.3-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002234_CHEBI_61993_AMYLOMALT-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002411_AMYLOMALT-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002411_RXN-9024_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002411_RXN-9024_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2625,12 +2515,34 @@
           <http://model.geneontology.org/RXN-9024>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4038_BFO_0000066_reaction_RXN3O-4038_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4038_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000006364_CPLX3O-10513_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006364> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2638,11 +2550,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002233_CHEBI_24384_RXN3O-4038_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002233_CHEBI_24384_RXN3O-4038_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2653,15 +2565,26 @@
           <http://model.geneontology.org/CHEBI_24384_RXN3O-4038>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002233_cd96b8b3-b7b4-4dc6-be00-a79c122e033d_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9023_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9023_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2681,7 +2604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2693,11 +2616,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002233_CHEBI_4167_AMYLOMALT-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002233_CHEBI_4167_AMYLOMALT-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2708,6 +2631,17 @@
           <http://model.geneontology.org/CHEBI_4167_AMYLOMALT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9024_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_43474_RXN-9025>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2717,7 +2651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2732,7 +2666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2749,9 +2683,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-9023_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/e1311b54-04cd-4a02-9375-5630e7164b07_GLYCOPHOSPHORYL-RXN> ;
+                <http://model.geneontology.org/cd96b8b3-b7b4-4dc6-be00-a79c122e033d_GLYCOPHOSPHORYL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/2993b045-a6a4-4082-93da-9246b422ec73_RXN-9023> ;
+                <http://model.geneontology.org/9d1581d0-602c-4255-b6c9-a81e71cab33a_RXN-9023> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YPR184W-MONOMER_RXN-9023_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2759,7 +2693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2771,11 +2705,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002234_CHEBI_15377_3.2.1.3-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002234_CHEBI_15377_3.2.1.3-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2786,15 +2720,18 @@
           <http://model.geneontology.org/CHEBI_15377_3.2.1.3-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_4167>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_CHEBI_15377_RXN-9024_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_CHEBI_15377_RXN-9024_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2805,18 +2742,15 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-9024>
 ] .
 
-<http://model.geneontology.org/e1311b54-04cd-4a02-9375-5630e7164b07_GLYCOPHOSPHORYL-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_BFO_0000066_reaction_GLYCOPHOSPHORYL-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_BFO_0000066_reaction_GLYCOPHOSPHORYL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2827,8 +2761,49 @@
           <http://model.geneontology.org/reaction_GLYCOPHOSPHORYL-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_4167>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002411_RXN-9025_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002411_RXN-9024_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002333_YPR184W-MONOMER_RXN-9023_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -2839,7 +2814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycogen catabolism - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2864,7 +2839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2875,15 +2850,26 @@
 <http://purl.obolibrary.org/obo/GO_0004339>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002411_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_CHEBI_15377_3.2.1.33-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_CHEBI_15377_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2898,11 +2884,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002234_CHEBI_58601_RXN-9025_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002234_CHEBI_58601_RXN-9025_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2912,17 +2898,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58601_RXN-9025>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002233_e1311b54-04cd-4a02-9375-5630e7164b07_GLYCOPHOSPHORYL-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-4038>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004135> ;
@@ -2943,7 +2918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2955,11 +2930,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2970,33 +2945,25 @@
           <http://model.geneontology.org/reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9025_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000001361>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/9a6f2328-0099-4ef7-8a45-20e50129d2f9_3.2.1.33-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002411_RXN-9023_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/818d6267-d97f-4bef-9b99-719fc902ab9e_3.2.1.33-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a debranched &alpha;-limit dextrin" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27761> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000004711>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3010,7 +2977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3018,14 +2985,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002413_3.2.1.3-RXN_SGD_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_28654472-3f02-41fd-9809-9cb9573d84a5_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3034,6 +3012,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_CHEBI_43474_RXN-9025_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002233_CHEBI_28460_RXN3O-4038_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_GLYCOLYSIS.ttl
+++ b/models/YeastPathways_GLYCOLYSIS.ttl
@@ -1,23 +1,27 @@
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57540_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller>
+        a       <http://identifiers.org/sgd/S000002457> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "triosephosphate isomerase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOLYSISProtein32760> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,15 +32,26 @@
           <http://model.geneontology.org/YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002413_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002233_CHEBI_4170_PGLUCISOM-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002233_CHEBI_4170_PGLUCISOM-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -51,11 +66,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,6 +80,39 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_F16BDEPHOS-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002234_CHEBI_58289_3PGAREARR-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002333_CPLX3O-77_6PFRUCTPHOS-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -76,11 +124,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_57634_F16BDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_57634_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -91,6 +139,17 @@
           <http://model.geneontology.org/CHEBI_57634_F16BDEPHOS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YKL152C-MONOMER_RXN-15513_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001635> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -98,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -106,25 +165,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000066_reaction_PEPDEPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002234_CHEBI_58289_RXN-15513_SGD_YeastPathways_GLYCOLYSIS>
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -132,11 +180,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '3-phospho-D-glycerate + ATP &harr; 3-phospho-D-glyceroyl-phosphate + ADP' 'null' '2-phospho-D-glycerate &harr; 3-phospho-D-glycerate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_3PGAREARR-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_3PGAREARR-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -150,26 +198,15 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_58289_3PGAREARR-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_15378_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_15378_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,15 +217,37 @@
           <http://model.geneontology.org/CHEBI_15378_GAPOXNPHOSPHN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000066_reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002413_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000003472_CPLX3O-77_component_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000003472_CPLX3O-77_component_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -199,6 +258,17 @@
           <http://model.geneontology.org/SGD_S000003472_CPLX3O-77_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002333_YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -208,17 +278,6 @@
 <http://purl.obolibrary.org/obo/GO_0003872>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller>
         a       <http://identifiers.org/sgd/S000003486> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -226,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,26 +293,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_57634_PGLUCISOM-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" , "Provides Input For Rule. The relation 'D-glyceraldehyde 3-phosphate &harr; glycerone phosphate' 'null' 'D-glyceraldehyde 3-phosphate + NAD<sup>+</sup> + phosphate &harr; 3-phospho-D-glyceroyl-phosphate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -283,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -300,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -312,11 +360,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_15361_PEPDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_15361_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -327,28 +375,6 @@
           <http://model.geneontology.org/CHEBI_15361_PEPDEPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000004818_CPLX3O-77_component_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000005874>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -356,11 +382,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002234_CHEBI_58289_3PGAREARR-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002234_CHEBI_58289_3PGAREARR-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -371,36 +397,14 @@
           <http://model.geneontology.org/CHEBI_58289_3PGAREARR-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002413_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002333_YKL152C-MONOMER_3PGAREARR-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002333_YLR377C-MONOMER_F16BDEPHOS-RXN_controller_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -408,11 +412,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -423,14 +427,14 @@
           <http://model.geneontology.org/CHEBI_456216_PHOSGLYPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002413_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -443,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -451,37 +455,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YAL038W-MONOMER_PEPDEPHOS-RXN_controller_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate + H<sub>2</sub>O &rarr; &beta;-D-fructofuranose 6-phosphate + phosphate' 'null' 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002413_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002413_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -497,6 +479,17 @@
 
 <http://identifiers.org/sgd/S000000036>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_456216_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003588>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -520,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,28 +523,6 @@
 
 <http://identifiers.org/sgd/S000003769>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002333_YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000066_reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -563,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -574,14 +545,25 @@
 <http://purl.obolibrary.org/obo/GO_0004807>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002333_YKL152C-MONOMER_3PGAREARR-RXN_controller_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YAL038W-MONOMER_PEPDEPHOS-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57540_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -594,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -606,11 +588,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -630,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -638,15 +620,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002333_YKL060C-MONOMER_F16ALDOLASE-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_59776_F16ALDOLASE-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_59776_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,11 +654,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -676,14 +669,14 @@
           <http://model.geneontology.org/YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YOR347C-MONOMER_PEPDEPHOS-RXN_controller_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -692,29 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -722,11 +693,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -737,29 +708,29 @@
           <http://model.geneontology.org/YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller>
 ] .
 
-<http://identifiers.org/sgd/S000003486>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002413_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLYCOLYSIS>
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_3PGAREARR-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003486>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_57634_PGLUCISOM-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_57634_PGLUCISOM-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,26 +741,15 @@
           <http://model.geneontology.org/CHEBI_57634_PGLUCISOM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002233_CHEBI_4170_PGLUCISOM-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_15377_F16BDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_15377_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -800,17 +760,39 @@
           <http://model.geneontology.org/CHEBI_15377_F16BDEPHOS-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000001635>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002233_CHEBI_57642_F16ALDOLASE-RXN_SGD_YeastPathways_GLYCOLYSIS>
+<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002233_CHEBI_57642_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001635>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000066_reaction_6PFRUCTPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -821,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -829,29 +811,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_YeastPathways_GLYCOLYSIS>
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_15377>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_15378_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_15378_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -865,15 +847,26 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_43474_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -884,14 +877,14 @@
           <http://model.geneontology.org/YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -899,11 +892,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -932,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -958,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -966,15 +959,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_30616_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000004818_CPLX3O-77_component_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000004818_CPLX3O-77_component_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -985,26 +989,15 @@
           <http://model.geneontology.org/SGD_S000004818_CPLX3O-77_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_57642_F16ALDOLASE-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,14 +1008,14 @@
           <http://model.geneontology.org/YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_YeastPathways_GLYCOLYSIS>
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1030,11 +1023,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_30616_PEPDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_30616_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1045,25 +1038,36 @@
           <http://model.geneontology.org/CHEBI_30616_PEPDEPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLYCOLYSIS>
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_15378_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002234_CHEBI_58289_RXN-15513_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1086,7 +1090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1101,13 +1105,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOLYSISProtein32816> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_15378_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58272_PHOSGLYPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58272> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1118,7 +1133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1130,11 +1145,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002333_YKL152C-MONOMER_3PGAREARR-RXN_controller_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002333_YKL152C-MONOMER_3PGAREARR-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1151,6 +1166,17 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002234_CHEBI_57634_PGLUCISOM-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57634_PGLUCISOM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57634> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1160,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1175,11 +1201,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1199,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1215,7 +1241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1223,11 +1249,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1242,11 +1268,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2-phospho-D-glycerate &harr; 3-phospho-D-glycerate' 'null' '2-phospho-D-glycerate &harr; phospho<i>enol</i>pyruvate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002413_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002413_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1257,14 +1283,14 @@
           <http://model.geneontology.org/2PGADEHYDRAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_59776_F16ALDOLASE-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002233_CHEBI_4170_PGLUCISOM-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1287,7 +1313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1295,15 +1321,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002333_YLR377C-MONOMER_F16BDEPHOS-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1314,34 +1351,34 @@
           <http://model.geneontology.org/CHEBI_30616_PHOSGLYPHOS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS>
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1349,11 +1386,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1364,14 +1401,25 @@
           <http://model.geneontology.org/reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16ALDOLASE-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_15377_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1384,7 +1432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1395,14 +1443,14 @@
 <http://identifiers.org/sgd/S000000400>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000066_reaction_6PFRUCTPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS>
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1415,7 +1463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1427,11 +1475,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000066_reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000066_reaction_TRIOSEPISOMERIZATION-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1446,11 +1494,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002333_YKL060C-MONOMER_F16ALDOLASE-RXN_controller_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002333_YKL060C-MONOMER_F16ALDOLASE-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1461,15 +1509,26 @@
           <http://model.geneontology.org/YKL060C-MONOMER_F16ALDOLASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YOR347C-MONOMER_PEPDEPHOS-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000066_reaction_PEPDEPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000066_reaction_PEPDEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1483,31 +1542,20 @@
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002413_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58272>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0004332>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_456216_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
+<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1515,11 +1563,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2-phospho-D-glycerate &harr; phospho<i>enol</i>pyruvate + H<sub>2</sub>O' 'null' 'pyruvate + ATP &larr; phospho<i>enol</i>pyruvate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002413_PEPDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002413_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1534,11 +1582,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1554,40 +1602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16BDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1595,11 +1610,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1620,11 +1635,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1657,7 +1672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1670,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1678,11 +1693,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1693,14 +1708,25 @@
           <http://model.geneontology.org/reaction_RXN-15513_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_58289_3PGAREARR-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1708,11 +1734,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1723,6 +1749,17 @@
           <http://model.geneontology.org/CHEBI_57945_GAPOXNPHOSPHN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_59776_F16ALDOLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59776> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1732,7 +1769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1743,15 +1780,37 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_RXN-15513_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1781,7 +1840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1793,11 +1852,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1817,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1829,11 +1888,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YAL038W-MONOMER_PEPDEPHOS-RXN_controller_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YAL038W-MONOMER_PEPDEPHOS-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1847,14 +1906,14 @@
 <http://purl.obolibrary.org/obo/GO_0004634>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002234_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1883,7 +1942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1891,25 +1950,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS>
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_43474_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000066_reaction_PGLUCISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1920,7 +1990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1937,7 +2007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1945,15 +2015,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1964,6 +2045,17 @@
           <http://model.geneontology.org/YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_4170_PGLUCISOM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_4170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1973,7 +2065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2000,13 +2092,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOLYSISBiochemicalReaction32525> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000066_reaction_3PGAREARR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YLR377C-MONOMER_F16BDEPHOS-RXN_controller>
         a       <http://identifiers.org/sgd/S000004369> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2015,7 +2118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2027,11 +2130,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2042,6 +2145,17 @@
           <http://model.geneontology.org/CHEBI_58272_PHOSGLYPHOS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000066_reaction_F16BDEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004743>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2049,11 +2163,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_43474_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_43474_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2064,6 +2178,17 @@
           <http://model.geneontology.org/CHEBI_43474_GAPOXNPHOSPHN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003769> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2071,7 +2196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2079,26 +2204,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_TRIOSEPISOMERIZATION-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002233_CHEBI_57642_F16ALDOLASE-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002233_CHEBI_57642_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2113,11 +2227,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" , "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' 'null' 'D-glyceraldehyde 3-phosphate + NAD<sup>+</sup> + phosphate &harr; 3-phospho-D-glyceroyl-phosphate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2135,24 +2249,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOLYSISProtein32868> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002333_YKL060C-MONOMER_F16ALDOLASE-RXN_controller_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YKL152C-MONOMER_3PGAREARR-RXN_controller>
         a       <http://identifiers.org/sgd/S000001635> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2161,7 +2264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2169,26 +2272,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_30616_PEPDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_15378_PEPDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_15378_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2208,7 +2300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2229,11 +2321,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2247,14 +2339,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_57604>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_57634_F16BDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000066_reaction_RXN-15513_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2262,11 +2354,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" , "Provides Input For Rule. The relation 'D-glucopyranose 6-phosphate &harr; &beta;-D-fructofuranose 6-phosphate' 'null' 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002413_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002413_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2282,7 +2374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2296,7 +2388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2308,11 +2400,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_43474_F16BDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_43474_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2323,6 +2415,17 @@
           <http://model.geneontology.org/CHEBI_43474_F16BDEPHOS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002413_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_GLYCOLYSIS>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2332,7 +2435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycolysis I (from glucose 6-phosphate) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2340,15 +2443,26 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_456216_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_456216_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2368,7 +2482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2376,29 +2490,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002333_YGR254W-MONOMER_2PGADEHYDRAT-RXN_controller_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_58702>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58702>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2409,26 +2523,15 @@
           <http://model.geneontology.org/CHEBI_58272_PHOSGLYPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2439,39 +2542,6 @@
           <http://model.geneontology.org/YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002234_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57604_GAPOXNPHOSPHN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57604> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2481,7 +2551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2489,26 +2559,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002413_PEPDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000066_reaction_F16ALDOLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000066_reaction_F16ALDOLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2519,26 +2578,15 @@
           <http://model.geneontology.org/reaction_F16ALDOLASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002333_CPLX3O-77_6PFRUCTPHOS-RXN_controller_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_58289_3PGAREARR-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002233_CHEBI_58289_3PGAREARR-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2554,18 +2602,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS>
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000066_reaction_PEPDEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2578,7 +2626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2590,11 +2638,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YOR347C-MONOMER_PEPDEPHOS-RXN_controller_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YOR347C-MONOMER_PEPDEPHOS-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2605,25 +2653,14 @@
           <http://model.geneontology.org/YOR347C-MONOMER_PEPDEPHOS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_15377_F16BDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_57634_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_15378_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2631,11 +2668,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2651,7 +2688,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_57642_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2659,11 +2707,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2686,7 +2734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2694,15 +2742,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" , "Provides Input For Rule. The relation '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' 'null' 'D-glyceraldehyde 3-phosphate &harr; glycerone phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_TRIOSEPISOMERIZATION-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_TRIOSEPISOMERIZATION-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2725,7 +2784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2733,26 +2792,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_15378_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000066_reaction_6PFRUCTPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000066_reaction_6PFRUCTPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2766,18 +2814,40 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002233_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_456216_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2788,15 +2858,26 @@
           <http://model.geneontology.org/YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_57634_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57540_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_57540_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2812,7 +2893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2833,7 +2914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2841,67 +2922,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_PGLUCISOM-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_43474_GAPOXNPHOSPHN-RXN_SGD_YeastPathways_GLYCOLYSIS>
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2909,11 +2946,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002234_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002234_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2929,18 +2966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_456216_PEPDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2948,11 +2974,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_456216_PEPDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_456216_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2963,6 +2989,39 @@
           <http://model.geneontology.org/CHEBI_456216_PEPDEPHOS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15361_PEPDEPHOS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2972,7 +3031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2984,11 +3043,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000066_reaction_3PGAREARR-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000066_reaction_3PGAREARR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2999,48 +3058,15 @@
           <http://model.geneontology.org/reaction_3PGAREARR-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_15378_PEPDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15513_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3051,18 +3077,40 @@
           <http://model.geneontology.org/YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_15361_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0042132>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_15378_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_57634_F16BDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_57634_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3092,7 +3140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3100,15 +3148,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002333_CPLX3O-77_6PFRUCTPHOS-RXN_controller_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002333_CPLX3O-77_6PFRUCTPHOS-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3123,11 +3182,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002234_CHEBI_58289_RXN-15513_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002234_CHEBI_58289_RXN-15513_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3138,6 +3197,17 @@
           <http://model.geneontology.org/CHEBI_58289_RXN-15513>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57634_F16BDEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57634> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3147,7 +3217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3155,14 +3225,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3173,11 +3243,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3188,15 +3258,26 @@
           <http://model.geneontology.org/YJL052W-MONOMER_GAPOXNPHOSPHN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002413_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3210,14 +3291,14 @@
 <http://identifiers.org/sgd/S000003472>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_59776_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3228,7 +3309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3242,26 +3323,15 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3275,15 +3345,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_32966>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000066_reaction_PGLUCISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000066_reaction_PGLUCISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3294,25 +3375,14 @@
           <http://model.geneontology.org/reaction_PGLUCISOM-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000066_reaction_F16ALDOLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS>
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002233_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3323,11 +3393,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3337,17 +3407,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS>
 ] .
-
-<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002234_CHEBI_58289_3PGAREARR-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57642>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3362,11 +3421,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_30616_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_30616_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3381,11 +3440,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" , "Provides Input For Rule. The relation '3-phospho-D-glycerate + ATP &harr; 3-phospho-D-glyceroyl-phosphate + ADP' 'null' '2-phospho-D-glycerate &harr; 3-phospho-D-glycerate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_RXN-15513_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_RXN-15513_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3399,14 +3458,14 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000003472_CPLX3O-77_component_SGD_YeastPathways_GLYCOLYSIS>
+<http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000003472_CPLX3O-77_component_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3414,11 +3473,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_59776_TRIOSEPISOMERIZATION-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3429,36 +3488,25 @@
           <http://model.geneontology.org/CHEBI_59776_TRIOSEPISOMERIZATION-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_YeastPathways_GLYCOLYSIS>
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_30616_PEPDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002234_CHEBI_15361_PEPDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000066_reaction_F16ALDOLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002413_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3471,7 +3519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3488,7 +3536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3496,26 +3544,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_BFO_0000066_reaction_PGLUCISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002333_YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_TRIOSEPISOMERIZATION-RXN_RO_0002333_YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3526,6 +3563,28 @@
           <http://model.geneontology.org/YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YGR192C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-77_6PFRUCTPHOS-RXN_controller_BFO_0000051_SGD_S000004818_CPLX3O-77_component_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-77_6PFRUCTPHOS-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3535,7 +3594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3546,26 +3605,15 @@
 <http://purl.obolibrary.org/obo/GO_0004365>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3576,14 +3624,25 @@
           <http://model.geneontology.org/CHEBI_58702_2PGADEHYDRAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002233_CHEBI_30616_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002413_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_TRIOSEPISOMERIZATION-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3596,7 +3655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3607,29 +3666,51 @@
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000066_reaction_3PGAREARR-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS>
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_30616_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002413_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002233_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_RO_0002233_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3647,7 +3728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3662,11 +3743,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3689,7 +3770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3707,7 +3788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3719,11 +3800,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002333_YLR377C-MONOMER_F16BDEPHOS-RXN_controller_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002333_YLR377C-MONOMER_F16BDEPHOS-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3734,6 +3815,28 @@
           <http://model.geneontology.org/YLR377C-MONOMER_F16BDEPHOS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002333_YBR196C-MONOMER_PGLUCISOM-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57604_GAPOXNPHOSPHN-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOLYSIS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000001217>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3741,11 +3844,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" , "Provides Input For Rule. The relation 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' 'null' '&beta;-D-fructose 1,6-bisphosphate &harr; glycerone phosphate + D-glyceraldehyde 3-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16ALDOLASE-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3756,26 +3859,15 @@
           <http://model.geneontology.org/F16ALDOLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGLUCISOM-RXN_RO_0002413_6PFRUCTPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002333_YKL152C-MONOMER_RXN-15513_controller_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3786,25 +3878,14 @@
           <http://model.geneontology.org/YKL152C-MONOMER_RXN-15513_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLYCOLYSIS>
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002234_CHEBI_32966_6PFRUCTPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_RXN-15513_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
+                "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3812,11 +3893,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002333_YJR009C-MONOMER_GAPOXNPHOSPHN-RXN_controller_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3831,11 +3912,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" , "Provides Input For Rule. The relation 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' 'null' '&beta;-D-fructose 1,6-bisphosphate + H<sub>2</sub>O &rarr; &beta;-D-fructofuranose 6-phosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16BDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16BDEPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3850,11 +3931,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" , "Provides Input For Rule. The relation '2-phospho-D-glycerate &harr; 3-phospho-D-glycerate' 'null' '2-phospho-D-glycerate &harr; phospho<i>enol</i>pyruvate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002413_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15513_RO_0002413_2PGADEHYDRAT-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3872,11 +3953,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_57642_F16ALDOLASE-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_57642_F16ALDOLASE-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3892,7 +3973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3900,11 +3981,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" , "Provides Input For Rule. The relation 'D-glyceraldehyde 3-phosphate + NAD<sup>+</sup> + phosphate &harr; 3-phospho-D-glyceroyl-phosphate + NADH + H<SUP>+</SUP>' 'null' '3-phospho-D-glycerate + ATP &harr; 3-phospho-D-glyceroyl-phosphate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002413_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS> ;
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002413_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLYCOLYSIS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3914,72 +3995,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PHOSGLYPHOS-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_58702_2PGADEHYDRAT-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_57634_F16BDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000050_YeastPathways_GLYCOLYSIS/YeastPathways_GLYCOLYSIS_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002234_CHEBI_58272_PHOSGLYPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002413_3PGAREARR-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_RO_0002234_CHEBI_43474_F16BDEPHOS-RXN_SGD_YeastPathways_GLYCOLYSIS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOLYSIS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/F16BDEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0042132> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4000,7 +4015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4017,25 +4032,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOLYSISSmallMolecule32574> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller>
-        a       <http://identifiers.org/sgd/S000002457> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "triosephosphate isomerase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOLYSISProtein32760> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .

--- a/models/YeastPathways_GLYOXYLATE-BYPASS.ttl
+++ b/models/YeastPathways_GLYOXYLATE-BYPASS.ttl
@@ -1,11 +1,11 @@
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_CITSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13,11 +13,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' 'null' 'oxaloacetate + acetyl-CoA + H<sub>2</sub>O &rarr; citrate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_CITSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_CITSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,15 +28,26 @@
           <http://model.geneontology.org/CITSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_CITSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" , "Provides Input For Rule. The relation 'oxaloacetate + acetyl-CoA + H<sub>2</sub>O &rarr; citrate + coenzyme A + H<SUP>+</SUP>' 'null' 'citrate &harr; <i>cis</i>-aconitate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002413_ACONITATEDEHYDR-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002413_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -67,26 +78,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_16383>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002413_ACONITATEHYDR-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -102,18 +102,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
+<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002233_CHEBI_15562_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YNL117W-MONOMER_MALSYN-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -124,24 +135,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYOXYLATE-BYPASSProtein16779> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_57288_MALSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -158,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -187,11 +187,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_57287_MALSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_57287_MALSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -202,6 +202,17 @@
           <http://model.geneontology.org/CHEBI_57287_MALSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YIR031C-MONOMER_MALSYN-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_CITSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -211,7 +222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -223,11 +234,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -242,11 +253,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEHYDR-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEHYDR-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -257,41 +268,30 @@
           <http://model.geneontology.org/YLR304C-MONOMER_ACONITATEHYDR-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002413_ACONITATEDEHYDR-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_15377_CITSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_15378_CITSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002413_MALSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACONITATEDEHYDR-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003994> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -312,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -332,37 +332,15 @@
 <http://identifiers.org/sgd/S000002236>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,14 +351,14 @@
           <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YNL117W-MONOMER_MALSYN-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000066_reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -388,11 +366,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_16947_CITSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_16947_CITSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,17 +381,6 @@
           <http://model.geneontology.org/CHEBI_16947_CITSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -421,11 +388,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000066_reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000066_reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -443,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -451,8 +418,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_16947_CITSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000005486>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -462,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -470,11 +459,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_15377_MALSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_15377_MALSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -489,11 +478,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,23 +493,23 @@
           <http://model.geneontology.org/SGD_S000005486_CPLX3O-88_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_57287_MALSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000001568_CPLX3O-85_component>
         a       <http://identifiers.org/sgd/S000001568> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15589_MALSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -533,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -541,14 +530,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_YeastPathways_GLYOXYLATE-BYPASS>
+<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_30031_ISOCIT-CLEAV-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15378_MALSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -571,7 +571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -583,11 +583,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'acetyl-CoA + glyoxylate + H<sub>2</sub>O &rarr; (<i>S</i>)-malate + coenzyme A + H<SUP>+</SUP>' 'null' '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002413_MALATE-DEH-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002413_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -615,15 +615,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002233_CHEBI_16947_CITSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -646,7 +657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -658,11 +669,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000066_reaction_CITSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000066_reaction_CITSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -695,7 +706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -703,14 +714,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_16452_MALATE-DEH-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YNR001C-MONOMER_CITSYN-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -723,7 +734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -731,36 +742,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000066_reaction_ISOCIT-CLEAV-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYOXYLATE-BYPASS>
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_15377_CITSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -774,11 +763,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -793,11 +782,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YNR001C-MONOMER_CITSYN-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YNR001C-MONOMER_CITSYN-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -808,8 +797,30 @@
           <http://model.geneontology.org/YNR001C-MONOMER_CITSYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000066_reaction_MALSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_15377_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57288_MALSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -820,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -832,11 +843,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,72 +858,17 @@
           <http://model.geneontology.org/CHEBI_16383_ACONITATEDEHYDR-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000066_reaction_MALSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYOXYLATE-BYPASS>
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YCR005C-MONOMER_CITSYN-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15589_MALSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -920,11 +876,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15378_MALSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15378_MALSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -938,15 +894,26 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002233_CHEBI_15562_ACONITATEHYDR-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002233_CHEBI_15562_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -978,11 +945,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1012,7 +979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1020,22 +987,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57287>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://identifiers.org/sgd/S000005284>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57287>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000005284>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16452> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1046,24 +1024,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYOXYLATE-BYPASSSmallMolecule16627> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-83_MALATE-DEH-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1074,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1085,14 +1052,14 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_YeastPathways_GLYOXYLATE-BYPASS>
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_MALSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1103,7 +1070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1115,11 +1082,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1133,26 +1100,15 @@
 <http://purl.obolibrary.org/obo/GO_0003994>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_57288_CITSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_57288_CITSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1163,8 +1119,41 @@
           <http://model.geneontology.org/CHEBI_57288_CITSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_15377_MALSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002413_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15562_ACONITATEHYDR-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15562> ;
@@ -1175,7 +1164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1183,15 +1172,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1206,11 +1206,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1230,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1242,11 +1242,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'citrate &harr; <i>cis</i>-aconitate + H<sub>2</sub>O' 'null' '<i>cis</i>-aconitate + H<sub>2</sub>O &harr; D-<i>threo</i>-isocitrate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002413_ACONITATEHYDR-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002413_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1272,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1283,26 +1283,15 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000066_reaction_ACONITATEHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YIR031C-MONOMER_MALSYN-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YIR031C-MONOMER_MALSYN-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1313,15 +1302,26 @@
           <http://model.geneontology.org/YIR031C-MONOMER_MALSYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002333_YER065C-MONOMER_ISOCIT-CLEAV-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002333_YER065C-MONOMER_ISOCIT-CLEAV-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1339,11 +1339,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" , "Provides Input For Rule. The relation '<i>cis</i>-aconitate + H<sub>2</sub>O &harr; D-<i>threo</i>-isocitrate' 'null' 'D-<i>threo</i>-isocitrate &rarr; glyoxylate + succinate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002413_ISOCIT-CLEAV-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002413_ISOCIT-CLEAV-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1369,30 +1369,41 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_57288_CITSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEHYDR-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YPR001W-MONOMER_CITSYN-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002234_CHEBI_15562_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1401,11 +1412,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1420,11 +1431,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_57287_CITSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_57287_CITSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1435,14 +1446,14 @@
           <http://model.geneontology.org/CHEBI_57287_CITSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000066_reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYOXYLATE-BYPASS>
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_16452_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1450,11 +1461,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002233_CHEBI_16947_CITSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002233_CHEBI_16947_CITSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1474,24 +1485,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYOXYLATE-BYPASSSmallMolecule16563> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000066_reaction_CITSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YCR005C-MONOMER_CITSYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000598> ;
@@ -1500,7 +1500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1508,14 +1508,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002413_ISOCIT-CLEAV-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002413_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1532,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1547,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1559,11 +1559,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1574,15 +1574,26 @@
           <http://model.geneontology.org/CHEBI_36655_ISOCIT-CLEAV-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_57288_CITSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1600,11 +1611,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000066_reaction_ACONITATEHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000066_reaction_ACONITATEHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1615,17 +1626,6 @@
           <http://model.geneontology.org/reaction_ACONITATEHYDR-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YLR304C-MONOMER_ACONITATEHYDR-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004295> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1633,7 +1633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1641,14 +1641,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002233_CHEBI_15562_ACONITATEHYDR-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002413_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1661,7 +1672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1678,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1686,26 +1697,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_15377_ACONITATEHYDR-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1716,26 +1716,15 @@
           <http://model.geneontology.org/reaction_MALATE-DEH-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002413_MALATE-DEH-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_15377_CITSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_15377_CITSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1765,7 +1754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1773,36 +1762,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEHYDR-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YIR031C-MONOMER_MALSYN-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS>
+<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000066_reaction_ISOCIT-CLEAV-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_57287_CITSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1810,11 +1777,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1829,11 +1796,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YPR001W-MONOMER_CITSYN-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YPR001W-MONOMER_CITSYN-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1844,14 +1811,14 @@
           <http://model.geneontology.org/YPR001W-MONOMER_CITSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_YeastPathways_GLYOXYLATE-BYPASS>
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1859,11 +1826,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1874,39 +1841,28 @@
           <http://model.geneontology.org/YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_15377_MALSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_16947_CITSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YCR005C-MONOMER_CITSYN-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS>
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_57288_MALSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002413_MALSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1919,7 +1875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1927,12 +1883,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000066_reaction_CITSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_ACONITATEHYDR-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1940,11 +1907,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15589_MALSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15589_MALSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1974,7 +1941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1989,7 +1956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2001,11 +1968,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_30031_ISOCIT-CLEAV-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_30031_ISOCIT-CLEAV-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2020,11 +1987,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002234_CHEBI_15562_ACONITATEHYDR-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002234_CHEBI_15562_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2047,7 +2014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2061,28 +2028,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15589>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_30031_ISOCIT-CLEAV-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002333_YER065C-MONOMER_ISOCIT-CLEAV-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -2092,30 +2037,8 @@
 <http://identifiers.org/sgd/S000000867>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002234_CHEBI_15562_ACONITATEHYDR-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_36655>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_MALSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57288_CITSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2126,7 +2049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2134,15 +2057,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002333_YER065C-MONOMER_ISOCIT-CLEAV-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2157,11 +2091,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_15378_CITSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_15378_CITSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2177,7 +2111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2185,11 +2119,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2200,37 +2134,59 @@
           <http://model.geneontology.org/YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000005486_CPLX3O-88_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005486> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_15377_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YPR001W-MONOMER_CITSYN-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_57287_CITSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2238,11 +2194,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000066_reaction_MALSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000066_reaction_MALSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2257,11 +2213,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2272,15 +2228,26 @@
           <http://model.geneontology.org/SGD_S000001568_CPLX3O-85_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2296,7 +2263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2305,18 +2272,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_15378_CITSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
+<http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2324,11 +2291,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YNL117W-MONOMER_MALSYN-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YNL117W-MONOMER_MALSYN-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2343,11 +2310,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-<i>threo</i>-isocitrate &rarr; glyoxylate + succinate' 'null' 'acetyl-CoA + glyoxylate + H<sub>2</sub>O &rarr; (<i>S</i>)-malate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002413_MALSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002413_MALSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2362,11 +2329,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2386,8 +2353,52 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002413_ISOCIT-CLEAV-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000003736>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000050_YeastPathways_GLYOXYLATE-BYPASS/YeastPathways_GLYOXYLATE-BYPASS_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004295>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2396,11 +2407,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2415,11 +2426,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YCR005C-MONOMER_CITSYN-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YCR005C-MONOMER_CITSYN-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2430,6 +2441,17 @@
           <http://model.geneontology.org/YCR005C-MONOMER_CITSYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_57287_MALSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004295> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2437,7 +2459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2454,7 +2476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2467,7 +2489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2475,11 +2497,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_15377_ACONITATEDEHYDR-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_15377_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2490,14 +2512,14 @@
           <http://model.geneontology.org/CHEBI_15377_ACONITATEDEHYDR-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YNR001C-MONOMER_CITSYN-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS>
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2508,11 +2530,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_57288_MALSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_57288_MALSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2523,48 +2545,15 @@
           <http://model.geneontology.org/CHEBI_57288_MALSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002233_CHEBI_16947_CITSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15378_MALSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000066_reaction_ISOCIT-CLEAV-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000066_reaction_ISOCIT-CLEAV-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2579,11 +2568,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_15377_ACONITATEHYDR-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_15377_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2603,7 +2592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glyoxylate cycle - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2620,7 +2609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2632,11 +2621,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_MALSYN-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_MALSYN-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2647,14 +2636,14 @@
           <http://model.geneontology.org/CHEBI_15589_MALSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_YeastPathways_GLYOXYLATE-BYPASS>
+<http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2662,11 +2651,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_16452_MALATE-DEH-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_16452_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2677,36 +2666,47 @@
           <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000066_reaction_ACONITATEHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_15377_ACONITATEDEHYDR-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_YeastPathways_GLYOXYLATE-BYPASS>
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2719,7 +2719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_GLYSYN-ALA-PWY.ttl
+++ b/models/YeastPathways_GLYSYN-ALA-PWY.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17,11 +17,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_15361_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_GLYSYN-ALA-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_15361_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_GLYSYN-ALA-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,6 +35,28 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_GLYSYN-ALA-PWY/YeastPathways_GLYSYN-ALA-PWY_SGD_PWY_YeastPathways_GLYSYN-ALA-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYSYN-ALA-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_15361_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_GLYSYN-ALA-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYSYN-ALA-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -47,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -75,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -87,11 +109,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_57972_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_GLYSYN-ALA-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_57972_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_GLYSYN-ALA-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -101,6 +123,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57972_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002333_MONOMER3O-372_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_GLYSYN-ALA-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYSYN-ALA-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -114,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycine biosynthesis III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -125,28 +158,28 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_GLYSYN-ALA-PWY/YeastPathways_GLYSYN-ALA-PWY_SGD_YeastPathways_GLYSYN-ALA-PWY>
+<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYSYN-ALA-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-ALA-PWY" ;
+                "SGD_PWY:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_57305_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_GLYSYN-ALA-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_57972_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_GLYSYN-ALA-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-ALA-PWY" ;
+                "SGD_PWY:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -157,11 +190,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_36655_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_GLYSYN-ALA-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_36655_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_GLYSYN-ALA-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -187,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -201,6 +234,17 @@
 <http://purl.obolibrary.org/obo/GO_0019265>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_36655_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_GLYSYN-ALA-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYSYN-ALA-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0008453>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -208,11 +252,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYSYN-ALA-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYSYN-ALA-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,11 +280,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002333_MONOMER3O-372_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_GLYSYN-ALA-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002333_MONOMER3O-372_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_GLYSYN-ALA-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -270,11 +314,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_GLYSYN-ALA-PWY/YeastPathways_GLYSYN-ALA-PWY_SGD_YeastPathways_GLYSYN-ALA-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_GLYSYN-ALA-PWY/YeastPathways_GLYSYN-ALA-PWY_SGD_PWY_YeastPathways_GLYSYN-ALA-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -292,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -300,48 +344,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_36655_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_GLYSYN-ALA-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-ALA-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_57972_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_GLYSYN-ALA-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-ALA-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_15361_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_GLYSYN-ALA-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-ALA-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -351,40 +362,18 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYSYN-ALA-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-ALA-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002333_MONOMER3O-372_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_GLYSYN-ALA-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-ALA-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_57305_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_GLYSYN-ALA-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_57305_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_GLYSYN-ALA-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,13 +393,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYSYN-ALA-PWYSmallMolecule23537> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_57305_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_GLYSYN-ALA-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYSYN-ALA-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_GLYSYN-PWY.ttl
+++ b/models/YeastPathways_GLYSYN-PWY.ttl
@@ -1,3 +1,14 @@
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_GLYSYN-PWY/YeastPathways_GLYSYN-PWY_SGD_PWY_YeastPathways_GLYSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000467> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -5,7 +16,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17,11 +28,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_YeastPathways_GLYSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -31,17 +42,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_GLYSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004372>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -55,26 +55,15 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_YeastPathways_GLYSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_1a67eea8-a965-40a1-80c3-8fc8c0704db1_GLYOHMETRANS-RXN_SGD_YeastPathways_GLYSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_1d76c057-188a-4629-ab17-5a83259c3201_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -82,8 +71,36 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1a67eea8-a965-40a1-80c3-8fc8c0704db1_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/1d76c057-188a-4629-ab17-5a83259c3201_GLYOHMETRANS-RXN>
 ] .
+
+<http://model.geneontology.org/1d76c057-188a-4629-ab17-5a83259c3201_GLYOHMETRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYSYN-PWYSmallMolecule23596> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_8b39883c-c19f-4300-95b1-ef1b92062529_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004048> ;
@@ -92,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -112,23 +129,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/bb7ecaeb-3ef1-4134-9733-c1e34a7b2fd9_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYSYN-PWYSmallMolecule23619> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -136,11 +136,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_GLYSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_GLYSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,11 +158,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_YeastPathways_GLYSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -173,17 +173,6 @@
           <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_bb7ecaeb-3ef1-4134-9733-c1e34a7b2fd9_GLYOHMETRANS-RXN_SGD_YeastPathways_GLYSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -192,6 +181,17 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_GLYSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,11 +217,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_GLYSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_GLYSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,32 +232,26 @@
           <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/1a67eea8-a965-40a1-80c3-8fc8c0704db1_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_GLYSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYSYN-PWYSmallMolecule23596> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,41 +265,30 @@
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_1d76c057-188a-4629-ab17-5a83259c3201_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-PWY" ;
+                "SGD_PWY:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_YeastPathways_GLYSYN-PWY>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-PWY" ;
+                "SGD_PWY:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_YeastPathways_GLYSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_GLYSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -316,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -331,11 +314,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_bb7ecaeb-3ef1-4134-9733-c1e34a7b2fd9_GLYOHMETRANS-RXN_SGD_YeastPathways_GLYSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_8b39883c-c19f-4300-95b1-ef1b92062529_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,11 +326,22 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bb7ecaeb-3ef1-4134-9733-c1e34a7b2fd9_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/8b39883c-c19f-4300-95b1-ef1b92062529_GLYOHMETRANS-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -361,15 +355,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/1a67eea8-a965-40a1-80c3-8fc8c0704db1_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/1d76c057-188a-4629-ab17-5a83259c3201_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/bb7ecaeb-3ef1-4134-9733-c1e34a7b2fd9_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/8b39883c-c19f-4300-95b1-ef1b92062529_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -377,40 +371,46 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_GLYSYN-PWY/YeastPathways_GLYSYN-PWY_SGD_YeastPathways_GLYSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/8b39883c-c19f-4300-95b1-ef1b92062529_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYSYN-PWYSmallMolecule23619> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-PWY" ;
+                "SGD_PWY:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0019264>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_GLYSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_GLYSYN-PWY/YeastPathways_GLYSYN-PWY_SGD_YeastPathways_GLYSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_GLYSYN-PWY/YeastPathways_GLYSYN-PWY_SGD_PWY_YeastPathways_GLYSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,7 +437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -455,11 +455,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_YeastPathways_GLYSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -470,14 +470,14 @@
           <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_1a67eea8-a965-40a1-80c3-8fc8c0704db1_GLYOHMETRANS-RXN_SGD_YeastPathways_GLYSYN-PWY>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-PWY" ;
+                "SGD_PWY:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -493,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -506,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -519,7 +519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_GLYSYN-THR-PWY.ttl
+++ b/models/YeastPathways_GLYSYN-THR-PWY.ttl
@@ -1,3 +1,14 @@
+<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002233_CHEBI_57926_THREONINE-ALDOLASE-RXN_SGD_PWY_YeastPathways_GLYSYN-THR-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYSYN-THR-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15343_THREONINE-ALDOLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15343> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -32,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -44,11 +55,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002234_CHEBI_57305_THREONINE-ALDOLASE-RXN_SGD_YeastPathways_GLYSYN-THR-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002234_CHEBI_57305_THREONINE-ALDOLASE-RXN_SGD_PWY_YeastPathways_GLYSYN-THR-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,31 +73,31 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002234_CHEBI_57305_THREONINE-ALDOLASE-RXN_SGD_YeastPathways_GLYSYN-THR-PWY>
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_BFO_0000050_YeastPathways_GLYSYN-THR-PWY/YeastPathways_GLYSYN-THR-PWY_SGD_PWY_YeastPathways_GLYSYN-THR-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-THR-PWY" ;
+                "SGD_PWY:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_BFO_0000066_reaction_THREONINE-ALDOLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYSYN-THR-PWY>
+<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002234_CHEBI_15343_THREONINE-ALDOLASE-RXN_SGD_PWY_YeastPathways_GLYSYN-THR-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-THR-PWY" ;
+                "SGD_PWY:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -94,11 +105,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002234_CHEBI_15343_THREONINE-ALDOLASE-RXN_SGD_YeastPathways_GLYSYN-THR-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002234_CHEBI_15343_THREONINE-ALDOLASE-RXN_SGD_PWY_YeastPathways_GLYSYN-THR-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -109,22 +120,22 @@
           <http://model.geneontology.org/CHEBI_15343_THREONINE-ALDOLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002234_CHEBI_57305_THREONINE-ALDOLASE-RXN_SGD_PWY_YeastPathways_GLYSYN-THR-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYSYN-THR-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002333_YEL046C-MONOMER_THREONINE-ALDOLASE-RXN_controller_SGD_YeastPathways_GLYSYN-THR-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-THR-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15343>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -142,11 +153,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002233_CHEBI_57926_THREONINE-ALDOLASE-RXN_SGD_YeastPathways_GLYSYN-THR-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002233_CHEBI_57926_THREONINE-ALDOLASE-RXN_SGD_PWY_YeastPathways_GLYSYN-THR-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -160,40 +171,29 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002234_CHEBI_15343_THREONINE-ALDOLASE-RXN_SGD_YeastPathways_GLYSYN-THR-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-THR-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_BFO_0000050_YeastPathways_GLYSYN-THR-PWY/YeastPathways_GLYSYN-THR-PWY_SGD_YeastPathways_GLYSYN-THR-PWY>
+<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_BFO_0000066_reaction_THREONINE-ALDOLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYSYN-THR-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-THR-PWY" ;
+                "SGD_PWY:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_BFO_0000066_reaction_THREONINE-ALDOLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_GLYSYN-THR-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_BFO_0000066_reaction_THREONINE-ALDOLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYSYN-THR-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -209,12 +209,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002333_YEL046C-MONOMER_THREONINE-ALDOLASE-RXN_controller_SGD_PWY_YeastPathways_GLYSYN-THR-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYSYN-THR-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_GLYSYN-THR-PWY/YeastPathways_GLYSYN-THR-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0006545> ;
@@ -223,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -247,11 +258,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_BFO_0000050_YeastPathways_GLYSYN-THR-PWY/YeastPathways_GLYSYN-THR-PWY_SGD_YeastPathways_GLYSYN-THR-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_BFO_0000050_YeastPathways_GLYSYN-THR-PWY/YeastPathways_GLYSYN-THR-PWY_SGD_PWY_YeastPathways_GLYSYN-THR-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,7 +283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -295,7 +306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -305,17 +316,6 @@
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002233_CHEBI_57926_THREONINE-ALDOLASE-RXN_SGD_YeastPathways_GLYSYN-THR-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-THR-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004793>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -330,11 +330,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002333_YEL046C-MONOMER_THREONINE-ALDOLASE-RXN_controller_SGD_YeastPathways_GLYSYN-THR-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002333_YEL046C-MONOMER_THREONINE-ALDOLASE-RXN_controller_SGD_PWY_YeastPathways_GLYSYN-THR-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycine biosynthesis IV - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_HEME-BIOSYNTHESIS-II.ttl
+++ b/models/YeastPathways_HEME-BIOSYNTHESIS-II.ttl
@@ -1,11 +1,22 @@
-<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_15377_RXN0-1461_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_57308_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_BFO_0000066_reaction_UROGENDECARBOX-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13,11 +24,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002234_CHEBI_16526_UROGENDECARBOX-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002234_CHEBI_16526_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,17 +39,6 @@
           <http://model.geneontology.org/CHEBI_16526_UROGENDECARBOX-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_57307_RXN0-1461_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YDR044W-MONOMER_RXN0-1461_controller>
         a       <http://identifiers.org/sgd/S000002451> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -46,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -75,11 +75,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'protoporphyrinogen IX + 3 oxygen &rarr; protoporphyrin IX + 3 hydrogen peroxide' 'null' 'ferroheme <i>b</i> + 2 H<SUP>+</SUP> &larr; protoporphyrin IX + Fe<SUP>2+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002413_PROTOHEMEFERROCHELAT-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002413_PROTOHEMEFERROCHELAT-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -90,15 +90,26 @@
           <http://model.geneontology.org/PROTOHEMEFERROCHELAT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002333_YER014W-MONOMER_PROTOPORGENOXI-RXN_controller_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002234_CHEBI_15378_PROTOHEMEFERROCHELAT-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002234_CHEBI_15378_PROTOHEMEFERROCHELAT-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -109,15 +120,26 @@
           <http://model.geneontology.org/CHEBI_15378_PROTOHEMEFERROCHELAT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002234_CHEBI_17627_PROTOHEMEFERROCHELAT-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_15378_UROGENDECARBOX-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_15378_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -137,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -151,8 +173,16 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004109>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_57307_RXN0-1461_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57307_RXN0-1461>
         a       <http://purl.obolibrary.org/obo/CHEBI_57307> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -163,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -171,16 +201,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_57308_UROGENDECARBOX-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004109>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_RXN0-1461>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -191,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -202,17 +224,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57308>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002234_CHEBI_16240_PROTOPORGENOXI-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57306_PROTOPORGENOXI-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57306> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -222,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,11 +245,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_16526_RXN0-1461_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_16526_RXN0-1461_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,8 +260,41 @@
           <http://model.geneontology.org/CHEBI_16526_RXN0-1461>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_BFO_0000066_reaction_PROTOPORGENOXI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002333_YDR047W-MONOMER_UROGENDECARBOX-RXN_controller_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_16526_RXN0-1461_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -260,80 +304,36 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_BFO_0000066_reaction_PROTOHEMEFERROCHELAT-RXN_location_lociGO_0005829_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002413_PROTOHEMEFERROCHELAT-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17627>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002234_CHEBI_16526_UROGENDECARBOX-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_BFO_0000066_reaction_PROTOHEMEFERROCHELAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002454>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_16526_RXN0-1461_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002413_PROTOPORGENOXI-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002333_YER014W-MONOMER_PROTOPORGENOXI-RXN_controller_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002333_YER014W-MONOMER_PROTOPORGENOXI-RXN_controller_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -344,17 +344,6 @@
           <http://model.geneontology.org/YER014W-MONOMER_PROTOPORGENOXI-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002333_YER014W-MONOMER_PROTOPORGENOXI-RXN_controller_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_17627_PROTOHEMEFERROCHELAT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17627> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -364,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -376,11 +365,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002233_CHEBI_57306_PROTOPORGENOXI-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002233_CHEBI_57306_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,11 +384,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_BFO_0000066_reaction_UROGENDECARBOX-RXN_location_lociGO_0005829_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_BFO_0000066_reaction_UROGENDECARBOX-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -413,17 +402,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002233_CHEBI_57307_RXN0-1461_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15379_RXN0-1461>
         a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -433,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -450,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -468,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -482,6 +460,17 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002413_RXN0-1461_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -489,11 +478,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_15377_RXN0-1461_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_15377_RXN0-1461_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,14 +493,14 @@
           <http://model.geneontology.org/CHEBI_15377_RXN0-1461>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002333_YOR176W-MONOMER_PROTOHEMEFERROCHELAT-RXN_controller_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002413_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -527,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -539,11 +528,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_15379_RXN0-1461_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_15379_RXN0-1461_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -561,11 +550,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_BFO_0000066_reaction_PROTOPORGENOXI-RXN_location_lociGO_0005829_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_BFO_0000066_reaction_PROTOPORGENOXI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -593,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -620,7 +609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -628,44 +617,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_BFO_0000066_reaction_UROGENDECARBOX-RXN_location_lociGO_0005829_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002333_YDR044W-MONOMER_RXN0-1461_controller_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000005702>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002413_RXN0-1461_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PROTOPORGENOXI-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004729> ;
@@ -686,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -698,11 +654,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002234_CHEBI_57306_PROTOPORGENOXI-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002234_CHEBI_57306_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,25 +669,14 @@
           <http://model.geneontology.org/CHEBI_57306_PROTOPORGENOXI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_BFO_0000050_YeastPathways_HEME-BIOSYNTHESIS-II/YeastPathways_HEME-BIOSYNTHESIS-II_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002234_CHEBI_57306_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_BFO_0000066_reaction_PROTOPORGENOXI-RXN_location_lociGO_0005829_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -739,11 +684,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002233_CHEBI_29033_PROTOHEMEFERROCHELAT-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002233_CHEBI_29033_PROTOHEMEFERROCHELAT-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -763,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -775,11 +720,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_BFO_0000050_YeastPathways_HEME-BIOSYNTHESIS-II/YeastPathways_HEME-BIOSYNTHESIS-II_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_BFO_0000050_YeastPathways_HEME-BIOSYNTHESIS-II/YeastPathways_HEME-BIOSYNTHESIS-II_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -795,7 +740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -808,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "heme <i>b</i> biosynthesis I (aerobic) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -835,7 +780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -849,14 +794,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_57306>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002333_YDR047W-MONOMER_UROGENDECARBOX-RXN_controller_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
+<http://model.geneontology.org/ev_w_id_RXN0-1461_BFO_0000066_reaction_RXN0-1461_location_lociGO_0005829_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -868,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -876,11 +821,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_57309_UROGENDECARBOX-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_57309_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -891,26 +836,15 @@
           <http://model.geneontology.org/CHEBI_57309_UROGENDECARBOX-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_15379_RXN0-1461_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" , "Provides Input For Rule. The relation 'uroporphyrinogen-III + 4 H<SUP>+</SUP> &rarr; 4 CO<SUB>2</SUB> + coproporphyrinogen III' 'null' 'coproporphyrinogen III + oxygen + 2 H<SUP>+</SUP> &rarr; protoporphyrinogen IX + 2 CO<SUB>2</SUB> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002413_RXN0-1461_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002413_RXN0-1461_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -930,15 +864,26 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002234_CHEBI_57309_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_15378_RXN0-1461_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_15378_RXN0-1461_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,11 +898,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_BFO_0000050_YeastPathways_HEME-BIOSYNTHESIS-II/YeastPathways_HEME-BIOSYNTHESIS-II_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_BFO_0000050_YeastPathways_HEME-BIOSYNTHESIS-II/YeastPathways_HEME-BIOSYNTHESIS-II_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -968,6 +913,17 @@
           <http://model.geneontology.org/YeastPathways_HEME-BIOSYNTHESIS-II/YeastPathways_HEME-BIOSYNTHESIS-II>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002234_CHEBI_15378_PROTOHEMEFERROCHELAT-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16526_UROGENDECARBOX-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -977,24 +933,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEME-BIOSYNTHESIS-IISmallMolecule42199> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_BFO_0000050_YeastPathways_HEME-BIOSYNTHESIS-II/YeastPathways_HEME-BIOSYNTHESIS-II_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YOR176W-MONOMER_PROTOHEMEFERROCHELAT-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005702> ;
@@ -1003,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1011,14 +956,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002234_CHEBI_17627_PROTOHEMEFERROCHELAT-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
+<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002333_YDR044W-MONOMER_RXN0-1461_controller_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_BFO_0000050_YeastPathways_HEME-BIOSYNTHESIS-II/YeastPathways_HEME-BIOSYNTHESIS-II_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1026,11 +982,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002234_CHEBI_16240_PROTOPORGENOXI-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002234_CHEBI_16240_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1041,26 +997,15 @@
           <http://model.geneontology.org/CHEBI_16240_PROTOPORGENOXI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002234_CHEBI_57306_PROTOPORGENOXI-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_BFO_0000066_reaction_PROTOHEMEFERROCHELAT-RXN_location_lociGO_0005829_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_BFO_0000066_reaction_PROTOHEMEFERROCHELAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1071,26 +1016,15 @@
           <http://model.geneontology.org/reaction_PROTOHEMEFERROCHELAT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1461_BFO_0000050_YeastPathways_HEME-BIOSYNTHESIS-II/YeastPathways_HEME-BIOSYNTHESIS-II_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" , "Provides Input For Rule. The relation 'coproporphyrinogen III + oxygen + 2 H<SUP>+</SUP> &rarr; protoporphyrinogen IX + 2 CO<SUB>2</SUB> + 2 H<sub>2</sub>O' 'null' 'protoporphyrinogen IX + 3 oxygen &rarr; protoporphyrin IX + 3 hydrogen peroxide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002413_PROTOPORGENOXI-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002413_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1101,39 +1035,28 @@
           <http://model.geneontology.org/PROTOPORGENOXI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002233_CHEBI_29033_PROTOHEMEFERROCHELAT-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
+<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_BFO_0000050_YeastPathways_HEME-BIOSYNTHESIS-II/YeastPathways_HEME-BIOSYNTHESIS-II_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004853>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002233_CHEBI_15379_PROTOPORGENOXI-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002234_CHEBI_57309_UROGENDECARBOX-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
+<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_15379_RXN0-1461_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1149,7 +1072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1161,11 +1084,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002333_YDR047W-MONOMER_UROGENDECARBOX-RXN_controller_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002333_YDR047W-MONOMER_UROGENDECARBOX-RXN_controller_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1176,6 +1099,17 @@
           <http://model.geneontology.org/YDR047W-MONOMER_UROGENDECARBOX-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_BFO_0000050_YeastPathways_HEME-BIOSYNTHESIS-II/YeastPathways_HEME-BIOSYNTHESIS-II_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57309_UROGENDECARBOX-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57309> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1185,13 +1119,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEME-BIOSYNTHESIS-IISmallMolecule42140> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_15377_RXN0-1461_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1200,11 +1145,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_BFO_0000066_reaction_RXN0-1461_location_lociGO_0005829_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_BFO_0000066_reaction_RXN0-1461_location_lociGO_0005829_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1219,11 +1164,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002333_YOR176W-MONOMER_PROTOHEMEFERROCHELAT-RXN_controller_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002333_YOR176W-MONOMER_PROTOHEMEFERROCHELAT-RXN_controller_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,17 +1191,6 @@
 <http://identifiers.org/sgd/S000002451>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002233_CHEBI_57306_PROTOPORGENOXI-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000000816>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1264,11 +1198,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002233_CHEBI_57307_RXN0-1461_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002233_CHEBI_57307_RXN0-1461_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1283,11 +1217,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_BFO_0000050_YeastPathways_HEME-BIOSYNTHESIS-II/YeastPathways_HEME-BIOSYNTHESIS-II_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_BFO_0000050_YeastPathways_HEME-BIOSYNTHESIS-II/YeastPathways_HEME-BIOSYNTHESIS-II_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1305,11 +1239,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002333_YDR044W-MONOMER_RXN0-1461_controller_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002333_YDR044W-MONOMER_RXN0-1461_controller_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1320,23 +1254,78 @@
           <http://model.geneontology.org/YDR044W-MONOMER_RXN0-1461_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_15378_RXN0-1461_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
+<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002333_YOR176W-MONOMER_PROTOHEMEFERROCHELAT-RXN_controller_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_57309_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_15378_RXN0-1461_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002233_CHEBI_15379_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002233_CHEBI_57306_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002233_CHEBI_29033_PROTOHEMEFERROCHELAT-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1344,11 +1333,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002234_CHEBI_57309_UROGENDECARBOX-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002234_CHEBI_57309_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1368,7 +1357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1376,18 +1365,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002234_CHEBI_16240_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_15378_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_BFO_0000050_YeastPathways_HEME-BIOSYNTHESIS-II/YeastPathways_HEME-BIOSYNTHESIS-II_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_BFO_0000050_YeastPathways_HEME-BIOSYNTHESIS-II/YeastPathways_HEME-BIOSYNTHESIS-II_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1403,7 +1414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1411,11 +1422,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002234_CHEBI_17627_PROTOHEMEFERROCHELAT-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002234_CHEBI_17627_PROTOHEMEFERROCHELAT-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1426,14 +1437,25 @@
           <http://model.geneontology.org/CHEBI_17627_PROTOHEMEFERROCHELAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_BFO_0000050_YeastPathways_HEME-BIOSYNTHESIS-II/YeastPathways_HEME-BIOSYNTHESIS-II_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN0-1461_BFO_0000050_YeastPathways_HEME-BIOSYNTHESIS-II/YeastPathways_HEME-BIOSYNTHESIS-II_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002234_CHEBI_16526_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1441,11 +1463,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_57308_UROGENDECARBOX-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_57308_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1466,13 +1488,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEME-BIOSYNTHESIS-IIProtein42290> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002413_PROTOHEMEFERROCHELAT-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57309>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1486,7 +1519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1494,14 +1527,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_57309_UROGENDECARBOX-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
+<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002233_CHEBI_57307_RXN0-1461_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
+                "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1509,11 +1542,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002233_CHEBI_15379_PROTOPORGENOXI-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002233_CHEBI_15379_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1536,7 +1569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1544,26 +1577,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_15378_UROGENDECARBOX-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_57307_RXN0-1461_SGD_YeastPathways_HEME-BIOSYNTHESIS-II> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_57307_RXN0-1461_SGD_PWY_YeastPathways_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1573,28 +1595,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57307_RXN0-1461>
 ] .
-
-<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002234_CHEBI_15378_PROTOHEMEFERROCHELAT-RXN_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1461_BFO_0000066_reaction_RXN0-1461_location_lociGO_0005829_SGD_YeastPathways_HEME-BIOSYNTHESIS-II>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004729>
         a       <http://www.w3.org/2002/07/owl#Class> .

--- a/models/YeastPathways_HEXPPSYN-PWY-2.ttl
+++ b/models/YeastPathways_HEXPPSYN-PWY-2.ttl
@@ -1,52 +1,8 @@
-<http://purl.obolibrary.org/obo/GO_0004337>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/CHEBI_58057>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8813_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002413_RXN3O-9805_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_GPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004337>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/RXN3O-9805>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -65,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -92,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -100,15 +56,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_57907_RXN-8813_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_57907_RXN-8813_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -119,17 +86,6 @@
           <http://model.geneontology.org/CHEBI_57907_RXN-8813>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_FARNESYLTRANSTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -139,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -164,30 +120,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2BiochemicalReaction56143> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/CHEBI_29888_RXN3O-9805>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2SmallMolecule56132> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_29888_GPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -198,13 +137,41 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2SmallMolecule56132> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_29888_RXN3O-9805>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2SmallMolecule56132> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_GPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29888_RXN-8813>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -215,7 +182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -223,15 +190,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002413_RXN3O-9805_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,11 +227,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_29888_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_29888_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -264,15 +242,18 @@
           <http://model.geneontology.org/CHEBI_29888_FARNESYLTRANSTRANSFERASE-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002233_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002233_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -283,54 +264,40 @@
           <http://model.geneontology.org/CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_29888_RXN-8813_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-8813_BFO_0000066_reaction_RXN-8813_location_lociGO_0005829_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_29888_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_58179_RXN3O-9805_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_GPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -341,17 +308,6 @@
           <http://model.geneontology.org/CHEBI_58057_GPPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YPL069C-MONOMER_FARNESYLTRANSTRANSFERASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000005990> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -359,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -371,11 +327,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_57907_RXN-8813_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_57907_RXN-8813_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -409,12 +365,45 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002413_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_BFO_0000066_reaction_FARNESYLTRANSTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_GPPSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -422,11 +411,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -444,11 +433,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_175763_FPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_175763_FPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -459,25 +448,25 @@
           <http://model.geneontology.org/CHEBI_175763_FPPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_128769_RXN3O-9805_SGD_YeastPathways_HEXPPSYN-PWY-2>
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_GPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2>
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_57907_RXN-8813_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -485,11 +474,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002233_CHEBI_128769_RXN-8813_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002233_CHEBI_128769_RXN-8813_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -536,14 +525,14 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_YeastPathways_HEXPPSYN-PWY-2>
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_58179_RXN3O-9805_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -551,11 +540,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -566,24 +555,15 @@
           <http://model.geneontology.org/CHEBI_29888_GPPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_RXN-8813_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_128769_RXN3O-9805_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_128769_RXN3O-9805_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -594,38 +574,28 @@
           <http://model.geneontology.org/CHEBI_128769_RXN3O-9805>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002333_YPL069C-MONOMER_FARNESYLTRANSTRANSFERASE-RXN_controller_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/reaction_RXN-8813_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002413_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8813_BFO_0000066_reaction_RXN-8813_location_lociGO_0005829_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_57623_GPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57623> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -636,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,11 +618,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_GPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_GPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,18 +633,26 @@
           <http://model.geneontology.org/CHEBI_128769_GPPSYN-RXN>
 ] .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_29888_RXN3O-9805_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -692,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -700,14 +678,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2>
+<http://model.geneontology.org/ev_w_id_RXN-8813_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -720,35 +698,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2SmallMolecule56197> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002413_RXN-8813_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002233_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_128769_FPPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_128769> ;
@@ -759,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -774,11 +730,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -793,11 +749,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_128769_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_128769_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -812,11 +768,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8813_BFO_0000066_reaction_RXN-8813_location_lociGO_0005829_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8813_BFO_0000066_reaction_RXN-8813_location_lociGO_0005829_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -836,37 +792,15 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_GPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_GPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -877,6 +811,28 @@
           <http://model.geneontology.org/CHEBI_57623_GPPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002333_YPL069C-MONOMER_FARNESYLTRANSTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_128769>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -884,11 +840,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000066_reaction_RXN3O-9805_location_lociGO_0005829_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000066_reaction_RXN3O-9805_location_lociGO_0005829_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,17 +855,6 @@
           <http://model.geneontology.org/reaction_RXN3O-9805_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_29888_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -917,11 +862,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -932,15 +877,26 @@
           <http://model.geneontology.org/reaction_GPPSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'isopentenyl diphosphate + (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate &rarr; geranylgeranyl diphosphate + diphosphate' 'null' 'geranylgeranyl diphosphate + isopentenyl diphosphate &rarr; geranylfarnesyl diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002413_RXN-8813_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002413_RXN-8813_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -951,17 +907,6 @@
           <http://model.geneontology.org/RXN-8813>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_175763_FPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_FPPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -971,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -979,14 +924,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -995,7 +940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1008,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1020,11 +965,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1042,11 +987,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_BFO_0000066_reaction_FARNESYLTRANSTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_BFO_0000066_reaction_FARNESYLTRANSTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1057,37 +1002,15 @@
           <http://model.geneontology.org/reaction_FARNESYLTRANSTRANSFERASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8813_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8813_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1098,6 +1021,17 @@
           <http://model.geneontology.org/YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_175763_FPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YJL167W-MONOMER_FPPSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000003703> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1105,35 +1039,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2Protein56204> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000066_reaction_RXN3O-9805_location_lociGO_0005829_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_128769_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_128769_FARNESYLTRANSTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_128769> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1144,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1156,11 +1068,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002333_YBR003W-MONOMER_RXN3O-9805_controller_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002333_YBR003W-MONOMER_RXN3O-9805_controller_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1171,14 +1083,25 @@
           <http://model.geneontology.org/YBR003W-MONOMER_RXN3O-9805_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_29888_RXN3O-9805_SGD_YeastPathways_HEXPPSYN-PWY-2>
+<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_57907_RXN-8813_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1187,25 +1110,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_58179>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1216,8 +1136,16 @@
           <http://model.geneontology.org/YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_29888_RXN-8813_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58179_RXN3O-9805>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58179> ;
@@ -1228,24 +1156,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2SmallMolecule56117> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_HEXPPSYN-PWY-2>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -1256,7 +1173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "hexaprenyl diphosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1264,40 +1181,18 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002333_YBR003W-MONOMER_RXN3O-9805_controller_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_57907_RXN-8813_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1308,16 +1203,8 @@
           <http://model.geneontology.org/YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_58179>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0044687>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1326,11 +1213,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002333_YPL069C-MONOMER_FARNESYLTRANSTRANSFERASE-RXN_controller_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002333_YPL069C-MONOMER_FARNESYLTRANSTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1341,16 +1228,8 @@
           <http://model.geneontology.org/YPL069C-MONOMER_FARNESYLTRANSTRANSFERASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_57907_RXN-8813_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1363,18 +1242,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_175763>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1382,11 +1264,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1401,11 +1283,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1414,6 +1296,25 @@
           <http://model.geneontology.org/FARNESYLTRANSTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" , "Provides Input For Rule. The relation 'dimethylallyl diphosphate + isopentenyl diphosphate &rarr; geranyl diphosphate + diphosphate' 'null' 'geranyl diphosphate + isopentenyl diphosphate &rarr; (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GPPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/FPPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/FARNESYLTRANSTRANSFERASE-RXN>
@@ -1435,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1443,30 +1344,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/CHEBI_175763>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_128769_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004161>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" , "Provides Input For Rule. The relation 'dimethylallyl diphosphate + isopentenyl diphosphate &rarr; geranyl diphosphate + diphosphate' 'null' 'geranyl diphosphate + isopentenyl diphosphate &rarr; (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GPPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FPPSYN-RXN>
-] .
 
 <http://model.geneontology.org/YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2>
         a       <http://purl.obolibrary.org/obo/GO_0006744> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1475,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1483,40 +1384,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002233_CHEBI_128769_RXN-8813_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002233_CHEBI_128769_RXN-8813_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_58179_RXN3O-9805_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_58179_RXN3O-9805_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1527,6 +1417,17 @@
           <http://model.geneontology.org/CHEBI_58179_RXN3O-9805>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_175763_FPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_175763> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1536,7 +1437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1544,14 +1445,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_BFO_0000066_reaction_FARNESYLTRANSTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_HEXPPSYN-PWY-2>
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1565,13 +1466,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2Protein56204> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002333_YBR003W-MONOMER_RXN3O-9805_controller_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1580,11 +1503,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" , "Provides Input For Rule. The relation 'geranylgeranyl diphosphate + isopentenyl diphosphate &rarr; geranylfarnesyl diphosphate + diphosphate' 'null' 'geranylfarnesyl diphosphate + isopentenyl diphosphate &rarr; all-<i>trans</i>-hexaprenyl diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002413_RXN3O-9805_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002413_RXN3O-9805_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1594,6 +1517,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN3O-9805>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000066_reaction_RXN3O-9805_location_lociGO_0005829_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1607,7 +1552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1619,11 +1564,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" , "Provides Input For Rule. The relation 'geranyl diphosphate + isopentenyl diphosphate &rarr; (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate + diphosphate' 'null' 'isopentenyl diphosphate + (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate &rarr; geranylgeranyl diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002413_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002413_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1643,7 +1588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1655,11 +1600,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1679,7 +1624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1687,26 +1632,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_29888_RXN-8813_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_29888_RXN-8813_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1717,6 +1651,42 @@
           <http://model.geneontology.org/CHEBI_29888_RXN-8813>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_128769_RXN3O-9805_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://purl.obolibrary.org/obo/CHEBI_58756>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1724,11 +1694,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1739,18 +1709,48 @@
           <http://model.geneontology.org/reaction_FPPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002233_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002413_RXN-8813_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1771,11 +1771,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_29888_RXN3O-9805_SGD_YeastPathways_HEXPPSYN-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_29888_RXN3O-9805_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_HISTSYN-PWY.ttl
+++ b/models/YeastPathways_HISTSYN-PWY.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_43474_HISTIDPHOS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_43474_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,15 +17,29 @@
           <http://model.geneontology.org/CHEBI_43474_HISTIDPHOS-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_29985>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57945_HISTALDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57945_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,17 +50,14 @@
           <http://model.geneontology.org/CHEBI_57945_HISTALDEHYD-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_29985>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002413_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_30616_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -59,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -86,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -94,14 +105,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000066_reaction_IMIDPHOSDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -109,11 +120,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002234_CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002234_CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -124,20 +135,70 @@
           <http://model.geneontology.org/CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_57945_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/CHEBI_57595_HISTALDEHYD-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57595> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "his" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYSmallMolecule24666> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002413_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -145,11 +206,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -160,15 +221,37 @@
           <http://model.geneontology.org/YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_15378_HISTOLDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_15378_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -196,32 +279,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CHEBI_57595_HISTALDEHYD-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57595> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "his" ;
+<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_57766_IMIDPHOSDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYSmallMolecule24666> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002333_YIL116W-MONOMER_HISTAMINOTRANS-RXN_controller_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002333_YIL116W-MONOMER_HISTAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,25 +309,14 @@
           <http://model.geneontology.org/YIL116W-MONOMER_HISTAMINOTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58525_PRIBFAICARPISOM-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57945_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_15377_HISTALDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -258,11 +324,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_15378_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_15378_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,27 +348,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYSmallMolecule24333> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_15378_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YER055C-MONOMER_ATPPHOSPHORIBOSYLTRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000857> ;
@@ -311,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -319,40 +371,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002233_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000066_reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004400>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,15 +399,37 @@
           <http://model.geneontology.org/CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000066_reaction_GLUTAMIDOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" , "Provides Input For Rule. The relation '1-(5-phospho-&beta;-D-ribosyl)-AMP + H<sub>2</sub>O &rarr; 1-(5-phospho-&beta;-D-ribosyl)-5-[(5-phosphoribosylamino)methylideneamino]imidazole-4-carboxamide' 'null' '1-(5-phospho-&beta;-D-ribosyl)-5-[(5-phosphoribosylamino)methylideneamino]imidazole-4-carboxamide &rarr; phosphoribulosylformimino-AICAR-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002413_PRIBFAICARPISOM-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002413_PRIBFAICARPISOM-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,18 +440,29 @@
           <http://model.geneontology.org/PRIBFAICARPISOM-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004400>
+<http://identifiers.org/sgd/S000005728>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002413_HISTCYCLOHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_15377_HISTALDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_15377_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,22 +473,30 @@
           <http://model.geneontology.org/CHEBI_15377_HISTALDEHYD-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000005728>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000066_reaction_HISTPRATPHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTALDEHYD-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000066_reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YCL030C-MONOMER_HISTCYCLOHYD-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000535> ;
@@ -428,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -441,7 +518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -449,11 +526,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_BFO_0000066_reaction_ATPPHOSPHORIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_BFO_0000066_reaction_ATPPHOSPHORIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -464,33 +541,22 @@
           <http://model.geneontology.org/reaction_ATPPHOSPHORIBOSYLTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002413_PRIBFAICARPISOM-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_59457_HISTPRATPHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_29888>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_29888>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_ATPPHOSPHORIBOSYLTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -501,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -509,14 +575,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTCYCLOHYD-RXN_controller_SGD_YeastPathways_HISTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002233_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_64802_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -524,11 +601,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002233_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002233_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -543,11 +620,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" , "Provides Input For Rule. The relation 'L-histidinol phosphate + H<sub>2</sub>O &rarr; histidinol + phosphate' 'null' 'histidinol + NAD<sup>+</sup> &rarr; histidinal + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002413_HISTOLDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002413_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -562,11 +639,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000066_reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000066_reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -584,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -611,13 +688,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYBiochemicalReaction24445> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_16810_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58475_GLUTAMIDOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58475> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -628,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -636,25 +724,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_15378_HISTOLDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002413_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -663,18 +751,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_15378_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -697,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -709,11 +797,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002234_CHEBI_58525_PRIBFAICARPISOM-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002234_CHEBI_58525_PRIBFAICARPISOM-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -724,56 +812,26 @@
           <http://model.geneontology.org/CHEBI_58525_PRIBFAICARPISOM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_64802_HISTOLDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_15377_IMIDPHOSDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58475_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000066_reaction_HISTCYCLOHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTCYCLOHYD-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_HISTCYCLOHYD-RXN_location_lociGO_0005829>
-] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTOLDEHYD-RXN_controller_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTOLDEHYD-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -784,6 +842,17 @@
           <http://model.geneontology.org/YCL030C-MONOMER_HISTOLDEHYD-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_59457_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57699_HISTIDPHOS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57699> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -793,7 +862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -801,14 +870,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57945_HISTALDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_15377_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -821,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -829,16 +898,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57699_HISTIDPHOS-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000066_reaction_HISTCYCLOHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HISTCYCLOHYD-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_HISTCYCLOHYD-RXN_location_lociGO_0005829>
+] .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -847,11 +924,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58475_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58475_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -865,19 +942,19 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_58435>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000066_reaction_HISTALDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_59457_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58435>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0003949>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -891,7 +968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -906,35 +983,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_HISTSYN-PWY" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_15378_HISTPRATPHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YIL020C-MONOMER_PRIBFAICARPISOM-RXN_controller>
         a       <http://identifiers.org/sgd/S000001282> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -943,7 +998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -958,11 +1013,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_59457_HISTPRATPHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_59457_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -973,14 +1028,14 @@
           <http://model.geneontology.org/CHEBI_59457_HISTPRATPHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58525_PRIBFAICARPISOM-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -991,11 +1046,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_15377_HISTIDPHOS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_15377_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1010,11 +1065,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_15378_HISTALDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_15378_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,11 +1087,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1050,17 +1105,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_64802>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002234_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58359_GLUTAMIDOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58359> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1070,7 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1088,7 +1132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1105,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1113,26 +1157,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002333_YOR202W-MONOMER_IMIDPHOSDEHYD-RXN_controller_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002333_YOR202W-MONOMER_IMIDPHOSDEHYD-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1152,7 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1164,11 +1197,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57540_HISTOLDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57540_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1186,11 +1219,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_16810_HISTAMINOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_16810_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1205,11 +1238,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1220,14 +1253,14 @@
           <http://model.geneontology.org/CHEBI_58359_GLUTAMIDOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002413_IMIDPHOSDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1240,7 +1273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1265,7 +1298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1273,11 +1306,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000066_reaction_HISTPRATPHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000066_reaction_HISTPRATPHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1288,15 +1321,26 @@
           <http://model.geneontology.org/reaction_HISTPRATPHYD-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_15378_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002234_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002234_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1316,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1328,11 +1372,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1362,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1370,62 +1414,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002413_HISTCYCLOHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002234_CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_BFO_0000066_reaction_ATPPHOSPHORIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002333_YOR202W-MONOMER_IMIDPHOSDEHYD-RXN_controller_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002413_HISTPRATPHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1436,26 +1458,15 @@
           <http://model.geneontology.org/YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_30616_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_57699_HISTIDPHOS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_57699_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1475,7 +1486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1487,11 +1498,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTALDEHYD-RXN_controller_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTALDEHYD-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1502,26 +1513,15 @@
           <http://model.geneontology.org/YCL030C-MONOMER_HISTALDEHYD-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_15377_IMIDPHOSDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002333_YER055C-MONOMER_ATPPHOSPHORIBOSYLTRANS-RXN_controller_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002333_YER055C-MONOMER_ATPPHOSPHORIBOSYLTRANS-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1532,14 +1532,14 @@
           <http://model.geneontology.org/YER055C-MONOMER_ATPPHOSPHORIBOSYLTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_57766_IMIDPHOSDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002413_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1552,7 +1552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1561,6 +1561,9 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58525>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_57766>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_57595>
@@ -1588,7 +1591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1596,15 +1599,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57766>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/reaction_IMIDPHOSDEHYD-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_29888_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1615,11 +1626,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000066_reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000066_reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1630,15 +1641,18 @@
           <http://model.geneontology.org/reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_58475>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_57945_HISTOLDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_57945_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1649,18 +1663,37 @@
           <http://model.geneontology.org/CHEBI_57945_HISTOLDEHYD-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58475>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_43474_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002413_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" , "Provides Input For Rule. The relation 'L-histidinol phosphate + 2-oxoglutarate &larr; imidazole acetol-phosphate + L-glutamate' 'null' 'L-histidinol phosphate + H<sub>2</sub>O &rarr; histidinol + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002413_HISTIDPHOS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002413_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1675,11 +1708,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1699,6 +1732,28 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004635>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1710,12 +1765,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000535>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000066_reaction_HISTOLDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1729,7 +1795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1737,30 +1803,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002413_HISTIDPHOS-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_73200> ;
@@ -1771,13 +1815,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYSmallMolecule24303> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57699_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YCL030C-MONOMER_HISTPRATPHYD-RXN_controller>
         a       <http://identifiers.org/sgd/S000000535> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1786,7 +1841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1798,11 +1853,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_15378_HISTPRATPHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_15378_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1820,11 +1875,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1838,26 +1893,15 @@
 <http://purl.obolibrary.org/obo/GO_0004401>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_57540_HISTALDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_57540_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1868,26 +1912,15 @@
           <http://model.geneontology.org/CHEBI_57540_HISTALDEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57540_HISTOLDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_15378_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_15378_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1898,15 +1931,59 @@
           <http://model.geneontology.org/CHEBI_15378_ATPPHOSPHORIBOSYLTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTCYCLOHYD-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_15378_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_15377_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000066_reaction_HISTCYCLOHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1914,11 +1991,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_15377_IMIDPHOSDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_15377_IMIDPHOSDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1929,26 +2006,18 @@
           <http://model.geneontology.org/CHEBI_15377_IMIDPHOSDEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_58278>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1959,14 +2028,25 @@
           <http://model.geneontology.org/YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_15377_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002333_YIL020C-MONOMER_PRIBFAICARPISOM-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1974,11 +2054,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_29985_HISTAMINOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_29985_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1989,9 +2069,6 @@
           <http://model.geneontology.org/CHEBI_29985_HISTAMINOTRANS-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58278>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/CHEBI_58017_ATPPHOSPHORIBOSYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58017> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2001,7 +2078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2009,15 +2086,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2037,7 +2125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2045,14 +2133,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_16810_HISTAMINOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2063,35 +2151,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYProtein24604> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000066_reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_29888_HISTPRATPHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_GLUTAMIDOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2102,7 +2168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2110,14 +2176,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000066_reaction_HISTCYCLOHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2140,7 +2206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2152,11 +2218,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002333_YIL020C-MONOMER_PRIBFAICARPISOM-RXN_controller_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002333_YIL020C-MONOMER_PRIBFAICARPISOM-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2167,26 +2233,15 @@
           <http://model.geneontology.org/YIL020C-MONOMER_PRIBFAICARPISOM-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_BFO_0000066_reaction_ATPPHOSPHORIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'histidinol + NAD<sup>+</sup> &rarr; histidinal + NADH + H<SUP>+</SUP>' 'null' 'histidinal + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; L-histidine + NADH + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002413_HISTALDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002413_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2197,26 +2252,15 @@
           <http://model.geneontology.org/HISTALDEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57595_HISTALDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_15377_HISTCYCLOHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_15377_HISTCYCLOHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2231,11 +2275,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002333_YBR248C-MONOMER_GLUTAMIDOTRANS-RXN_controller_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002333_YBR248C-MONOMER_GLUTAMIDOTRANS-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2245,17 +2289,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YBR248C-MONOMER_GLUTAMIDOTRANS-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002233_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/HISTPRATPHYD-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004636> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2276,13 +2309,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYBiochemicalReaction24419> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002333_YBR248C-MONOMER_GLUTAMIDOTRANS-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002234_CHEBI_58525_PRIBFAICARPISOM-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_64802_HISTOLDEHYD-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_64802> ;
@@ -2293,7 +2348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2301,14 +2356,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_43474_HISTIDPHOS-RXN_SGD_YeastPathways_HISTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000066_reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2321,7 +2376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2332,14 +2387,25 @@
 <http://purl.obolibrary.org/obo/GO_0003879>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_15378_HISTALDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57540_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTPRATPHYD-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2352,7 +2418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2364,11 +2430,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTPRATPHYD-RXN_controller_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTPRATPHYD-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2379,26 +2445,15 @@
           <http://model.geneontology.org/YCL030C-MONOMER_HISTPRATPHYD-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002333_YFR025C-MONOMER_HISTIDPHOS-RXN_controller_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2409,15 +2464,26 @@
           <http://model.geneontology.org/CHEBI_57980_HISTAMINOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57595_HISTALDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57595_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2432,11 +2498,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2447,31 +2513,53 @@
           <http://model.geneontology.org/CHEBI_29888_ATPPHOSPHORIBOSYLTRANS-RXN>
 ] .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002333_YIL116W-MONOMER_HISTAMINOTRANS-RXN_controller_SGD_YeastPathways_HISTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_57540_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002333_YOR202W-MONOMER_IMIDPHOSDEHYD-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTALDEHYD-RXN_controller_SGD_YeastPathways_HISTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000066_reaction_HISTALDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2480,7 +2568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2488,11 +2576,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" , "Provides Input For Rule. The relation 'D-erythro-imidazole-glycerol-phosphate &rarr; imidazole acetol-phosphate + H<sub>2</sub>O' 'null' 'L-histidinol phosphate + 2-oxoglutarate &larr; imidazole acetol-phosphate + L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002413_HISTAMINOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002413_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2506,26 +2594,15 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002234_CHEBI_58525_PRIBFAICARPISOM-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57699_HISTIDPHOS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57699_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2540,11 +2617,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2555,37 +2632,15 @@
           <http://model.geneontology.org/CHEBI_57980_HISTAMINOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_29985_HISTAMINOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58525_PRIBFAICARPISOM-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58525_PRIBFAICARPISOM-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2596,38 +2651,30 @@
           <http://model.geneontology.org/CHEBI_58525_PRIBFAICARPISOM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_59457_HISTPRATPHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58475_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_15377_HISTPRATPHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_HISTPRATPHYD-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_64802_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ATPPHOSPHORIBOSYLTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003879> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2648,13 +2695,43 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYBiochemicalReaction24290> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002333_YER055C-MONOMER_ATPPHOSPHORIBOSYLTRANS-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_15377_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HISTPRATPHYD-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_HISTPRATPHYD-RXN>
+] .
 
 <http://model.geneontology.org/YCL030C-MONOMER_HISTALDEHYD-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000535> ;
@@ -2663,7 +2740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2671,15 +2748,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000066_reaction_HISTIDPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTCYCLOHYD-RXN_controller_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTCYCLOHYD-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2690,37 +2778,15 @@
           <http://model.geneontology.org/YCL030C-MONOMER_HISTCYCLOHYD-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTOLDEHYD-RXN_controller_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002333_YER055C-MONOMER_ATPPHOSPHORIBOSYLTRANS-RXN_controller_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000066_reaction_HISTALDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000066_reaction_HISTALDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2731,23 +2797,6 @@
           <http://model.geneontology.org/reaction_HISTALDEHYD-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#Ontology> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
-        <http://geneontology.org/lego/modelstate>
-                "development" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/title>
-                "L-histidine biosynthesis - imported from: Saccharomyces Genome Database" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <https://w3id.org/biolink/vocab/in_taxon>
-                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
 <http://model.geneontology.org/CHEBI_57980_HISTAMINOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57980> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2757,7 +2806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2765,14 +2814,42 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_57766_IMIDPHOSDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002413_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#Ontology> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
+        <http://geneontology.org/lego/modelstate>
+                "development" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/title>
+                "L-histidine biosynthesis - imported from: Saccharomyces Genome Database" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <https://w3id.org/biolink/vocab/in_taxon>
+                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_15378_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2780,11 +2857,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2795,23 +2872,34 @@
           <http://model.geneontology.org/YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_57945_HISTOLDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_HISTIDPHOS-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_15378_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2824,7 +2912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2839,7 +2927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2851,11 +2939,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000066_reaction_IMIDPHOSDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000066_reaction_IMIDPHOSDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2866,26 +2954,15 @@
           <http://model.geneontology.org/reaction_IMIDPHOSDEHYD-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000066_reaction_GLUTAMIDOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002333_YFR025C-MONOMER_HISTIDPHOS-RXN_controller_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002333_YFR025C-MONOMER_HISTIDPHOS-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2896,15 +2973,52 @@
           <http://model.geneontology.org/YFR025C-MONOMER_HISTIDPHOS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/YOR202W-MONOMER_IMIDPHOSDEHYD-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005728> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "imidazole glycerol-phosphate dehydratase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYProtein24529> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002234_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2915,41 +3029,37 @@
           <http://model.geneontology.org/YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002413_HISTALDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002333_YFR025C-MONOMER_HISTIDPHOS-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002413_PRIBFAICARPISOM-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/YOR202W-MONOMER_IMIDPHOSDEHYD-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005728> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "imidazole glycerol-phosphate dehydratase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYProtein24529> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '1-(5-phospho-&beta;-D-ribosyl)-ATP + diphosphate &larr; ATP + 5-phospho-&alpha;-D-ribose 1-diphosphate + H<SUP>+</SUP>' 'null' '1-(5-phospho-&beta;-D-ribosyl)-ATP + H<sub>2</sub>O &rarr; 1-(5-phospho-&beta;-D-ribosyl)-AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002413_HISTPRATPHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002413_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2959,6 +3069,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/HISTPRATPHYD-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002413_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_29985_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57980>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2972,7 +3104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2980,15 +3112,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTOLDEHYD-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002233_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002233_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2999,26 +3142,15 @@
           <http://model.geneontology.org/CHEBI_58435_HISTCYCLOHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_15377_HISTIDPHOS-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_64802_HISTOLDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_64802_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3038,7 +3170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3050,11 +3182,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3072,11 +3204,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3087,17 +3219,6 @@
           <http://model.geneontology.org/CHEBI_58278_GLUTAMIDOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTPRATPHYD-RXN_controller_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_59457_HISTPRATPHYD-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59457> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3107,7 +3228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3118,17 +3239,6 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57766_IMIDPHOSDEHYD-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57766> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3138,7 +3248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3149,40 +3259,18 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002333_YIL020C-MONOMER_PRIBFAICARPISOM-RXN_controller_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004636>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_64802_HISTOLDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_29888_HISTPRATPHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_29888_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3197,11 +3285,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000066_reaction_HISTIDPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000066_reaction_HISTIDPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3212,14 +3300,14 @@
           <http://model.geneontology.org/reaction_HISTIDPHOS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000066_reaction_HISTPRATPHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3227,11 +3315,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_64802_HISTOLDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_64802_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3245,6 +3333,28 @@
 <http://identifiers.org/sgd/S000001921>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57595_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_15377_HISTCYCLOHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58435_HISTCYCLOHYD-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58435> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3254,7 +3364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3266,11 +3376,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_30616_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_30616_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3281,51 +3391,51 @@
           <http://model.geneontology.org/CHEBI_30616_ATPPHOSPHORIBOSYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002233_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002333_YBR248C-MONOMER_GLUTAMIDOTRANS-RXN_controller_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002333_YIL116W-MONOMER_HISTAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_57699_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000857>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000066_reaction_HISTOLDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_57766_IMIDPHOSDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_57766_IMIDPHOSDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3335,17 +3445,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57766_IMIDPHOSDEHYD-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002234_CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/HISTAMINOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004400> ;
@@ -3366,7 +3465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3378,11 +3477,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000066_reaction_HISTOLDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000066_reaction_HISTOLDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3393,17 +3492,6 @@
           <http://model.geneontology.org/reaction_HISTOLDEHYD-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000000452>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3411,11 +3499,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_57766_IMIDPHOSDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_57766_IMIDPHOSDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3431,7 +3519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3439,11 +3527,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000066_reaction_GLUTAMIDOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000066_reaction_GLUTAMIDOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3454,28 +3542,6 @@
           <http://model.geneontology.org/reaction_GLUTAMIDOTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002413_HISTOLDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_HISTPRATPHYD-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3485,7 +3551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3510,7 +3576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3518,41 +3584,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_15377_HISTCYCLOHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000066_reaction_HISTIDPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000001282>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_57540_HISTALDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57945_HISTOLDEHYD-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3563,7 +3596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3575,11 +3608,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '1-(5-phospho-&beta;-D-ribosyl)-5-[(5-phosphoribosylamino)methylideneamino]imidazole-4-carboxamide &rarr; phosphoribulosylformimino-AICAR-phosphate' 'null' 'phosphoribulosylformimino-AICAR-phosphate + L-glutamine &rarr; L-glutamate + D-erythro-imidazole-glycerol-phosphate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002413_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002413_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3590,37 +3623,15 @@
           <http://model.geneontology.org/GLUTAMIDOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_15377_HISTPRATPHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000066_reaction_IMIDPHOSDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3635,11 +3646,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_59457_HISTPRATPHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_59457_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3657,11 +3668,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'phosphoribulosylformimino-AICAR-phosphate + L-glutamine &rarr; L-glutamate + D-erythro-imidazole-glycerol-phosphate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide + H<SUP>+</SUP>' 'null' 'D-erythro-imidazole-glycerol-phosphate &rarr; imidazole acetol-phosphate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002413_IMIDPHOSDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002413_IMIDPHOSDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3672,14 +3683,14 @@
           <http://model.geneontology.org/IMIDPHOSDEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002413_HISTAMINOTRANS-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_57766_IMIDPHOSDEHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3688,7 +3699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3701,7 +3712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3709,14 +3720,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_57699_HISTIDPHOS-RXN_SGD_YeastPathways_HISTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_15378_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
+                "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3724,11 +3735,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '1-(5-phospho-&beta;-D-ribosyl)-ATP + H<sub>2</sub>O &rarr; 1-(5-phospho-&beta;-D-ribosyl)-AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' '1-(5-phospho-&beta;-D-ribosyl)-AMP + H<sub>2</sub>O &rarr; 1-(5-phospho-&beta;-D-ribosyl)-5-[(5-phosphoribosylamino)methylideneamino]imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002413_HISTCYCLOHYD-RXN_SGD_YeastPathways_HISTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002413_HISTCYCLOHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3738,14 +3749,3 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/HISTCYCLOHYD-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002413_IMIDPHOSDEHYD-RXN_SGD_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_HOMOCYS-CYS-CONVERT.ttl
+++ b/models/YeastPathways_HOMOCYS-CYS-CONVERT.ttl
@@ -1,15 +1,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_30089>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_35235_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_35235_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_35235_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -29,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "homocysteine and cysteine interconversion - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -46,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -54,26 +65,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_28938_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_28938_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -84,12 +84,23 @@
           <http://model.geneontology.org/CHEBI_28938_CYSTATHIONINE-BETA-LYASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_CYSTAGLY-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -97,11 +108,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -121,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -148,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -160,11 +171,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000050_YeastPathways_HOMOCYS-CYS-CONVERT/YeastPathways_HOMOCYS-CYS-CONVERT_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000050_YeastPathways_HOMOCYS-CYS-CONVERT/YeastPathways_HOMOCYS-CYS-CONVERT_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -175,14 +186,14 @@
           <http://model.geneontology.org/YeastPathways_HOMOCYS-CYS-CONVERT/YeastPathways_HOMOCYS-CYS-CONVERT>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_15361_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_35235_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -198,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -209,47 +220,14 @@
 <http://identifiers.org/sgd/S000000010>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002333_YGL184C-MONOMER_CYSTATHIONINE-BETA-LYASE-RXN_controller_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_58161_RXN-721_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16763_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -258,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -271,7 +249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -279,26 +257,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-LYASE-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,32 +276,29 @@
           <http://model.geneontology.org/CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002333_YJR130C-MONOMER_RXN-721_controller_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
+<http://purl.obolibrary.org/obo/GO_0050667>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_HOMOCYS-CYS-CONVERT/YeastPathways_HOMOCYS-CYS-CONVERT_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0050667>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" , "Provides Input For Rule. The relation 'L-cysteine + <i>O</i>-acetyl-L-homoserine &rarr; L-cystathionine + acetate' 'null' 'L-cystathionine + H<sub>2</sub>O &harr; 2-oxobutanoate + L-cysteine + ammonia' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -354,7 +318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -362,33 +326,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_30089_RXN-721_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_16763>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_35235_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000003387> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -397,24 +353,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HOMOCYS-CYS-CONVERTProtein61109> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003387>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -426,11 +371,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_15361_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_15361_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -462,11 +407,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_RXN-721_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_RXN-721_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -484,13 +429,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HOMOCYS-CYS-CONVERTProtein61149> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33384> ;
@@ -501,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -509,26 +465,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" , "Provides Input For Rule. The relation 'L-homocysteine + L-serine &harr; L-cystathionine + H<sub>2</sub>O' 'null' 'L-cystathionine + H<sub>2</sub>O &rarr; L-homocysteine + pyruvate + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,6 +487,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_28938_CYSTATHIONINE-BETA-LYASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_28938> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -551,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -565,39 +521,17 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_58161_RXN-721_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_28938_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -605,11 +539,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -620,6 +554,17 @@
           <http://model.geneontology.org/CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002413_RXN-721_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16763_CYSTAGLY-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16763> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -629,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -641,11 +586,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002333_YJR130C-MONOMER_RXN-721_controller_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002333_YJR130C-MONOMER_RXN-721_controller_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,11 +605,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000050_YeastPathways_HOMOCYS-CYS-CONVERT/YeastPathways_HOMOCYS-CYS-CONVERT_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000050_YeastPathways_HOMOCYS-CYS-CONVERT/YeastPathways_HOMOCYS-CYS-CONVERT_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -687,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -699,11 +644,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-cystathionine + H<sub>2</sub>O &harr; 2-oxobutanoate + L-cysteine + ammonia' 'null' 'L-cysteine + <i>O</i>-acetyl-L-homoserine &rarr; L-cystathionine + acetate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002413_RXN-721_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002413_RXN-721_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -714,36 +659,36 @@
           <http://model.geneontology.org/RXN-721>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_28938_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000050_YeastPathways_HOMOCYS-CYS-CONVERT/YeastPathways_HOMOCYS-CYS-CONVERT_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -752,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -763,11 +708,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_58161_RXN-721_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_58161_RXN-721_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -781,26 +726,15 @@
 <http://purl.obolibrary.org/obo/GO_0004122>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_35235_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -818,11 +752,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-homocysteine + L-serine &harr; L-cystathionine + H<sub>2</sub>O' 'null' 'L-cystathionine + H<sub>2</sub>O &harr; 2-oxobutanoate + L-cysteine + ammonia' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,6 +769,17 @@
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0047804>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -850,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -858,11 +803,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -873,26 +818,15 @@
           <http://model.geneontology.org/reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_58161_RXN-721_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_58161_RXN-721_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -910,11 +844,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" , "Provides Input For Rule. The relation 'L-cystathionine + H<sub>2</sub>O &rarr; L-homocysteine + pyruvate + ammonium' 'null' 'L-homocysteine + L-serine &harr; L-cystathionine + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002413_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002413_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -929,11 +863,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -944,30 +878,52 @@
           <http://model.geneontology.org/YAL012W-MONOMER_CYSTAGLY-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_HOMOCYS-CYS-CONVERT/YeastPathways_HOMOCYS-CYS-CONVERT_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002333_YGL184C-MONOMER_CYSTATHIONINE-BETA-LYASE-RXN_controller_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_15377_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16134>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002413_RXN-721_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003152>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -979,11 +935,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_15377_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_15377_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -994,6 +950,28 @@
           <http://model.geneontology.org/CHEBI_15377_CYSTATHIONINE-BETA-LYASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16763_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000050_YeastPathways_HOMOCYS-CYS-CONVERT/YeastPathways_HOMOCYS-CYS-CONVERT_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_HOMOCYS-CYS-CONVERT/YeastPathways_HOMOCYS-CYS-CONVERT>
         a       <http://purl.obolibrary.org/obo/GO_0050667> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1003,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1015,11 +993,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1030,15 +1008,26 @@
           <http://model.geneontology.org/reaction_CYSTAGLY-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_RXN-721_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1048,28 +1037,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000050_YeastPathways_HOMOCYS-CYS-CONVERT/YeastPathways_HOMOCYS-CYS-CONVERT_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_58161_RXN-721_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_35235>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1081,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1089,32 +1056,65 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://identifiers.org/sgd/S000003891>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_15361_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_58161_RXN-721_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-LYASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003891>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_30089_RXN-721_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_30089_RXN-721_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1125,29 +1125,29 @@
           <http://model.geneontology.org/CHEBI_30089_RXN-721>
 ] .
 
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002413_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002333_YGL184C-MONOMER_CYSTATHIONINE-BETA-LYASE-RXN_controller_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002333_YGL184C-MONOMER_CYSTATHIONINE-BETA-LYASE-RXN_controller_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1158,15 +1158,26 @@
           <http://model.geneontology.org/YGL184C-MONOMER_CYSTATHIONINE-BETA-LYASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_35235_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_35235_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1187,13 +1198,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HOMOCYS-CYS-CONVERTProtein61185> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000066_reaction_RXN-721_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30089_RXN-721>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30089> ;
@@ -1204,7 +1226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1215,14 +1237,14 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000066_reaction_RXN-721_location_lociGO_0005829_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1230,11 +1252,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-LYASE-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-LYASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1264,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1279,11 +1301,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_HOMOCYS-CYS-CONVERT/YeastPathways_HOMOCYS-CYS-CONVERT_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_HOMOCYS-CYS-CONVERT/YeastPathways_HOMOCYS-CYS-CONVERT_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1294,26 +1316,15 @@
           <http://model.geneontology.org/YeastPathways_HOMOCYS-CYS-CONVERT/YeastPathways_HOMOCYS-CYS-CONVERT>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1324,14 +1335,14 @@
           <http://model.geneontology.org/CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002413_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1340,28 +1351,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_58199>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_15377_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1378,7 +1367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1386,31 +1375,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000050_YeastPathways_HOMOCYS-CYS-CONVERT/YeastPathways_HOMOCYS-CYS-CONVERT_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
+<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002333_YJR130C-MONOMER_RXN-721_controller_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_57716>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
+<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_57716_RXN-721_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1418,11 +1407,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_57716_RXN-721_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_57716_RXN-721_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1432,6 +1421,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57716_RXN-721>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CYSTATHIONINE-BETA-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004122> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1452,7 +1452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1472,7 +1472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1484,11 +1484,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1499,14 +1499,33 @@
           <http://model.geneontology.org/CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_RXN-721_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16763_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CYSTAGLY-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16763_CYSTAGLY-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1529,7 +1548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1539,32 +1558,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16763_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CYSTAGLY-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16763_CYSTAGLY-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000066_reaction_RXN-721_location_lociGO_0005829_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000066_reaction_RXN-721_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1575,6 +1575,17 @@
           <http://model.geneontology.org/reaction_RXN-721_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000050_YeastPathways_HOMOCYS-CYS-CONVERT/YeastPathways_HOMOCYS-CYS-CONVERT_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1582,11 +1593,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000050_YeastPathways_HOMOCYS-CYS-CONVERT/YeastPathways_HOMOCYS-CYS-CONVERT_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000050_YeastPathways_HOMOCYS-CYS-CONVERT/YeastPathways_HOMOCYS-CYS-CONVERT_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1606,7 +1617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1614,26 +1625,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000050_YeastPathways_HOMOCYS-CYS-CONVERT/YeastPathways_HOMOCYS-CYS-CONVERT_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1644,14 +1644,14 @@
           <http://model.geneontology.org/CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_57716_RXN-721_SGD_YeastPathways_HOMOCYS-CYS-CONVERT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_30089_RXN-721_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
+                "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1659,11 +1659,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-cysteine + <i>O</i>-acetyl-L-homoserine &rarr; L-cystathionine + acetate' 'null' 'L-cystathionine + H<sub>2</sub>O &rarr; L-homocysteine + pyruvate + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_HOMOCYS-CYS-CONVERT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_HOMOCYS-CYS-CONVERT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_HOMOCYSDEGR-PWY-1.ttl
+++ b/models/YeastPathways_HOMOCYSDEGR-PWY-1.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15,15 +15,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_YeastPathways_HOMOCYSDEGR-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -47,11 +58,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,12 +84,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -89,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -97,19 +105,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://purl.obolibrary.org/obo/CHEBI_16763>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_HOMOCYSDEGR-PWY-1/YeastPathways_HOMOCYSDEGR-PWY-1_SGD_YeastPathways_HOMOCYSDEGR-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYSDEGR-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -133,11 +133,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -155,11 +155,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -190,17 +190,6 @@
 <http://identifiers.org/sgd/S000003387>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYSDEGR-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -210,41 +199,8 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOCYSDEGR-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYSDEGR-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOCYSDEGR-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYSDEGR-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYSDEGR-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16763_CYSTAGLY-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16763> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -255,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -275,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -287,11 +243,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000050_YeastPathways_HOMOCYSDEGR-PWY-1/YeastPathways_HOMOCYSDEGR-PWY-1_SGD_YeastPathways_HOMOCYSDEGR-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000050_YeastPathways_HOMOCYSDEGR-PWY-1/YeastPathways_HOMOCYSDEGR-PWY-1_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -302,25 +258,36 @@
           <http://model.geneontology.org/YeastPathways_HOMOCYSDEGR-PWY-1/YeastPathways_HOMOCYSDEGR-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYSDEGR-PWY-1" ;
+                "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1>
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYSDEGR-PWY-1" ;
+                "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_HOMOCYSDEGR-PWY-1/YeastPathways_HOMOCYSDEGR-PWY-1_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -331,11 +298,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,11 +320,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,33 +335,11 @@
           <http://model.geneontology.org/CHEBI_15377_CYSTAGLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYSDEGR-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYSDEGR-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -408,13 +353,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_HOMOCYSDEGR-PWY-1" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -423,11 +379,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_YeastPathways_HOMOCYSDEGR-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-cysteine biosynthesis III (from L-homocysteine) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -458,14 +414,14 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000050_YeastPathways_HOMOCYSDEGR-PWY-1/YeastPathways_HOMOCYSDEGR-PWY-1_SGD_YeastPathways_HOMOCYSDEGR-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYSDEGR-PWY-1" ;
+                "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -476,11 +432,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -495,11 +451,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOCYSDEGR-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,30 +469,8 @@
 <http://purl.obolibrary.org/obo/GO_0019344>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_YeastPathways_HOMOCYSDEGR-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYSDEGR-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_35235>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_YeastPathways_HOMOCYSDEGR-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYSDEGR-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YAL012W-MONOMER_CYSTAGLY-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000010> ;
@@ -545,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -553,28 +487,50 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_35235_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1>
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_35235_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYSDEGR-PWY-1" ;
+                "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1>
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYSDEGR-PWY-1" ;
+                "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000050_YeastPathways_HOMOCYSDEGR-PWY-1/YeastPathways_HOMOCYSDEGR-PWY-1_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -585,11 +541,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_35235_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_35235_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -627,11 +583,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -642,15 +598,26 @@
           <http://model.geneontology.org/CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_HOMOCYSDEGR-PWY-1/YeastPathways_HOMOCYSDEGR-PWY-1_SGD_YeastPathways_HOMOCYSDEGR-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_HOMOCYSDEGR-PWY-1/YeastPathways_HOMOCYSDEGR-PWY-1_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,19 +628,19 @@
           <http://model.geneontology.org/YeastPathways_HOMOCYSDEGR-PWY-1/YeastPathways_HOMOCYSDEGR-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1>
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16763_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYSDEGR-PWY-1" ;
+                "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_58199>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -681,8 +648,41 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CYSTATHIONINE-BETA-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004122> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -703,7 +703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -723,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -735,11 +735,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-homocysteine + L-serine &harr; L-cystathionine + H<sub>2</sub>O' 'null' 'L-cystathionine + H<sub>2</sub>O &harr; 2-oxobutanoate + L-cysteine + ammonia' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -779,11 +779,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16763_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16763_CYSTAGLY-RXN_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,6 +794,17 @@
           <http://model.geneontology.org/CHEBI_16763_CYSTAGLY-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -801,11 +812,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOCYSDEGR-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOCYSDEGR-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -825,21 +836,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HOMOCYSDEGR-PWY-1SmallMolecule73849> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16763_CYSTAGLY-RXN_SGD_YeastPathways_HOMOCYSDEGR-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYSDEGR-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_HOMOSER-THRESYN-PWY.ttl
+++ b/models/YeastPathways_HOMOSER-THRESYN-PWY.ttl
@@ -1,3 +1,14 @@
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_57926_THRESYN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSER-THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57476_HOMOSERKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57476> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15,43 +26,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000066_reaction_THRESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOSER-THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSER-THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_30616_HOMOSERKIN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HOMOSER-THRESYN-PWYSmallMolecule73047> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_57926_THRESYN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_57926_THRESYN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,16 +45,22 @@
           <http://model.geneontology.org/CHEBI_57926_THRESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000050_YeastPathways_HOMOSER-THRESYN-PWY/YeastPathways_HOMOSER-THRESYN-PWY_SGD_YeastPathways_HOMOSER-THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_30616_HOMOSERKIN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSER-THRESYN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HOMOSER-THRESYN-PWYSmallMolecule73047> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57590_HOMOSERKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57590> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -82,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -94,11 +83,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_15378_HOMOSERKIN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_15378_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -109,22 +98,22 @@
           <http://model.geneontology.org/CHEBI_15378_HOMOSERKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_30616_HOMOSERKIN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSER-THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002333_YHR025W-MONOMER_HOMOSERKIN-RXN_controller_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSER-THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/HOMOSERKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004413> ;
@@ -145,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -156,39 +145,28 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_HOMOSER-THRESYN-PWY/YeastPathways_HOMOSER-THRESYN-PWY_SGD_YeastPathways_HOMOSER-THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSER-THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_43474_THRESYN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSER-THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_57590_HOMOSERKIN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY>
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002333_YCR053W-MONOMER_THRESYN-RXN_controller_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSER-THRESYN-PWY" ;
+                "SGD_PWY:HOMOSER-THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000066_reaction_THRESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -196,11 +174,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_43474_THRESYN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_43474_THRESYN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -215,11 +193,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_57476_HOMOSERKIN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_57476_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -245,17 +223,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_15377_THRESYN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSER-THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57926>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -279,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -294,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -309,11 +276,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-homoserine + ATP &rarr; O-phospho-L-homoserine + ADP + H<SUP>+</SUP>' 'null' 'O-phospho-L-homoserine + H<sub>2</sub>O &rarr; L-threonine + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -348,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -365,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -383,11 +350,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_57590_HOMOSERKIN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_57590_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -402,11 +369,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_30616_HOMOSERKIN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_30616_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -424,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -432,8 +399,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_57590_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSER-THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_57476_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSER-THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_43474_THRESYN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSER-THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -467,26 +467,15 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_57926_THRESYN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSER-THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002333_YHR025W-MONOMER_HOMOSERKIN-RXN_controller_SGD_YeastPathways_HOMOSER-THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002333_YHR025W-MONOMER_HOMOSERKIN-RXN_controller_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -497,26 +486,15 @@
           <http://model.geneontology.org/YHR025W-MONOMER_HOMOSERKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSER-THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_15377_THRESYN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_15377_THRESYN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,11 +512,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000066_reaction_HOMOSERKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOSER-THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000066_reaction_HOMOSERKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,14 +527,36 @@
           <http://model.geneontology.org/reaction_HOMOSERKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000066_reaction_HOMOSERKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOSER-THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSER-THRESYN-PWY" ;
+                "SGD_PWY:HOMOSER-THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_30616_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSER-THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_57590_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -569,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-threonine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -583,15 +583,26 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_15378_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSER-THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_57590_HOMOSERKIN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_57590_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -605,6 +616,17 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_HOMOSER-THRESYN-PWY/YeastPathways_HOMOSER-THRESYN-PWY_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSER-THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_HOMOSERKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -614,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -630,7 +652,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_456216_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -638,11 +671,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000066_reaction_THRESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOSER-THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000066_reaction_THRESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -653,26 +686,15 @@
           <http://model.geneontology.org/reaction_THRESYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_456216_HOMOSERKIN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSER-THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000050_YeastPathways_HOMOSER-THRESYN-PWY/YeastPathways_HOMOSER-THRESYN-PWY_SGD_YeastPathways_HOMOSER-THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000050_YeastPathways_HOMOSER-THRESYN-PWY/YeastPathways_HOMOSER-THRESYN-PWY_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -683,22 +705,44 @@
           <http://model.geneontology.org/YeastPathways_HOMOSER-THRESYN-PWY/YeastPathways_HOMOSER-THRESYN-PWY>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_456216>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002333_YHR025W-MONOMER_HOMOSERKIN-RXN_controller_SGD_YeastPathways_HOMOSER-THRESYN-PWY>
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000066_reaction_HOMOSERKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSER-THRESYN-PWY" ;
+                "SGD_PWY:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/CHEBI_456216>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000050_YeastPathways_HOMOSER-THRESYN-PWY/YeastPathways_HOMOSER-THRESYN-PWY_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSER-THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_15377_THRESYN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSER-THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -711,18 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_15378_HOMOSERKIN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSER-THRESYN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -733,11 +766,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002333_YCR053W-MONOMER_THRESYN-RXN_controller_SGD_YeastPathways_HOMOSER-THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002333_YCR053W-MONOMER_THRESYN-RXN_controller_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -752,11 +785,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_456216_HOMOSERKIN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_456216_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,37 +803,15 @@
 <http://identifiers.org/sgd/S000000649>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_57476_HOMOSERKIN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSER-THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_57590_HOMOSERKIN-RXN_SGD_YeastPathways_HOMOSER-THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSER-THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_HOMOSER-THRESYN-PWY/YeastPathways_HOMOSER-THRESYN-PWY_SGD_YeastPathways_HOMOSER-THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_HOMOSER-THRESYN-PWY/YeastPathways_HOMOSER-THRESYN-PWY_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -814,9 +825,6 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_43474>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/CHEBI_43474_THRESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -826,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -834,13 +842,5 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002333_YCR053W-MONOMER_THRESYN-RXN_controller_SGD_YeastPathways_HOMOSER-THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSER-THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_43474>
+        a       <http://www.w3.org/2002/07/owl#Class> .

--- a/models/YeastPathways_HOMOSERSYN-PWY.ttl
+++ b/models/YeastPathways_HOMOSERSYN-PWY.ttl
@@ -1,14 +1,3 @@
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YER052C-MONOMER_ASPARTATEKIN-RXN_controller>
         a       <http://identifiers.org/sgd/S000000854> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -16,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,17 +16,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004073>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -45,11 +23,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -64,11 +42,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,6 +57,17 @@
           <http://model.geneontology.org/CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_HOMOSERSYN-PWY/YeastPathways_HOMOSERSYN-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0009090> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -86,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -103,25 +92,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_537519>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
+                "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_HOMOSERSYN-PWY/YeastPathways_HOMOSERSYN-PWY_SGD_YeastPathways_HOMOSERSYN-PWY>
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
+                "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -134,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -146,11 +135,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -160,6 +149,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_HOMOSERDEHYDROG-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -173,7 +173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -183,6 +183,17 @@
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004072>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -197,11 +208,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -233,11 +244,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,6 +262,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_57476>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_HOMOSERSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -260,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-homoserine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -268,28 +290,17 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_HOMOSERSYN-PWY>
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
+                "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -306,11 +317,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,18 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -370,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -382,11 +382,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_HOMOSERSYN-PWY/YeastPathways_HOMOSERSYN-PWY_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_HOMOSERSYN-PWY/YeastPathways_HOMOSERSYN-PWY_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,11 +404,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,28 +419,6 @@
           <http://model.geneontology.org/YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29991_ASPARTATEKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -450,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -467,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -478,15 +456,37 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPARTATEKIN-RXN_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -501,11 +501,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,7 +523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -562,11 +562,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -577,17 +577,6 @@
           <http://model.geneontology.org/YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_HOMOSERSYN-PWY/YeastPathways_HOMOSERSYN-PWY_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -597,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -624,24 +613,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HOMOSERSYN-PWYBiochemicalReaction25505> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -652,26 +630,15 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -691,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -702,17 +669,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -720,11 +676,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" , "Provides Input For Rule. The relation 'L-aspartate + ATP &rarr; L-aspartyl-4-phosphate + ADP' 'null' 'L-aspartate 4-semialdehyde + NADP<sup>+</sup> + phosphate &larr; L-aspartyl-4-phosphate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -739,11 +695,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -757,17 +713,6 @@
 <http://identifiers.org/sgd/S000002565>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_ASPARTATEKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -777,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -789,11 +734,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -808,11 +753,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -823,15 +768,26 @@
           <http://model.geneontology.org/reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -842,14 +798,14 @@
           <http://model.geneontology.org/CHEBI_57476_HOMOSERDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_HOMOSERSYN-PWY/YeastPathways_HOMOSERSYN-PWY_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
+                "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -858,35 +814,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
+                "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
+                "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -894,11 +850,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -909,15 +865,26 @@
           <http://model.geneontology.org/YER052C-MONOMER_ASPARTATEKIN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -931,39 +898,17 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_HOMOSERSYN-PWY/YeastPathways_HOMOSERSYN-PWY_SGD_YeastPathways_HOMOSERSYN-PWY>
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
+                "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -971,11 +916,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_HOMOSERSYN-PWY/YeastPathways_HOMOSERSYN-PWY_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_HOMOSERSYN-PWY/YeastPathways_HOMOSERSYN-PWY_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -993,11 +938,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_HOMOSERSYN-PWY/YeastPathways_HOMOSERSYN-PWY_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_HOMOSERSYN-PWY/YeastPathways_HOMOSERSYN-PWY_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1012,11 +957,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1027,22 +972,44 @@
           <http://model.geneontology.org/CHEBI_13390_HOMOSERDEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -1053,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1063,6 +1030,28 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_13390>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1076,13 +1065,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HOMOSERSYN-PWYSmallMolecule25427> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29991>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1095,7 +1095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1108,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1123,13 +1123,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HOMOSERSYN-PWYProtein25502> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1138,11 +1149,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1152,6 +1163,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57535_ASPARTATEKIN-RXN>
 ] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
+] .
+
+<http://identifiers.org/sgd/S000003900>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/HOMOSERDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004412> ;
@@ -1170,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1178,61 +1211,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_HOMOSERSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
-] .
-
-<http://identifiers.org/sgd/S000003900>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
+                "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_HOMOSERSYN-PWY>
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
+                "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_HOMOSERSYN-PWY>
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_HOMOSERSYN-PWY/YeastPathways_HOMOSERSYN-PWY_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
+                "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1240,11 +1248,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" , "Provides Input For Rule. The relation 'L-aspartate 4-semialdehyde + NADP<sup>+</sup> + phosphate &larr; L-aspartyl-4-phosphate + NADPH + H<SUP>+</SUP>' 'null' 'L-homoserine + NAD(P)<sup>+</sup> &larr; L-aspartate 4-semialdehyde + NAD(P)H + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1255,14 +1263,17 @@
           <http://model.geneontology.org/HOMOSERDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_HOMOSERSYN-PWY/YeastPathways_HOMOSERSYN-PWY_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
+                "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1270,11 +1281,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_HOMOSERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1287,14 +1298,3 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPARTATEKIN-RXN_SGD_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_ILEUSYN-PWY-1.ttl
+++ b/models/YeastPathways_ILEUSYN-PWY-1.ttl
@@ -1,23 +1,12 @@
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -50,11 +39,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002234_CHEBI_58349_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002234_CHEBI_58349_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -82,14 +71,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYMETVALDEHYDRAT-RXN_controller_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
+                "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -102,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,11 +112,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>R</i>)-2,3-dihydroxy-3-methylpentanoate &rarr; (<i>S</i>)-3-methyl-2-oxopentanoate + H<sub>2</sub>O' 'null' 'L-isoleucine + 2-oxoglutarate &harr; L-glutamate + (<i>S</i>)-3-methyl-2-oxopentanoate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002413_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002413_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -142,11 +131,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_16763_THREDEHYD-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_16763_THREDEHYD-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -157,25 +146,14 @@
           <http://model.geneontology.org/CHEBI_16763_THREDEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002413_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002333_YER086W-MONOMER_THREDEHYD-RXN_controller_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
+                "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -185,23 +163,34 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002333_YLR355C-MONOMER_ACETOOHBUTREDUCTOISOM-RXN_controller_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
         a       <http://identifiers.org/sgd/S000004714> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_BFO_0000066_reaction_ACETOOHBUTSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000066_reaction_THREDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
+                "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -209,11 +198,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -224,40 +213,29 @@
           <http://model.geneontology.org/CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
+                "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_BFO_0000066_reaction_ACETOOHBUTREDUCTOISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_BFO_0000066_reaction_ACETOOHBUTREDUCTOISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -270,17 +248,6 @@
 
 <http://identifiers.org/sgd/S000004714>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACETOOHBUTSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003984> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -301,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -317,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -328,11 +295,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYMETVALDEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYMETVALDEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -342,6 +309,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_DIHYDROXYMETVALDEHYDRAT-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_49256_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/THREDEHYD-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004794> ;
@@ -362,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -370,26 +359,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002413_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002233_CHEBI_57926_THREDEHYD-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002233_CHEBI_57926_THREDEHYD-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -407,11 +385,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002333_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002333_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -430,18 +408,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002234_CHEBI_16526_ACETOOHBUTSYN-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYMETVALDEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
+                "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -457,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -474,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -482,15 +460,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_28938_THREDEHYD-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -501,6 +490,17 @@
           <http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002234_CHEBI_49256_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -508,11 +508,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_57783_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_57783_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,38 +523,38 @@
           <http://model.geneontology.org/CHEBI_57783_ACETOOHBUTREDUCTOISOM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_15361_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000515> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYMETVALDEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -565,15 +565,26 @@
           <http://model.geneontology.org/CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_BFO_0000066_reaction_ACETOOHBUTREDUCTOISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_15361_ACETOOHBUTSYN-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_15361_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -584,25 +595,47 @@
           <http://model.geneontology.org/CHEBI_15361_ACETOOHBUTSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_YeastPathways_ILEUSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
+                "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_YeastPathways_ILEUSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_BFO_0000066_reaction_ACETOOHBUTSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_57783_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002413_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -612,37 +645,15 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_16763_THREDEHYD-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002413_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002333_YER086W-MONOMER_THREDEHYD-RXN_controller_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002333_YER086W-MONOMER_THREDEHYD-RXN_controller_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -657,11 +668,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -672,28 +683,6 @@
           <http://model.geneontology.org/reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002234_CHEBI_58349_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58349_ACETOOHBUTREDUCTOISOM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -703,7 +692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -717,6 +706,28 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_1901705>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -724,11 +735,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -739,15 +750,26 @@
           <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002333_YLR355C-MONOMER_ACETOOHBUTREDUCTOISOM-RXN_controller_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002333_YLR355C-MONOMER_ACETOOHBUTREDUCTOISOM-RXN_controller_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -775,14 +797,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_15378_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
+                "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -796,11 +818,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -814,15 +836,26 @@
 <http://purl.obolibrary.org/obo/GO_0052656>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002234_CHEBI_16526_ACETOOHBUTSYN-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002234_CHEBI_16526_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -832,6 +865,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16526_ACETOOHBUTSYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002413_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003777>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -845,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -862,17 +906,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_BFO_0000066_reaction_ACETOOHBUTREDUCTOISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -883,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -898,11 +931,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -920,11 +953,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_15378_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_15378_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -935,52 +968,27 @@
           <http://model.geneontology.org/CHEBI_15378_ACETOOHBUTREDUCTOISOM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_ACETOOHBUTSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002333_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_35146>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002233_CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002233_CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -991,6 +999,20 @@
           <http://model.geneontology.org/CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_35146>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_15378_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -998,11 +1020,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1016,25 +1038,25 @@
 <http://purl.obolibrary.org/obo/GO_0003984>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_16763_THREDEHYD-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_16763_THREDEHYD-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
+                "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_YeastPathways_ILEUSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002333_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
+                "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1042,11 +1064,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_16763_THREDEHYD-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_16763_THREDEHYD-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1076,7 +1098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1088,11 +1110,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'pyruvate + 2-oxobutanoate + H<SUP>+</SUP> &rarr; (<i>S</i>)-2-aceto-2-hydroxybutanoate + CO<SUB>2</SUB>' 'null' '(<i>R</i>)-2,3-dihydroxy-3-methylpentanoate + NADP<sup>+</sup> &larr; (<i>S</i>)-2-aceto-2-hydroxybutanoate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002413_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002413_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1103,6 +1125,17 @@
           <http://model.geneontology.org/ACETOOHBUTREDUCTOISOM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002234_CHEBI_16526_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_ILEUSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1112,7 +1145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-isoleucine biosynthesis I (from threonine) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1120,54 +1153,54 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_15378_ACETOOHBUTSYN-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000004347>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000003909>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002234_CHEBI_58349_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
+                "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002234_CHEBI_49256_ACETOOHBUTSYN-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002413_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
+                "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003909>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1187,7 +1220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1199,11 +1232,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002234_CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002234_CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1217,6 +1250,17 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_49256>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1229,7 +1273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1237,14 +1281,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002234_CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
+                "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1252,11 +1296,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYMETVALDEHYDRAT-RXN_controller_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYMETVALDEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1267,26 +1311,15 @@
           <http://model.geneontology.org/YJR016C-MONOMER_DIHYDROXYMETVALDEHYDRAT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002413_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_15378_ACETOOHBUTSYN-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_15378_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1306,13 +1339,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ILEUSYN-PWY-1SmallMolecule71466> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002233_CHEBI_57926_THREDEHYD-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15361_ACETOOHBUTSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
@@ -1323,7 +1367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1351,7 +1395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1369,7 +1413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1377,26 +1421,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_57783_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-threonine &rarr; 2-oxobutanoate + ammonium' 'null' 'pyruvate + 2-oxobutanoate + H<SUP>+</SUP> &rarr; (<i>S</i>)-2-aceto-2-hydroxybutanoate + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002413_ACETOOHBUTSYN-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002413_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1412,7 +1445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1420,11 +1453,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1435,6 +1468,17 @@
           <http://model.geneontology.org/CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002234_CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-30_ACETOOHBUTSYN-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1444,7 +1488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1452,26 +1496,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000066_reaction_THREDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1501,7 +1534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1512,45 +1545,12 @@
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_35146_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_49256_ACETOOHBUTSYN-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_THREDEHYD-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1558,11 +1558,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1573,26 +1573,15 @@
           <http://model.geneontology.org/YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002233_CHEBI_57926_THREDEHYD-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" , "Provides Input For Rule. The relation '(<i>R</i>)-2,3-dihydroxy-3-methylpentanoate + NADP<sup>+</sup> &larr; (<i>S</i>)-2-aceto-2-hydroxybutanoate + NADPH + H<SUP>+</SUP>' 'null' '(<i>R</i>)-2,3-dihydroxy-3-methylpentanoate &rarr; (<i>S</i>)-3-methyl-2-oxopentanoate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002413_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002413_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1610,13 +1599,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ILEUSYN-PWY-1Protein71675> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller>
         a       <http://identifiers.org/sgd/S000001251> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1625,7 +1625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1637,11 +1637,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000066_reaction_THREDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_BFO_0000066_reaction_THREDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1656,11 +1656,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002234_CHEBI_49256_ACETOOHBUTSYN-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002234_CHEBI_49256_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1683,7 +1683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1691,19 +1691,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002333_YLR355C-MONOMER_ACETOOHBUTREDUCTOISOM-RXN_controller_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_15378_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
+                "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1711,26 +1711,15 @@
 <http://identifiers.org/sgd/S000000515>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1750,7 +1739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1767,7 +1756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1779,11 +1768,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_49256_ACETOOHBUTSYN-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002233_CHEBI_49256_ACETOOHBUTSYN-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1801,7 +1790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1815,36 +1804,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002333_YER086W-MONOMER_THREDEHYD-RXN_controller_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
+                "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_28938_THREDEHYD-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002233_CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
+                "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1852,11 +1830,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYMETVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1867,26 +1845,15 @@
           <http://model.geneontology.org/CHEBI_15377_DIHYDROXYMETVALDEHYDRAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_RO_0002233_CHEBI_15361_ACETOOHBUTSYN-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_BFO_0000066_reaction_ACETOOHBUTSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_BFO_0000066_reaction_ACETOOHBUTSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1909,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1917,28 +1884,50 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOOHBUTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_16763_THREDEHYD-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTSYN-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004794>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002413_ACETOOHBUTSYN-RXN_SGD_YeastPathways_ILEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYMETVALDEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:ILEUSYN-PWY-1" ;
+                "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1946,11 +1935,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_28938_THREDEHYD-RXN_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002234_CHEBI_28938_THREDEHYD-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1965,11 +1954,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_YeastPathways_ILEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000050_YeastPathways_ILEUSYN-PWY-1/YeastPathways_ILEUSYN-PWY-1_SGD_PWY_YeastPathways_ILEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1992,10 +1981,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ILEUSYN-PWY-1SmallMolecule71536> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002233_CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_ILEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ILEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_IPPSYN-PWY.ttl
+++ b/models/YeastPathways_IPPSYN-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -19,11 +19,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002333_YMR220W-MONOMER_PHOSPHOMEVALONATE-KINASE-RXN_controller_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002333_YMR220W-MONOMER_PHOSPHOMEVALONATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,11 +38,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'acetoacetyl-CoA + acetyl-CoA + H<sub>2</sub>O &harr; (<i>S</i>)-3-hydroxy-3-methylglutaryl-CoA + coenzyme A + H<SUP>+</SUP>' 'null' '(<i>R</i>)-mevalonate + coenzyme A + 2 NADP<sup>+</sup> &harr; (<i>S</i>)-3-hydroxy-3-methylglutaryl-CoA + 2 NADPH + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002413_1.1.1.34-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002413_1.1.1.34-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -57,11 +57,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 acetyl-CoA &harr; acetoacetyl-CoA + coenzyme A' 'null' 'acetoacetyl-CoA + acetyl-CoA + H<sub>2</sub>O &harr; (<i>S</i>)-3-hydroxy-3-methylglutaryl-CoA + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002413_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002413_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -82,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -125,42 +125,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_15378_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_57783_1.1.1.34-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_YeastPathways_IPPSYN-PWY>
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_PWY_YeastPathways_IPPSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -168,11 +157,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_57287_1.1.1.34-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_57287_1.1.1.34-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -183,37 +172,15 @@
           <http://model.geneontology.org/CHEBI_57287_1.1.1.34-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_15377_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_MEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,7 +200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -245,11 +212,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -260,53 +227,20 @@
           <http://model.geneontology.org/CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_57783_1.1.1.34-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_IPPISOM-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_IPPSYN-PWY>
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_PWY_YeastPathways_IPPSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -319,24 +253,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=IPPSYN-PWYSmallMolecule25889> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_456216_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_36464>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -351,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -363,11 +286,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000066_reaction_PHOSPHOMEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000066_reaction_PHOSPHOMEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,11 +305,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57288_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57288_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,6 +322,39 @@
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_57287_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACETYL-COA-ACETYLTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -419,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -431,11 +387,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -463,24 +419,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=IPPSYN-PWYBiochemicalReaction25822> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002413_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YPL117C-MONOMER_IPPISOM-RXN_controller>
         a       <http://identifiers.org/sgd/S000006038> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -489,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -500,6 +445,17 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000005949>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -507,11 +463,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000066_reaction_1.1.1.34-RXN_location_lociGO_0005829_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000066_reaction_1.1.1.34-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -526,11 +482,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002233_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002233_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -540,6 +496,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_57287_1.1.1.34-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PHOSPHOMEVALONATE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004631> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -560,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -568,26 +535,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57288_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YML075C-MONOMER_1.1.1.34-RXN_controller_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YML075C-MONOMER_1.1.1.34-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -602,11 +558,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_MEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -624,11 +580,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" , "Provides Input For Rule. The relation '(R)-mevalonate diphosphate + ATP &rarr; CO<SUB>2</SUB> + isopentenyl diphosphate + ADP + phosphate' 'null' 'isopentenyl diphosphate &harr; dimethylallyl diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_IPPISOM-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_IPPISOM-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -651,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -668,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -676,26 +632,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -706,17 +651,6 @@
           <http://model.geneontology.org/CHEBI_456216_PHOSPHOMEVALONATE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_36464_1.1.1.34-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -726,7 +660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -738,11 +672,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_57287_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_57287_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,15 +690,26 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002333_YNR043W-MONOMER_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -787,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -795,36 +740,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002413_MEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002333_YMR220W-MONOMER_PHOSPHOMEVALONATE-KINASE-RXN_controller_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -837,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -845,15 +768,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_57783_1.1.1.34-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_57783_1.1.1.34-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -871,11 +816,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -890,11 +835,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -914,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -925,14 +870,36 @@
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_58349_1.1.1.34-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_PWY_YeastPathways_IPPSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -942,26 +909,15 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002233_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" , "Provides Input For Rule. The relation '(<i>R</i>)-mevalonate + ATP &harr; (<i>R</i>)-mevalonate 5-phosphate + ADP + H<SUP>+</SUP>' 'null' '(<i>R</i>)-mevalonate 5-phosphate + ATP &harr; (R)-mevalonate diphosphate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002413_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002413_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -976,11 +932,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_15377_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_15377_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -991,11 +947,55 @@
           <http://model.geneontology.org/CHEBI_15377_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002333_YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57288_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YLR450W-MONOMER_1.1.1.34-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004833>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1004,11 +1004,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" , "Provides Input For Rule. The relation '(<i>R</i>)-mevalonate 5-phosphate + ATP &harr; (R)-mevalonate diphosphate + ADP' 'null' '(R)-mevalonate diphosphate + ATP &rarr; CO<SUB>2</SUB> + isopentenyl diphosphate + ADP + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002413_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002413_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1023,11 +1023,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1038,48 +1038,15 @@
           <http://model.geneontology.org/YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_57287_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_36464_1.1.1.34-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_58349_1.1.1.34-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1090,28 +1057,39 @@
           <http://model.geneontology.org/YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_YeastPathways_IPPSYN-PWY>
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_IPPISOM-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000006038>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YML075C-MONOMER_1.1.1.34-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1122,11 +1100,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_58349_1.1.1.34-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_58349_1.1.1.34-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1146,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1163,7 +1141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1175,11 +1153,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_36464_1.1.1.34-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_36464_1.1.1.34-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1190,25 +1168,25 @@
           <http://model.geneontology.org/CHEBI_36464_1.1.1.34-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002333_YPL117C-MONOMER_IPPISOM-RXN_controller_SGD_YeastPathways_IPPSYN-PWY>
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_456216_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002413_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1216,11 +1194,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_456216_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_456216_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1231,22 +1209,33 @@
           <http://model.geneontology.org/CHEBI_456216_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002333_YMR220W-MONOMER_PHOSPHOMEVALONATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_36464_1.1.1.34-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000066_reaction_1.1.1.34-RXN_location_lociGO_0005829_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1263,7 +1252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1275,11 +1264,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1290,14 +1279,25 @@
           <http://model.geneontology.org/CHEBI_30616_PHOSPHOMEVALONATE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000066_reaction_1.1.1.34-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_IPPSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002413_1.1.1.34-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1305,11 +1305,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_15378_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_15378_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1320,25 +1320,14 @@
           <http://model.geneontology.org/CHEBI_15378_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002234_CHEBI_57623_IPPISOM-RXN_SGD_YeastPathways_IPPSYN-PWY>
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000066_reaction_PHOSPHOMEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_IPPSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002333_YNR043W-MONOMER_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_controller_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1346,11 +1335,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1360,6 +1349,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1373,7 +1373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1400,7 +1400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1408,29 +1408,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
+<http://purl.obolibrary.org/obo/CHEBI_58349>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_58349>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002413_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_15378_1.1.1.34-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_15378_1.1.1.34-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1445,11 +1456,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002234_CHEBI_57623_IPPISOM-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002234_CHEBI_57623_IPPISOM-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1460,14 +1471,25 @@
           <http://model.geneontology.org/CHEBI_57623_IPPISOM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000066_reaction_IPPISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_IPPSYN-PWY>
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002413_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1475,11 +1497,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1490,34 +1512,23 @@
           <http://model.geneontology.org/CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_PHOSPHOMEVALONATE-KINASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1531,11 +1542,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" , "Provides Input For Rule. The relation '(<i>R</i>)-mevalonate + coenzyme A + 2 NADP<sup>+</sup> &harr; (<i>S</i>)-3-hydroxy-3-methylglutaryl-CoA + 2 NADPH + 2 H<SUP>+</SUP>' 'null' '(<i>R</i>)-mevalonate + ATP &harr; (<i>R</i>)-mevalonate 5-phosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002413_MEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002413_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1551,7 +1562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1559,11 +1570,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1574,26 +1585,15 @@
           <http://model.geneontology.org/CHEBI_58146_MEVALONATE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1604,14 +1604,25 @@
           <http://model.geneontology.org/YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_IPPSYN-PWY>
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_PWY_YeastPathways_IPPSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000066_reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1622,11 +1633,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1641,11 +1652,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002333_YML126C-MONOMER_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_controller_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002333_YML126C-MONOMER_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1655,28 +1666,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YML126C-MONOMER_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_57287_1.1.1.34-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000066_reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MEVALONATE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004496> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1697,7 +1686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1714,7 +1703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1726,11 +1715,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002333_YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002333_YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1741,22 +1730,22 @@
           <http://model.geneontology.org/YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_15378_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller>
         a       <http://identifiers.org/sgd/S000005949> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1765,7 +1754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1773,17 +1762,50 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/GO_0004496>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_15378_1.1.1.34-RXN_SGD_YeastPathways_IPPSYN-PWY>
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002234_CHEBI_57623_IPPISOM-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004496>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_15378_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_36464_1.1.1.34-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1806,7 +1828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1818,11 +1840,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_36464_1.1.1.34-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_36464_1.1.1.34-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1842,7 +1864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1854,11 +1876,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000066_reaction_MEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000066_reaction_MEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1869,26 +1891,15 @@
           <http://model.geneontology.org/reaction_MEVALONATE-KINASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002333_YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1908,7 +1919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1916,30 +1927,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002333_YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57288>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57783_1.1.1.34-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
@@ -1950,7 +1939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1967,7 +1956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1987,7 +1976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2004,7 +1993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2019,7 +2008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2030,6 +2019,17 @@
 <http://identifiers.org/sgd/S000004442>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004420>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2037,11 +2037,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2056,11 +2056,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2080,7 +2080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2088,15 +2088,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2107,25 +2118,14 @@
           <http://model.geneontology.org/YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_IPPSYN-PWY>
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2133,11 +2133,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2155,7 +2155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2167,11 +2167,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000066_reaction_IPPISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000066_reaction_IPPISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2182,15 +2182,26 @@
           <http://model.geneontology.org/reaction_IPPISOM-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002333_YPL117C-MONOMER_IPPISOM-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000066_reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000066_reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2201,29 +2212,40 @@
           <http://model.geneontology.org/reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002413_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_15378_1.1.1.34-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004821>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YLR450W-MONOMER_1.1.1.34-RXN_controller_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YLR450W-MONOMER_1.1.1.34-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2241,11 +2263,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_15378_MEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_15378_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2256,29 +2278,15 @@
           <http://model.geneontology.org/CHEBI_15378_MEVALONATE-KINASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002333_YNR043W-MONOMER_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_controller_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002333_YNR043W-MONOMER_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2289,16 +2297,8 @@
           <http://model.geneontology.org/YNR043W-MONOMER_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43074> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2309,7 +2309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2317,71 +2317,60 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002333_YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000066_reaction_MEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002233_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_MEVALONATE-KINASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002413_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000066_reaction_IPPISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002413_1.1.1.34-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2389,11 +2378,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2413,7 +2402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "mevalonate pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2425,11 +2414,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2440,16 +2429,22 @@
           <http://model.geneontology.org/CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YML075C-MONOMER_1.1.1.34-RXN_controller_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_30616_PHOSPHOMEVALONATE-KINASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=IPPSYN-PWYSmallMolecule25889> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004421> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2470,30 +2465,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=IPPSYN-PWYBiochemicalReaction26075> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/CHEBI_30616_PHOSPHOMEVALONATE-KINASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=IPPSYN-PWYSmallMolecule25889> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_58146_MEVALONATE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58146> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2504,7 +2482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2516,11 +2494,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2531,26 +2509,37 @@
           <http://model.geneontology.org/CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002333_YML126C-MONOMER_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_controller_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2559,22 +2548,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004452>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002333_YML126C-MONOMER_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2589,11 +2589,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002333_YPL117C-MONOMER_IPPISOM-RXN_controller_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002333_YPL117C-MONOMER_IPPISOM-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2611,11 +2611,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2633,7 +2633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2644,28 +2644,28 @@
 <http://identifiers.org/sgd/S000004595>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_57286>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_15378_MEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000066_reaction_PHOSPHOMEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_IPPSYN-PWY>
+<http://purl.obolibrary.org/obo/CHEBI_57286>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2675,26 +2675,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_57557>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002333_YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller_SGD_YeastPathways_IPPSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002333_YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2703,6 +2692,25 @@
           <http://model.geneontology.org/MEVALONATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN>
@@ -2714,7 +2722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2722,58 +2730,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_IPPSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829>
-] .
-
 <http://identifiers.org/sgd/S000004540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_MEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002413_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YLR450W-MONOMER_1.1.1.34-RXN_controller_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_MEVALONATE-KINASE-RXN_SGD_YeastPathways_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2786,7 +2753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2794,11 +2761,44 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_15377_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_IPPISOM-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000066_reaction_MEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_LEUSYN-PWY-1.ttl
+++ b/models/YeastPathways_LEUSYN-PWY-1.ttl
@@ -1,3 +1,14 @@
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002413_RXN-13163_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_2-ISOPROPYLMALATESYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -19,11 +30,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_57287_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_57287_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -34,6 +45,28 @@
           <http://model.geneontology.org/CHEBI_57287_2-ISOPROPYLMALATESYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000050_YeastPathways_LEUSYN-PWY-1/YeastPathways_LEUSYN-PWY-1_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_2-ISOPROPYLMALATESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -43,24 +76,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LEUSYN-PWY-1SmallMolecule49773> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000066_reaction_RXN-13163_location_lociGO_0005829_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005634> ;
@@ -69,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,11 +103,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_57945_RXN-13158_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_57945_RXN-13158_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -96,15 +118,26 @@
           <http://model.geneontology.org/CHEBI_57945_RXN-13158>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002234_CHEBI_35121_RXN-13163_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -115,26 +148,18 @@
           <http://model.geneontology.org/CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000066_reaction_RXN-13158_location_lociGO_0005829_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,11 +170,30 @@
           <http://model.geneontology.org/CHEBI_1178_2-ISOPROPYLMALATESYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000050_YeastPathways_LEUSYN-PWY-1/YeastPathways_LEUSYN-PWY-1_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_35121_RXN-13163>
         a       <http://purl.obolibrary.org/obo/CHEBI_35121> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -160,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -187,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,11 +243,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(2<i>R</i>,3<i>S</i>)-3-isopropylmalate &harr; (2<i>S</i>)-2-isopropylmalate' 'null' '(2<i>R</i>,3<i>S</i>)-3-isopropylmalate + NAD<sup>+</sup> &rarr; 4-methyl-2-oxopentanoate + CO<SUB>2</SUB> + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002413_RXN-13158_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002413_RXN-13158_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,19 +258,41 @@
           <http://model.geneontology.org/RXN-13158>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002413_RXN-13158_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002333_YGL009C-MONOMER_RXN-13163_controller_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
+                "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_57427_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_35121_RXN-13163_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -238,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -263,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -276,18 +342,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
+                "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -295,11 +361,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_17865_RXN-13158_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_17865_RXN-13158_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,11 +380,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,11 +399,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_57288_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_57288_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -348,8 +414,30 @@
           <http://model.geneontology.org/CHEBI_57288_2-ISOPROPYLMALATESYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_17865_RXN-13158_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -363,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -373,39 +461,6 @@
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_57945_RXN-13158_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002233_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000066_reaction_2-ISOPROPYLMALATESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -417,11 +472,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002333_YGL009C-MONOMER_RXN-13163_controller_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002333_YGL009C-MONOMER_RXN-13163_controller_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -444,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -456,11 +511,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002233_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002233_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -478,11 +533,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000050_YeastPathways_LEUSYN-PWY-1/YeastPathways_LEUSYN-PWY-1_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000050_YeastPathways_LEUSYN-PWY-1/YeastPathways_LEUSYN-PWY-1_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -493,25 +548,36 @@
           <http://model.geneontology.org/YeastPathways_LEUSYN-PWY-1/YeastPathways_LEUSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829_SGD_YeastPathways_LEUSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000066_reaction_RXN-13163_location_lociGO_0005829_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
+                "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_17865_RXN-13158_SGD_YeastPathways_LEUSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_11851_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_57288_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -522,11 +588,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_16526_RXN-13158_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_16526_RXN-13158_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -537,15 +603,48 @@
           <http://model.geneontology.org/CHEBI_16526_RXN-13158>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000050_YeastPathways_LEUSYN-PWY-1/YeastPathways_LEUSYN-PWY-1_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_16526_RXN-13158_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_17865_RXN-13158_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_17865_RXN-13158_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -565,7 +664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-leucine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -577,11 +676,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_15377_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_15377_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -591,6 +690,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_2-ISOPROPYLMALATESYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000050_YeastPathways_LEUSYN-PWY-1/YeastPathways_LEUSYN-PWY-1_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -604,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -625,24 +746,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_LEUSYN-PWY-1" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002413_RXN-13163_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_11851>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -651,11 +761,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002234_CHEBI_35121_RXN-13163_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002234_CHEBI_35121_RXN-13163_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -666,14 +776,14 @@
           <http://model.geneontology.org/CHEBI_35121_RXN-13163>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_15378_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
+                "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -686,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -694,15 +804,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_57540_RXN-13158_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" , "Provides Input For Rule. The relation '3-methyl-2-oxobutanoate + acetyl-CoA + H<sub>2</sub>O &rarr; (2<i>S</i>)-2-isopropylmalate + coenzyme A + H<SUP>+</SUP>' 'null' '(2<i>R</i>,3<i>S</i>)-3-isopropylmalate &harr; (2<i>S</i>)-2-isopropylmalate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002413_RXN-13163_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002413_RXN-13163_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -719,29 +840,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_57427_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_LEUSYN-PWY-1>
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000066_reaction_2-ISOPROPYLMALATESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
+                "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000066_reaction_RXN-13163_location_lociGO_0005829_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000066_reaction_RXN-13163_location_lociGO_0005829_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,11 +880,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -783,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -803,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -814,15 +935,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_57945>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/reaction_RXN-13158_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -835,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -843,29 +961,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000002977>
+<http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_35121_RXN-13163_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000002977>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_57540_RXN-13158_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_57540_RXN-13158_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -883,7 +993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -893,32 +1003,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_11851_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_LEUSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_11851_2-ISOPROPYLMALATESYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -927,6 +1018,36 @@
           <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERLEU-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_17865_RXN-13158_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_11851_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_11851_2-ISOPROPYLMALATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/RXN-13163>
@@ -948,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -956,52 +1077,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_16526_RXN-13158_SGD_YeastPathways_LEUSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002233_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000050_YeastPathways_LEUSYN-PWY-1/YeastPathways_LEUSYN-PWY-1_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
+                "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000050_YeastPathways_LEUSYN-PWY-1/YeastPathways_LEUSYN-PWY-1_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_15378_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003861>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1015,7 +1103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1023,22 +1111,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://purl.obolibrary.org/obo/CHEBI_17865>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_16526_RXN-13158>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1049,7 +1126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1057,14 +1134,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002234_CHEBI_35121_RXN-13163_SGD_YeastPathways_LEUSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_57287_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
+                "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1072,11 +1149,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_YNL104C-MONOMER_2-ISOPROPYLMALATESYN-RXN_controller_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_YNL104C-MONOMER_2-ISOPROPYLMALATESYN-RXN_controller_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1090,6 +1167,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_57945_RXN-13158_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1097,11 +1185,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000050_YeastPathways_LEUSYN-PWY-1/YeastPathways_LEUSYN-PWY-1_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000050_YeastPathways_LEUSYN-PWY-1/YeastPathways_LEUSYN-PWY-1_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1115,26 +1203,15 @@
 <http://identifiers.org/sgd/S000005634>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1148,29 +1225,29 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
+                "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_35121_RXN-13163_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_35121_RXN-13163_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1181,15 +1258,26 @@
           <http://model.geneontology.org/CHEBI_35121_RXN-13163>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002413_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000050_YeastPathways_LEUSYN-PWY-1/YeastPathways_LEUSYN-PWY-1_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000050_YeastPathways_LEUSYN-PWY-1/YeastPathways_LEUSYN-PWY-1_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1209,7 +1297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1217,14 +1305,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_11851_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_YNL104C-MONOMER_2-ISOPROPYLMALATESYN-RXN_controller_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
+                "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1235,11 +1323,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000066_reaction_2-ISOPROPYLMALATESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000066_reaction_2-ISOPROPYLMALATESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1250,39 +1338,6 @@
           <http://model.geneontology.org/reaction_2-ISOPROPYLMALATESYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002413_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002234_CHEBI_17865_RXN-13158_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_57540_RXN-13158_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57427_BRANCHED-CHAINAMINOTRANSFERLEU-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57427> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1292,7 +1347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1306,17 +1361,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_35121>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002333_YGL009C-MONOMER_RXN-13163_controller_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1327,7 +1371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1340,33 +1384,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_57287_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_15377_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002413_RXN-13158_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1382,7 +1437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1393,11 +1448,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(2<i>R</i>,3<i>S</i>)-3-isopropylmalate + NAD<sup>+</sup> &rarr; 4-methyl-2-oxopentanoate + CO<SUB>2</SUB> + NADH' 'null' 'L-leucine + 2-oxoglutarate &harr; L-glutamate + 4-methyl-2-oxopentanoate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002413_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002413_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1412,11 +1467,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_57427_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_57427_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1427,26 +1482,15 @@
           <http://model.geneontology.org/CHEBI_57427_BRANCHED-CHAINAMINOTRANSFERLEU-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-13163_BFO_0000050_YeastPathways_LEUSYN-PWY-1/YeastPathways_LEUSYN-PWY-1_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_15378_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002234_CHEBI_15378_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1457,53 +1501,17 @@
           <http://model.geneontology.org/CHEBI_15378_2-ISOPROPYLMALATESYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0003852>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000050_YeastPathways_LEUSYN-PWY-1/YeastPathways_LEUSYN-PWY-1_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0009098>
+<http://purl.obolibrary.org/obo/GO_0003852>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000001251>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_15377_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://purl.obolibrary.org/obo/GO_0009098>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003909> ;
@@ -1512,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1520,15 +1528,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000066_reaction_RXN-13158_location_lociGO_0005829_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000066_reaction_RXN-13158_location_lociGO_0005829_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13158_BFO_0000066_reaction_RXN-13158_location_lociGO_0005829_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1539,26 +1558,18 @@
           <http://model.geneontology.org/reaction_RXN-13158_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_57288_2-ISOPROPYLMALATESYN-RXN_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000050_YeastPathways_LEUSYN-PWY-1/YeastPathways_LEUSYN-PWY-1_SGD_YeastPathways_LEUSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_BFO_0000050_YeastPathways_LEUSYN-PWY-1/YeastPathways_LEUSYN-PWY-1_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1586,21 +1597,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LEUSYN-PWY-1BiochemicalReaction49818> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002333_YNL104C-MONOMER_2-ISOPROPYLMALATESYN-RXN_controller_SGD_YeastPathways_LEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_LIPASYN-PWY-1.ttl
+++ b/models/YeastPathways_LIPASYN-PWY-1.ttl
@@ -1,22 +1,11 @@
-<http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_BFO_0000066_reaction_PHOSPHOLIPASE-C-RXN_location_lociGO_0005829_SGD_YeastPathways_LIPASYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002234_CHEBI_15378_PHOSCHOL-RXN_SGD_YeastPathways_LIPASYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_203600_3.1.4.11-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
+                "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -27,7 +16,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -45,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -70,14 +59,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002233_CHEBI_16110_PHOSCHOL-RXN_SGD_YeastPathways_LIPASYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002234_CHEBI_15378_PHOSPHOLIPASE-C-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
+                "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -85,11 +74,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002234_CHEBI_295975_PHOSPHOLIPASE-C-RXN_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002234_CHEBI_295975_PHOSPHOLIPASE-C-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -104,11 +93,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002234_CHEBI_15354_PHOSCHOL-RXN_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002234_CHEBI_15354_PHOSCHOL-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -125,17 +114,6 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002234_CHEBI_15378_PHOSPHOLIPASE-C-RXN_SGD_YeastPathways_LIPASYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_17815_PHOSPHOLIPASE-C-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17815> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -145,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -157,11 +135,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_15378_3.1.4.11-RXN_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_15378_3.1.4.11-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -175,14 +153,25 @@
 <http://purl.obolibrary.org/obo/GO_0004630>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002233_CHEBI_15377_PHOSCHOL-RXN_SGD_YeastPathways_LIPASYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002234_CHEBI_15354_PHOSCHOL-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
+                "SGD_PWY:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002333_YKR031C-MONOMER_PHOSCHOL-RXN_controller_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -192,14 +181,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_16110>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002234_CHEBI_295975_PHOSPHOLIPASE-C-RXN_SGD_YeastPathways_LIPASYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002233_CHEBI_15377_PHOSCHOL-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
+                "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -211,6 +200,17 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_203600>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_17815_3.1.4.11-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0034480>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -224,24 +224,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LIPASYN-PWY-1SmallMolecule26337> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002411_PHOSPHOLIPASE-C-RXN_SGD_YeastPathways_LIPASYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29089>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -250,11 +239,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002234_CHEBI_17815_PHOSPHOLIPASE-C-RXN_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002234_CHEBI_17815_PHOSPHOLIPASE-C-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,13 +263,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LIPASYN-PWY-1SmallMolecule26249> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_BFO_0000066_reaction_PHOSPHOLIPASE-C-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001739>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -289,11 +289,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002233_CHEBI_16110_PHOSCHOL-RXN_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002233_CHEBI_16110_PHOSCHOL-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,58 +304,25 @@
           <http://model.geneontology.org/CHEBI_16110_PHOSCHOL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002411_PHOSCHOL-RXN_SGD_YeastPathways_LIPASYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_BFO_0000050_YeastPathways_LIPASYN-PWY-1/YeastPathways_LIPASYN-PWY-1_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
+                "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_BFO_0000066_reaction_3.1.4.11-RXN_location_lociGO_0005829_SGD_YeastPathways_LIPASYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_CHEBI_15377_3.1.4.11-RXN_SGD_YeastPathways_LIPASYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_BFO_0000066_reaction_PHOSCHOL-RXN_location_lociGO_0005829_SGD_YeastPathways_LIPASYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -364,11 +331,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_8dfe6ece-ad06-4110-822d-5d44802a38d8_3.1.4.11-RXN_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_c82fbfbb-620d-485c-8773-0672e0f6c922_3.1.4.11-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -376,22 +343,47 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.1.4.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8dfe6ece-ad06-4110-822d-5d44802a38d8_3.1.4.11-RXN>
+          <http://model.geneontology.org/c82fbfbb-620d-485c-8773-0672e0f6c922_3.1.4.11-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002333_YER019W-MONOMER_PHOSPHOLIPASE-C-RXN_controller_SGD_YeastPathways_LIPASYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002234_CHEBI_295975_PHOSPHOLIPASE-C-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
+                "SGD_PWY:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002234_CHEBI_15378_PHOSCHOL-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002233_CHEBI_16110_PHOSCHOL-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004435>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_15354_PHOSCHOL-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15354> ;
@@ -402,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -410,29 +402,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002233_CHEBI_16110_PHOSPHOLIPASE-C-RXN_SGD_YeastPathways_LIPASYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/GO_0009395>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_BFO_0000066_reaction_PHOSCHOL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
+                "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0009395>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_BFO_0000066_reaction_3.1.4.11-RXN_location_lociGO_0005829_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_BFO_0000066_reaction_3.1.4.11-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -443,17 +435,14 @@
           <http://model.geneontology.org/reaction_3.1.4.11-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002333_YKR031C-MONOMER_PHOSCHOL-RXN_controller_SGD_YeastPathways_LIPASYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002233_CHEBI_15377_PHOSPHOLIPASE-C-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
+                "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -461,11 +450,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_BFO_0000050_YeastPathways_LIPASYN-PWY-1/YeastPathways_LIPASYN-PWY-1_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_BFO_0000050_YeastPathways_LIPASYN-PWY-1/YeastPathways_LIPASYN-PWY-1_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,7 +474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -493,25 +482,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_BFO_0000050_YeastPathways_LIPASYN-PWY-1/YeastPathways_LIPASYN-PWY-1_SGD_YeastPathways_LIPASYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_BFO_0000066_reaction_3.1.4.11-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_15378_3.1.4.11-RXN_SGD_YeastPathways_LIPASYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
+                "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -520,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -531,11 +509,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002234_CHEBI_15378_PHOSPHOLIPASE-C-RXN_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002234_CHEBI_15378_PHOSPHOLIPASE-C-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -546,6 +524,17 @@
           <http://model.geneontology.org/CHEBI_15378_PHOSPHOLIPASE-C-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_BFO_0000050_YeastPathways_LIPASYN-PWY-1/YeastPathways_LIPASYN-PWY-1_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_PHOSCHOL-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -555,7 +544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -567,11 +556,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002233_CHEBI_15377_PHOSCHOL-RXN_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002233_CHEBI_15377_PHOSCHOL-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -591,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -603,11 +592,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002411_PHOSPHOLIPASE-C-RXN_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002411_PHOSPHOLIPASE-C-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -621,17 +610,6 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002333_YPL268W-MONOMER_3.1.4.11-RXN_controller_SGD_YeastPathways_LIPASYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_PHOSPHOLIPASE-C-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -641,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -649,32 +627,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/8dfe6ece-ad06-4110-822d-5d44802a38d8_3.1.4.11-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LIPASYN-PWY-1SmallMolecule26368> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_CHEBI_15377_3.1.4.11-RXN_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_CHEBI_15377_3.1.4.11-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -690,20 +651,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002234_CHEBI_17815_PHOSPHOLIPASE-C-RXN_SGD_YeastPathways_LIPASYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002233_CHEBI_16110_PHOSPHOLIPASE-C-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
+                "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/c82fbfbb-620d-485c-8773-0672e0f6c922_3.1.4.11-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LIPASYN-PWY-1SmallMolecule26368> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -717,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -729,11 +707,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_BFO_0000050_YeastPathways_LIPASYN-PWY-1/YeastPathways_LIPASYN-PWY-1_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_BFO_0000050_YeastPathways_LIPASYN-PWY-1/YeastPathways_LIPASYN-PWY-1_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -744,15 +722,26 @@
           <http://model.geneontology.org/YeastPathways_LIPASYN-PWY-1/YeastPathways_LIPASYN-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002411_PHOSPHOLIPASE-C-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002333_YKR031C-MONOMER_PHOSCHOL-RXN_controller_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002333_YKR031C-MONOMER_PHOSCHOL-RXN_controller_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -763,14 +752,25 @@
           <http://model.geneontology.org/YKR031C-MONOMER_PHOSCHOL-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_17815_3.1.4.11-RXN_SGD_YeastPathways_LIPASYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_c82fbfbb-620d-485c-8773-0672e0f6c922_3.1.4.11-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
+                "SGD_PWY:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002234_CHEBI_17815_PHOSPHOLIPASE-C-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -803,11 +803,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002233_CHEBI_16110_PHOSPHOLIPASE-C-RXN_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002233_CHEBI_16110_PHOSPHOLIPASE-C-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -818,26 +818,15 @@
           <http://model.geneontology.org/CHEBI_16110_PHOSPHOLIPASE-C-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_203600_3.1.4.11-RXN_SGD_YeastPathways_LIPASYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_BFO_0000066_reaction_PHOSCHOL-RXN_location_lociGO_0005829_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_BFO_0000066_reaction_PHOSCHOL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -852,11 +841,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002333_YPL268W-MONOMER_3.1.4.11-RXN_controller_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002333_YPL268W-MONOMER_3.1.4.11-RXN_controller_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -867,8 +856,41 @@
           <http://model.geneontology.org/YPL268W-MONOMER_3.1.4.11-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002411_PHOSCHOL-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_BFO_0000050_YeastPathways_LIPASYN-PWY-1/YeastPathways_LIPASYN-PWY-1_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_CHEBI_15377_3.1.4.11-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000006189>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -885,7 +907,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_3.1.4.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_3.1.4.11-RXN> , <http://model.geneontology.org/8dfe6ece-ad06-4110-822d-5d44802a38d8_3.1.4.11-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_3.1.4.11-RXN> , <http://model.geneontology.org/c82fbfbb-620d-485c-8773-0672e0f6c922_3.1.4.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_203600_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_17815_3.1.4.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -895,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -912,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -923,17 +945,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15354>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002233_CHEBI_15377_PHOSPHOLIPASE-C-RXN_SGD_YeastPathways_LIPASYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -941,11 +952,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002411_PHOSCHOL-RXN_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002411_PHOSCHOL-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -956,17 +967,6 @@
           <http://model.geneontology.org/PHOSCHOL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_BFO_0000050_YeastPathways_LIPASYN-PWY-1/YeastPathways_LIPASYN-PWY-1_SGD_YeastPathways_LIPASYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YER019W-MONOMER_PHOSPHOLIPASE-C-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000821> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -974,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -986,11 +986,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002234_CHEBI_29089_PHOSCHOL-RXN_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002234_CHEBI_29089_PHOSCHOL-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1016,7 +1016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1033,7 +1033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phospholipids degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1050,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1058,15 +1058,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002333_YPL268W-MONOMER_3.1.4.11-RXN_controller_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002233_CHEBI_15377_PHOSPHOLIPASE-C-RXN_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002233_CHEBI_15377_PHOSPHOLIPASE-C-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1081,11 +1092,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_BFO_0000050_YeastPathways_LIPASYN-PWY-1/YeastPathways_LIPASYN-PWY-1_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_BFO_0000050_YeastPathways_LIPASYN-PWY-1/YeastPathways_LIPASYN-PWY-1_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1096,15 +1107,26 @@
           <http://model.geneontology.org/YeastPathways_LIPASYN-PWY-1/YeastPathways_LIPASYN-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002333_YER019W-MONOMER_PHOSPHOLIPASE-C-RXN_controller_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_203600_3.1.4.11-RXN_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_203600_3.1.4.11-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1114,6 +1136,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_203600_3.1.4.11-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_15378_3.1.4.11-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1130,24 +1163,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LIPASYN-PWY-1SmallMolecule26281> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_8dfe6ece-ad06-4110-822d-5d44802a38d8_3.1.4.11-RXN_SGD_YeastPathways_LIPASYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PHOSPHOLIPASE-C-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0034480> ;
@@ -1168,7 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1179,28 +1201,6 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002234_CHEBI_29089_PHOSCHOL-RXN_SGD_YeastPathways_LIPASYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002234_CHEBI_15354_PHOSCHOL-RXN_SGD_YeastPathways_LIPASYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1208,11 +1208,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002333_YER019W-MONOMER_PHOSPHOLIPASE-C-RXN_controller_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002333_YER019W-MONOMER_PHOSPHOLIPASE-C-RXN_controller_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1227,11 +1227,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002234_CHEBI_15378_PHOSCHOL-RXN_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002234_CHEBI_15378_PHOSCHOL-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1251,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1259,38 +1259,38 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002234_CHEBI_29089_PHOSCHOL-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_PHOSPHOLIPASE-C-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17815>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_BFO_0000050_YeastPathways_LIPASYN-PWY-1/YeastPathways_LIPASYN-PWY-1_SGD_YeastPathways_LIPASYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_BFO_0000066_reaction_PHOSPHOLIPASE-C-RXN_location_lociGO_0005829_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_BFO_0000066_reaction_PHOSPHOLIPASE-C-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1308,11 +1308,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_17815_3.1.4.11-RXN_SGD_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_17815_3.1.4.11-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_LYSDEGII-PWY.ttl
+++ b/models/YeastPathways_LYSDEGII-PWY.ttl
@@ -1,11 +1,22 @@
-<http://model.geneontology.org/ev_w_id_KETAMID-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_YeastPathways_LYSDEGII-PWY>
+<http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002413_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002234_CHEBI_356010_AMVAL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
+                "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13,11 +24,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002233_CHEBI_79192_ACETCAPR-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002233_CHEBI_79192_ACETCAPR-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,11 +46,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>N</i><sup>6</sup>-acetyl-L-lysine + 2-oxoglutarate &harr; 2-keto-6-acetamidocaproate + L-glutamate' 'null' '2-keto-6-acetamidocaproate + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; 5-acetamidovalerate + CO<SUB>2</SUB> + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002413_KETAMID-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002413_KETAMID-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,17 +61,6 @@
           <http://model.geneontology.org/KETAMID-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002234_CHEBI_356010_AMVAL-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57540_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -86,23 +86,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002234_CHEBI_57945_KETAMID-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_356010_AMVAL-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_356010> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -113,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -121,26 +110,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002233_CHEBI_79192_ACETCAPR-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002233_CHEBI_32551_LYSACET-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002233_CHEBI_32551_LYSACET-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -155,11 +133,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" , "Provides Input For Rule. The relation '5-acetamidovalerate + H<sub>2</sub>O &rarr; acetate + 5-aminopentanoate' 'null' '5-aminopentanoate + 2-oxoglutarate &harr; glutarate semialdehyde + L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002413_VAGL-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002413_VAGL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -170,36 +148,14 @@
           <http://model.geneontology.org/VAGL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_LYSACET-RXN_BFO_0000066_reaction_LYSACET-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSDEGII-PWY>
+<http://model.geneontology.org/ev_w_id_AMVAL-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_PWY_YeastPathways_LYSDEGII-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002234_CHEBI_16120_VAGL-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002233_CHEBI_15377_KETAMID-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
+                "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -208,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -223,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -231,11 +187,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002233_CHEBI_16810_VAGL-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002233_CHEBI_16810_VAGL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -253,11 +209,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,15 +230,37 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002233_CHEBI_356010_AMVAL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002234_CHEBI_30089_AMVAL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_BFO_0000066_reaction_ACETCAPR-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_BFO_0000066_reaction_ACETCAPR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -293,29 +271,29 @@
           <http://model.geneontology.org/reaction_ACETCAPR-RXN_location_lociGO_0005829>
 ] .
 
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002413_ACETCAPR-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002233_CHEBI_15377_KETAMID-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
+                "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002234_CHEBI_57945_KETAMID-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002234_CHEBI_57945_KETAMID-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,14 +304,25 @@
           <http://model.geneontology.org/CHEBI_57945_KETAMID-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002233_CHEBI_57288_LYSACET-RXN_SGD_YeastPathways_LYSDEGII-PWY>
+<http://model.geneontology.org/ev_w_id_LYSACET-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_PWY_YeastPathways_LYSDEGII-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_VAGL-RXN_BFO_0000066_reaction_VAGL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -354,13 +343,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSDEGII-PWYBiochemicalReaction26601> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002234_CHEBI_29985_ACETCAPR-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30089>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -374,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,6 +385,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_79193>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002233_CHEBI_57288_LYSACET-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_LYSDEGII-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -394,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-lysine degradation III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -402,15 +413,26 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002234_CHEBI_16526_KETAMID-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002234_CHEBI_57287_LYSACET-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002234_CHEBI_57287_LYSACET-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,6 +443,17 @@
           <http://model.geneontology.org/CHEBI_57287_LYSACET-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002233_CHEBI_15377_AMVAL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -428,11 +461,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15377_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15377_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -446,14 +479,47 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_KETAMID-RXN_BFO_0000066_reaction_KETAMID-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSDEGII-PWY>
+<http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSDEGII-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15377_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16120_VAGL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002234_CHEBI_29985_VAGL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -461,11 +527,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002234_CHEBI_29985_VAGL-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002234_CHEBI_29985_VAGL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -476,14 +542,14 @@
           <http://model.geneontology.org/CHEBI_29985_VAGL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002233_CHEBI_16810_ACETCAPR-RXN_SGD_YeastPathways_LYSDEGII-PWY>
+<http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002233_CHEBI_57540_KETAMID-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
+                "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -491,11 +557,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002233_CHEBI_15377_KETAMID-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002233_CHEBI_15377_KETAMID-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,9 +572,6 @@
           <http://model.geneontology.org/CHEBI_15377_KETAMID-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 <http://model.geneontology.org/CHEBI_57945_KETAMID-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -518,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -526,15 +589,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_BFO_0000066_reaction_ACETCAPR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KETAMID-RXN_BFO_0000066_reaction_KETAMID-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002234_CHEBI_29985_ACETCAPR-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002234_CHEBI_29985_ACETCAPR-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -571,13 +659,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSDEGII-PWYSmallMolecule26446> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002233_CHEBI_79192_ACETCAPR-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16810_ACETCAPR-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16810> ;
@@ -588,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -605,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -620,11 +719,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LYSACET-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_LYSACET-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -635,15 +734,37 @@
           <http://model.geneontology.org/YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002234_CHEBI_16120_VAGL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002234_CHEBI_30089_AMVAL-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002234_CHEBI_30089_AMVAL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -654,55 +775,11 @@
           <http://model.geneontology.org/CHEBI_30089_AMVAL-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57287>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002413_AMVAL-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0019473>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AMVAL-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002234_CHEBI_29985_VAGL-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_BFO_0000066_reaction_ACETCAPR-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57287>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/LYSACET-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
@@ -721,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -729,25 +806,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002233_CHEBI_16810_VAGL-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15377_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_LYSDEGII-PWY>
+<http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002233_CHEBI_79193_KETAMID-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
+                "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -761,11 +827,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_VAGL-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_VAGL-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -776,15 +842,26 @@
           <http://model.geneontology.org/YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_KETAMID-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -795,43 +872,43 @@
           <http://model.geneontology.org/CHEBI_15378_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_VAGL-RXN_BFO_0000066_reaction_VAGL-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002233_CHEBI_356010_AMVAL-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002234_CHEBI_79193_KETAMID-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002234_CHEBI_57945_KETAMID-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002234_CHEBI_15378_KETAMID-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002234_CHEBI_15378_KETAMID-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -846,11 +923,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMVAL-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMVAL-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -870,13 +947,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSDEGII-PWYSmallMolecule26534> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002233_CHEBI_58260_LYSACET-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -885,11 +973,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002233_CHEBI_57288_LYSACET-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002233_CHEBI_57288_LYSACET-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -905,7 +993,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_LYSACET-RXN_BFO_0000066_reaction_LYSACET-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -913,11 +1012,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -927,6 +1026,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002234_CHEBI_79192_ACETCAPR-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -943,15 +1064,21 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002233_CHEBI_356010_AMVAL-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002233_CHEBI_356010_AMVAL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -962,43 +1089,15 @@
           <http://model.geneontology.org/CHEBI_356010_AMVAL-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002234_CHEBI_30089_AMVAL-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002234_CHEBI_16526_KETAMID-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1009,26 +1108,15 @@
           <http://model.geneontology.org/YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002233_CHEBI_16810_ACETCAPR-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002233_CHEBI_16810_ACETCAPR-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1039,23 +1127,12 @@
           <http://model.geneontology.org/CHEBI_16810_ACETCAPR-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_30921_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_ACETCAPR-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1068,7 +1145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1085,7 +1162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1102,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1110,14 +1187,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002234_CHEBI_58260_LYSACET-RXN_SGD_YeastPathways_LYSDEGII-PWY>
+<http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002234_CHEBI_15378_LYSACET-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
+                "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1130,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1145,11 +1222,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002234_CHEBI_79193_KETAMID-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002234_CHEBI_79193_KETAMID-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1164,11 +1241,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002233_CHEBI_15377_AMVAL-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002233_CHEBI_15377_AMVAL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1196,7 +1273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1204,37 +1281,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_LYSACET-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002234_CHEBI_58260_LYSACET-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002234_CHEBI_58260_LYSACET-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1245,14 +1300,14 @@
           <http://model.geneontology.org/CHEBI_58260_LYSACET-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_YeastPathways_LYSDEGII-PWY>
+<http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002233_CHEBI_16810_VAGL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
+                "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1260,11 +1315,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16120_VAGL-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16120_VAGL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1275,14 +1330,36 @@
           <http://model.geneontology.org/CHEBI_16120_VAGL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002233_CHEBI_58260_LYSACET-RXN_SGD_YeastPathways_LYSDEGII-PWY>
+<http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002234_CHEBI_58260_LYSACET-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1290,11 +1367,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '5-aminopentanoate + 2-oxoglutarate &harr; glutarate semialdehyde + L-glutamate' 'null' 'glutarate semialdehyde + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; glutarate + NADH + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002413_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002413_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1305,26 +1382,15 @@
           <http://model.geneontology.org/GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002234_CHEBI_15378_KETAMID-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002233_CHEBI_57540_KETAMID-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002233_CHEBI_57540_KETAMID-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1339,11 +1405,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002234_CHEBI_79192_ACETCAPR-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002234_CHEBI_79192_ACETCAPR-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1374,7 +1440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1382,26 +1448,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002234_CHEBI_79193_KETAMID-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LYSACET-RXN_BFO_0000066_reaction_LYSACET-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_LYSACET-RXN_BFO_0000066_reaction_LYSACET-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1416,11 +1471,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002234_CHEBI_356010_AMVAL-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002234_CHEBI_356010_AMVAL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1431,17 +1486,6 @@
           <http://model.geneontology.org/CHEBI_356010_AMVAL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002233_CHEBI_32551_LYSACET-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57288_LYSACET-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57288> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1451,7 +1495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1469,24 +1513,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_LYSDEGII-PWY" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002413_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57288>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1500,7 +1533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1517,7 +1550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1540,7 +1573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1551,14 +1584,14 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002413_KETAMID-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_VAGL-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
+                "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1566,11 +1599,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_VAGL-RXN_BFO_0000066_reaction_VAGL-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_VAGL-RXN_BFO_0000066_reaction_VAGL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1585,11 +1618,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_30921_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_30921_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1600,26 +1633,15 @@
           <http://model.geneontology.org/CHEBI_30921_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1637,11 +1659,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002234_CHEBI_16526_KETAMID-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002234_CHEBI_16526_KETAMID-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1652,15 +1674,26 @@
           <http://model.geneontology.org/CHEBI_16526_KETAMID-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002234_CHEBI_57287_LYSACET-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMVAL-RXN_BFO_0000066_reaction_AMVAL-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMVAL-RXN_BFO_0000066_reaction_AMVAL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1671,23 +1704,6 @@
           <http://model.geneontology.org/reaction_AMVAL-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/CHEBI_57540_KETAMID-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSDEGII-PWYSmallMolecule26434> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_15377_KETAMID-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1697,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1705,16 +1721,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002233_CHEBI_57540_KETAMID-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_57540_KETAMID-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD<sup>+</sup>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSDEGII-PWYSmallMolecule26434> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_79192>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1724,18 +1746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002413_VAGL-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1748,7 +1759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1756,15 +1767,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002413_AMVAL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002234_CHEBI_15378_LYSACET-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002234_CHEBI_15378_LYSACET-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1779,11 +1812,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1806,7 +1839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1817,6 +1850,28 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002233_CHEBI_32551_LYSACET-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002413_ACETCAPR-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_32551_LYSACET-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_32551> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1826,7 +1881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1834,14 +1889,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16120_VAGL-RXN_SGD_YeastPathways_LYSDEGII-PWY>
+<http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002234_CHEBI_15378_KETAMID-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
+                "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1854,7 +1909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1866,11 +1921,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002234_CHEBI_16120_VAGL-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_VAGL-RXN_RO_0002234_CHEBI_16120_VAGL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1885,11 +1940,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_BFO_0000066_reaction_KETAMID-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_BFO_0000066_reaction_KETAMID-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1904,11 +1959,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002233_CHEBI_58260_LYSACET-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002233_CHEBI_58260_LYSACET-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1928,24 +1983,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSDEGII-PWYSmallMolecule26597> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002234_CHEBI_15378_LYSACET-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_LYSACET-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1956,7 +2000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1964,26 +2008,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002234_CHEBI_29985_ACETCAPR-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" , "Provides Input For Rule. The relation '2-keto-6-acetamidocaproate + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; 5-acetamidovalerate + CO<SUB>2</SUB> + NADH + H<SUP>+</SUP>' 'null' '5-acetamidovalerate + H<sub>2</sub>O &rarr; acetate + 5-aminopentanoate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002413_AMVAL-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETAMID-RXN_RO_0002413_AMVAL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1994,26 +2027,15 @@
           <http://model.geneontology.org/AMVAL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002233_CHEBI_79193_KETAMID-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002233_CHEBI_79193_KETAMID-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002233_CHEBI_79193_KETAMID-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2024,14 +2046,14 @@
           <http://model.geneontology.org/CHEBI_79193_KETAMID-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002234_CHEBI_57287_LYSACET-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002413_KETAMID-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
+                "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2044,24 +2066,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSDEGII-PWYSmallMolecule26664> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002233_CHEBI_15377_AMVAL-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/KETAMID-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
@@ -2080,7 +2091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2088,29 +2099,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_VAGL-RXN_BFO_0000050_YeastPathways_LYSDEGII-PWY/YeastPathways_LYSDEGII-PWY_SGD_YeastPathways_LYSDEGII-PWY>
+<http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_30921_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
+                "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0047949>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_AMVAL-RXN_RO_0002413_VAGL-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMVAL-RXN_BFO_0000066_reaction_AMVAL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-lysine + acetyl-CoA &rarr; <i>N</i><sup>6</sup>-acetyl-L-lysine + coenzyme A + H<SUP>+</SUP>' 'null' '<i>N</i><sup>6</sup>-acetyl-L-lysine + 2-oxoglutarate &harr; 2-keto-6-acetamidocaproate + L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002413_ACETCAPR-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_LYSACET-RXN_RO_0002413_ACETCAPR-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2121,26 +2151,18 @@
           <http://model.geneontology.org/ACETCAPR-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0047949>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_LYSDEGII-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2151,38 +2173,16 @@
           <http://model.geneontology.org/CHEBI_57540_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002234_CHEBI_79192_ACETCAPR-RXN_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMVAL-RXN_BFO_0000066_reaction_AMVAL-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSDEGII-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSDEGII-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16120>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ACETCAPR-RXN_RO_0002233_CHEBI_16810_ACETCAPR-RXN_SGD_PWY_YeastPathways_LYSDEGII-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSDEGII-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_LYSINE-AMINOAD-PWY-2.ttl
+++ b/models/YeastPathways_LYSINE-AMINOAD-PWY-2.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -19,11 +19,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002233_CHEBI_15378_RXN3O-9808_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002233_CHEBI_15378_RXN3O-9808_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -34,15 +34,37 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-9808>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002234_CHEBI_16526_RXN-7970_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002233_CHEBI_57540_1.5.1.7-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(1<i>R</i>,2<i>S</i>)-homoisocitrate + NAD<sup>+</sup> &rarr; CO<SUB>2</SUB> + 2-oxoadipate + NADH' 'null' '2-oxoglutarate + L-2-aminoadipate &larr; 2-oxoadipate + L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002413_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002413_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -63,11 +85,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" , "Provides Input For Rule. The relation '(1<i>R</i>,2<i>S</i>)-homoisocitrate &harr; <i>cis</i>-homoaconitate + H<sub>2</sub>O' 'null' '(1<i>R</i>,2<i>S</i>)-homoisocitrate + NAD<sup>+</sup> &rarr; CO<SUB>2</SUB> + 2-oxoadipate + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002413_RXN-7970_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002413_RXN-7970_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,14 +100,25 @@
           <http://model.geneontology.org/RXN-7970>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002233_CHEBI_15377_1.5.1.7-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://model.geneontology.org/ev_w_id_RXN3O-127_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002233_CHEBI_15377_HOMOCITRATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -98,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -106,25 +139,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002234_CHEBI_58321_RXN3O-9808_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002233_CHEBI_15378_RXN3O-127_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://model.geneontology.org/ev_w_id_RXN-7970_BFO_0000066_reaction_RXN-7970_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_HOMOCITRATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002234_CHEBI_15377_RXN3O-9808_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -138,11 +182,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,14 +197,14 @@
           <http://model.geneontology.org/YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-1983_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -168,11 +212,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002234_CHEBI_57951_RXN3O-127_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002234_CHEBI_57951_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -187,11 +231,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002234_CHEBI_57287_HOMOCITRATE-SYNTHASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002234_CHEBI_57287_HOMOCITRATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -202,17 +246,50 @@
           <http://model.geneontology.org/CHEBI_57287_HOMOCITRATE-SYNTHASE-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000001356>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002333_YDL182W-MONOMER_HOMOCITRATE-SYNTHASE-RXN_controller_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002333_YIR034C-MONOMER_1.5.1.7-RXN_controller_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7970_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001356>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002413_HOMOACONITATE-HYDRATASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002333_MONOMER3O-363_RXN3O-127_controller_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -230,18 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002234_CHEBI_57945_1.5.1.7-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -249,11 +315,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002234_CHEBI_57945_1.5.1.7-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002234_CHEBI_57945_1.5.1.7-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -264,26 +330,15 @@
           <http://model.geneontology.org/CHEBI_57945_1.5.1.7-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002234_CHEBI_58174_RXN3O-1983_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002234_CHEBI_58174_RXN3O-1983_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -294,21 +349,21 @@
           <http://model.geneontology.org/CHEBI_58174_RXN3O-1983>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_32551>
+<http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004755>
+<http://purl.obolibrary.org/obo/CHEBI_32551>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002233_CHEBI_57540_RXN-7970_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002233_CHEBI_57540_RXN-7970_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -319,30 +374,30 @@
           <http://model.geneontology.org/CHEBI_57540_RXN-7970>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002333_YIL094C-MONOMER_RXN-7970_controller_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002234_CHEBI_16526_RXN-7970_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/ECO_0000363>
+<http://purl.obolibrary.org/obo/GO_0004755>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_58672_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002413_1.5.1.7-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_1.5.1.7-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -353,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -361,15 +416,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002333_YDR234W-MONOMER_RXN3O-1983_controller_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_BFO_0000066_reaction_HOMOACONITATE-HYDRATASE-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_BFO_0000066_reaction_HOMOACONITATE-HYDRATASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -389,13 +455,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSINE-AMINOAD-PWY-2SmallMolecule73582> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_BFO_0000066_reaction_HOMOCITRATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002233_CHEBI_16810_HOMOCITRATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58321_RXN3O-9808>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58321> ;
@@ -406,24 +494,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSINE-AMINOAD-PWY-2SmallMolecule73528> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002234_CHEBI_58174_RXN3O-1983_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -432,11 +509,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" , "Provides Input For Rule. The relation '2-oxoglutarate + L-2-aminoadipate &larr; 2-oxoadipate + L-glutamate' 'null' 'L-2-aminoadipate + NADPH + 2 H<SUP>+</SUP> &rarr; (<i>S</i>)-2-amino-6-oxohexanoate + NADP<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002413_RXN3O-9808_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002413_RXN3O-9808_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -445,25 +522,6 @@
           <http://model.geneontology.org/2-AMINOADIPATE-AMINOTRANSFERASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN3O-9808>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002234_CHEBI_15377_RXN3O-9808_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9808> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN3O-9808>
 ] .
 
 <http://model.geneontology.org/RXN3O-127>
@@ -485,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -493,16 +551,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-127_BFO_0000066_reaction_RXN3O-127_location_lociGO_0005829_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002234_CHEBI_15377_RXN3O-9808_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9808> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_RXN3O-9808>
+] .
 
 <http://model.geneontology.org/CHEBI_57783_RXN3O-9808>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
@@ -513,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -525,11 +591,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002233_CHEBI_15378_RXN3O-127_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002233_CHEBI_15378_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,7 +615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -566,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -574,14 +640,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002233_CHEBI_15377_HOMOACONITATE-HYDRATASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002234_CHEBI_57499_RXN-7970_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002333_YDL182W-MONOMER_HOMOCITRATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -590,18 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002413_RXN3O-9808_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -609,11 +675,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002233_CHEBI_57540_1.5.1.7-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002233_CHEBI_57540_1.5.1.7-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -643,11 +709,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" , "Provides Input For Rule. The relation 'L-saccharopine + NADP<sup>+</sup> + H<sub>2</sub>O &larr; L-glutamate + (<i>S</i>)-2-amino-6-oxohexanoate + NADPH + H<SUP>+</SUP>' 'null' 'L-saccharopine + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; 2-oxoglutarate + L-lysine + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002413_1.5.1.7-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002413_1.5.1.7-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -682,11 +748,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002333_YDL182W-MONOMER_HOMOCITRATE-SYNTHASE-RXN_controller_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002333_YDL182W-MONOMER_HOMOCITRATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,17 +766,6 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002233_CHEBI_57288_HOMOCITRATE-SYNTHASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29985_RXN3O-127>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -720,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -745,7 +800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -757,11 +812,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -776,11 +831,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9808_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9808_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,17 +846,6 @@
           <http://model.geneontology.org/YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002333_YIR034C-MONOMER_1.5.1.7-RXN_controller_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58884_HOMOCITRATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58884> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -811,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -823,11 +867,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002234_CHEBI_57945_RXN-7970_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002234_CHEBI_57945_RXN-7970_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -841,25 +885,14 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002413_HOMOACONITATE-HYDRATASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_BFO_0000066_reaction_1.5.1.7-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -872,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -884,11 +917,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002234_CHEBI_15404_HOMOACONITATE-HYDRATASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002234_CHEBI_15404_HOMOACONITATE-HYDRATASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -908,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -918,6 +951,17 @@
 
 <http://identifiers.org/sgd/S000002289>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002234_CHEBI_15404_HOMOACONITATE-HYDRATASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/1.5.1.7-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004754> ;
@@ -936,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -948,11 +992,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002333_YBR115C-MONOMER_RXN3O-9808_controller_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002333_YBR115C-MONOMER_RXN3O-9808_controller_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -970,11 +1014,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002233_CHEBI_58321_RXN3O-9808_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002233_CHEBI_58321_RXN3O-9808_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -985,14 +1029,14 @@
           <http://model.geneontology.org/CHEBI_58321_RXN3O-9808>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002234_CHEBI_32551_1.5.1.7-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1000,11 +1044,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002233_CHEBI_57288_HOMOCITRATE-SYNTHASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002233_CHEBI_57288_HOMOCITRATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,6 +1059,17 @@
           <http://model.geneontology.org/CHEBI_57288_HOMOCITRATE-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002233_CHEBI_15377_HOMOACONITATE-HYDRATASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_RXN3O-127>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1024,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1047,13 +1102,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSINE-AMINOAD-PWY-2SmallMolecule73636> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000000319>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/RXN3O-1983>
         a       <http://purl.obolibrary.org/obo/GO_0004409> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1074,7 +1132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1082,29 +1140,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://identifiers.org/sgd/S000000319>
+<http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002234_CHEBI_57951_RXN3O-127_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002234_CHEBI_58349_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_HOMOACONITATE-HYDRATASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1115,11 +1181,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002234_CHEBI_16810_1.5.1.7-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002234_CHEBI_16810_1.5.1.7-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1137,11 +1203,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002233_CHEBI_58884_HOMOCITRATE-SYNTHASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002233_CHEBI_58884_HOMOCITRATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1152,26 +1218,15 @@
           <http://model.geneontology.org/CHEBI_58884_HOMOCITRATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002413_1.5.1.7-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7970_BFO_0000066_reaction_RXN-7970_location_lociGO_0005829_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7970_BFO_0000066_reaction_RXN-7970_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1182,30 +1237,19 @@
           <http://model.geneontology.org/reaction_RXN-7970_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_29985_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002234_CHEBI_57951_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_58672_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YIR034C-MONOMER_1.5.1.7-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001473> ;
@@ -1214,7 +1258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1225,25 +1269,25 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1983_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002333_YBR115C-MONOMER_RXN3O-9808_controller_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002333_YDL131W-MONOMER_HOMOCITRATE-SYNTHASE-RXN_controller_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002333_YDL131W-MONOMER_HOMOCITRATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1251,11 +1295,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_16810_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_16810_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1266,26 +1310,15 @@
           <http://model.geneontology.org/CHEBI_16810_2-AMINOADIPATE-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002234_CHEBI_58349_RXN3O-127_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002233_CHEBI_57783_RXN3O-9808_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002233_CHEBI_57783_RXN3O-9808_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1296,17 +1329,6 @@
           <http://model.geneontology.org/CHEBI_57783_RXN3O-9808>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002233_CHEBI_29985_RXN3O-127_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004043>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1314,11 +1336,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-127_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-127_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1329,26 +1351,15 @@
           <http://model.geneontology.org/YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9808_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1359,23 +1370,12 @@
           <http://model.geneontology.org/YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_57499_RXN-7970_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_1.5.1.7-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1386,13 +1386,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSINE-AMINOAD-PWY-2Protein73662> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1416,7 +1427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1428,11 +1439,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_BFO_0000066_reaction_1.5.1.7-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_BFO_0000066_reaction_1.5.1.7-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1443,15 +1454,26 @@
           <http://model.geneontology.org/reaction_1.5.1.7-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002413_RXN-7970_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002234_CHEBI_58349_RXN3O-127_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002234_CHEBI_58349_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1466,11 +1488,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002234_CHEBI_58884_HOMOCITRATE-SYNTHASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002234_CHEBI_58884_HOMOCITRATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1481,48 +1503,59 @@
           <http://model.geneontology.org/CHEBI_58884_HOMOCITRATE-SYNTHASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002642>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002233_CHEBI_58672_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002234_CHEBI_58349_RXN3O-9808_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN3O-9808_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002333_YDR234W-MONOMER_RXN3O-1983_controller_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-127_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/HOMOCITRATE-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004410> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1543,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1554,17 +1587,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002233_CHEBI_57783_RXN3O-9808_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1572,11 +1594,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002333_YIR034C-MONOMER_1.5.1.7-RXN_controller_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002333_YIR034C-MONOMER_1.5.1.7-RXN_controller_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1594,11 +1616,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002333_YDR234W-MONOMER_RXN3O-1983_controller_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002333_YDR234W-MONOMER_RXN3O-1983_controller_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1618,7 +1640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1630,11 +1652,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002234_CHEBI_16526_RXN-7970_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002234_CHEBI_16526_RXN-7970_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1645,14 +1667,14 @@
           <http://model.geneontology.org/CHEBI_16526_RXN-7970>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_16810_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002333_YIL094C-MONOMER_RXN-7970_controller_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1660,11 +1682,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002233_CHEBI_15377_HOMOACONITATE-HYDRATASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002233_CHEBI_15377_HOMOACONITATE-HYDRATASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1675,18 +1697,40 @@
           <http://model.geneontology.org/CHEBI_15377_HOMOACONITATE-HYDRATASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002233_CHEBI_58884_HOMOCITRATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_57499_RXN-7970_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002234_CHEBI_58321_RXN3O-9808_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002234_CHEBI_58321_RXN3O-9808_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1700,26 +1744,15 @@
 <http://purl.obolibrary.org/obo/GO_0004409>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002234_CHEBI_57287_HOMOCITRATE-SYNTHASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002233_CHEBI_29985_RXN3O-127_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002233_CHEBI_29985_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1730,17 +1763,6 @@
           <http://model.geneontology.org/CHEBI_29985_RXN3O-127>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002333_YDR234W-MONOMER_HOMOACONITATE-HYDRATASE-RXN_controller_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YDL182W-MONOMER_HOMOCITRATE-SYNTHASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002341> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1748,7 +1770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1760,11 +1782,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002233_CHEBI_15377_HOMOCITRATE-SYNTHASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002233_CHEBI_15377_HOMOCITRATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1775,30 +1797,30 @@
           <http://model.geneontology.org/CHEBI_15377_HOMOCITRATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002233_CHEBI_58884_HOMOCITRATE-SYNTHASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_29985_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002234_CHEBI_15378_1.5.1.7-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001473>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002413_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-127>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -1809,7 +1831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1821,11 +1843,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002233_CHEBI_57951_RXN3O-127_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002233_CHEBI_57951_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1836,26 +1858,15 @@
           <http://model.geneontology.org/CHEBI_57951_RXN3O-127>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002234_CHEBI_32551_1.5.1.7-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1983_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1983_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1866,17 +1877,6 @@
           <http://model.geneontology.org/YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_BFO_0000066_reaction_HOMOACONITATE-HYDRATASE-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57945_1.5.1.7-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1886,7 +1886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1898,11 +1898,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2-oxoglutarate + acetyl-CoA + H<sub>2</sub>O &rarr; (2<i>R</i>)-homocitrate + coenzyme A + H<SUP>+</SUP>' 'null' '(2<i>R</i>)-homocitrate &rarr; <i>cis</i>-homoaconitate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002413_RXN3O-1983_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002413_RXN3O-1983_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1913,6 +1913,28 @@
           <http://model.geneontology.org/RXN3O-1983>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002233_CHEBI_57288_HOMOCITRATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_16810_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YIL094C-MONOMER_RXN-7970_controller>
         a       <http://identifiers.org/sgd/S000001356> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1920,7 +1942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1928,14 +1950,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002233_CHEBI_57951_RXN3O-127_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002233_CHEBI_15378_RXN3O-9808_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1943,11 +1965,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_29985_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_29985_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1958,26 +1980,15 @@
           <http://model.geneontology.org/CHEBI_29985_2-AMINOADIPATE-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_HOMOCITRATE-SYNTHASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9808_BFO_0000066_reaction_RXN3O-9808_location_lociGO_0005829_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9808_BFO_0000066_reaction_RXN3O-9808_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1988,17 +1999,6 @@
           <http://model.geneontology.org/reaction_RXN3O-9808_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002234_CHEBI_58349_RXN3O-9808_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0047046>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2006,11 +2006,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002333_YIL094C-MONOMER_RXN-7970_controller_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002333_YIL094C-MONOMER_RXN-7970_controller_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2021,14 +2021,14 @@
           <http://model.geneontology.org/YIL094C-MONOMER_RXN-7970_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002234_CHEBI_57945_RXN-7970_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002233_CHEBI_15378_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2036,11 +2036,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002333_YDR234W-MONOMER_HOMOACONITATE-HYDRATASE-RXN_controller_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002333_YDR234W-MONOMER_HOMOACONITATE-HYDRATASE-RXN_controller_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2054,6 +2054,17 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9808_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57951_RXN3O-127>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57951> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2063,24 +2074,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSINE-AMINOAD-PWY-2SmallMolecule73711> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002234_CHEBI_15377_RXN3O-1983_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16810_2-AMINOADIPATE-AMINOTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16810> ;
@@ -2091,7 +2091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2104,18 +2104,40 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9808_BFO_0000066_reaction_RXN3O-9808_location_lociGO_0005829_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002233_CHEBI_29985_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002234_CHEBI_58174_RXN3O-1983_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002233_CHEBI_57783_RXN3O-9808_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2123,11 +2145,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-2-aminoadipate + NADPH + 2 H<SUP>+</SUP> &rarr; (<i>S</i>)-2-amino-6-oxohexanoate + NADP<sup>+</sup> + H<sub>2</sub>O' 'null' 'L-saccharopine + NADP<sup>+</sup> + H<sub>2</sub>O &larr; L-glutamate + (<i>S</i>)-2-amino-6-oxohexanoate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002413_RXN3O-127_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002413_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2142,11 +2164,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002234_CHEBI_15377_RXN3O-127_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002234_CHEBI_15377_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2161,11 +2183,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_HOMOCITRATE-SYNTHASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_HOMOCITRATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2195,7 +2217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2203,32 +2225,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_BFO_0000066_reaction_1.5.1.7-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002413_RXN3O-1983_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57288>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002234_CHEBI_32551_1.5.1.7-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002234_CHEBI_32551_1.5.1.7-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2243,11 +2276,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002234_CHEBI_15377_RXN3O-1983_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002234_CHEBI_15377_RXN3O-1983_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2262,11 +2295,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002233_CHEBI_15404_HOMOACONITATE-HYDRATASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002233_CHEBI_15404_HOMOACONITATE-HYDRATASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2279,17 +2312,6 @@
 
 <http://purl.obolibrary.org/obo/GO_0004754>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-7970_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/HOMOACONITATE-HYDRATASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004409> ;
@@ -2310,7 +2332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2322,11 +2344,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2337,39 +2359,28 @@
           <http://model.geneontology.org/YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002233_CHEBI_58321_RXN3O-9808_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002234_CHEBI_16810_1.5.1.7-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002233_CHEBI_15404_HOMOACONITATE-HYDRATASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57951>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002413_RXN3O-1983_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002234_CHEBI_57945_1.5.1.7-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2377,11 +2388,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_58672_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_58672_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2392,26 +2403,15 @@
           <http://model.geneontology.org/CHEBI_58672_2-AMINOADIPATE-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002234_CHEBI_15377_RXN3O-127_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002233_CHEBI_58672_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002233_CHEBI_58672_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2426,11 +2426,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-127_BFO_0000066_reaction_RXN3O-127_location_lociGO_0005829_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-127_BFO_0000066_reaction_RXN3O-127_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2441,17 +2441,6 @@
           <http://model.geneontology.org/reaction_RXN3O-127_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002413_RXN3O-127_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16526_RXN-7970>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2461,13 +2450,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSINE-AMINOAD-PWY-2SmallMolecule73622> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002333_YDR234W-MONOMER_HOMOACONITATE-HYDRATASE-RXN_controller_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16810_HOMOCITRATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16810> ;
@@ -2478,7 +2478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2486,15 +2486,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002233_CHEBI_57783_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_BFO_0000066_reaction_HOMOCITRATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_BFO_0000066_reaction_HOMOCITRATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2505,39 +2516,6 @@
           <http://model.geneontology.org/reaction_HOMOCITRATE-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1983_BFO_0000066_reaction_RXN3O-1983_location_lociGO_0005829_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002233_CHEBI_57540_1.5.1.7-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002233_CHEBI_57540_RXN-7970_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_HOMOCITRATE-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2547,13 +2525,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSINE-AMINOAD-PWY-2SmallMolecule73515> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9808_BFO_0000066_reaction_RXN3O-9808_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YBR115C-MONOMER_RXN3O-9808_controller>
         a       <http://identifiers.org/sgd/S000000319> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2562,7 +2551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2579,24 +2568,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSINE-AMINOAD-PWY-2SmallMolecule73801> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002333_MONOMER3O-363_RXN3O-127_controller_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9808>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -2607,7 +2585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2624,22 +2602,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSINE-AMINOAD-PWY-2SmallMolecule73582> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/reaction_RXN3O-1983_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YDR234W-MONOMER_RXN3O-1983_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002642> ;
@@ -2648,7 +2617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2660,11 +2629,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002233_CHEBI_15377_1.5.1.7-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002233_CHEBI_15377_1.5.1.7-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2675,25 +2644,12 @@
           <http://model.geneontology.org/CHEBI_15377_1.5.1.7-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002233_CHEBI_15404_HOMOACONITATE-HYDRATASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/reaction_RXN3O-1983_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002233_CHEBI_58672_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2701,11 +2657,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002333_MONOMER3O-363_RXN3O-127_controller_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002333_MONOMER3O-363_RXN3O-127_controller_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2716,24 +2672,19 @@
           <http://model.geneontology.org/MONOMER3O-363_RXN3O-127_controller>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002333_YDL131W-MONOMER_HOMOCITRATE-SYNTHASE-RXN_controller_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOCITRATE-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDL131W-MONOMER_HOMOCITRATE-SYNTHASE-RXN_controller>
-] .
+<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002234_CHEBI_57287_HOMOCITRATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_15377_HOMOACONITATE-HYDRATASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2744,7 +2695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2752,19 +2703,46 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002233_CHEBI_15378_RXN3O-9808_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002333_YDL131W-MONOMER_HOMOCITRATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HOMOCITRATE-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YDL131W-MONOMER_HOMOCITRATE-SYNTHASE-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002233_CHEBI_15377_1.5.1.7-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-363_RXN3O-127_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005333> ;
@@ -2773,7 +2751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2783,17 +2761,6 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002234_CHEBI_15377_RXN3O-9808_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -2807,24 +2774,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSINE-AMINOAD-PWY-2SmallMolecule73696> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002233_CHEBI_15377_HOMOCITRATE-SYNTHASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_1.5.1.7-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2835,7 +2791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2843,29 +2799,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_58321>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002234_CHEBI_15378_1.5.1.7-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002234_CHEBI_58321_RXN3O-9808_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58321>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2876,15 +2832,26 @@
           <http://model.geneontology.org/YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002234_CHEBI_15377_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" , "Provides Input For Rule. The relation '(2<i>R</i>)-homocitrate &rarr; <i>cis</i>-homoaconitate + H<sub>2</sub>O' 'null' '(1<i>R</i>,2<i>S</i>)-homoisocitrate &harr; <i>cis</i>-homoaconitate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002413_HOMOACONITATE-HYDRATASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002413_HOMOACONITATE-HYDRATASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2899,11 +2866,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002234_CHEBI_57499_RXN-7970_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002234_CHEBI_57499_RXN-7970_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2914,26 +2881,15 @@
           <http://model.geneontology.org/CHEBI_57499_RXN-7970>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002233_CHEBI_16810_HOMOCITRATE-SYNTHASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002233_CHEBI_58174_RXN3O-1983_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002233_CHEBI_58174_RXN3O-1983_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2944,14 +2900,25 @@
           <http://model.geneontology.org/CHEBI_58174_RXN3O-1983>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_BFO_0000066_reaction_HOMOCITRATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002233_CHEBI_57540_RXN-7970_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002233_CHEBI_58321_RXN3O-9808_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2964,7 +2931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2975,6 +2942,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002413_RXN3O-9808_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58349_RXN3O-9808>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2984,7 +2962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2997,7 +2975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3005,11 +2983,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002234_CHEBI_58349_RXN3O-9808_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002234_CHEBI_58349_RXN3O-9808_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3023,15 +3001,26 @@
 <http://purl.obolibrary.org/obo/GO_0004410>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002233_CHEBI_58174_RXN3O-1983_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002233_CHEBI_57783_RXN3O-127_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002233_CHEBI_57783_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3046,11 +3035,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002233_CHEBI_16810_HOMOCITRATE-SYNTHASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002233_CHEBI_16810_HOMOCITRATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3061,10 +3050,13 @@
           <http://model.geneontology.org/CHEBI_16810_HOMOCITRATE-SYNTHASE-RXN>
 ] .
 
+<http://identifiers.org/sgd/S000005333>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/CHEBI_57499>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000005333>
+<http://purl.obolibrary.org/obo/GO_0047536>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YeastPathways_LYSINE-AMINOAD-PWY-2>
@@ -3076,7 +3068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-lysine biosynthesis IV - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3084,17 +3076,25 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://purl.obolibrary.org/obo/GO_0047536>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002234_CHEBI_58884_HOMOCITRATE-SYNTHASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002233_CHEBI_57951_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1983_BFO_0000066_reaction_RXN3O-1983_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3107,13 +3107,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSINE-AMINOAD-PWY-2SmallMolecule73542> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-127_BFO_0000066_reaction_RXN3O-127_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58174_RXN3O-1983>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58174> ;
@@ -3124,7 +3135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3132,14 +3143,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002234_CHEBI_57499_RXN-7970_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002234_CHEBI_16810_1.5.1.7-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3152,7 +3163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3160,40 +3171,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002333_YBR115C-MONOMER_RXN3O-9808_controller_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58884>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002233_CHEBI_58174_RXN3O-1983_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002234_CHEBI_15378_1.5.1.7-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002234_CHEBI_15378_1.5.1.7-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3204,24 +3193,16 @@
           <http://model.geneontology.org/CHEBI_15378_1.5.1.7-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1983_BFO_0000066_reaction_RXN3O-1983_location_lociGO_0005829_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-1983> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-1983_location_lociGO_0005829>
-] .
+<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002413_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-9808>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -3232,7 +3213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3240,14 +3221,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7970_BFO_0000066_reaction_RXN-7970_location_lociGO_0005829_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-1983_BFO_0000066_reaction_RXN3O-1983_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-1983> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-1983_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002413_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3255,11 +3255,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7970_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7970_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3270,62 +3270,51 @@
           <http://model.geneontology.org/YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_BFO_0000066_reaction_HOMOACONITATE-HYDRATASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002233_CHEBI_57783_RXN3O-127_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002234_CHEBI_57945_RXN-7970_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002234_CHEBI_15404_HOMOACONITATE-HYDRATASE-RXN_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
+<http://model.geneontology.org/ev_w_id_RXN3O-1983_RO_0002234_CHEBI_15377_RXN3O-1983_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58174>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002413_RXN-7970_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_57499_RXN-7970_SGD_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_57499_RXN-7970_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3335,3 +3324,14 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57499_RXN-7970>
 ] .
+
+<http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002234_CHEBI_58884_HOMOCITRATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_NADSYN-PWY.ttl
+++ b/models/YeastPathways_NADSYN-PWY.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -33,11 +33,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -71,14 +71,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -86,11 +86,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -104,23 +104,6 @@
 <http://identifiers.org/sgd/S000003242>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23167> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -130,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -138,27 +121,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23167> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15377_ARYLFORMAMIDASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -169,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -177,18 +166,10 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_58437_NICONUCADENYLYLTRAN-RXN>
@@ -200,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -208,8 +189,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_NADSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -220,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "NAD <i>de novo</i> biosynthesis II (from tryptophan) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -232,11 +221,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -247,15 +236,26 @@
           <http://model.geneontology.org/CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_1.13.11.6-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_1.13.11.6-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -266,15 +266,26 @@
           <http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -289,11 +300,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,17 +315,6 @@
           <http://model.geneontology.org/CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,7 +344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -358,6 +358,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_29959_RXN-5721_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29888_QUINOPRIBOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -367,24 +389,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23126> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_29959_RXN-5721_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YJR078W-MONOMER_RXN-8665_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003839> ;
@@ -393,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -405,11 +416,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -420,25 +431,17 @@
           <http://model.geneontology.org/CHEBI_58629_RXN-8665>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_SGD_YeastPathways_NADSYN-PWY>
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -446,11 +449,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" , "Provides Input For Rule. The relation '&beta;-nicotinate D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; nicotinate adenine dinucleotide + diphosphate' 'null' 'ATP + nicotinate adenine dinucleotide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + AMP + NAD<sup>+</sup> + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,14 +464,14 @@
           <http://model.geneontology.org/NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -476,11 +479,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -491,23 +494,6 @@
           <http://model.geneontology.org/YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY>
 ] .
 
-<http://model.geneontology.org/CHEBI_29888_NICONUCADENYLYLTRAN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23126> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_58629_RXN-8665>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58629> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -517,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -525,8 +511,44 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_29888_NICONUCADENYLYLTRAN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23126> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29959>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -535,11 +557,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,6 +572,28 @@
           <http://model.geneontology.org/reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000002836> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -557,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -565,30 +609,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_1.13.11.6-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_YeastPathways_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.13.11.6-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN>
-] .
 
 <http://model.geneontology.org/1.13.11.6-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0000334> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -609,13 +645,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYBiochemicalReaction23341> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.13.11.6-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN>
+] .
 
 <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004502> ;
@@ -636,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -651,11 +706,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,11 +725,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -690,18 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002413_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -714,7 +758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -722,25 +766,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -753,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -778,25 +811,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -804,11 +826,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -819,18 +841,40 @@
           <http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2-amino-3-carboxymuconate-6-semialdehyde &rarr; quinolinate + H<sub>2</sub>O' 'null' 'CO<SUB>2</SUB> + &beta;-nicotinate D-ribonucleotide + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + quinolinate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002413_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002413_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -841,14 +885,14 @@
           <http://model.geneontology.org/QUINOPRIBOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -856,11 +900,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -878,11 +922,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -896,17 +940,6 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -916,7 +949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -924,25 +957,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -952,14 +974,36 @@
 <http://purl.obolibrary.org/obo/CHEBI_36559>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -967,11 +1011,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -985,15 +1029,26 @@
 <http://purl.obolibrary.org/obo/GO_0004061>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1011,11 +1066,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1026,29 +1081,44 @@
           <http://model.geneontology.org/CHEBI_30616_NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003596> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Kynurenine aminotransferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23479> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1059,54 +1129,50 @@
           <http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN>
 ] .
 
-<http://model.geneontology.org/YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003596> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Kynurenine aminotransferase" ;
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23479> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1114,11 +1180,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1133,11 +1199,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1151,15 +1217,26 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1179,7 +1256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1187,26 +1264,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1217,45 +1283,23 @@
           <http://model.geneontology.org/reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1269,11 +1313,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>' 'null' '3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1284,17 +1328,6 @@
           <http://model.geneontology.org/1.13.11.6-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1302,11 +1335,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1317,17 +1350,6 @@
           <http://model.geneontology.org/CHEBI_15379_RXN-8665>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58125>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1335,30 +1357,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_YeastPathways_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1367,6 +1370,25 @@
           <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_57959_ARYLFORMAMIDASE-RXN>
@@ -1378,13 +1400,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23412> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0030429> ;
@@ -1405,7 +1449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1420,7 +1464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1431,34 +1475,12 @@
 <http://purl.obolibrary.org/obo/GO_0003952>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_RXN-8665_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1467,7 +1489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1483,24 +1505,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23167> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1524,7 +1535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1532,15 +1543,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1555,11 +1577,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1574,11 +1596,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1589,6 +1611,17 @@
           <http://model.geneontology.org/CHEBI_15378_NAD-SYNTH-GLN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57972> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1598,7 +1631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1610,11 +1643,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1628,28 +1661,17 @@
 <http://purl.obolibrary.org/obo/GO_0000334>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1657,11 +1679,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1691,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1699,26 +1721,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1729,14 +1740,14 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-5721>
 ] .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1744,11 +1755,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1768,7 +1779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1780,11 +1791,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1795,33 +1806,19 @@
           <http://model.geneontology.org/CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0004514>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004514>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1829,36 +1826,31 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_YeastPathways_NADSYN-PWY>
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1871,46 +1863,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23192> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_YeastPathways_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-8665> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR078W-MONOMER_RXN-8665_controller>
-] .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1919,11 +1878,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1934,14 +1893,55 @@
           <http://model.geneontology.org/YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_NADSYN-PWY>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_PWY_YeastPathways_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-8665> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YJR078W-MONOMER_RXN-8665_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1949,11 +1949,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1964,6 +1964,17 @@
           <http://model.geneontology.org/reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_RXN-5721>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1973,7 +1984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1985,11 +1996,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2009,7 +2020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2019,17 +2030,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0033754>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2044,7 +2044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2052,30 +2052,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_NADSYN-PWY>
+<http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_1.13.11.6-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0030429>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2084,11 +2073,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2099,26 +2088,15 @@
           <http://model.geneontology.org/YJR025C-MONOMER_1.13.11.6-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2133,11 +2111,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2152,11 +2130,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" , "Provides Input For Rule. The relation '<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>' 'null' 'L-kynurenine + NADPH + oxygen + H<SUP>+</SUP> &rarr; 3-hydroxy-L-kynurenine + NADP<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2167,36 +2145,36 @@
           <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2209,7 +2187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2221,11 +2199,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2236,26 +2214,15 @@
           <http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2270,11 +2237,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2285,14 +2252,25 @@
           <http://model.geneontology.org/CHEBI_29888_NICONUCADENYLYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_RXN-8665_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2300,11 +2278,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2324,7 +2302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2337,18 +2315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2361,57 +2328,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23167> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36559> ;
@@ -2422,7 +2345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2434,11 +2357,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2453,11 +2376,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_29959_RXN-5721_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_29959_RXN-5721_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2472,11 +2395,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2494,7 +2417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2506,11 +2429,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2527,6 +2450,17 @@
 <http://identifiers.org/sgd/S000003596>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58017_QUINOPRIBOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58017> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2536,7 +2470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2544,43 +2478,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_456215> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "AMP" ;
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23252> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2591,16 +2530,22 @@
           <http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_456215> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "AMP" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23252> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_NAD-SYNTH-GLN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2611,7 +2556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2623,11 +2568,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2638,26 +2583,15 @@
           <http://model.geneontology.org/reaction_RXN-5721_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2677,7 +2611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2689,11 +2623,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2721,7 +2655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2741,7 +2675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2749,40 +2683,65 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_994>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2812,7 +2771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2829,7 +2788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2841,11 +2800,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2856,17 +2815,14 @@
           <http://model.geneontology.org/YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_994>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2874,11 +2830,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" , "Provides Input For Rule. The relation 'L-kynurenine + NADPH + oxygen + H<SUP>+</SUP> &rarr; 3-hydroxy-L-kynurenine + NADP<sup>+</sup> + H<sub>2</sub>O' 'null' '3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2889,23 +2845,12 @@
           <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN-8665_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2913,11 +2858,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2931,25 +2876,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_57972>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2962,7 +2896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2974,11 +2908,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2989,17 +2923,6 @@
           <http://model.geneontology.org/CHEBI_15378_1.13.11.6-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003242> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3007,7 +2930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3019,11 +2942,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3034,15 +2957,30 @@
           <http://model.geneontology.org/CHEBI_29888_QUINOPRIBOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004221> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Kynureninase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23397> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3052,32 +2990,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_29888_NAD-SYNTH-GLN-RXN>
 ] .
-
-<http://model.geneontology.org/YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004221> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Kynureninase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYProtein23397> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/NAD-SYNTH-GLN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003952> ;
@@ -3096,7 +3008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3108,11 +3020,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3122,6 +3034,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_29959_RXN-5721_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57959>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3148,7 +3082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3156,14 +3090,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_29959_RXN-5721_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3176,7 +3110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3188,11 +3122,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3207,11 +3141,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_29959_RXN-5721_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_29959_RXN-5721_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3222,15 +3156,26 @@
           <http://model.geneontology.org/CHEBI_29959_RXN-5721>
 ] .
 
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3241,26 +3186,15 @@
           <http://model.geneontology.org/CHEBI_30616_NICONUCADENYLYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3271,8 +3205,30 @@
           <http://model.geneontology.org/CHEBI_57959_ARYLFORMAMIDASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_994> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3283,7 +3239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3294,11 +3250,30 @@
 <http://purl.obolibrary.org/obo/GO_0004515>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://identifiers.org/sgd/S000000194>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_NAD-SYNTH-GLN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3309,7 +3284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3317,54 +3292,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000000194>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" , "Provides Input For Rule. The relation 'L-tryptophan + oxygen &rarr; <i>N</i>-Formyl-L-kynurenine' 'null' '<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3375,26 +3320,15 @@
           <http://model.geneontology.org/ARYLFORMAMIDASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3409,11 +3343,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3424,25 +3358,14 @@
           <http://model.geneontology.org/CHEBI_15377_NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3455,7 +3378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3463,14 +3386,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3478,11 +3401,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_RXN-8665_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_RXN-8665_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3492,6 +3415,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58629_RXN-8665>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003786>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3505,7 +3439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3521,43 +3455,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3568,11 +3480,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>' 'null' '2-amino-3-carboxymuconate-6-semialdehyde &rarr; quinolinate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3587,11 +3499,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" , "Provides Input For Rule. The relation 'CO<SUB>2</SUB> + &beta;-nicotinate D-ribonucleotide + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + quinolinate + 2 H<SUP>+</SUP>' 'null' '&beta;-nicotinate D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; nicotinate adenine dinucleotide + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3602,26 +3514,15 @@
           <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3632,15 +3533,26 @@
           <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3651,14 +3563,25 @@
           <http://model.geneontology.org/YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_YeastPathways_NADSYN-PWY>
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3669,7 +3592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3677,15 +3600,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3703,7 +3637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3715,11 +3649,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3734,11 +3668,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3749,15 +3683,26 @@
           <http://model.geneontology.org/CHEBI_58437_NICONUCADENYLYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3767,6 +3712,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58629>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3783,13 +3739,57 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23139> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15379> ;
@@ -3800,7 +3800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3808,23 +3808,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002413_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NADSYN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3832,11 +3832,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_YeastPathways_NADSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_NONOXIPENT-PWY.ttl
+++ b/models/YeastPathways_NONOXIPENT-PWY.ttl
@@ -1,25 +1,3 @@
-<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_59776_1TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002413_2TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004751>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -32,24 +10,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NONOXIPENT-PWYSmallMolecule34300> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002233_CHEBI_57737_2TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57634_2TRANSKETO-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57634> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -60,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -72,11 +39,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -87,14 +54,47 @@
           <http://model.geneontology.org/YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002413_1TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
+<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002234_CHEBI_57634_2TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_BFO_0000066_reaction_TRANSALDOL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002413_TRANSALDOL-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
+                "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -102,11 +102,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_57483_1TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_57483_1TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -120,26 +120,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_16897>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_BFO_0000066_reaction_2TRANSKETO-RXN_location_lociGO_0005829_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002333_YOR095C-MONOMER_RIB5PISOM-RXN_controller_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002333_YOR095C-MONOMER_RIB5PISOM-RXN_controller_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -157,11 +146,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YPR074C-MONOMER_1TRANSKETO-RXN_controller_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YPR074C-MONOMER_1TRANSKETO-RXN_controller_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -191,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -202,12 +191,23 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002233_CHEBI_58121_RIB5PISOM-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_2TRANSKETO-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -218,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -233,11 +233,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_BFO_0000066_reaction_1TRANSKETO-RXN_location_lociGO_0005829_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_BFO_0000066_reaction_1TRANSKETO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -247,6 +247,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_1TRANSKETO-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002234_CHEBI_59776_2TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RIBULP3EPIM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004750> ;
@@ -267,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -275,14 +297,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002333_YJL121C-MONOMER_RIBULP3EPIM-RXN_controller_SGD_YeastPathways_NONOXIPENT-PWY>
+<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
+                "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -290,11 +312,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002234_CHEBI_59776_2TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002234_CHEBI_59776_2TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -316,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -329,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -347,11 +369,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_BFO_0000066_reaction_TRANSALDOL-RXN_location_lociGO_0005829_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_BFO_0000066_reaction_TRANSALDOL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -366,11 +388,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002234_CHEBI_78346_RIB5PISOM-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002234_CHEBI_78346_RIB5PISOM-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -381,29 +403,29 @@
           <http://model.geneontology.org/CHEBI_78346_RIB5PISOM-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004801>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002234_CHEBI_59776_2TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YPR074C-MONOMER_1TRANSKETO-RXN_controller_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
+                "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004801>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YBR117C-MONOMER_1TRANSKETO-RXN_controller_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YBR117C-MONOMER_1TRANSKETO-RXN_controller_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,23 +441,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002233_CHEBI_16897_TRANSALDOL-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -449,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,29 +468,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002234_CHEBI_57634_TRANSALDOL-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002233_CHEBI_78346_RIB5PISOM-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
+                "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002234_CHEBI_78346_RIB5PISOM-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -490,18 +512,51 @@
           <http://model.geneontology.org/YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002234_CHEBI_16897_TRANSALDOL-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57483>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002233_CHEBI_57737_2TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_BFO_0000066_reaction_1TRANSKETO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002234_CHEBI_57634_2TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002234_CHEBI_57634_2TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,17 +570,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57634>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002233_CHEBI_58121_RIB5PISOM-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -536,11 +580,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002333_YLR354C-MONOMER_TRANSALDOL-RXN_controller_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002333_YLR354C-MONOMER_TRANSALDOL-RXN_controller_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,14 +595,14 @@
           <http://model.geneontology.org/YLR354C-MONOMER_TRANSALDOL-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_YeastPathways_NONOXIPENT-PWY>
+<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
+                "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -566,11 +610,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002233_CHEBI_58121_RIBULP3EPIM-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002233_CHEBI_58121_RIBULP3EPIM-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -588,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -596,70 +640,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_BFO_0000066_reaction_RIB5PISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002234_CHEBI_57483_1TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002233_CHEBI_78346_RIB5PISOM-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002234_CHEBI_78346_RIB5PISOM-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
+                "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58121>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002234_CHEBI_57483_1TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_TRANSALDOL-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_57483_1TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -670,11 +670,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -685,26 +685,15 @@
           <http://model.geneontology.org/YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_BFO_0000066_reaction_1TRANSKETO-RXN_location_lociGO_0005829_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002233_CHEBI_58121_RIB5PISOM-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002233_CHEBI_58121_RIB5PISOM-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -719,11 +708,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002234_CHEBI_59776_1TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002234_CHEBI_59776_1TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -737,25 +726,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_78346>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002413_TRANSALDOL-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_57483_1TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YPR074C-MONOMER_1TRANSKETO-RXN_controller_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
+                "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -769,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -789,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -801,11 +779,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-sedoheptulose 7-phosphate + D-glyceraldehyde 3-phosphate &harr; &beta;-D-fructofuranose 6-phosphate + D-erythrose 4-phosphate' 'null' 'D-erythrose 4-phosphate + D-xylulose 5-phosphate &harr; &beta;-D-fructofuranose 6-phosphate + D-glyceraldehyde 3-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002413_2TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002413_2TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -816,14 +794,14 @@
           <http://model.geneontology.org/2TRANSKETO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002333_YPR074C-MONOMER_2TRANSKETO-RXN_controller_SGD_YeastPathways_NONOXIPENT-PWY>
+<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002333_YJL121C-MONOMER_RIBULP3EPIM-RXN_controller_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
+                "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -834,11 +812,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002233_CHEBI_57737_2TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002233_CHEBI_57737_2TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -868,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -885,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -893,40 +871,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002234_CHEBI_57737_RIBULP3EPIM-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002234_CHEBI_57634_TRANSALDOL-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002234_CHEBI_57634_TRANSALDOL-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -937,26 +893,15 @@
           <http://model.geneontology.org/CHEBI_57634_TRANSALDOL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000066_reaction_RIBULP3EPIM-RXN_location_lociGO_0005829_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000066_reaction_RIBULP3EPIM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -974,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1001,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1009,14 +954,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_BFO_0000066_reaction_TRANSALDOL-RXN_location_lociGO_0005829_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002333_YPR074C-MONOMER_2TRANSKETO-RXN_controller_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
+                "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1024,11 +969,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" , "Provides Input For Rule. The relation 'D-ribulose 5-phosphate &harr; D-xylulose 5-phosphate' 'null' 'D-sedoheptulose 7-phosphate + D-glyceraldehyde 3-phosphate &harr; D-ribose 5-phosphate + D-xylulose 5-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002413_1TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002413_1TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1044,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1052,11 +997,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_BFO_0000066_reaction_RIB5PISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_BFO_0000066_reaction_RIB5PISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1071,11 +1016,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002234_CHEBI_57483_1TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002234_CHEBI_57483_1TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1086,28 +1031,6 @@
           <http://model.geneontology.org/CHEBI_57483_1TRANSKETO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002234_CHEBI_16897_TRANSALDOL-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002413_1TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57737_2TRANSKETO-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57737> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1117,7 +1040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1125,14 +1048,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000066_reaction_RIBULP3EPIM-RXN_location_lociGO_0005829_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
+                "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1143,11 +1066,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002233_CHEBI_16897_TRANSALDOL-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002233_CHEBI_16897_TRANSALDOL-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1167,7 +1090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1181,14 +1104,14 @@
 <http://identifiers.org/sgd/S000005621>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002233_CHEBI_58121_RIBULP3EPIM-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002413_2TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
+                "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1201,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1213,11 +1136,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002234_CHEBI_16897_TRANSALDOL-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002234_CHEBI_16897_TRANSALDOL-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1237,7 +1160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1249,11 +1172,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1267,17 +1190,39 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_YeastPathways_NONOXIPENT-PWY>
+<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002234_CHEBI_57737_RIBULP3EPIM-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002333_YLR354C-MONOMER_TRANSALDOL-RXN_controller_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002233_CHEBI_57737_RIBULP3EPIM-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1285,11 +1230,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002333_YJL121C-MONOMER_RIBULP3EPIM-RXN_controller_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002333_YJL121C-MONOMER_RIBULP3EPIM-RXN_controller_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1304,11 +1249,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1322,14 +1267,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_57737>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002233_CHEBI_57737_RIBULP3EPIM-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YBR117C-MONOMER_1TRANSKETO-RXN_controller_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
+                "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1337,11 +1282,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002233_CHEBI_78346_RIB5PISOM-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002233_CHEBI_78346_RIB5PISOM-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1352,24 +1297,38 @@
           <http://model.geneontology.org/CHEBI_78346_RIB5PISOM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002413_1TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/GO_0009052>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YBR117C-MONOMER_1TRANSKETO-RXN_controller_SGD_YeastPathways_NONOXIPENT-PWY>
+<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002234_CHEBI_57634_TRANSALDOL-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
+                "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YLR354C-MONOMER_TRANSALDOL-RXN_controller>
@@ -1379,7 +1338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1387,18 +1346,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002234_CHEBI_59776_1TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_BFO_0000066_reaction_2TRANSKETO-RXN_location_lociGO_0005829_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_BFO_0000066_reaction_2TRANSKETO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1408,6 +1375,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_2TRANSKETO-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_BFO_0000066_reaction_RIB5PISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/2TRANSKETO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004802> ;
@@ -1426,7 +1404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1441,11 +1419,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_59776_1TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_59776_1TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1460,11 +1438,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-ribose 5-phosphate &harr; D-ribulose 5-phosphate' 'null' 'D-sedoheptulose 7-phosphate + D-glyceraldehyde 3-phosphate &harr; D-ribose 5-phosphate + D-xylulose 5-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002413_1TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002413_1TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1475,15 +1453,26 @@
           <http://model.geneontology.org/1TRANSKETO-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_59776_1TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" , "Provides Input For Rule. The relation 'D-sedoheptulose 7-phosphate + D-glyceraldehyde 3-phosphate &harr; D-ribose 5-phosphate + D-xylulose 5-phosphate' 'null' 'D-sedoheptulose 7-phosphate + D-glyceraldehyde 3-phosphate &harr; &beta;-D-fructofuranose 6-phosphate + D-erythrose 4-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002413_TRANSALDOL-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002413_TRANSALDOL-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1494,14 +1483,14 @@
           <http://model.geneontology.org/TRANSALDOL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002234_CHEBI_57634_2TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002333_YOR095C-MONOMER_RIB5PISOM-RXN_controller_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
+                "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1517,13 +1506,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pentose phosphate pathway (non-oxidative branch) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002233_CHEBI_58121_RIBULP3EPIM-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YPR074C-MONOMER_1TRANSKETO-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006278> ;
@@ -1532,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1540,18 +1540,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002234_CHEBI_57737_RIBULP3EPIM-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002234_CHEBI_57737_RIBULP3EPIM-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1562,6 +1559,17 @@
           <http://model.geneontology.org/CHEBI_57737_RIBULP3EPIM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_BFO_0000066_reaction_2TRANSKETO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_78346_RIB5PISOM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_78346> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1571,7 +1579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1579,14 +1587,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002333_YOR095C-MONOMER_RIB5PISOM-RXN_controller_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002233_CHEBI_16897_TRANSALDOL-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
+                "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1594,11 +1605,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002233_CHEBI_57737_RIBULP3EPIM-RXN_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002233_CHEBI_57737_RIBULP3EPIM-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1609,6 +1620,17 @@
           <http://model.geneontology.org/CHEBI_57737_RIBULP3EPIM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002413_1TRANSKETO-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57737_RIBULP3EPIM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57737> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1618,7 +1640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1626,25 +1648,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000050_YeastPathways_NONOXIPENT-PWY/YeastPathways_NONOXIPENT-PWY_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002333_YLR354C-MONOMER_TRANSALDOL-RXN_controller_SGD_YeastPathways_NONOXIPENT-PWY>
+<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000066_reaction_RIBULP3EPIM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
+                "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1652,11 +1663,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002333_YPR074C-MONOMER_2TRANSKETO-RXN_controller_SGD_YeastPathways_NONOXIPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002333_YPR074C-MONOMER_2TRANSKETO-RXN_controller_SGD_PWY_YeastPathways_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1666,14 +1677,3 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YPR074C-MONOMER_2TRANSKETO-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002234_CHEBI_59776_1TRANSKETO-RXN_SGD_YeastPathways_NONOXIPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_OXIDATIVEPENT-PWY.ttl
+++ b/models/YeastPathways_OXIDATIVEPENT-PWY.ttl
@@ -4,26 +4,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_BFO_0000066_reaction_6PGLUCONOLACT-RXN_location_lociGO_0005829_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_57783_RXN-9952_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_57783_RXN-9952_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -34,15 +23,26 @@
           <http://model.geneontology.org/CHEBI_57783_RXN-9952>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002233_CHEBI_4170_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_15378_GLU6PDEHYDROG-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_15378_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,17 +56,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002234_CHEBI_58759_6PGLUCONOLACT-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -79,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -87,14 +76,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_16526_RXN-9952_SGD_YeastPathways_OXIDATIVEPENT-PWY>
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_57783_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002234_CHEBI_58759_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,15 +115,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9952_BFO_0000066_reaction_RXN-9952_location_lociGO_0005829_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002234_CHEBI_58759_6PGLUCONOLACT-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002234_CHEBI_58759_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -134,6 +145,17 @@
           <http://model.geneontology.org/CHEBI_58759_6PGLUCONOLACT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_BFO_0000050_YeastPathways_OXIDATIVEPENT-PWY/YeastPathways_OXIDATIVEPENT-PWY_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57955>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -142,18 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002234_CHEBI_15378_6PGLUCONOLACT-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -163,41 +174,19 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002233_CHEBI_58349_RXN-9952_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_16526_RXN-9952_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_BFO_0000050_YeastPathways_OXIDATIVEPENT-PWY/YeastPathways_OXIDATIVEPENT-PWY_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_15378_GLU6PDEHYDROG-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_4170_GLU6PDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_4170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -208,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -220,11 +209,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_16526_RXN-9952_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_16526_RXN-9952_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,11 +228,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002233_CHEBI_58349_GLU6PDEHYDROG-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002233_CHEBI_58349_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -253,6 +242,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58349_GLU6PDEHYDROG-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002233_CHEBI_58349_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9952>
         a       <http://purl.obolibrary.org/obo/GO_0004616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -269,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -286,14 +286,14 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002233_CHEBI_58349_GLU6PDEHYDROG-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002413_RXN-9952_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -321,24 +321,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=OXIDATIVEPENT-PWYSmallMolecule35918> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002233_CHEBI_57955_GLU6PDEHYDROG-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001206>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -350,11 +339,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002234_CHEBI_15378_6PGLUCONOLACT-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002234_CHEBI_15378_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -364,17 +353,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_6PGLUCONOLACT-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002333_MONOMER3O-4032_6PGLUCONOLACT-RXN_controller_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/6PGLUCONOLACT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0017057> ;
@@ -395,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -403,14 +381,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002333_MONOMER3O-4047_6PGLUCONOLACT-RXN_controller_SGD_YeastPathways_OXIDATIVEPENT-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002233_CHEBI_58349_RXN-9952_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_57783_RXN-9952_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -421,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -429,26 +418,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002233_CHEBI_15377_6PGLUCONOLACT-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002233_CHEBI_15377_6PGLUCONOLACT-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002233_CHEBI_15377_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -459,18 +440,26 @@
           <http://model.geneontology.org/CHEBI_15377_6PGLUCONOLACT-RXN>
 ] .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002233_CHEBI_15377_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-glucopyranose 6-phosphate + NADP<sup>+</sup> &rarr; 6-phospho D-glucono-1,5-lactone + NADPH + H<SUP>+</SUP>' 'null' '6-phospho D-glucono-1,5-lactone + H<sub>2</sub>O &rarr; D-gluconate 6-phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002413_6PGLUCONOLACT-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002413_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -487,29 +476,29 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_58759>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-9952_BFO_0000066_reaction_RXN-9952_location_lociGO_0005829_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002233_CHEBI_58759_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58759>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002233_CHEBI_58759_6PGLUCONOLACT-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002233_CHEBI_58759_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -524,11 +513,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002233_CHEBI_4170_GLU6PDEHYDROG-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002233_CHEBI_4170_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -538,17 +527,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_4170_GLU6PDEHYDROG-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_BFO_0000066_reaction_GLU6PDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -566,11 +544,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002233_CHEBI_57955_GLU6PDEHYDROG-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002233_CHEBI_57955_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -590,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -601,17 +579,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_BFO_0000050_YeastPathways_OXIDATIVEPENT-PWY/YeastPathways_OXIDATIVEPENT-PWY_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -619,11 +586,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_BFO_0000066_reaction_6PGLUCONOLACT-RXN_location_lociGO_0005829_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_BFO_0000066_reaction_6PGLUCONOLACT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -638,11 +605,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002333_YNL241C-MONOMER_GLU6PDEHYDROG-RXN_controller_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002333_YNL241C-MONOMER_GLU6PDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -653,14 +620,14 @@
           <http://model.geneontology.org/YNL241C-MONOMER_GLU6PDEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_57955_GLU6PDEHYDROG-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002413_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -683,7 +650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -691,15 +658,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_15378_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002233_CHEBI_58349_RXN-9952_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002233_CHEBI_58349_RXN-9952_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -714,11 +692,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_BFO_0000066_reaction_GLU6PDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_BFO_0000066_reaction_GLU6PDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -729,15 +707,26 @@
           <http://model.geneontology.org/reaction_GLU6PDEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_58121_RXN-9952_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" , "Provides Input For Rule. The relation '6-phospho D-glucono-1,5-lactone + H<sub>2</sub>O &rarr; D-gluconate 6-phosphate + H<SUP>+</SUP>' 'null' 'D-gluconate 6-phosphate + NADP<sup>+</sup> &rarr; D-ribulose 5-phosphate + CO<SUB>2</SUB> + NADPH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002413_RXN-9952_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002413_RXN-9952_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,29 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002413_6PGLUCONOLACT-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_58121_RXN-9952_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -791,7 +758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pentose phosphate pathway (oxidative branch) I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -808,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -823,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -834,29 +801,40 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002333_YNL241C-MONOMER_GLU6PDEHYDROG-RXN_controller_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002333_YNL241C-MONOMER_GLU6PDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_BFO_0000050_YeastPathways_OXIDATIVEPENT-PWY/YeastPathways_OXIDATIVEPENT-PWY_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_BFO_0000050_YeastPathways_OXIDATIVEPENT-PWY/YeastPathways_OXIDATIVEPENT-PWY_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_BFO_0000050_YeastPathways_OXIDATIVEPENT-PWY/YeastPathways_OXIDATIVEPENT-PWY_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -867,26 +845,15 @@
           <http://model.geneontology.org/YeastPathways_OXIDATIVEPENT-PWY/YeastPathways_OXIDATIVEPENT-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9952_BFO_0000050_YeastPathways_OXIDATIVEPENT-PWY/YeastPathways_OXIDATIVEPENT-PWY_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_57955_GLU6PDEHYDROG-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_57955_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -912,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -929,7 +896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -941,11 +908,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9952_BFO_0000066_reaction_RXN-9952_location_lociGO_0005829_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9952_BFO_0000066_reaction_RXN-9952_location_lociGO_0005829_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -965,7 +932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -978,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -986,11 +953,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_BFO_0000050_YeastPathways_OXIDATIVEPENT-PWY/YeastPathways_OXIDATIVEPENT-PWY_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_BFO_0000050_YeastPathways_OXIDATIVEPENT-PWY/YeastPathways_OXIDATIVEPENT-PWY_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1005,11 +972,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002333_MONOMER3O-4047_6PGLUCONOLACT-RXN_controller_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002333_MONOMER3O-4047_6PGLUCONOLACT-RXN_controller_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1020,47 +987,58 @@
           <http://model.geneontology.org/MONOMER3O-4047_6PGLUCONOLACT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002233_CHEBI_4170_GLU6PDEHYDROG-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-9952_BFO_0000050_YeastPathways_OXIDATIVEPENT-PWY/YeastPathways_OXIDATIVEPENT-PWY_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002233_CHEBI_58759_6PGLUCONOLACT-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_57783_RXN-9952_SGD_YeastPathways_OXIDATIVEPENT-PWY>
+<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002233_CHEBI_57955_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_57955_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002333_MONOMER3O-4047_6PGLUCONOLACT-RXN_controller_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57955_GLU6PDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57955> ;
@@ -1071,7 +1049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1088,7 +1066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1103,11 +1081,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_58121_RXN-9952_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_58121_RXN-9952_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1122,11 +1100,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_57783_GLU6PDEHYDROG-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_57783_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1146,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1157,15 +1135,37 @@
 <http://purl.obolibrary.org/obo/GO_0004345>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_BFO_0000066_reaction_6PGLUCONOLACT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002234_CHEBI_15378_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9952_BFO_0000050_YeastPathways_OXIDATIVEPENT-PWY/YeastPathways_OXIDATIVEPENT-PWY_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9952_BFO_0000050_YeastPathways_OXIDATIVEPENT-PWY/YeastPathways_OXIDATIVEPENT-PWY_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1179,14 +1179,14 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002413_RXN-9952_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_BFO_0000066_reaction_GLU6PDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1194,11 +1194,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002333_MONOMER3O-4032_6PGLUCONOLACT-RXN_controller_SGD_YeastPathways_OXIDATIVEPENT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002333_MONOMER3O-4032_6PGLUCONOLACT-RXN_controller_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1212,6 +1212,17 @@
 <http://purl.obolibrary.org/obo/GO_0017057>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002333_MONOMER3O-4032_6PGLUCONOLACT-RXN_controller_SGD_PWY_YeastPathways_OXIDATIVEPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:OXIDATIVEPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57783_RXN-9952>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1221,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1231,14 +1242,3 @@
 
 <http://purl.obolibrary.org/obo/GO_0009051>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_57783_GLU6PDEHYDROG-RXN_SGD_YeastPathways_OXIDATIVEPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_P4-PWY-1.ttl
+++ b/models/YeastPathways_P4-PWY-1.ttl
@@ -1,12 +1,23 @@
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002333_YHR025W-MONOMER_HOMOSERKIN-RXN_controller_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002333_YHR025W-MONOMER_HOMOSERKIN-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,23 +60,45 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_YeastPathways_P4-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -73,11 +106,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -93,26 +126,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/63a337d0-8117-4a7d-a1dc-2e82f5cf09ef_RXN3O-22>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule24122> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29991>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -121,11 +137,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -135,17 +151,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -157,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -169,11 +174,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -184,18 +189,57 @@
           <http://model.geneontology.org/YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_537519>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/74e09ff5-88fe-4096-a3c2-b9ae3bad37be_RXN3O-22>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule24122> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-homoserine + NAD(P)<sup>+</sup> &larr; L-aspartate 4-semialdehyde + NAD(P)H + H<SUP>+</SUP>' 'null' 'L-homoserine + acetyl-CoA &rarr; <i>O</i>-acetyl-L-homoserine + coenzyme A' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -212,26 +256,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_16136>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -242,25 +275,25 @@
           <http://model.geneontology.org/CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -268,11 +301,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -290,11 +323,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000066_reaction_HOMOSERKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000066_reaction_HOMOSERKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -308,15 +341,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000066_reaction_HOMOSERKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -336,9 +380,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/842c1e43-6742-46df-b7cb-c3598a5e37b0_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/1b4034f8-6df3-446f-bda0-2f80e2c17c1e_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/63a337d0-8117-4a7d-a1dc-2e82f5cf09ef_RXN3O-22> , <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/74e09ff5-88fe-4096-a3c2-b9ae3bad37be_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -346,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -354,39 +398,50 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_YeastPathways_P4-PWY-1>
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_57590_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -394,11 +449,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_842c1e43-6742-46df-b7cb-c3598a5e37b0_RXN3O-22_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_1b4034f8-6df3-446f-bda0-2f80e2c17c1e_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,29 +461,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/842c1e43-6742-46df-b7cb-c3598a5e37b0_RXN3O-22>
+          <http://model.geneontology.org/1b4034f8-6df3-446f-bda0-2f80e2c17c1e_RXN3O-22>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -455,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -467,11 +511,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -482,17 +526,6 @@
           <http://model.geneontology.org/YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -502,7 +535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -510,61 +543,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_P4-PWY-1>
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000066_reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_P4-PWY-1>
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002413_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -577,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -597,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -612,11 +623,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -636,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -650,15 +661,26 @@
 <http://identifiers.org/sgd/S000004294>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_15378_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -673,11 +695,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -688,40 +710,37 @@
           <http://model.geneontology.org/reaction_ASPARTATEKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1>
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0004795>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-homoserine + ATP &rarr; O-phospho-L-homoserine + ADP + H<SUP>+</SUP>' 'null' 'O-phospho-L-homoserine + H<sub>2</sub>O &rarr; L-threonine + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -732,12 +751,26 @@
           <http://model.geneontology.org/THRESYN-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0004795>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_ASPARTATEKIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -750,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -762,11 +795,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -786,7 +819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -794,15 +827,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -812,6 +856,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16452_ASPAMINOTRANS-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ASPARTATEKIN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004072> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -832,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -843,15 +898,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000066_reaction_THRESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000066_reaction_THRESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -873,30 +939,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002413_ASPARTATEKIN-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002333_YHR025W-MONOMER_HOMOSERKIN-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57590>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" , "Provides Input For Rule. The relation 'L-homoserine + NAD(P)<sup>+</sup> &larr; L-aspartate 4-semialdehyde + NAD(P)H + H<SUP>+</SUP>' 'null' 'L-homoserine + ATP &rarr; O-phospho-L-homoserine + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERKIN-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -907,20 +976,6 @@
           <http://model.geneontology.org/HOMOSERKIN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57590>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_842c1e43-6742-46df-b7cb-c3598a5e37b0_RXN3O-22_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16452_ASPAMINOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16452> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -930,7 +985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -942,11 +997,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -957,17 +1012,6 @@
           <http://model.geneontology.org/CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002333_YHR025W-MONOMER_HOMOSERKIN-RXN_controller_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YER091C-MONOMER_HOMOCYSMET-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000893> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -975,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -990,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1007,7 +1051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1025,11 +1069,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000066_reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000066_reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1043,15 +1087,48 @@
 <http://identifiers.org/sgd/S000004017>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_30616_HOMOSERKIN-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_30616_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,26 +1142,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_15378_HOMOSERKIN-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" , "Provides Input For Rule. The relation 'L-aspartate + ATP &rarr; L-aspartyl-4-phosphate + ADP' 'null' 'L-aspartate 4-semialdehyde + NADP<sup>+</sup> + phosphate &larr; L-aspartyl-4-phosphate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1104,7 +1170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1121,24 +1187,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule23872> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1147,11 +1202,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1165,14 +1220,14 @@
 <http://purl.obolibrary.org/obo/GO_0004072>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_57926_THRESYN-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1180,11 +1235,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1198,45 +1253,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_57288>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_456216_HOMOSERKIN-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1244,11 +1266,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" , "Provides Input For Rule. The relation '2-oxoglutarate + L-aspartate &harr; oxaloacetate + L-glutamate' 'null' 'L-aspartate + ATP &rarr; L-aspartyl-4-phosphate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002413_ASPARTATEKIN-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002413_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1263,11 +1285,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1278,15 +1300,26 @@
           <http://model.geneontology.org/CHEBI_456216_RXN3O-22>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1297,48 +1330,15 @@
           <http://model.geneontology.org/CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1349,17 +1349,6 @@
           <http://model.geneontology.org/YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1369,7 +1358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1377,14 +1366,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_57590_HOMOSERKIN-RXN_SGD_YeastPathways_P4-PWY-1>
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1392,11 +1392,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1406,23 +1406,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller>
 ] .
-
-<http://model.geneontology.org/842c1e43-6742-46df-b7cb-c3598a5e37b0_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule24122> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/HOMOCYSMET-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003871> ;
@@ -1443,7 +1426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1451,15 +1434,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002333_YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002333_YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1489,7 +1483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1501,11 +1495,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1526,13 +1520,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1Protein24114> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_HOMOSERKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -1543,7 +1548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1551,14 +1556,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_YeastPathways_P4-PWY-1>
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1571,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1594,7 +1599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1606,11 +1611,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1626,18 +1631,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_63a337d0-8117-4a7d-a1dc-2e82f5cf09ef_RXN3O-22_SGD_YeastPathways_P4-PWY-1>
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1645,11 +1661,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1669,24 +1685,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule23872> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58199>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1695,11 +1700,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1717,11 +1722,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_15377_THRESYN-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_15377_THRESYN-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1732,15 +1737,37 @@
           <http://model.geneontology.org/CHEBI_15377_THRESYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002411_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1754,25 +1781,14 @@
 <http://identifiers.org/sgd/S000005767>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000066_reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1780,11 +1796,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1798,6 +1814,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_57476>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004326>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1806,6 +1833,17 @@
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002411_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/HOMOSERKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004413> ;
@@ -1826,7 +1864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1838,11 +1876,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1853,17 +1891,6 @@
           <http://model.geneontology.org/CHEBI_16136_ACETYLHOMOSER-CYS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58207_HOMOCYSMET-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58207> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1873,7 +1900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1881,26 +1908,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1920,7 +1936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1940,35 +1956,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule23944> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_P4-PWY-1>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -1979,7 +1973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of threonine and methionine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1987,26 +1981,15 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_15378_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2029,13 +2012,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_P4-PWY-1" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004073>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2049,13 +2043,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule24046> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_ACETYLHOMOSER-CYS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -2066,7 +2082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2078,11 +2094,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_63a337d0-8117-4a7d-a1dc-2e82f5cf09ef_RXN3O-22_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_74e09ff5-88fe-4096-a3c2-b9ae3bad37be_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2090,40 +2106,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/63a337d0-8117-4a7d-a1dc-2e82f5cf09ef_RXN3O-22>
+          <http://model.geneontology.org/74e09ff5-88fe-4096-a3c2-b9ae3bad37be_RXN3O-22>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002411_HOMOSERKIN-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2134,26 +2128,15 @@
           <http://model.geneontology.org/CHEBI_13390_HOMOSERDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2164,6 +2147,17 @@
           <http://model.geneontology.org/reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57844_HOMOCYSMET-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57844> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2173,7 +2167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2181,14 +2175,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000066_reaction_HOMOSERKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_30089_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2196,11 +2201,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002411_HOMOSERKIN-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002411_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2215,11 +2220,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002411_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002411_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2229,28 +2234,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACETYLHOMOSER-CYS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003961> ;
@@ -2273,7 +2256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2281,25 +2264,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_15377_THRESYN-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000066_reaction_THRESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2307,11 +2279,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2331,7 +2303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2339,54 +2311,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002413_HOMOCYSMET-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2397,26 +2347,15 @@
           <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002411_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002411_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2431,11 +2370,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2446,14 +2385,14 @@
           <http://model.geneontology.org/CHEBI_16810_ASPAMINOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2461,11 +2400,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_57590_HOMOSERKIN-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_57590_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2476,15 +2415,26 @@
           <http://model.geneontology.org/CHEBI_57590_HOMOSERKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000066_reaction_THRESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2495,15 +2445,26 @@
           <http://model.geneontology.org/reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2513,6 +2474,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004412>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2526,7 +2509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2538,11 +2521,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2553,15 +2536,26 @@
           <http://model.geneontology.org/CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_15378_HOMOSERKIN-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_15378_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2572,14 +2566,25 @@
           <http://model.geneontology.org/CHEBI_15378_HOMOSERKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_57590_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_74e09ff5-88fe-4096-a3c2-b9ae3bad37be_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2595,7 +2600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2603,18 +2608,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_43474_THRESYN-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_13390>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002333_YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2625,25 +2652,14 @@
           <http://model.geneontology.org/reaction_HOMOCYSMET-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002333_YCR053W-MONOMER_THRESYN-RXN_controller_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002413_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2651,11 +2667,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_456216_HOMOSERKIN-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_456216_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2673,7 +2689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2681,18 +2697,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2715,7 +2753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2727,11 +2765,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>O</i>-acetyl-L-homoserine + hydrogen sulfide &rarr; L-homocysteine + acetate + H<SUP>+</SUP>' 'null' 'L-homocysteine + 5-methyltetrahydropteroyl tri-L-glutamate &harr; L-methionine + tetrahydropteroyl tri-L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002413_HOMOCYSMET-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002413_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2745,15 +2783,37 @@
 <http://identifiers.org/sgd/S000003900>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_57926_THRESYN-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2764,19 +2824,19 @@
           <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -2785,11 +2845,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2809,7 +2869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2823,15 +2883,26 @@
 <http://identifiers.org/sgd/S000000854>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2842,25 +2913,25 @@
           <http://model.geneontology.org/CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1>
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERKIN-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2873,7 +2944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2884,14 +2955,25 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_P4-PWY-1>
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_1b4034f8-6df3-446f-bda0-2f80e2c17c1e_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2899,11 +2981,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" , "Provides Input For Rule. The relation 'L-homoserine + acetyl-CoA &rarr; <i>O</i>-acetyl-L-homoserine + coenzyme A' 'null' '<i>O</i>-acetyl-L-homoserine + hydrogen sulfide &rarr; L-homocysteine + acetate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2914,25 +2996,14 @@
           <http://model.geneontology.org/ACETYLHOMOSER-CYS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_30089_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_P4-PWY-1>
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2955,7 +3026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2967,11 +3038,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2982,28 +3053,6 @@
           <http://model.geneontology.org/CHEBI_456216_ASPARTATEKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001589> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3011,7 +3060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3028,7 +3077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3040,11 +3089,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3059,11 +3108,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3074,36 +3123,36 @@
           <http://model.geneontology.org/YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002333_YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller_SGD_YeastPathways_P4-PWY-1>
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_30616_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3111,11 +3160,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3126,15 +3175,26 @@
           <http://model.geneontology.org/CHEBI_29991_ASPAMINOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_43474_THRESYN-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_43474_THRESYN-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3144,17 +3204,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_43474_THRESYN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_30616_HOMOSERKIN-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/THRESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004795> ;
@@ -3173,7 +3222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3185,11 +3234,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3200,14 +3249,14 @@
           <http://model.geneontology.org/CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3232,7 +3281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3247,11 +3296,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3262,29 +3311,57 @@
           <http://model.geneontology.org/YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller>
 ] .
 
-<http://identifiers.org/sgd/S000005221>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0004413>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_YeastPathways_P4-PWY-1>
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002411_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000005221>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002333_YCR053W-MONOMER_THRESYN-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004413>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/1b4034f8-6df3-446f-bda0-2f80e2c17c1e_RXN3O-22>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule24122> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3295,11 +3372,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_15378_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_15378_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3310,26 +3387,37 @@
           <http://model.geneontology.org/CHEBI_15378_ACETYLHOMOSER-CYS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3342,7 +3430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3357,11 +3445,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_57590_HOMOSERKIN-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_57590_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3372,15 +3460,26 @@
           <http://model.geneontology.org/CHEBI_57590_HOMOSERKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_15378_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3398,13 +3497,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1Protein23880> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3416,7 +3526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3428,11 +3538,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3462,7 +3572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3479,7 +3589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3491,11 +3601,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3513,11 +3623,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3533,7 +3643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3541,11 +3651,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3556,60 +3666,38 @@
           <http://model.geneontology.org/CHEBI_57535_ASPARTATEKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_THRESYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003871>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_456216_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3620,17 +3708,6 @@
           <http://model.geneontology.org/YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58140_HOMOCYSMET-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58140> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3640,24 +3717,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule24182> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30089>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3671,24 +3737,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule24070> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller>
         a       <http://identifiers.org/sgd/S000004294> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3697,7 +3752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3709,11 +3764,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3727,8 +3782,30 @@
 <http://purl.obolibrary.org/obo/GO_0004069>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_15377_THRESYN-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58199_ACETYLHOMOSER-CYS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58199> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3739,7 +3816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3747,26 +3824,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_43474_THRESYN-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3777,17 +3843,6 @@
           <http://model.geneontology.org/CHEBI_30616_RXN3O-22>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57716> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3797,7 +3852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3805,40 +3860,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3849,15 +3882,48 @@
           <http://model.geneontology.org/reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3868,48 +3934,15 @@
           <http://model.geneontology.org/YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002411_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_57926_THRESYN-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_57926_THRESYN-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3924,11 +3957,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3939,37 +3972,15 @@
           <http://model.geneontology.org/CHEBI_57476_HOMOSERDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_57590_HOMOSERKIN-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" , "Provides Input For Rule. The relation 'L-aspartate 4-semialdehyde + NADP<sup>+</sup> + phosphate &larr; L-aspartyl-4-phosphate + NADPH + H<SUP>+</SUP>' 'null' 'L-homoserine + NAD(P)<sup>+</sup> &larr; L-aspartate 4-semialdehyde + NAD(P)H + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3980,26 +3991,15 @@
           <http://model.geneontology.org/HOMOSERDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002333_YCR053W-MONOMER_THRESYN-RXN_controller_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002333_YCR053W-MONOMER_THRESYN-RXN_controller_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4009,17 +4009,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YCR053W-MONOMER_THRESYN-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002411_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004414>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4033,7 +4022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4048,11 +4037,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4072,7 +4061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4087,11 +4076,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_30089_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_30089_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4102,26 +4091,15 @@
           <http://model.geneontology.org/CHEBI_30089_ACETYLHOMOSER-CYS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4132,5 +4110,27 @@
           <http://model.geneontology.org/YeastPathways_P4-PWY-1/YeastPathways_P4-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_13392>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PANTOSYN2-PWY.ttl
+++ b/models/YeastPathways_PANTOSYN2-PWY.ttl
@@ -1,12 +1,23 @@
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_BFO_0000066_reaction_P-PANTOCYSLIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002233_CHEBI_15378_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002233_CHEBI_15378_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -29,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,11 +52,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002233_CHEBI_30616_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002233_CHEBI_30616_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,25 +67,14 @@
           <http://model.geneontology.org/CHEBI_30616_PANTOATE-BETA-ALANINE-LIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002234_CHEBI_15378_P-PANTOCYSLIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002234_CHEBI_61723_P-PANTOCYSDECARB-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -87,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,15 +95,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002234_CHEBI_57328_PANTEPADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002233_CHEBI_59458_P-PANTOCYSLIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002233_CHEBI_59458_P-PANTOCYSLIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -114,51 +125,18 @@
           <http://model.geneontology.org/CHEBI_59458_P-PANTOCYSLIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_CHEBI_11851_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_BFO_0000066_reaction_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002333_YMR169C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_dfcd410f-01c1-4364-a46d-aff05128186f_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_ec74ad10-5a6b-432f-be3a-0cda61bbd086_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -166,20 +144,31 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/dfcd410f-01c1-4364-a46d-aff05128186f_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
+          <http://model.geneontology.org/ec74ad10-5a6b-432f-be3a-0cda61bbd086_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004595>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_PANTEPADENYLYLTRAN-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004595>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -187,11 +176,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002234_CHEBI_10986_PANTOTHENATE-KIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002234_CHEBI_10986_PANTOTHENATE-KIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -202,57 +191,27 @@
           <http://model.geneontology.org/CHEBI_10986_PANTOTHENATE-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15980>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002333_MONOMER3O-90_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_29032>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9015_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_10986>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002234_CHEBI_15378_P-PANTOCYSLIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002234_CHEBI_15378_P-PANTOCYSLIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,26 +222,34 @@
           <http://model.geneontology.org/CHEBI_15378_P-PANTOCYSLIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_15379_RXN-9015_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002233_CHEBI_59458_P-PANTOCYSLIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_10986>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002234_CHEBI_57287_DEPHOSPHOCOAKIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -293,11 +260,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" , "Provides Input For Rule. The relation '3-aminopropanal + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; &beta;-alanine + NADH' 'null' '&beta;-alanine + (R)-pantoate + ATP &rarr; (<i>R</i>)-pantothenate + AMP + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002413_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002413_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,11 +279,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -336,9 +303,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/e34f0da1-9a97-4913-a9dc-461d788a0864_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/CHEBI_11851_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/CHEBI_15377_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
+                <http://model.geneontology.org/5e6cc8cd-69ce-48ff-b1b9-ff6d4b56bfd6_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/CHEBI_11851_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/CHEBI_15377_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/dfcd410f-01c1-4364-a46d-aff05128186f_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/CHEBI_11561_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
+                <http://model.geneontology.org/ec74ad10-5a6b-432f-be3a-0cda61bbd086_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/CHEBI_11561_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-90_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -346,7 +313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -364,11 +331,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_57834_RXN-9015_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_57834_RXN-9015_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -379,40 +346,29 @@
           <http://model.geneontology.org/CHEBI_57834_RXN-9015>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002413_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002413_P-PANTOCYSLIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002234_CHEBI_57328_PANTEPADENYLYLTRAN-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002234_CHEBI_57328_PANTEPADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -433,7 +389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -441,28 +397,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002413_P-PANTOCYSDECARB-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://purl.obolibrary.org/obo/CHEBI_59458>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002413_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_59458>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002233_CHEBI_15378_P-PANTOCYSDECARB-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002333_MONOMER3O-487_PANTEPADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -470,11 +426,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,37 +441,15 @@
           <http://model.geneontology.org/YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002233_CHEBI_30616_DEPHOSPHOCOAKIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_18090_RXN-9015_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002333_YIL145C-MONOMER_PANTOATE-BETA-ALANINE-LIG-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002333_YIL145C-MONOMER_PANTOATE-BETA-ALANINE-LIG-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -526,17 +460,6 @@
           <http://model.geneontology.org/YIL145C-MONOMER_PANTOATE-BETA-ALANINE-LIG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_BFO_0000066_reaction_DEPHOSPHOCOAKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/MONOMER3O-317_P-PANTOCYSDECARB-RXN_controller>
         a       <http://identifiers.org/sgd/S000005580> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -544,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -552,10 +475,10 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57945>
+<http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_57287>
+<http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YMR170C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller>
@@ -565,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -573,25 +496,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_PANTEPADENYLYLTRAN-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_CHEBI_11561_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -599,11 +511,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(R)-4'-phosphopantothenoyl-L-cysteine + H<SUP>+</SUP> &rarr; 4'-phosphopantetheine + CO<SUB>2</SUB>' 'null' '4'-phosphopantetheine + ATP + H<SUP>+</SUP> &rarr; 3'-dephospho-CoA + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002413_PANTEPADENYLYLTRAN-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002413_PANTEPADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -614,28 +526,6 @@
           <http://model.geneontology.org/PANTEPADENYLYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_18090_RXN-9015_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002333_YMR170C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/MONOMER3O-268_PANTOTHENATE-KIN-RXN_controller>
         a       <http://identifiers.org/sgd/S000002939> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -643,24 +533,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYProtein25197> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_BFO_0000066_reaction_PANTOATE-BETA-ALANINE-LIG-RXN_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/2-DEHYDROPANTOATE-REDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008677> ;
@@ -681,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -698,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -712,26 +591,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002233_CHEBI_35235_P-PANTOCYSLIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -745,14 +613,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_45725>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002233_CHEBI_57328_PANTEPADENYLYLTRAN-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_PANTEPADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -760,11 +628,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_15377_RXN-9015_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_15377_RXN-9015_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -775,14 +643,14 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-9015>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_BFO_0000066_reaction_PANTEPADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002333_MONOMER3O-299_P-PANTOCYSDECARB-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -793,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -805,11 +673,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002234_CHEBI_57287_DEPHOSPHOCOAKIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002234_CHEBI_57287_DEPHOSPHOCOAKIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -820,26 +688,15 @@
           <http://model.geneontology.org/CHEBI_57287_DEPHOSPHOCOAKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002413_PANTOTHENATE-KIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_BFO_0000066_reaction_PANTEPADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_BFO_0000066_reaction_PANTEPADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -853,6 +710,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002413_DEPHOSPHOCOAKIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER3O-90_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_controller>
         a       <http://identifiers.org/sgd/S000000380> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -860,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -871,25 +739,36 @@
 <http://purl.obolibrary.org/obo/GO_0008677>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002233_CHEBI_10986_PANTOTHENATE-KIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002413_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002413_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002234_CHEBI_29888_P-PANTOCYSLIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -900,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -917,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -935,11 +814,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002233_CHEBI_57783_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002233_CHEBI_57783_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -950,14 +829,14 @@
           <http://model.geneontology.org/CHEBI_57783_2-DEHYDROPANTOATE-REDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_BFO_0000066_reaction_3-PROPANAL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002233_CHEBI_61723_P-PANTOCYSDECARB-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -965,11 +844,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002233_CHEBI_57966_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002233_CHEBI_57966_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -980,26 +859,15 @@
           <http://model.geneontology.org/CHEBI_57966_3-PROPANAL-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002233_CHEBI_61723_P-PANTOCYSDECARB-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002234_CHEBI_16526_P-PANTOCYSDECARB-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002234_CHEBI_16526_P-PANTOCYSDECARB-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1010,28 +878,45 @@
           <http://model.geneontology.org/CHEBI_16526_P-PANTOCYSDECARB-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15377>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/5e6cc8cd-69ce-48ff-b1b9-ff6d4b56bfd6_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule24983> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002234_CHEBI_57328_PANTEPADENYLYLTRAN-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57966_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002234_CHEBI_16526_P-PANTOCYSDECARB-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_CHEBI_15377_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1039,11 +924,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002333_MONOMER3O-90_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002333_MONOMER3O-90_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1069,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1084,7 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1096,11 +981,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002234_CHEBI_15378_PANTOTHENATE-KIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002234_CHEBI_15378_PANTOTHENATE-KIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1110,17 +995,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_PANTOTHENATE-KIN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/P-PANTOCYSLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004632> ;
@@ -1141,7 +1015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1153,11 +1027,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002234_CHEBI_29888_P-PANTOCYSLIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002234_CHEBI_29888_P-PANTOCYSLIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1168,9 +1042,6 @@
           <http://model.geneontology.org/CHEBI_29888_P-PANTOCYSLIG-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 <http://model.geneontology.org/MONOMER3O-504_DEPHOSPHOCOAKIN-RXN_controller>
         a       <http://identifiers.org/sgd/S000002604> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1178,7 +1049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1186,16 +1057,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_16240_RXN-9015_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1205,18 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1224,11 +1076,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_BFO_0000066_reaction_DEPHOSPHOCOAKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_BFO_0000066_reaction_DEPHOSPHOCOAKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,11 +1098,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002333_YMR020W-MONOMER_RXN-9015_controller_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002333_YMR020W-MONOMER_RXN-9015_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1261,52 +1113,18 @@
           <http://model.geneontology.org/YMR020W-MONOMER_RXN-9015_controller>
 ] .
 
-<http://model.geneontology.org/dfcd410f-01c1-4364-a46d-aff05128186f_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule25018> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_15378_P-PANTOCYSLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule25069> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002333_MONOMER3O-487_PANTEPADENYLYLTRAN-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002333_MONOMER3O-487_PANTEPADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1317,62 +1135,71 @@
           <http://model.geneontology.org/MONOMER3O-487_PANTEPADENYLYLTRAN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_BFO_0000066_reaction_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_15378_P-PANTOCYSLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule25069> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002234_CHEBI_58349_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004633>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002333_MONOMER3O-474_P-PANTOCYSDECARB-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002234_CHEBI_59458_P-PANTOCYSLIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002234_CHEBI_58349_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002234_CHEBI_29032_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002234_CHEBI_15378_DEPHOSPHOCOAKIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_BFO_0000066_reaction_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_BFO_0000066_reaction_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1383,29 +1210,32 @@
           <http://model.geneontology.org/reaction_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ec74ad10-5a6b-432f-be3a-0cda61bbd086_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule25018> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" , "Provides Input For Rule. The relation '&beta;-alanine + (R)-pantoate + ATP &rarr; (<i>R</i>)-pantothenate + AMP + diphosphate + H<SUP>+</SUP>' 'null' '(<i>R</i>)-pantothenate + ATP &rarr; (<i>R</i>)-4'-phosphopantothenate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002413_PANTOTHENATE-KIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002413_PANTOTHENATE-KIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1416,28 +1246,6 @@
           <http://model.geneontology.org/PANTOTHENATE-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002233_CHEBI_59458_P-PANTOCYSLIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_dfcd410f-01c1-4364-a46d-aff05128186f_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_DEPHOSPHOCOAKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1447,13 +1255,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule25190> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002233_CHEBI_10986_PANTOTHENATE-KIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15379_RXN-9015>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15379> ;
@@ -1464,7 +1283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1472,15 +1291,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002413_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1495,11 +1325,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_CHEBI_11851_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_CHEBI_11851_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1510,14 +1340,14 @@
           <http://model.geneontology.org/CHEBI_11851_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_CHEBI_11851_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1528,11 +1358,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1543,18 +1373,40 @@
           <http://model.geneontology.org/YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002233_CHEBI_11561_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_37563>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002413_P-PANTOCYSDECARB-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_BFO_0000066_reaction_P-PANTOCYSLIG-RXN_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_BFO_0000066_reaction_P-PANTOCYSLIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1564,6 +1416,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_P-PANTOCYSLIG-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_PANTEPADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_35235>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1577,7 +1440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1592,11 +1455,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1607,25 +1470,14 @@
           <http://model.geneontology.org/CHEBI_57945_3-PROPANAL-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002233_CHEBI_57783_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_CHEBI_11561_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1646,7 +1498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1661,11 +1513,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_15379_RXN-9015_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_15379_RXN-9015_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1680,11 +1532,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002333_MONOMER3O-504_DEPHOSPHOCOAKIN-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002333_MONOMER3O-504_DEPHOSPHOCOAKIN-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1695,29 +1547,29 @@
           <http://model.geneontology.org/MONOMER3O-504_DEPHOSPHOCOAKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_CHEBI_15377_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://purl.obolibrary.org/obo/CHEBI_456216>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_BFO_0000066_reaction_2-DEHYDROPANTOATE-REDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_456216>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_PANTEPADENYLYLTRAN-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_PANTEPADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1737,7 +1589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1764,7 +1616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1772,25 +1624,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002234_CHEBI_29888_P-PANTOCYSLIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002234_CHEBI_456216_DEPHOSPHOCOAKIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002233_CHEBI_30616_PANTOTHENATE-KIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1798,11 +1639,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002234_CHEBI_15980_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002234_CHEBI_15980_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1813,15 +1654,26 @@
           <http://model.geneontology.org/CHEBI_15980_2-DEHYDROPANTOATE-REDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_BFO_0000066_reaction_DEPHOSPHOCOAKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002234_CHEBI_15378_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002234_CHEBI_15378_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1832,17 +1684,6 @@
           <http://model.geneontology.org/CHEBI_15378_PANTOATE-BETA-ALANINE-LIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002234_CHEBI_60377_P-PANTOCYSLIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_PANTEPADENYLYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1852,7 +1693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1864,11 +1705,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002234_CHEBI_61723_P-PANTOCYSDECARB-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002234_CHEBI_61723_P-PANTOCYSDECARB-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1904,7 +1745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1919,11 +1760,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" , "Provides Input For Rule. The relation 'a 5,10-methylenetetrahydrofolate + 3-methyl-2-oxobutanoate + H<sub>2</sub>O &rarr; 2-dehydropantoate + a tetrahydrofolate' 'null' '(R)-pantoate + NADP<sup>+</sup> &larr; 2-dehydropantoate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002413_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002413_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1943,7 +1784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1955,11 +1796,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002234_CHEBI_456216_PANTOTHENATE-KIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002234_CHEBI_456216_PANTOTHENATE-KIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1974,11 +1815,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002234_CHEBI_59458_P-PANTOCYSLIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002234_CHEBI_59458_P-PANTOCYSLIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1989,6 +1830,28 @@
           <http://model.geneontology.org/CHEBI_59458_P-PANTOCYSLIG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002333_MONOMER3O-504_DEPHOSPHOCOAKIN-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_BFO_0000066_reaction_PANTOATE-BETA-ALANINE-LIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_PANTOTHENATE-KIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1998,7 +1861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2006,14 +1869,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002333_MONOMER3O-504_DEPHOSPHOCOAKIN-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002233_CHEBI_57328_PANTEPADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2025,7 +1888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2033,11 +1896,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002233_CHEBI_30616_DEPHOSPHOCOAKIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002233_CHEBI_30616_DEPHOSPHOCOAKIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2051,15 +1914,37 @@
 <http://identifiers.org/sgd/S000001407>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_BFO_0000066_reaction_P-PANTOCYSDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_45725_RXN-9015_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" , "Provides Input For Rule. The relation 'spermine + oxygen + H<sub>2</sub>O &rarr; spermidine + 3-aminopropanal + hydrogen peroxide' 'null' '3-aminopropanal + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; &beta;-alanine + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002413_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002413_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2070,14 +1955,14 @@
           <http://model.geneontology.org/3-PROPANAL-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002234_CHEBI_59458_P-PANTOCYSLIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002234_CHEBI_15378_DEPHOSPHOCOAKIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2085,11 +1970,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '4'-phosphopantetheine + ATP + H<SUP>+</SUP> &rarr; 3'-dephospho-CoA + diphosphate' 'null' '3'-dephospho-CoA + ATP &rarr; ADP + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002413_DEPHOSPHOCOAKIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002413_DEPHOSPHOCOAKIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2106,14 +1991,14 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_15377_RXN-9015_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2126,7 +2011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2134,25 +2019,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002413_PANTEPADENYLYLTRAN-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002333_MONOMER3O-90_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002233_CHEBI_30616_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2165,7 +2039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pantothenate and coenzyme A biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2176,14 +2050,36 @@
 <http://identifiers.org/sgd/S000002939>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002413_DEPHOSPHOCOAKIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002233_CHEBI_35235_P-PANTOCYSLIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002413_PANTEPADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_57834_RXN-9015_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2191,11 +2087,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_CHEBI_15377_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_CHEBI_15377_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2206,39 +2102,6 @@
           <http://model.geneontology.org/CHEBI_15377_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57966_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002413_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002234_CHEBI_10986_PANTOTHENATE-KIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29032_PANTOATE-BETA-ALANINE-LIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29032> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2248,7 +2111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2263,11 +2126,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_BFO_0000066_reaction_PANTOTHENATE-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_BFO_0000066_reaction_PANTOTHENATE-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2278,26 +2141,15 @@
           <http://model.geneontology.org/reaction_PANTOTHENATE-KIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_45725_RXN-9015_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002233_CHEBI_10986_PANTOTHENATE-KIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002233_CHEBI_10986_PANTOTHENATE-KIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2308,15 +2160,6 @@
           <http://model.geneontology.org/CHEBI_10986_PANTOTHENATE-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_PANTEPADENYLYLTRAN-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_PANTOATE-BETA-ALANINE-LIG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2326,7 +2169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2334,8 +2177,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/reaction_PANTEPADENYLYLTRAN-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9015_BFO_0000066_reaction_RXN-9015_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004140>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002233_CHEBI_15378_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_2-DEHYDROPANTOATE-REDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -2346,13 +2220,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule25069> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_ec74ad10-5a6b-432f-be3a-0cda61bbd086_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29888_PANTOATE-BETA-ALANINE-LIG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2363,7 +2248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2380,7 +2265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2388,15 +2273,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002233_CHEBI_15378_P-PANTOCYSDECARB-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57966_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57966_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2407,14 +2303,14 @@
           <http://model.geneontology.org/CHEBI_57966_3-PROPANAL-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_57834_RXN-9015_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002413_P-PANTOCYSLIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2422,11 +2318,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_45725_RXN-9015_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_45725_RXN-9015_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2441,11 +2337,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2460,11 +2356,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_PANTEPADENYLYLTRAN-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_PANTEPADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2481,31 +2377,25 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/e34f0da1-9a97-4913-a9dc-461d788a0864_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule24983> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002233_CHEBI_30616_DEPHOSPHOCOAKIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002333_MONOMER3O-317_P-PANTOCYSDECARB-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2513,11 +2403,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002234_CHEBI_58349_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002234_CHEBI_58349_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2535,7 +2425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2555,7 +2445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2567,11 +2457,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002234_CHEBI_29032_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002234_CHEBI_29032_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2582,15 +2472,37 @@
           <http://model.geneontology.org/CHEBI_29032_PANTOATE-BETA-ALANINE-LIG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002234_CHEBI_10986_PANTOTHENATE-KIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002234_CHEBI_456215_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002333_MONOMER3O-299_P-PANTOCYSDECARB-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002333_MONOMER3O-299_P-PANTOCYSDECARB-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2601,19 +2513,30 @@
           <http://model.geneontology.org/MONOMER3O-299_P-PANTOCYSDECARB-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15377_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://purl.obolibrary.org/obo/GO_0052904>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0052904>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002233_CHEBI_30616_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-285_P-PANTOCYSLIG-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001345> ;
@@ -2622,7 +2545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2633,26 +2556,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002333_MONOMER3O-285_P-PANTOCYSLIG-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2672,7 +2584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2680,15 +2592,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_PANTEPADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002333_MONOMER3O-268_PANTOTHENATE-KIN-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002333_MONOMER3O-268_PANTOTHENATE-KIN-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2703,11 +2626,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002234_CHEBI_60377_P-PANTOCYSLIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002234_CHEBI_60377_P-PANTOCYSLIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2717,28 +2640,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_60377_P-PANTOCYSLIG-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002333_MONOMER3O-299_P-PANTOCYSDECARB-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002233_CHEBI_57966_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/3-PROPANAL-DEHYDROGENASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004029> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2753,13 +2654,13 @@
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_57945_3-PROPANAL-DEHYDROGENASE-RXN> , <http://model.geneontology.org/CHEBI_57966_3-PROPANAL-DEHYDROGENASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YMR170C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller> , <http://model.geneontology.org/YMR169C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller> ;
+                <http://model.geneontology.org/YMR169C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller> , <http://model.geneontology.org/YMR170C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/PANTOATE-BETA-ALANINE-LIG-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2772,18 +2673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002333_MONOMER3O-317_P-PANTOCYSDECARB-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2791,11 +2681,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002233_CHEBI_57328_PANTEPADENYLYLTRAN-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002233_CHEBI_57328_PANTEPADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2810,11 +2700,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2825,17 +2715,28 @@
           <http://model.geneontology.org/YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY>
 ] .
 
-<http://identifiers.org/sgd/S000004779>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002234_CHEBI_456215_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002234_CHEBI_15378_P-PANTOCYSLIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004779>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002234_CHEBI_15378_PANTOTHENATE-KIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2848,7 +2749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2864,7 +2765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2877,7 +2778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2904,7 +2805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2921,7 +2822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2933,11 +2834,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2948,25 +2849,36 @@
           <http://model.geneontology.org/YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002333_MONOMER3O-214_2-DEHYDROPANTOATE-REDUCT-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002233_CHEBI_37563_P-PANTOCYSLIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15377_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2974,11 +2886,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_BFO_0000066_reaction_2-DEHYDROPANTOATE-REDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_BFO_0000066_reaction_2-DEHYDROPANTOATE-REDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2992,6 +2904,17 @@
 <http://identifiers.org/sgd/S000004780>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002333_YMR020W-MONOMER_RXN-9015_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -2999,11 +2922,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_BFO_0000066_reaction_PANTOATE-BETA-ALANINE-LIG-RXN_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_BFO_0000066_reaction_PANTOATE-BETA-ALANINE-LIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3023,7 +2946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3040,7 +2963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3048,15 +2971,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002413_PANTOTHENATE-KIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_BFO_0000066_reaction_P-PANTOCYSDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_BFO_0000066_reaction_P-PANTOCYSDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3067,14 +3001,14 @@
           <http://model.geneontology.org/reaction_P-PANTOCYSDECARB-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002233_CHEBI_37563_P-PANTOCYSLIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3087,7 +3021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3095,14 +3029,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_e34f0da1-9a97-4913-a9dc-461d788a0864_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_5e6cc8cd-69ce-48ff-b1b9-ff6d4b56bfd6_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002333_MONOMER3O-474_P-PANTOCYSDECARB-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3110,11 +3055,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_e34f0da1-9a97-4913-a9dc-461d788a0864_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_5e6cc8cd-69ce-48ff-b1b9-ff6d4b56bfd6_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3122,19 +3067,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e34f0da1-9a97-4913-a9dc-461d788a0864_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
+          <http://model.geneontology.org/5e6cc8cd-69ce-48ff-b1b9-ff6d4b56bfd6_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002234_CHEBI_456216_DEPHOSPHOCOAKIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3148,7 +3082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3163,11 +3097,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002233_CHEBI_29032_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002233_CHEBI_29032_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3181,15 +3115,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002233_CHEBI_35235_P-PANTOCYSLIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002233_CHEBI_35235_P-PANTOCYSLIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3209,13 +3154,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule25069> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002234_CHEBI_29888_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57834>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3224,11 +3180,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002333_YMR169C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002333_YMR169C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3239,14 +3195,14 @@
           <http://model.geneontology.org/YMR169C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002234_CHEBI_57287_DEPHOSPHOCOAKIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002233_CHEBI_29032_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3254,11 +3210,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_16240_RXN-9015_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_16240_RXN-9015_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3269,15 +3225,26 @@
           <http://model.geneontology.org/CHEBI_16240_RXN-9015>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_15379_RXN-9015_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002233_CHEBI_61723_P-PANTOCYSDECARB-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002233_CHEBI_61723_P-PANTOCYSDECARB-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3288,37 +3255,15 @@
           <http://model.geneontology.org/CHEBI_61723_P-PANTOCYSDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002233_CHEBI_15980_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_BFO_0000066_reaction_PANTOTHENATE-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002333_MONOMER3O-214_2-DEHYDROPANTOATE-REDUCT-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002333_MONOMER3O-214_2-DEHYDROPANTOATE-REDUCT-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3329,15 +3274,26 @@
           <http://model.geneontology.org/MONOMER3O-214_2-DEHYDROPANTOATE-REDUCT-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002233_CHEBI_30616_PANTOTHENATE-KIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002234_CHEBI_29888_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002234_CHEBI_29888_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3352,11 +3308,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002333_MONOMER3O-317_P-PANTOCYSDECARB-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002333_MONOMER3O-317_P-PANTOCYSDECARB-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3367,17 +3323,6 @@
           <http://model.geneontology.org/MONOMER3O-317_P-PANTOCYSDECARB-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002333_YIL145C-MONOMER_PANTOATE-BETA-ALANINE-LIG-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_11561_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_11561> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3387,7 +3332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3395,36 +3340,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002333_MONOMER3O-268_PANTOTHENATE-KIN-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002234_CHEBI_456216_PANTOTHENATE-KIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002233_CHEBI_15980_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002233_CHEBI_15378_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_BFO_0000066_reaction_PANTEPADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3432,11 +3366,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_BFO_0000066_reaction_3-PROPANAL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_BFO_0000066_reaction_3-PROPANAL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3456,7 +3390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3471,11 +3405,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" , "Provides Input For Rule. The relation '(<i>R</i>)-pantothenate + ATP &rarr; (<i>R</i>)-4'-phosphopantothenate + ADP + H<SUP>+</SUP>' 'null' '(<i>R</i>)-4'-phosphopantothenate + L-cysteine + CTP &rarr; (R)-4'-phosphopantothenoyl-L-cysteine + CMP + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002413_P-PANTOCYSLIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002413_P-PANTOCYSLIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3486,37 +3420,15 @@
           <http://model.geneontology.org/P-PANTOCYSLIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9015_BFO_0000066_reaction_RXN-9015_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002233_CHEBI_57783_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002333_MONOMER3O-285_P-PANTOCYSLIG-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002333_MONOMER3O-285_P-PANTOCYSLIG-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3527,6 +3439,17 @@
           <http://model.geneontology.org/MONOMER3O-285_P-PANTOCYSLIG-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002333_YMR169C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58349_2-DEHYDROPANTOATE-REDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3536,7 +3459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3553,7 +3476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3561,12 +3484,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002234_CHEBI_61723_P-PANTOCYSDECARB-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_P-PANTOCYSLIG-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3579,7 +3513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3591,11 +3525,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002234_CHEBI_15378_DEPHOSPHOCOAKIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002234_CHEBI_15378_DEPHOSPHOCOAKIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3620,7 +3554,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15377_RXN-9015> , <http://model.geneontology.org/CHEBI_15379_RXN-9015> , <http://model.geneontology.org/CHEBI_45725_RXN-9015> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16240_RXN-9015> , <http://model.geneontology.org/CHEBI_57834_RXN-9015> , <http://model.geneontology.org/CHEBI_18090_RXN-9015> ;
+                <http://model.geneontology.org/CHEBI_16240_RXN-9015> , <http://model.geneontology.org/CHEBI_18090_RXN-9015> , <http://model.geneontology.org/CHEBI_57834_RXN-9015> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YMR020W-MONOMER_RXN-9015_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3628,24 +3562,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYBiochemicalReaction24910> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002234_CHEBI_15980_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_35235_P-PANTOCYSLIG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_35235> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3656,13 +3579,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule25215> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_18090_RXN-9015_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_11851_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_11851> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3673,7 +3607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3681,51 +3615,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_BFO_0000066_reaction_2-DEHYDROPANTOATE-REDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002233_CHEBI_29032_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002333_MONOMER3O-214_2-DEHYDROPANTOATE-REDUCT-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002233_CHEBI_11561_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002233_CHEBI_11561_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3736,15 +3637,26 @@
           <http://model.geneontology.org/CHEBI_11561_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002234_CHEBI_29032_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002233_CHEBI_15980_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002233_CHEBI_15980_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3754,6 +3666,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15980_2-DEHYDROPANTOATE-REDUCT-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_16240_RXN-9015_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3767,7 +3690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3782,7 +3705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3794,11 +3717,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002233_CHEBI_15378_P-PANTOCYSDECARB-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002233_CHEBI_15378_P-PANTOCYSDECARB-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3809,14 +3732,36 @@
           <http://model.geneontology.org/CHEBI_15378_P-PANTOCYSDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002234_CHEBI_15378_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002333_MONOMER3O-285_P-PANTOCYSLIG-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3827,11 +3772,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_CHEBI_11561_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_CHEBI_11561_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3852,11 +3797,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002233_CHEBI_30616_PANTOTHENATE-KIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002233_CHEBI_30616_PANTOTHENATE-KIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3871,11 +3816,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002233_CHEBI_37563_P-PANTOCYSLIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002233_CHEBI_37563_P-PANTOCYSLIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3890,11 +3835,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002333_YMR170C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002333_YMR170C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3905,25 +3850,14 @@
           <http://model.geneontology.org/YMR170C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002233_CHEBI_11561_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9015_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_BFO_0000066_reaction_P-PANTOCYSDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3931,11 +3865,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_18090_RXN-9015_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_18090_RXN-9015_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3949,17 +3883,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57328>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002413_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_61723_P-PANTOCYSDECARB-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_61723> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3969,7 +3892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3981,11 +3904,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_PANTEPADENYLYLTRAN-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_PANTEPADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3996,19 +3919,30 @@
           <http://model.geneontology.org/CHEBI_29888_PANTEPADENYLYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002234_CHEBI_15378_PANTOTHENATE-KIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_BFO_0000066_reaction_PANTOTHENATE-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002234_CHEBI_60377_P-PANTOCYSLIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN-9015>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4019,7 +3953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4037,11 +3971,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" , "Provides Input For Rule. The relation '(R)-pantoate + NADP<sup>+</sup> &larr; 2-dehydropantoate + NADPH + H<SUP>+</SUP>' 'null' '&beta;-alanine + (R)-pantoate + ATP &rarr; (<i>R</i>)-pantothenate + AMP + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002413_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002413_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4052,14 +3986,14 @@
           <http://model.geneontology.org/PANTOATE-BETA-ALANINE-LIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_PANTEPADENYLYLTRAN-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002234_CHEBI_16526_P-PANTOCYSDECARB-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4067,11 +4001,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002234_CHEBI_456215_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002234_CHEBI_456215_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4082,12 +4016,34 @@
           <http://model.geneontology.org/CHEBI_456215_PANTOATE-BETA-ALANINE-LIG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002333_YIL145C-MONOMER_PANTOATE-BETA-ALANINE-LIG-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_18090_RXN-9015_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_PANTOATE-BETA-ALANINE-LIG-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4095,11 +4051,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002333_MONOMER3O-474_P-PANTOCYSDECARB-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002333_MONOMER3O-474_P-PANTOCYSDECARB-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4110,17 +4066,6 @@
           <http://model.geneontology.org/MONOMER3O-474_P-PANTOCYSDECARB-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002333_YMR020W-MONOMER_RXN-9015_controller_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0015937> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4130,7 +4075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -4142,11 +4087,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15377_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15377_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4166,13 +4111,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule24833> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002333_MONOMER3O-268_PANTOTHENATE-KIN-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_PANTOTHENATE-KIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4183,7 +4139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4196,7 +4152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4204,11 +4160,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4219,14 +4175,14 @@
           <http://model.geneontology.org/YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_BFO_0000066_reaction_P-PANTOCYSLIG-RXN_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY>
+<http://model.geneontology.org/ev_w_id_PANTOTHENATE-KIN-RXN_RO_0002234_CHEBI_456216_PANTOTHENATE-KIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4239,7 +4195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4256,7 +4212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4264,26 +4220,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002234_CHEBI_29888_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>R</i>)-4'-phosphopantothenate + L-cysteine + CTP &rarr; (R)-4'-phosphopantothenoyl-L-cysteine + CMP + diphosphate + H<SUP>+</SUP>' 'null' '(R)-4'-phosphopantothenoyl-L-cysteine + H<SUP>+</SUP> &rarr; 4'-phosphopantetheine + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002413_P-PANTOCYSDECARB-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002413_P-PANTOCYSDECARB-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4298,11 +4243,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_18090_RXN-9015_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_18090_RXN-9015_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4313,15 +4258,73 @@
           <http://model.geneontology.org/CHEBI_18090_RXN-9015>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002413_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_BFO_0000066_reaction_3-PROPANAL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002234_CHEBI_15378_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_61723>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002333_YMR170C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_BFO_0000066_reaction_RXN-9015_location_lociGO_0005829_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_BFO_0000066_reaction_RXN-9015_location_lociGO_0005829_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4332,8 +4335,16 @@
           <http://model.geneontology.org/reaction_RXN-9015_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_61723>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002233_CHEBI_57966_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -4342,11 +4353,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002234_CHEBI_456216_DEPHOSPHOCOAKIN-RXN_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DEPHOSPHOCOAKIN-RXN_RO_0002234_CHEBI_456216_DEPHOSPHOCOAKIN-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4357,37 +4368,15 @@
           <http://model.geneontology.org/CHEBI_456216_DEPHOSPHOCOAKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_RO_0002333_MONOMER3O-487_PANTEPADENYLYLTRAN-RXN_controller_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_15377_RXN-9015_SGD_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PANTEPADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4405,7 +4394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4432,7 +4421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4448,6 +4437,17 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002234_CHEBI_15980_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PENTOSE-P-PWY.ttl
+++ b/models/YeastPathways_PENTOSE-P-PWY.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,11 +21,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_57783_RXN-9952_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_57783_RXN-9952_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -56,15 +56,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002233_CHEBI_4170_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_57955_GLU6PDEHYDROG-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_57955_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,8 +86,16 @@
           <http://model.geneontology.org/CHEBI_57955_GLU6PDEHYDROG-RXN>
 ] .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002233_CHEBI_78346_RIB5PISOM-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -88,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,37 +142,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_BFO_0000066_reaction_2TRANSKETO-RXN_location_lociGO_0005829_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_15378_GLU6PDEHYDROG-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_BFO_0000066_reaction_6PGLUCONOLACT-RXN_location_lociGO_0005829_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_BFO_0000066_reaction_6PGLUCONOLACT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -177,11 +177,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002234_CHEBI_16897_TRANSALDOL-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002234_CHEBI_16897_TRANSALDOL-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -195,15 +195,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_4170>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002413_1TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002333_YOR095C-MONOMER_RIB5PISOM-RXN_controller_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002333_YOR095C-MONOMER_RIB5PISOM-RXN_controller_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,55 +225,11 @@
           <http://model.geneontology.org/YOR095C-MONOMER_RIB5PISOM-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YPR074C-MONOMER_1TRANSKETO-RXN_controller_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002234_CHEBI_57737_RIBULP3EPIM-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_57483_1TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002234_CHEBI_58759_6PGLUCONOLACT-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YOR095C-MONOMER_RIB5PISOM-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005621> ;
@@ -271,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -289,11 +256,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002234_CHEBI_57483_1TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002234_CHEBI_57483_1TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,26 +271,15 @@
           <http://model.geneontology.org/CHEBI_57483_1TRANSKETO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9952_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9952_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,24 +309,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PENTOSE-P-PWYBiochemicalReaction35151> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002234_CHEBI_57483_1TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -379,11 +324,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_BFO_0000066_reaction_GLU6PDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_BFO_0000066_reaction_GLU6PDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -411,14 +356,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002333_YOR095C-MONOMER_RIB5PISOM-RXN_controller_SGD_YeastPathways_PENTOSE-P-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_57783_RXN-9952_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -441,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -458,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -486,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -498,11 +443,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002233_CHEBI_57737_2TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002233_CHEBI_57737_2TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -517,11 +462,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" , "Provides Input For Rule. The relation 'D-gluconate 6-phosphate + NADP<sup>+</sup> &rarr; D-ribulose 5-phosphate + CO<SUB>2</SUB> + NADPH' 'null' 'D-ribulose 5-phosphate &harr; D-xylulose 5-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002413_RIBULP3EPIM-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002413_RIBULP3EPIM-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -532,28 +477,6 @@
           <http://model.geneontology.org/RIBULP3EPIM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002234_CHEBI_16897_TRANSALDOL-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002333_YNL241C-MONOMER_GLU6PDEHYDROG-RXN_controller_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/MONOMER3O-4047_6PGLUCONOLACT-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003480> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -561,24 +484,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PENTOSE-P-PWYProtein35020> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002233_CHEBI_58349_GLU6PDEHYDROG-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YPR074C-MONOMER_1TRANSKETO-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006278> ;
@@ -587,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -595,15 +507,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_BFO_0000066_reaction_1TRANSKETO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_57783_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004750>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_57483_1TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002234_CHEBI_15378_6PGLUCONOLACT-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002234_CHEBI_15378_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -614,15 +562,37 @@
           <http://model.geneontology.org/CHEBI_15378_6PGLUCONOLACT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9952_BFO_0000066_reaction_RXN-9952_location_lociGO_0005829_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" , "Provides Input For Rule. The relation 'D-sedoheptulose 7-phosphate + D-glyceraldehyde 3-phosphate &harr; &beta;-D-fructofuranose 6-phosphate + D-erythrose 4-phosphate' 'null' 'D-erythrose 4-phosphate + D-xylulose 5-phosphate &harr; &beta;-D-fructofuranose 6-phosphate + D-glyceraldehyde 3-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002413_2TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002413_2TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -633,21 +603,21 @@
           <http://model.geneontology.org/2TRANSKETO-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004750>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000066_reaction_RIBULP3EPIM-RXN_location_lociGO_0005829_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000066_reaction_RIBULP3EPIM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -658,28 +628,47 @@
           <http://model.geneontology.org/reaction_RIBULP3EPIM-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002233_CHEBI_15377_6PGLUCONOLACT-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002234_CHEBI_57737_RIBULP3EPIM-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57634>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002234_CHEBI_59776_2TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004345>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_78346>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002333_YLR354C-MONOMER_TRANSALDOL-RXN_controller_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004346>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -693,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -701,59 +690,35 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000066_reaction_RIBULP3EPIM-RXN_location_lociGO_0005829_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002233_CHEBI_58759_6PGLUCONOLACT-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9952> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58759_6PGLUCONOLACT-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_BFO_0000066_reaction_TRANSALDOL-RXN_location_lociGO_0005829_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/GO_0006098> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "The pentose phosphate pathway is important for generating NADPH, which is a source of reducing energy, as well as a variety of sugar molecules that are required for the biosynthesis of nucleic acids and amino acids. |CITS:[8929392]||CITS:[8910528]||CITS:[9813062]||CITS:[ 11298766]||CITS:[1628611]||CITS:[15960801]||CITS:[7916691]||CITS:[14690456]|. This pathway is also important for protecting yeast from oxidative stress, since NADPH is an essential cofactor for glutathione- and thioredoxin-dependent enzymes that defend cells against oxidative damage |CITS:[8929392]||CITS:[8910528]||CITS:[11557322]||CITS:[16179340]|. The pentose phosphate pathway is of industrial interest for the fermentation of xylose to ethanol |CITS:[11916674]|. Xylose is the predominant sugar found in biomass such as agricultural wastes, wood, municipal solid wastes, and wastes from pulp and paper industries, and possibly could serve as a low-cost and abundant raw material for fuel ethanol production |CITS:[8534086]|. Saccharomyces cerevisiae does not naturally metabolize xylose, but recombinant S. cerevisiae strains containing the xylose reductase and xylitol dehydrogenase genes from Pichia stipitis are able to metabolize xylose via the pentose phosphate pathway |CITS:[15630585]||CITS:[8534086]|. Changes in the levels of enzymes in the pentose phosphate pathway effect the fitness, ethanol production, and amount of xylose metabolized by these recombinant xylose-utilizing strains. The pentose phosphate pathway is also of medical interest because mutations in the human homologs of some yeast pentose phosphate genes are associated with a variety of diseases. Zwf1p is homologus to human glucose-6-phosphate dehydrogenase (G6PD), which has been implicated in neonatal jaundice and haemolytic anemia. Sol3p and Sol4p have similarity to human PGLS, which is associated with 6- phosphogluconolactonase deficiency and may contribute to some forms of G6PD-associated hemolytic anemia |CITS:[10518023]|. Sol3p and Sol4p also have similarity to human H6PD, which is associated with cortisone reductase deficiency |CITS:[10518023]|. Gnd1p and Gnd2p have similarity to human PGD, mutation in which may also contribute to some forms of G6PD-associated hemolytic anemia |CITS:[10518023]|. Tal1p is similar to human TALDO1, mutation in which has been reported to be associated with transaldolase deficiency and hepatosplenomegaly |CITS:[ 8300619]|. Rki1p has similarity to human RPIA, which has been associated with ribose 5-phosphate isomerase deficiency, leukoencephalopathy and peripheral neuropathy |CITS:[16054529]|." ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "pentose phosphate pathway" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+                "YeastPathways_PENTOSE-P-PWY" ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Pathway" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YPR074C-MONOMER_1TRANSKETO-RXN_controller_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YPR074C-MONOMER_1TRANSKETO-RXN_controller_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -771,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -779,44 +744,35 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/GO_0006098> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "The pentose phosphate pathway is important for generating NADPH, which is a source of reducing energy, as well as a variety of sugar molecules that are required for the biosynthesis of nucleic acids and amino acids. |CITS:[8929392]||CITS:[8910528]||CITS:[9813062]||CITS:[ 11298766]||CITS:[1628611]||CITS:[15960801]||CITS:[7916691]||CITS:[14690456]|. This pathway is also important for protecting yeast from oxidative stress, since NADPH is an essential cofactor for glutathione- and thioredoxin-dependent enzymes that defend cells against oxidative damage |CITS:[8929392]||CITS:[8910528]||CITS:[11557322]||CITS:[16179340]|. The pentose phosphate pathway is of industrial interest for the fermentation of xylose to ethanol |CITS:[11916674]|. Xylose is the predominant sugar found in biomass such as agricultural wastes, wood, municipal solid wastes, and wastes from pulp and paper industries, and possibly could serve as a low-cost and abundant raw material for fuel ethanol production |CITS:[8534086]|. Saccharomyces cerevisiae does not naturally metabolize xylose, but recombinant S. cerevisiae strains containing the xylose reductase and xylitol dehydrogenase genes from Pichia stipitis are able to metabolize xylose via the pentose phosphate pathway |CITS:[15630585]||CITS:[8534086]|. Changes in the levels of enzymes in the pentose phosphate pathway effect the fitness, ethanol production, and amount of xylose metabolized by these recombinant xylose-utilizing strains. The pentose phosphate pathway is also of medical interest because mutations in the human homologs of some yeast pentose phosphate genes are associated with a variety of diseases. Zwf1p is homologus to human glucose-6-phosphate dehydrogenase (G6PD), which has been implicated in neonatal jaundice and haemolytic anemia. Sol3p and Sol4p have similarity to human PGLS, which is associated with 6- phosphogluconolactonase deficiency and may contribute to some forms of G6PD-associated hemolytic anemia |CITS:[10518023]|. Sol3p and Sol4p also have similarity to human H6PD, which is associated with cortisone reductase deficiency |CITS:[10518023]|. Gnd1p and Gnd2p have similarity to human PGD, mutation in which may also contribute to some forms of G6PD-associated hemolytic anemia |CITS:[10518023]|. Tal1p is similar to human TALDO1, mutation in which has been reported to be associated with transaldolase deficiency and hepatosplenomegaly |CITS:[ 8300619]|. Rki1p has similarity to human RPIA, which has been associated with ribose 5-phosphate isomerase deficiency, leukoencephalopathy and peripheral neuropathy |CITS:[16054529]|." ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "pentose phosphate pathway" ;
+<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-                "YeastPathways_PENTOSE-P-PWY" ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002233_CHEBI_58121_RXN-9952_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002333_MONOMER3O-4032_6PGLUCONOLACT-RXN_controller_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002233_CHEBI_58759_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9952> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58759_6PGLUCONOLACT-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -830,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -842,11 +798,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_15378_GLU6PDEHYDROG-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_15378_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -857,17 +813,39 @@
           <http://model.geneontology.org/CHEBI_15378_GLU6PDEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57955>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002333_MONOMER3O-4047_6PGLUCONOLACT-RXN_controller_SGD_YeastPathways_PENTOSE-P-PWY>
+<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002234_CHEBI_57634_TRANSALDOL-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002233_CHEBI_58121_RXN-9952_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -875,11 +853,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002333_YPR074C-MONOMER_2TRANSKETO-RXN_controller_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002333_YPR074C-MONOMER_2TRANSKETO-RXN_controller_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -893,15 +871,26 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YPR074C-MONOMER_1TRANSKETO-RXN_controller_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_57483_1TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_57483_1TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -912,15 +901,26 @@
           <http://model.geneontology.org/CHEBI_57483_1TRANSKETO-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002413_RXN-9952_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002233_CHEBI_58121_RXN-9952_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002233_CHEBI_58121_RXN-9952_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -936,7 +936,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002233_CHEBI_58349_RXN-9952_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -949,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -966,7 +977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -979,18 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002233_CHEBI_57737_RIBULP3EPIM-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1001,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1009,14 +1009,47 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002413_RIB5PISOM-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002233_CHEBI_57737_RIBULP3EPIM-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002333_MONOMER3O-4032_6PGLUCONOLACT-RXN_controller_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002333_YJL121C-MONOMER_RIBULP3EPIM-RXN_controller_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1029,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1044,11 +1077,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002333_MONOMER3O-4047_6PGLUCONOLACT-RXN_controller_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002333_MONOMER3O-4047_6PGLUCONOLACT-RXN_controller_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1063,11 +1096,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002233_CHEBI_57737_RIBULP3EPIM-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002233_CHEBI_57737_RIBULP3EPIM-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1082,11 +1115,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002333_YJL121C-MONOMER_RIBULP3EPIM-RXN_controller_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002333_YJL121C-MONOMER_RIBULP3EPIM-RXN_controller_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1097,14 +1130,25 @@
           <http://model.geneontology.org/YJL121C-MONOMER_RIBULP3EPIM-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002233_CHEBI_16897_TRANSALDOL-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002233_CHEBI_58759_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002233_CHEBI_57955_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1120,7 +1164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1131,14 +1175,14 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002333_YLR354C-MONOMER_TRANSALDOL-RXN_controller_SGD_YeastPathways_PENTOSE-P-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-9952_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1147,18 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1169,11 +1202,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_BFO_0000066_reaction_2TRANSKETO-RXN_location_lociGO_0005829_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_BFO_0000066_reaction_2TRANSKETO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1188,11 +1221,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_58121_RXN-9952_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_58121_RXN-9952_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1208,7 +1241,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_16526_RXN-9952_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1221,7 +1265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1233,11 +1277,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002333_YNL241C-MONOMER_GLU6PDEHYDROG-RXN_controller_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002333_YNL241C-MONOMER_GLU6PDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1251,17 +1295,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_58759>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9952_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_6PGLUCONOLACT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1271,7 +1304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1289,7 +1322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1297,28 +1330,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_59776_1TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002234_CHEBI_15378_6PGLUCONOLACT-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_58121_RXN-9952_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1326,11 +1348,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002233_CHEBI_15377_6PGLUCONOLACT-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002233_CHEBI_15377_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1341,26 +1363,15 @@
           <http://model.geneontology.org/CHEBI_15377_6PGLUCONOLACT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002233_CHEBI_57955_GLU6PDEHYDROG-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002234_CHEBI_57634_TRANSALDOL-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002234_CHEBI_57634_TRANSALDOL-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1371,15 +1382,26 @@
           <http://model.geneontology.org/CHEBI_57634_TRANSALDOL-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002233_CHEBI_58349_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-ribose 5-phosphate &harr; D-ribulose 5-phosphate' 'null' 'D-sedoheptulose 7-phosphate + D-glyceraldehyde 3-phosphate &harr; D-ribose 5-phosphate + D-xylulose 5-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002413_1TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002413_1TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1390,32 +1412,7 @@
           <http://model.geneontology.org/1TRANSKETO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002234_CHEBI_59776_1TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16897>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_16526_RXN-9952_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
@@ -1424,36 +1421,17 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_58121_RXN-9952_SGD_YeastPathways_PENTOSE-P-PWY>
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002233_CHEBI_78346_RIB5PISOM-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1469,7 +1447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1481,11 +1459,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002234_CHEBI_59776_1TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002234_CHEBI_59776_1TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1500,11 +1478,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9952_BFO_0000066_reaction_RXN-9952_location_lociGO_0005829_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9952_BFO_0000066_reaction_RXN-9952_location_lociGO_0005829_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1515,15 +1493,37 @@
           <http://model.geneontology.org/reaction_RXN-9952_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002413_TRANSALDOL-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002233_CHEBI_16897_TRANSALDOL-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002233_CHEBI_4170_GLU6PDEHYDROG-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002233_CHEBI_4170_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1533,6 +1533,50 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_4170_GLU6PDEHYDROG-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002234_CHEBI_57483_1TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002333_YNL241C-MONOMER_GLU6PDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_BFO_0000066_reaction_RIB5PISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1556,13 +1600,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PENTOSE-P-PWYBiochemicalReaction34999> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002234_CHEBI_58759_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57783_GLU6PDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1573,7 +1628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1585,11 +1640,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002234_CHEBI_57634_2TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002234_CHEBI_57634_2TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1600,6 +1655,17 @@
           <http://model.geneontology.org/CHEBI_57634_2TRANSKETO-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002234_CHEBI_57634_2TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_59776>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1607,11 +1673,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1629,11 +1695,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1644,40 +1710,40 @@
           <http://model.geneontology.org/YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_BFO_0000066_reaction_GLU6PDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PENTOSE-P-PWY>
+<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002234_CHEBI_16897_TRANSALDOL-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_59776_1TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004801>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002234_CHEBI_57634_2TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002234_CHEBI_58759_6PGLUCONOLACT-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002234_CHEBI_58759_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1692,11 +1758,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1714,11 +1780,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002233_CHEBI_58121_RXN-9952_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002233_CHEBI_58121_RXN-9952_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1729,36 +1795,36 @@
           <http://model.geneontology.org/CHEBI_58121_RXN-9952>
 ] .
 
-<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002413_RXN-9952_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_YeastPathways_PENTOSE-P-PWY>
+<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002234_CHEBI_78346_RIB5PISOM-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_BFO_0000066_reaction_6PGLUCONOLACT-RXN_location_lociGO_0005829_SGD_YeastPathways_PENTOSE-P-PWY>
+<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002233_CHEBI_57737_2TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002233_CHEBI_15377_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1766,11 +1832,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-sedoheptulose 7-phosphate + D-glyceraldehyde 3-phosphate &harr; D-ribose 5-phosphate + D-xylulose 5-phosphate' 'null' 'D-sedoheptulose 7-phosphate + D-glyceraldehyde 3-phosphate &harr; &beta;-D-fructofuranose 6-phosphate + D-erythrose 4-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002413_TRANSALDOL-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002413_TRANSALDOL-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1781,14 +1847,14 @@
           <http://model.geneontology.org/TRANSALDOL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002413_TRANSALDOL-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002413_RIB5PISOM-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1796,11 +1862,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_16526_RXN-9952_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_16526_RXN-9952_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1811,15 +1877,26 @@
           <http://model.geneontology.org/CHEBI_16526_RXN-9952>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002413_1TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_57783_GLU6PDEHYDROG-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_57783_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1833,14 +1910,14 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002233_CHEBI_58759_6PGLUCONOLACT-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_57955_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1853,7 +1930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1880,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1888,14 +1965,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_57955_GLU6PDEHYDROG-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_15378_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1903,11 +1980,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1922,11 +1999,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_59776_1TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_59776_1TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1937,26 +2014,15 @@
           <http://model.geneontology.org/CHEBI_59776_1TRANSKETO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002413_6PGLUCONOLACT-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002234_CHEBI_78346_RIB5PISOM-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002234_CHEBI_78346_RIB5PISOM-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1976,7 +2042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1987,6 +2053,17 @@
 <http://identifiers.org/sgd/S000005185>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002333_YPR074C-MONOMER_2TRANSKETO-RXN_controller_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_59776_1TRANSKETO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59776> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1996,7 +2073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2007,39 +2084,28 @@
 <http://identifiers.org/sgd/S000006278>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_57783_GLU6PDEHYDROG-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_BFO_0000066_reaction_1TRANSKETO-RXN_location_lociGO_0005829_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9952_BFO_0000066_reaction_RXN-9952_location_lociGO_0005829_SGD_YeastPathways_PENTOSE-P-PWY>
+<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002234_CHEBI_15378_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002333_YOR095C-MONOMER_RIB5PISOM-RXN_controller_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2047,11 +2113,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" , "Provides Input For Rule. The relation '6-phospho D-glucono-1,5-lactone + H<sub>2</sub>O &rarr; D-gluconate 6-phosphate + H<SUP>+</SUP>' 'null' 'D-gluconate 6-phosphate + NADP<sup>+</sup> &rarr; D-ribulose 5-phosphate + CO<SUB>2</SUB> + NADPH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002413_RXN-9952_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002413_RXN-9952_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2066,11 +2132,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002233_CHEBI_78346_RIB5PISOM-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002233_CHEBI_78346_RIB5PISOM-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2085,11 +2151,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-ribulose 5-phosphate &harr; D-xylulose 5-phosphate' 'null' 'D-sedoheptulose 7-phosphate + D-glyceraldehyde 3-phosphate &harr; D-ribose 5-phosphate + D-xylulose 5-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002413_1TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002413_1TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2104,11 +2170,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2124,29 +2190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002233_CHEBI_4170_GLU6PDEHYDROG-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002333_YJL121C-MONOMER_RIBULP3EPIM-RXN_controller_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2167,7 +2211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2179,11 +2223,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002233_CHEBI_16897_TRANSALDOL-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002233_CHEBI_16897_TRANSALDOL-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2203,7 +2247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pentose phosphate pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2215,11 +2259,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" , "Provides Input For Rule. The relation 'D-gluconate 6-phosphate + NADP<sup>+</sup> &rarr; D-ribulose 5-phosphate + CO<SUB>2</SUB> + NADPH' 'null' 'D-ribose 5-phosphate &harr; D-ribulose 5-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002413_RIB5PISOM-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002413_RIB5PISOM-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2230,37 +2274,15 @@
           <http://model.geneontology.org/RIB5PISOM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002233_CHEBI_57737_2TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002413_1TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-glucopyranose 6-phosphate + NADP<sup>+</sup> &rarr; 6-phospho D-glucono-1,5-lactone + NADPH + H<SUP>+</SUP>' 'null' '6-phospho D-glucono-1,5-lactone + H<sub>2</sub>O &rarr; D-gluconate 6-phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002413_6PGLUCONOLACT-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002413_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2271,14 +2293,14 @@
           <http://model.geneontology.org/6PGLUCONOLACT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002234_CHEBI_59776_2TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002413_RIBULP3EPIM-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2289,7 +2311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2306,7 +2328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2314,36 +2336,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002233_CHEBI_58121_RXN-9952_SGD_YeastPathways_PENTOSE-P-PWY>
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_BFO_0000066_reaction_GLU6PDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002233_CHEBI_58349_RXN-9952_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2351,11 +2351,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002233_CHEBI_57955_GLU6PDEHYDROG-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002233_CHEBI_57955_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2373,11 +2373,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002333_YLR354C-MONOMER_TRANSALDOL-RXN_controller_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002333_YLR354C-MONOMER_TRANSALDOL-RXN_controller_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2388,6 +2388,17 @@
           <http://model.geneontology.org/YLR354C-MONOMER_TRANSALDOL-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002233_CHEBI_58121_RXN-9952_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000003657>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2395,11 +2406,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2413,79 +2424,57 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/GO_0017057>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002333_YPR074C-MONOMER_2TRANSKETO-RXN_controller_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57483>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://purl.obolibrary.org/obo/GO_0017057>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002413_1TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_BFO_0000066_reaction_RIB5PISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_PENTOSE-P-PWY>
+<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000066_reaction_RIBULP3EPIM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002413_6PGLUCONOLACT-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_BFO_0000066_reaction_TRANSALDOL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_6PGLUCONOLACT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YBR117C-MONOMER_1TRANSKETO-RXN_controller_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002413_2TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2508,7 +2497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2516,26 +2505,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002413_RIBULP3EPIM-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YBR117C-MONOMER_1TRANSKETO-RXN_controller_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YBR117C-MONOMER_1TRANSKETO-RXN_controller_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2550,11 +2528,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002233_CHEBI_58349_RXN-9952_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002233_CHEBI_58349_RXN-9952_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2565,14 +2543,14 @@
           <http://model.geneontology.org/CHEBI_58349_RXN-9952>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002234_CHEBI_78346_RIB5PISOM-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002234_CHEBI_59776_1TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2580,11 +2558,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002233_CHEBI_58349_GLU6PDEHYDROG-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002233_CHEBI_58349_GLU6PDEHYDROG-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2605,7 +2583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2617,11 +2595,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002234_CHEBI_59776_2TRANSKETO-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_RO_0002234_CHEBI_59776_2TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2632,14 +2610,14 @@
           <http://model.geneontology.org/CHEBI_59776_2TRANSKETO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9952_RO_0002234_CHEBI_57783_RXN-9952_SGD_YeastPathways_PENTOSE-P-PWY>
+<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_BFO_0000066_reaction_6PGLUCONOLACT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2647,11 +2625,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_BFO_0000066_reaction_TRANSALDOL-RXN_location_lociGO_0005829_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_BFO_0000066_reaction_TRANSALDOL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2662,23 +2640,12 @@
           <http://model.geneontology.org/reaction_TRANSALDOL-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_2TRANSKETO-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2686,11 +2653,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_BFO_0000066_reaction_RIB5PISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_BFO_0000066_reaction_RIB5PISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2701,25 +2668,14 @@
           <http://model.geneontology.org/reaction_RIB5PISOM-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_BFO_0000050_YeastPathways_PENTOSE-P-PWY/YeastPathways_PENTOSE-P-PWY_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002234_CHEBI_57634_TRANSALDOL-RXN_SGD_YeastPathways_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
+                "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2730,11 +2686,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002333_MONOMER3O-4032_6PGLUCONOLACT-RXN_controller_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002333_MONOMER3O-4032_6PGLUCONOLACT-RXN_controller_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2745,15 +2701,26 @@
           <http://model.geneontology.org/MONOMER3O-4032_6PGLUCONOLACT-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002413_2TRANSKETO-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_BFO_0000066_reaction_1TRANSKETO-RXN_location_lociGO_0005829_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_BFO_0000066_reaction_1TRANSKETO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2773,7 +2740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2790,7 +2757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2802,11 +2769,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002234_CHEBI_57737_RIBULP3EPIM-RXN_SGD_YeastPathways_PENTOSE-P-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_RO_0002234_CHEBI_57737_RIBULP3EPIM-RXN_SGD_PWY_YeastPathways_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2817,6 +2784,17 @@
           <http://model.geneontology.org/CHEBI_57737_RIBULP3EPIM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_BFO_0000066_reaction_2TRANSKETO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57634_2TRANSKETO-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57634> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2826,13 +2804,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PENTOSE-P-PWYSmallMolecule35145> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_6PGLUCONOLACT-RXN_RO_0002333_MONOMER3O-4047_6PGLUCONOLACT-RXN_controller_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YBR117C-MONOMER_1TRANSKETO-RXN_controller_SGD_PWY_YeastPathways_PENTOSE-P-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_4170_GLU6PDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_4170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2843,7 +2843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PERIPLASMA-NAD-DEGRADATION.ttl
+++ b/models/YeastPathways_PERIPLASMA-NAD-DEGRADATION.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16,24 +16,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PERIPLASMA-NAD-DEGRADATIONSmallMolecule22996> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_BFO_0000066_reaction_NADPYROPHOSPHAT-RXN_location_lociGO_0005829_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PERIPLASMA-NAD-DEGRADATION" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_NADPYROPHOSPHAT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -44,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -52,15 +41,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002233_CHEBI_15377_NADPYROPHOSPHAT-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'NAD<sup>+</sup> + H<sub>2</sub>O &rarr; AMP + &beta;-nicotinamide D-ribonucleotide + 2 H<SUP>+</SUP>' 'null' 'AMP + H<sub>2</sub>O &rarr; adenosine + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002413_AMP-DEPHOSPHORYLATION-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
+          <http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002413_AMP-DEPHOSPHORYLATION-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,11 +75,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_RO_0002234_CHEBI_16335_AMP-DEPHOSPHORYLATION-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_RO_0002234_CHEBI_16335_AMP-DEPHOSPHORYLATION-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -113,17 +113,6 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_RO_0002233_CHEBI_456215_NADPYROPHOSPHAT-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PERIPLASMA-NAD-DEGRADATION" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_14649_NADPYROPHOSPHAT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_14649> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -133,24 +122,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PERIPLASMA-NAD-DEGRADATIONSmallMolecule22983> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002234_CHEBI_15378_NADPYROPHOSPHAT-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PERIPLASMA-NAD-DEGRADATION" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -161,14 +139,14 @@
 <http://purl.obolibrary.org/obo/GO_0035529>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002333_YGL067W-MONOMER_NADPYROPHOSPHAT-RXN_controller_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
+<http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_BFO_0000050_YeastPathways_PERIPLASMA-NAD-DEGRADATION/YeastPathways_PERIPLASMA-NAD-DEGRADATION_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PERIPLASMA-NAD-DEGRADATION" ;
+                "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -187,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,11 +177,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002333_YGL067W-MONOMER_NADPYROPHOSPHAT-RXN_controller_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
+          <http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002333_YGL067W-MONOMER_NADPYROPHOSPHAT-RXN_controller_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -218,11 +196,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_RO_0002233_CHEBI_456215_NADPYROPHOSPHAT-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_RO_0002233_CHEBI_456215_NADPYROPHOSPHAT-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,14 +211,14 @@
           <http://model.geneontology.org/CHEBI_456215_NADPYROPHOSPHAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002234_CHEBI_456215_NADPYROPHOSPHAT-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
+<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002234_CHEBI_15378_NADPYROPHOSPHAT-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PERIPLASMA-NAD-DEGRADATION" ;
+                "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -253,19 +231,19 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_BFO_0000066_reaction_AMP-DEPHOSPHORYLATION-RXN_location_lociGO_0005829_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
+<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002234_CHEBI_456215_NADPYROPHOSPHAT-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PERIPLASMA-NAD-DEGRADATION" ;
+                "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -273,14 +251,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_16335>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002234_CHEBI_14649_NADPYROPHOSPHAT-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002413_AMP-DEPHOSPHORYLATION-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PERIPLASMA-NAD-DEGRADATION" ;
+                "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -296,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "periplasmic NAD degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -308,11 +286,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002233_CHEBI_15377_NADPYROPHOSPHAT-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
+          <http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002233_CHEBI_15377_NADPYROPHOSPHAT-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -322,6 +300,39 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_NADPYROPHOSPHAT-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_RO_0002234_CHEBI_16335_AMP-DEPHOSPHORYLATION-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002233_CHEBI_57540_NADPYROPHOSPHAT-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_BFO_0000066_reaction_AMP-DEPHOSPHORYLATION-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/NADPYROPHOSPHAT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0035529> ;
@@ -342,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -357,11 +368,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002234_CHEBI_456215_NADPYROPHOSPHAT-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
+          <http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002234_CHEBI_456215_NADPYROPHOSPHAT-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -376,11 +387,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_RO_0002233_CHEBI_15377_AMP-DEPHOSPHORYLATION-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_RO_0002233_CHEBI_15377_AMP-DEPHOSPHORYLATION-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -414,14 +425,14 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_RO_0002233_CHEBI_15377_AMP-DEPHOSPHORYLATION-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
+<http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_RO_0002234_CHEBI_43474_AMP-DEPHOSPHORYLATION-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PERIPLASMA-NAD-DEGRADATION" ;
+                "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -432,11 +443,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_BFO_0000066_reaction_NADPYROPHOSPHAT-RXN_location_lociGO_0005829_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
+          <http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_BFO_0000066_reaction_NADPYROPHOSPHAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,18 +463,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002413_AMP-DEPHOSPHORYLATION-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_RO_0002233_CHEBI_15377_AMP-DEPHOSPHORYLATION-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PERIPLASMA-NAD-DEGRADATION" ;
+                "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_BFO_0000066_reaction_NADPYROPHOSPHAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -471,11 +493,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002234_CHEBI_15378_NADPYROPHOSPHAT-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
+          <http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002234_CHEBI_15378_NADPYROPHOSPHAT-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -490,11 +512,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_BFO_0000066_reaction_AMP-DEPHOSPHORYLATION-RXN_location_lociGO_0005829_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_BFO_0000066_reaction_AMP-DEPHOSPHORYLATION-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -514,7 +536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -531,24 +553,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PERIPLASMA-NAD-DEGRADATIONSmallMolecule22935> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_RO_0002234_CHEBI_43474_AMP-DEPHOSPHORYLATION-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PERIPLASMA-NAD-DEGRADATION" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0019677>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -565,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -573,30 +584,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_BFO_0000050_YeastPathways_PERIPLASMA-NAD-DEGRADATION/YeastPathways_PERIPLASMA-NAD-DEGRADATION_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PERIPLASMA-NAD-DEGRADATION" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002233_CHEBI_15377_NADPYROPHOSPHAT-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PERIPLASMA-NAD-DEGRADATION" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -605,11 +594,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_BFO_0000050_YeastPathways_PERIPLASMA-NAD-DEGRADATION/YeastPathways_PERIPLASMA-NAD-DEGRADATION_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
+          <http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_BFO_0000050_YeastPathways_PERIPLASMA-NAD-DEGRADATION/YeastPathways_PERIPLASMA-NAD-DEGRADATION_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -626,15 +615,26 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002234_CHEBI_14649_NADPYROPHOSPHAT-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002234_CHEBI_14649_NADPYROPHOSPHAT-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
+          <http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002234_CHEBI_14649_NADPYROPHOSPHAT-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -645,26 +645,15 @@
           <http://model.geneontology.org/CHEBI_14649_NADPYROPHOSPHAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_BFO_0000050_YeastPathways_PERIPLASMA-NAD-DEGRADATION/YeastPathways_PERIPLASMA-NAD-DEGRADATION_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PERIPLASMA-NAD-DEGRADATION" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_BFO_0000050_YeastPathways_PERIPLASMA-NAD-DEGRADATION/YeastPathways_PERIPLASMA-NAD-DEGRADATION_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_BFO_0000050_YeastPathways_PERIPLASMA-NAD-DEGRADATION/YeastPathways_PERIPLASMA-NAD-DEGRADATION_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,17 +663,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PERIPLASMA-NAD-DEGRADATION/YeastPathways_PERIPLASMA-NAD-DEGRADATION>
 ] .
-
-<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002233_CHEBI_57540_NADPYROPHOSPHAT-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PERIPLASMA-NAD-DEGRADATION" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -696,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -710,6 +688,17 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_RO_0002233_CHEBI_456215_NADPYROPHOSPHAT-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -722,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -734,11 +723,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_RO_0002234_CHEBI_43474_AMP-DEPHOSPHORYLATION-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_RO_0002234_CHEBI_43474_AMP-DEPHOSPHORYLATION-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,14 +738,14 @@
           <http://model.geneontology.org/CHEBI_43474_AMP-DEPHOSPHORYLATION-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_RO_0002234_CHEBI_16335_AMP-DEPHOSPHORYLATION-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
+<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_BFO_0000050_YeastPathways_PERIPLASMA-NAD-DEGRADATION/YeastPathways_PERIPLASMA-NAD-DEGRADATION_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PERIPLASMA-NAD-DEGRADATION" ;
+                "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -767,11 +756,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002233_CHEBI_57540_NADPYROPHOSPHAT-RXN_SGD_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
+          <http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002233_CHEBI_57540_NADPYROPHOSPHAT-RXN_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -784,6 +773,17 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002333_YGL067W-MONOMER_NADPYROPHOSPHAT-RXN_controller_SGD_PWY_YeastPathways_PERIPLASMA-NAD-DEGRADATION>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .

--- a/models/YeastPathways_PHOS-PWY.ttl
+++ b/models/YeastPathways_PHOS-PWY.ttl
@@ -1,12 +1,23 @@
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002333_YJR073C-MONOMER_2.1.1.71-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,6 +28,26 @@
           <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_58779_2.7.7.15-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YGR202C-MONOMER_2.7.7.15-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003434> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -24,22 +55,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYProtein38954> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57856_RXN3O-349>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57856> ;
@@ -50,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,11 +84,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_60377_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_60377_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,25 +99,36 @@
           <http://model.geneontology.org/CHEBI_60377_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_15378_2.7.8.11-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_05d1f440-1f08-4aac-9f22-efe7f6108711_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_60377_RXN-5781_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_57876_2.7.7.14-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_16749_2.7.8.11-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -103,11 +136,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_CHEBI_29888_CDPDIGLYSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_CHEBI_29888_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -127,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -139,11 +172,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_58779_2.7.7.15-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_58779_2.7.7.15-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -157,14 +190,14 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002411_2.1.1.71-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002413_2.7.7.15-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -177,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -194,35 +227,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38662> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_05277f31-8d2d-4cb1-89db-0e9f40fa5050_CDPDIGLYSYN-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002413_2.1.1.17-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57597> ;
@@ -233,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -245,11 +256,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15378_2.1.1.17-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15378_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -264,11 +275,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_16110_RXN-5781_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_16110_RXN-5781_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -283,11 +294,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -305,11 +316,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_456216_CHOLINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_456216_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -337,37 +348,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_29888>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002333_YJR073C-MONOMER_2.1.1.71-RXN_controller_SGD_YeastPathways_PHOS-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.71-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR073C-MONOMER_2.1.1.71-RXN_controller>
-] .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_BFO_0000066_reaction_RXN4FS-2_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_BFO_0000066_reaction_RXN4FS-2_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,11 +371,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -397,6 +386,50 @@
           <http://model.geneontology.org/YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_29888>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002333_YJR073C-MONOMER_2.1.1.71-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.71-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YJR073C-MONOMER_2.1.1.71-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_db3f79e0-ee31-40a6-8eb6-bd1ce3ccda11_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_15378_2.7.8.11-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008654> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -406,7 +439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -417,39 +450,6 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002333_YGR202C-MONOMER_2.7.7.15-RXN_controller_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_2.7.8.11-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -467,26 +467,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000066_reaction_CHOLINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -507,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -515,15 +504,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -538,11 +538,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN3O-349_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN3O-349_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -553,41 +553,36 @@
           <http://model.geneontology.org/RXN3O-349>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_29888_2.7.7.14-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004306>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002333_YPR113W-MONOMER_2.7.8.11-RXN_controller_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/9f437cfa-4e93-465b-96a8-7487ce6f1c65_CDPDIGLYSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN4FS-2>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -598,7 +593,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN4FS-2_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/73de99fe-3e35-4dde-8119-c6498197de5d_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_RXN4FS-2> ;
+                <http://model.geneontology.org/c58c0a4a-fd04-406b-a31e-c78261278a3c_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_RXN4FS-2> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16110_RXN4FS-2> , <http://model.geneontology.org/CHEBI_15378_RXN4FS-2> , <http://model.geneontology.org/CHEBI_57856_RXN4FS-2> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -606,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -614,14 +609,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000066_reaction_2.1.1.17-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_60377_RXN-5781_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -629,11 +624,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" , "Provides Input For Rule. The relation 'a CDP-diacylglycerol + L-serine &harr; CMP + a 3-<i>O</i>-<i>sn</i>-phosphatidyl-L-serine + H<SUP>+</SUP>' 'null' 'a 3-<i>O</i>-<i>sn</i>-phosphatidyl-L-serine + H<SUP>+</SUP> &rarr; an L-1-phosphatidylethanolamine + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002413_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002413_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -644,14 +639,25 @@
           <http://model.geneontology.org/PHOSPHASERDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_60377_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002333_YLR133W-MONOMER_CHOLINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -659,11 +665,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_2f4936b8-7db5-447d-bbf7-1f56dcf895d6_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_5ba5f8c6-84e0-4951-b60e-c310d4348ad3_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,18 +677,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PGPPHOSPHA-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2f4936b8-7db5-447d-bbf7-1f56dcf895d6_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/5ba5f8c6-84e0-4951-b60e-c310d4348ad3_PHOSPHAGLYPSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000066_reaction_2.7.7.15-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000066_reaction_2.7.7.15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -693,36 +699,25 @@
           <http://model.geneontology.org/reaction_2.7.7.15-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_16110_RXN-5781_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002413_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002333_YER026C-MONOMER_PHOSPHASERSYN-RXN_controller_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002333_YGR157W-MONOMER_2.1.1.17-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000066_reaction_PGPPHOSPHA-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -735,7 +730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -747,11 +742,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -766,11 +761,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002333_YJR073C-MONOMER_RXN4FS-2_controller_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002333_YJR073C-MONOMER_RXN4FS-2_controller_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -781,14 +776,14 @@
           <http://model.geneontology.org/YJR073C-MONOMER_RXN4FS-2_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002413_2.1.1.17-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -801,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -809,14 +804,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_58779_2.7.7.15-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -827,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -839,11 +845,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_15378_2.7.8.11-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_15378_2.7.8.11-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -854,14 +860,14 @@
           <http://model.geneontology.org/CHEBI_15378_2.7.8.11-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_2f4936b8-7db5-447d-bbf7-1f56dcf895d6_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_15378_RXN4FS-2_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -872,7 +878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -889,24 +895,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38635> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002333_YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -915,11 +910,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_59789_2.1.1.71-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_59789_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -934,11 +929,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_d645e201-ef62-4b79-b53e-5da4a62173f6_2.1.1.71-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_db3f79e0-ee31-40a6-8eb6-bd1ce3ccda11_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -946,19 +941,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-349> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d645e201-ef62-4b79-b53e-5da4a62173f6_2.1.1.71-RXN>
+          <http://model.geneontology.org/db3f79e0-ee31-40a6-8eb6-bd1ce3ccda11_2.1.1.71-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_16110_RXN4FS-2_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_295975>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -975,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -986,15 +970,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1005,12 +1000,45 @@
           <http://model.geneontology.org/YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002333_YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_456216_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_60377_2.7.8.11-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1018,11 +1046,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1040,11 +1068,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1055,14 +1083,14 @@
           <http://model.geneontology.org/CHEBI_15378_ETHANOLAMINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000066_reaction_2.1.1.71-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1071,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1084,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1096,11 +1124,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1111,6 +1139,17 @@
           <http://model.geneontology.org/CHEBI_58190_ETHANOLAMINE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_295975_CHOLINE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_295975> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1120,35 +1159,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38935> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_CHEBI_17268_2.7.8.11-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004608>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1157,11 +1174,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_c9669904-1f4a-46d6-bbb2-87af24642a05_CDPDIGLYSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_855056bd-56d4-4740-8849-1d39080f4cae_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1169,39 +1186,39 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c9669904-1f4a-46d6-bbb2-87af24642a05_CDPDIGLYSYN-RXN>
+          <http://model.geneontology.org/855056bd-56d4-4740-8849-1d39080f4cae_CDPDIGLYSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_62237_CARDIOLIPSYN-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000066_reaction_2.1.1.17-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_CHEBI_59789_RXN4FS-2_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000066_reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002413_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1222,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1239,7 +1256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1252,22 +1269,19 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/c9669904-1f4a-46d6-bbb2-87af24642a05_CDPDIGLYSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002333_YHR123W-MONOMER_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_controller_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002333_YHR123W-MONOMER_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1297,13 +1311,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYBiochemicalReaction38957> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000066_reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002333_YNL130C-MONOMER_RXN-5781_controller_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PHOSPHASERSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003882> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1314,7 +1350,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/c9669904-1f4a-46d6-bbb2-87af24642a05_CDPDIGLYSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/855056bd-56d4-4740-8849-1d39080f4cae_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1324,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1332,32 +1368,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/fabafd9b-8273-400d-904f-a5f75fc23bfd_2.1.1.17-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000066_reaction_2.7.7.15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39119> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_f241ebcd-b34b-4e5d-98a2-d376a4976465_CDPDIGLYSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_9f437cfa-4e93-465b-96a8-7487ce6f1c65_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1365,18 +1395,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CDPDIGLYSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f241ebcd-b34b-4e5d-98a2-d376a4976465_CDPDIGLYSYN-RXN>
+          <http://model.geneontology.org/9f437cfa-4e93-465b-96a8-7487ce6f1c65_CDPDIGLYSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002333_YGR202C-MONOMER_2.7.7.15-RXN_controller_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002333_YGR202C-MONOMER_2.7.7.15-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1387,49 +1417,8 @@
           <http://model.geneontology.org/YGR202C-MONOMER_2.7.7.15-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_29089_CDPDIGLYSYN-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_YeastPathways_PHOS-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.17-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN>
-] .
 
 <http://model.geneontology.org/CDPDIGLYSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004605> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1442,7 +1431,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_37563_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_29089_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/f241ebcd-b34b-4e5d-98a2-d376a4976465_CDPDIGLYSYN-RXN> ;
+                <http://model.geneontology.org/9f437cfa-4e93-465b-96a8-7487ce6f1c65_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1450,7 +1439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1462,11 +1451,30 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_60377_RXN-5781_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.17-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_60377_RXN-5781_SGD_PWY_YeastPathways_PHOS-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1480,17 +1488,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YER026C-MONOMER_PHOSPHASERSYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000828> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1498,13 +1495,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYProtein39202> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_15378_RXN-5781_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000000510> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1513,7 +1521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1521,48 +1529,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/23f2c9fc-ef77-41ef-88d4-28dc715b3e9a_2.1.1.71-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15378_2.1.1.17-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_17815_RXN-5781_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38625> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_37ec37dc-fc66-4d2c-a476-a1c28ace94d4_CDPDIGLYSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_87efaba4-5053-4dee-9885-cdf36515cc3a_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1570,7 +1562,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/37ec37dc-fc66-4d2c-a476-a1c28ace94d4_CDPDIGLYSYN-RXN>
+          <http://model.geneontology.org/87efaba4-5053-4dee-9885-cdf36515cc3a_CDPDIGLYSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_ETHANOLAMINE-KINASE-RXN>
@@ -1582,7 +1574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1597,7 +1589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1605,37 +1597,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002411_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002333_YLR133W-MONOMER_CHOLINE-KINASE-RXN_controller_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002333_YLR133W-MONOMER_CHOLINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1646,54 +1616,30 @@
           <http://model.geneontology.org/YLR133W-MONOMER_CHOLINE-KINASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_c9669904-1f4a-46d6-bbb2-87af24642a05_CDPDIGLYSYN-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_CHEBI_59789_RXN4FS-2_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_CHEBI_59789_RXN4FS-2_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1704,57 +1650,15 @@
           <http://model.geneontology.org/CHEBI_59789_RXN4FS-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_58779_2.7.7.15-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_17754_CARDIOLIPSYN-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000066_reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000066_reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1765,15 +1669,26 @@
           <http://model.geneontology.org/reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_57856_RXN3O-349_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1784,15 +1699,26 @@
           <http://model.geneontology.org/YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_CHEBI_29888_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000066_reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000066_reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1807,11 +1733,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN4FS-2_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN4FS-2_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1831,24 +1757,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38754> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_59789_2.1.1.71-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-5781>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -1859,7 +1774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1870,39 +1785,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_17754>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_15378_CDPDIGLYSYN-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_57856_RXN4FS-2_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000003239>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1925,7 +1818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1946,11 +1839,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1961,6 +1854,17 @@
           <http://model.geneontology.org/YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57603_ETHANOLAMINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57603> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1970,7 +1874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1978,14 +1882,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_15378_2.7.7.15-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_15378_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1998,7 +1902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2006,26 +1910,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000066_reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_43474_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_43474_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2040,11 +1933,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_15378_2.7.7.15-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_15378_2.7.7.15-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2067,7 +1960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2075,15 +1968,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000066_reaction_PGPPHOSPHA-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_0baab9b6-969a-4e1b-9dc0-0bf1604eeeea_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000066_reaction_CHOLINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000066_reaction_CHOLINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2094,15 +2009,26 @@
           <http://model.geneontology.org/reaction_CHOLINE-KINASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2117,11 +2043,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000066_reaction_RXN-5781_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000066_reaction_RXN-5781_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2132,9 +2058,6 @@
           <http://model.geneontology.org/reaction_RXN-5781_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/d645e201-ef62-4b79-b53e-5da4a62173f6_2.1.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/YLR133W-MONOMER_CHOLINE-KINASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000004123> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2142,7 +2065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2150,14 +2073,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002333_YHR123W-MONOMER_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2165,11 +2088,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_64716_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_64716_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2180,17 +2103,6 @@
           <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_62237>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2200,15 +2112,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_37563>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002333_YER026C-MONOMER_PHOSPHASERSYN-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_15354_CHOLINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_15354_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2219,26 +2142,18 @@
           <http://model.geneontology.org/CHEBI_15354_CHOLINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_15354_CHOLINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/0baab9b6-969a-4e1b-9dc0-0bf1604eeeea_2.1.1.17-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_16749_2.7.8.11-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_16749_2.7.8.11-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2252,15 +2167,26 @@
 <http://identifiers.org/sgd/S000001165>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_513ec18d-e97b-4b7b-99e0-62a95fe75c23_2.1.1.17-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_0baab9b6-969a-4e1b-9dc0-0bf1604eeeea_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2268,18 +2194,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/513ec18d-e97b-4b7b-99e0-62a95fe75c23_2.1.1.17-RXN>
+          <http://model.geneontology.org/0baab9b6-969a-4e1b-9dc0-0bf1604eeeea_2.1.1.17-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_16110_RXN3O-349_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_16110_RXN3O-349_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2290,17 +2216,6 @@
           <http://model.geneontology.org/CHEBI_16110_RXN3O-349>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15354>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2308,11 +2223,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000066_reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000066_reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2327,11 +2242,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000066_reaction_CDPDIGLYSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000066_reaction_CDPDIGLYSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2342,6 +2257,17 @@
           <http://model.geneontology.org/reaction_CDPDIGLYSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002413_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_60377_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_60377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2351,7 +2277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2359,26 +2285,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_456216>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000066_reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_62237_CARDIOLIPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_456216>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_2.1.1.71-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2386,11 +2323,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_456216_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_456216_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2400,45 +2337,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_456216_ETHANOLAMINE-KINASE-RXN>
 ] .
-
-<http://model.geneontology.org/adacf817-d48e-48d5-806f-52db2b6e83b6_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39003> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002413_2.7.7.14-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_73de99fe-3e35-4dde-8119-c6498197de5d_2.1.1.71-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/2.1.1.17-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004608> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2451,7 +2349,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/fabafd9b-8273-400d-904f-a5f75fc23bfd_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
+                <http://model.geneontology.org/7895a567-25c8-4789-9b65-abc0b04cb4a7_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR157W-MONOMER_2.1.1.17-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2459,7 +2357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2471,11 +2369,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_29888_2.7.7.14-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_29888_2.7.7.14-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2486,23 +2384,23 @@
           <http://model.geneontology.org/CHEBI_29888_2.7.7.14-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_PGPPHOSPHA-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_57603_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2515,7 +2413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2530,11 +2428,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2560,7 +2458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2568,14 +2466,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002413_2.7.7.15-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2583,11 +2481,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a 1,2-diacyl-<i>sn</i>-glycerol + CDP-ethanolamine &rarr; an L-1-phosphatidylethanolamine + CMP + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + an L-1-phosphatidylethanolamine &rarr; a phosphatidyl-<i>N</i>-methylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002413_2.1.1.17-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002413_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2603,7 +2501,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_9f437cfa-4e93-465b-96a8-7487ce6f1c65_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2611,11 +2520,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002333_YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002333_YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2630,11 +2539,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'CTP + phosphocholine + H<SUP>+</SUP> &rarr; CDP-choline + diphosphate' 'null' 'a 1,2-diacyl-<i>sn</i>-glycerol + CDP-choline &harr; a phosphatidylcholine + CMP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002413_RXN-5781_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002413_RXN-5781_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2648,6 +2557,39 @@
 <http://purl.obolibrary.org/obo/CHEBI_57856>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_17754_CARDIOLIPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2658,11 +2600,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_fabafd9b-8273-400d-904f-a5f75fc23bfd_2.1.1.17-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_7895a567-25c8-4789-9b65-abc0b04cb4a7_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2670,18 +2612,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.17-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fabafd9b-8273-400d-904f-a5f75fc23bfd_2.1.1.17-RXN>
+          <http://model.geneontology.org/7895a567-25c8-4789-9b65-abc0b04cb4a7_2.1.1.17-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002333_YNL130C-MONOMER_RXN-5781_controller_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002333_YNL130C-MONOMER_RXN-5781_controller_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2692,15 +2634,26 @@
           <http://model.geneontology.org/YNL130C-MONOMER_RXN-5781_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_37563_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2715,11 +2668,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2739,7 +2692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of phosphatidic acid and phospholipid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2747,32 +2700,15 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/5733d001-6f30-4eda-9858-5b50d9450669_2.1.1.71-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38625> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'choline + ATP &rarr; phosphocholine + ADP + H<SUP>+</SUP>' 'null' 'CTP + phosphocholine + H<SUP>+</SUP> &rarr; CDP-choline + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002413_2.7.7.15-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002413_2.7.7.15-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2787,11 +2723,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002333_YGR157W-MONOMER_2.1.1.17-RXN_controller_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002333_YGR157W-MONOMER_2.1.1.17-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2801,6 +2737,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YGR157W-MONOMER_2.1.1.17-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000066_reaction_RXN-5781_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_30616_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000828>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2812,7 +2770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2827,11 +2785,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_73de99fe-3e35-4dde-8119-c6498197de5d_2.1.1.71-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_c58c0a4a-fd04-406b-a31e-c78261278a3c_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2839,18 +2797,40 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN4FS-2> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/73de99fe-3e35-4dde-8119-c6498197de5d_2.1.1.71-RXN>
+          <http://model.geneontology.org/c58c0a4a-fd04-406b-a31e-c78261278a3c_2.1.1.71-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002333_YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_c58c0a4a-fd04-406b-a31e-c78261278a3c_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002233_CHEBI_64716_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002233_CHEBI_64716_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2861,36 +2841,14 @@
           <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002333_YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002413_CARDIOLIPSYN-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_37563_2.7.7.14-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2898,11 +2856,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2913,25 +2871,25 @@
           <http://model.geneontology.org/YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_15378_2.1.1.71-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002333_YGR202C-MONOMER_2.7.7.15-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_15378_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2944,7 +2902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2952,37 +2910,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002413_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_17815_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_17815_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2997,11 +2933,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3012,39 +2948,50 @@
           <http://model.geneontology.org/YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_23f2c9fc-ef77-41ef-88d4-28dc715b3e9a_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_30616_CHOLINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_64716_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_30616_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_16110_RXN3O-349_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3057,7 +3004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3065,16 +3012,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000066_reaction_2.1.1.71-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/855056bd-56d4-4740-8849-1d39080f4cae_CDPDIGLYSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/YHR123W-MONOMER_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000001165> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3083,7 +3022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3100,7 +3039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3127,24 +3066,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYBiochemicalReaction38984> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_29888_2.7.7.15-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_11750> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3155,7 +3083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3163,26 +3091,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/7895a567-25c8-4789-9b65-abc0b04cb4a7_2.1.1.17-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39119> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3200,11 +3134,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_17815_RXN-5781_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_17815_RXN-5781_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3220,7 +3154,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002411_2.7.8.11-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000066_reaction_RXN3O-349_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3228,11 +3184,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000066_reaction_2.1.1.17-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000066_reaction_2.1.1.17-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3243,17 +3199,6 @@
           <http://model.geneontology.org/reaction_2.1.1.17-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29089_CDPDIGLYSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29089> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3263,35 +3208,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38912> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002333_YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000066_reaction_RXN3O-349_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-349>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3302,7 +3225,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_59789_RXN3O-349> , <http://model.geneontology.org/d645e201-ef62-4b79-b53e-5da4a62173f6_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/db3f79e0-ee31-40a6-8eb6-bd1ce3ccda11_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_57856_RXN3O-349> , <http://model.geneontology.org/CHEBI_16110_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -3310,7 +3233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3318,26 +3241,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002333_YJR073C-MONOMER_RXN4FS-2_controller_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate + H<sub>2</sub>O &rarr; an L-1-phosphatidyl-<i>sn</i>-glycerol + phosphate' 'null' '2 an L-1-phosphatidyl-<i>sn</i>-glycerol &rarr; a cardiolipin + glycerol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002413_CARDIOLIPSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002413_CARDIOLIPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3351,6 +3263,17 @@
 <http://identifiers.org/sgd/S000005074>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57597>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3358,11 +3281,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_30616_CHOLINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_30616_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3371,36 +3294,6 @@
           <http://model.geneontology.org/CHOLINE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30616_CHOLINE-KINASE-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_60377_2.7.8.11-RXN_SGD_YeastPathways_PHOS-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.7.8.11-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_60377_2.7.8.11-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16038_PHOSPHASERDECARB-RXN>
@@ -3412,7 +3305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3420,45 +3313,61 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_adacf817-d48e-48d5-806f-52db2b6e83b6_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/37ec37dc-fc66-4d2c-a476-a1c28ace94d4_CDPDIGLYSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://purl.obolibrary.org/obo/CHEBI_58779>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_60377_2.7.8.11-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.7.8.11-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_60377_2.7.8.11-RXN>
+] .
 
 <http://identifiers.org/sgd/S000003434>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_57876_2.7.7.14-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_58779>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_d645e201-ef62-4b79-b53e-5da4a62173f6_2.1.1.71-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002333_YPR113W-MONOMER_2.7.8.11-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000066_reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_16110_RXN4FS-2_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3466,11 +3375,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_15378_2.1.1.71-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_15378_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3485,11 +3394,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_57856_RXN3O-349_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_57856_RXN3O-349_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3507,13 +3416,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYProtein38894> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002233_CHEBI_64716_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16110_RXN-5781>
         a       <http://purl.obolibrary.org/obo/CHEBI_16110> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3524,13 +3444,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38635> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002333_YJR073C-MONOMER_RXN3O-349_controller_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0008444> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3541,9 +3472,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/37ec37dc-fc66-4d2c-a476-a1c28ace94d4_CDPDIGLYSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/87efaba4-5053-4dee-9885-cdf36515cc3a_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/adacf817-d48e-48d5-806f-52db2b6e83b6_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/6a7f0829-0282-4e0c-aa50-9905dd719dc0_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3551,7 +3482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3559,18 +3490,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/73de99fe-3e35-4dde-8119-c6498197de5d_2.1.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3600,7 +3528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3617,7 +3545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3629,11 +3557,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_15378_CDPDIGLYSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_15378_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3644,47 +3572,25 @@
           <http://model.geneontology.org/CHEBI_15378_CDPDIGLYSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002333_YNL130C-MONOMER_RXN-5781_controller_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_64716_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_456216_CHOLINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000066_reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3692,11 +3598,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3707,14 +3613,14 @@
           <http://model.geneontology.org/CHEBI_58190_ETHANOLAMINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_15378_RXN4FS-2_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3724,15 +3630,18 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/05d1f440-1f08-4aac-9f22-efe7f6108711_CDPDIGLYSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_57876_2.7.7.14-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_57876_2.7.7.14-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3746,15 +3655,37 @@
 <http://purl.obolibrary.org/obo/GO_0003881>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002413_2.7.7.14-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002411_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3765,17 +3696,6 @@
           <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_37563_2.7.7.15-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_37563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3785,7 +3705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3793,26 +3713,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002333_YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3835,7 +3744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3843,18 +3752,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000000510>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_15378_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002411_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002411_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3865,16 +3793,8 @@
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002413_RXN-5781_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000000510>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58779_2.7.7.15-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58779> ;
@@ -3885,7 +3805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3893,39 +3813,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_f241ebcd-b34b-4e5d-98a2-d376a4976465_CDPDIGLYSYN-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002301>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_456216_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002411_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000066_reaction_CDPDIGLYSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3938,7 +3847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3950,11 +3859,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" , "Provides Input For Rule. The relation 'a 1,2-diacyl-<i>sn</i>-glycerol + CDP-choline &harr; a phosphatidylcholine + CMP + H<SUP>+</SUP>' 'null' 'CTP + phosphocholine + H<SUP>+</SUP> &rarr; CDP-choline + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002413_2.7.7.15-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002413_2.7.7.15-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3965,24 +3874,33 @@
           <http://model.geneontology.org/2.7.7.15-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000066_reaction_2.7.8.11-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.7.8.11-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_2.7.8.11-RXN_location_lociGO_0005829>
-] .
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/6a7f0829-0282-4e0c-aa50-9905dd719dc0_PHOSPHAGLYPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39003> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_17815_RXN-5781>
         a       <http://purl.obolibrary.org/obo/CHEBI_17815> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3993,7 +3911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4005,11 +3923,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4020,50 +3938,47 @@
           <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002413_2.7.7.15-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002333_YHR123W-MONOMER_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_controller_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000002554>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000066_reaction_RXN-5781_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_CHEBI_15377_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000066_reaction_2.7.8.11-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.7.8.11-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_2.7.8.11-RXN_location_lociGO_0005829>
+] .
+
+<http://identifiers.org/sgd/S000002554>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_16110_RXN-5781_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4071,30 +3986,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002411_2.1.1.71-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.17-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.1.1.71-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4103,6 +3999,25 @@
           <http://model.geneontology.org/ETHANOLAMINE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002411_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.17-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/2.1.1.71-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_ETHANOLAMINE-KINASE-RXN>
@@ -4114,7 +4029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4122,19 +4037,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000066_reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/2f4936b8-7db5-447d-bbf7-1f56dcf895d6_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://identifiers.org/sgd/S000006317>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4143,11 +4055,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_15378_RXN4FS-2_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_15378_RXN4FS-2_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4158,15 +4070,26 @@
           <http://model.geneontology.org/CHEBI_15378_RXN4FS-2>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002411_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_17754_CARDIOLIPSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_17754_CARDIOLIPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4177,17 +4100,6 @@
           <http://model.geneontology.org/CHEBI_17754_CARDIOLIPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002333_YJR073C-MONOMER_RXN3O-349_controller_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_59789_RXN4FS-2>
         a       <http://purl.obolibrary.org/obo/CHEBI_59789> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4197,7 +4109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4205,29 +4117,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/05277f31-8d2d-4cb1-89db-0e9f40fa5050_CDPDIGLYSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" , "Provides Input For Rule. The relation 'a 3-<i>O</i>-<i>sn</i>-phosphatidyl-L-serine + H<SUP>+</SUP> &rarr; an L-1-phosphatidylethanolamine + CO<SUB>2</SUB>' 'null' '<i>S</i>-adenosyl-L-methionine + an L-1-phosphatidylethanolamine &rarr; a phosphatidyl-<i>N</i>-methylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002413_2.1.1.17-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002413_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4241,17 +4139,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_16110>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002233_CHEBI_64716_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0043337>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -4259,11 +4146,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_57876_2.7.7.14-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_57876_2.7.7.14-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4278,11 +4165,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000066_reaction_2.7.7.14-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000066_reaction_2.7.7.14-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4302,7 +4189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4313,27 +4200,8 @@
 <http://purl.obolibrary.org/obo/CHEBI_11750>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002413_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004605>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_60377_RXN-5781>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_60377> ;
@@ -4344,7 +4212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4352,18 +4220,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0004605>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_30616_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4374,43 +4250,35 @@
           <http://model.geneontology.org/YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY>
 ] .
 
+<http://model.geneontology.org/db3f79e0-ee31-40a6-8eb6-bd1ce3ccda11_2.1.1.71-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002413_RXN-5781_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_29089>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_60377_2.7.8.11-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_CHEBI_15377_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4421,16 +4289,8 @@
           <http://model.geneontology.org/CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000066_reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/5ba5f8c6-84e0-4951-b60e-c310d4348ad3_PHOSPHAGLYPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/YGR157W-MONOMER_2.1.1.17-RXN_controller>
         a       <http://identifiers.org/sgd/S000003389> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4439,7 +4299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4447,26 +4307,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_29089_CDPDIGLYSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_29089_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4477,15 +4326,26 @@
           <http://model.geneontology.org/CHEBI_29089_CDPDIGLYSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15378_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_37563_2.7.7.15-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_37563_2.7.7.15-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4505,7 +4365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4513,15 +4373,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4532,15 +4403,37 @@
           <http://model.geneontology.org/CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_29089_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_58779_2.7.7.15-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_58779_2.7.7.15-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4570,7 +4463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4588,7 +4481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4596,25 +4489,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002333_YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_855056bd-56d4-4740-8849-1d39080f4cae_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4625,11 +4507,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4640,40 +4522,40 @@
           <http://model.geneontology.org/YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002333_YGR157W-MONOMER_2.1.1.17-RXN_controller_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_37563_2.7.7.14-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_15378_CHOLINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_15378_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4688,11 +4570,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002333_YPR113W-MONOMER_2.7.8.11-RXN_controller_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002333_YPR113W-MONOMER_2.7.8.11-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4712,7 +4594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4720,14 +4602,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_CHEBI_29888_CDPDIGLYSYN-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002333_YGR007W-MONOMER_2.7.7.14-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4735,52 +4617,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002333_YJR073C-MONOMER_RXN3O-349_controller_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.71-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN3O-349_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002333_YJR073C-MONOMER_RXN3O-349_controller_SGD_YeastPathways_PHOS-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4791,8 +4632,60 @@
           <http://model.geneontology.org/YJR073C-MONOMER_RXN3O-349_controller>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.71-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_29888_2.7.7.14-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002413_2.7.7.15-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16749>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4806,13 +4699,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38662> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YJR073C-MONOMER_RXN3O-349_controller>
         a       <http://identifiers.org/sgd/S000003834> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4821,7 +4725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4833,11 +4737,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4848,17 +4752,6 @@
           <http://model.geneontology.org/CHEBI_15378_PHOSPHASERDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_57603_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_2.7.7.14-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4868,7 +4761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4881,18 +4774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_513ec18d-e97b-4b7b-99e0-62a95fe75c23_2.1.1.17-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4900,11 +4782,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002333_YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002333_YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4918,6 +4800,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_57876>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_15378_2.7.7.14-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN4FS-2_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000000233>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -4926,7 +4830,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4934,11 +4849,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002333_YGR007W-MONOMER_2.7.7.14-RXN_controller_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002333_YGR007W-MONOMER_2.7.7.14-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4949,30 +4864,19 @@
           <http://model.geneontology.org/YGR007W-MONOMER_2.7.7.14-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_5733d001-6f30-4eda-9858-5b50d9450669_2.1.1.71-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002333_YJR073C-MONOMER_2.1.1.71-RXN_controller_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0003882>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000000233> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4981,7 +4885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4993,11 +4897,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5008,14 +4912,25 @@
           <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_16110_RXN3O-349_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_59789_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5028,7 +4943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5039,26 +4954,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_58190>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_15378_RXN-5781_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000066_reaction_PGPPHOSPHA-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000066_reaction_PGPPHOSPHA-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5073,11 +4977,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" , "Provides Input For Rule. The relation '<i>O</i>-phosphoethanolamine + CTP + H<SUP>+</SUP> &rarr; CDP-ethanolamine + diphosphate' 'null' 'a 1,2-diacyl-<i>sn</i>-glycerol + CDP-ethanolamine &rarr; an L-1-phosphatidylethanolamine + CMP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002413_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002413_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5088,25 +4992,14 @@
           <http://model.geneontology.org/ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_fabafd9b-8273-400d-904f-a5f75fc23bfd_2.1.1.17-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000066_reaction_2.7.8.11-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5114,11 +5007,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002411_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002411_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5129,26 +5022,15 @@
           <http://model.geneontology.org/PHOSPHASERSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_BFO_0000066_reaction_RXN4FS-2_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_16110_RXN4FS-2_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_16110_RXN4FS-2_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5162,17 +5044,6 @@
 <http://identifiers.org/sgd/S000004123>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002411_2.7.8.11-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004105>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -5180,11 +5051,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5195,25 +5066,17 @@
           <http://model.geneontology.org/YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000066_reaction_2.7.7.15-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/c58c0a4a-fd04-406b-a31e-c78261278a3c_2.1.1.71-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_57856_RXN3O-349_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002333_YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5221,11 +5084,30 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_CHEBI_17268_2.7.8.11-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_6a7f0829-0282-4e0c-aa50-9905dd719dc0_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/6a7f0829-0282-4e0c-aa50-9905dd719dc0_PHOSPHAGLYPSYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_CHEBI_17268_2.7.8.11-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5236,36 +5118,36 @@
           <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_adacf817-d48e-48d5-806f-52db2b6e83b6_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/adacf817-d48e-48d5-806f-52db2b6e83b6_PHOSPHAGLYPSYN-RXN>
-] .
-
-<http://model.geneontology.org/513ec18d-e97b-4b7b-99e0-62a95fe75c23_2.1.1.17-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_37ec37dc-fc66-4d2c-a476-a1c28ace94d4_CDPDIGLYSYN-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_17815_RXN-5781_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_57876_2.7.7.14-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5273,11 +5155,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000066_reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000066_reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5292,11 +5174,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5316,7 +5198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5327,15 +5209,32 @@
 <http://purl.obolibrary.org/obo/CHEBI_17268>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/CHEBI_15378_2.7.7.15-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38662> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_62237_CARDIOLIPSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_62237_CARDIOLIPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5346,23 +5245,6 @@
           <http://model.geneontology.org/CHEBI_62237_CARDIOLIPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_15378_2.7.7.15-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38662> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/2.7.8.11-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003881> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -5372,7 +5254,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.7.8.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/05277f31-8d2d-4cb1-89db-0e9f40fa5050_CDPDIGLYSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/05d1f440-1f08-4aac-9f22-efe7f6108711_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_60377_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_16749_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -5380,7 +5262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5393,23 +5275,34 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_60377_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002333_YGR007W-MONOMER_2.7.7.14-RXN_controller_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YJR073C-MONOMER_2.1.1.71-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003834> ;
@@ -5418,7 +5311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5438,7 +5331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5450,11 +5343,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_15378_2.7.7.14-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_15378_2.7.7.14-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5465,48 +5358,37 @@
           <http://model.geneontology.org/CHEBI_15378_2.7.7.14-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_37563_2.7.7.15-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_CHOLINE-KINASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_CHEBI_17268_2.7.8.11-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_17815_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002413_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5514,11 +5396,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000066_reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000066_reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5529,25 +5411,14 @@
           <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000066_reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_43474_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5556,7 +5427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5564,11 +5435,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5579,21 +5450,54 @@
           <http://model.geneontology.org/CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000066_reaction_CHOLINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16038>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002413_CARDIOLIPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000066_reaction_2.7.8.11-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_37563_CDPDIGLYSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_37563_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5608,11 +5512,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_29888_2.7.7.15-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_29888_2.7.7.15-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5623,14 +5527,25 @@
           <http://model.geneontology.org/CHEBI_29888_2.7.7.15-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000066_reaction_2.7.7.14-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_7895a567-25c8-4789-9b65-abc0b04cb4a7_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5638,11 +5553,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5657,11 +5572,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_15378_RXN-5781_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_15378_RXN-5781_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5681,9 +5596,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.1.1.71-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> , <http://model.geneontology.org/513ec18d-e97b-4b7b-99e0-62a95fe75c23_2.1.1.17-RXN> ;
+                <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> , <http://model.geneontology.org/0baab9b6-969a-4e1b-9dc0-0bf1604eeeea_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/5733d001-6f30-4eda-9858-5b50d9450669_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/23f2c9fc-ef77-41ef-88d4-28dc715b3e9a_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YJR073C-MONOMER_2.1.1.71-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -5691,7 +5606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5702,22 +5617,27 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/f241ebcd-b34b-4e5d-98a2-d376a4976465_CDPDIGLYSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_37563_2.7.7.15-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57856> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5728,7 +5648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5745,7 +5665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5757,11 +5677,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5772,36 +5692,14 @@
           <http://model.geneontology.org/reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002411_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_15378_CHOLINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_58779_2.7.7.15-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5814,7 +5712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5826,11 +5724,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5844,6 +5742,28 @@
 <http://purl.obolibrary.org/obo/GO_0004142>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_15354_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33384> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5853,7 +5773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5866,7 +5786,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_29888_2.7.7.15-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5874,11 +5805,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_5733d001-6f30-4eda-9858-5b50d9450669_2.1.1.71-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_23f2c9fc-ef77-41ef-88d4-28dc715b3e9a_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5886,18 +5817,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5733d001-6f30-4eda-9858-5b50d9450669_2.1.1.71-RXN>
+          <http://model.geneontology.org/23f2c9fc-ef77-41ef-88d4-28dc715b3e9a_2.1.1.71-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5908,14 +5839,25 @@
           <http://model.geneontology.org/YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_5ba5f8c6-84e0-4951-b60e-c310d4348ad3_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5928,7 +5870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5940,11 +5882,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5955,14 +5897,14 @@
           <http://model.geneontology.org/CHEBI_16038_PHOSPHASERDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000066_reaction_2.7.7.14-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_456216_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5971,7 +5913,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_15378_2.7.7.15-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5979,11 +5932,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ethanolamine + ATP &rarr; <i>O</i>-phosphoethanolamine + ADP + H<SUP>+</SUP>' 'null' '<i>O</i>-phosphoethanolamine + CTP + H<SUP>+</SUP> &rarr; CDP-ethanolamine + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002413_2.7.7.14-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002413_2.7.7.14-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6003,13 +5956,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38662> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_BFO_0000066_reaction_RXN4FS-2_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57876_2.7.7.14-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57876> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6020,7 +5984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6028,22 +5992,44 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000005113>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/CHEBI_60377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_15378_2.7.7.14-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_87efaba4-5053-4dee-9885-cdf36515cc3a_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://identifiers.org/sgd/S000005113>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6055,7 +6041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6066,26 +6052,15 @@
 <http://purl.obolibrary.org/obo/GO_0004305>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002333_YER026C-MONOMER_PHOSPHASERSYN-RXN_controller_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002333_YER026C-MONOMER_PHOSPHASERSYN-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6096,14 +6071,14 @@
           <http://model.geneontology.org/YER026C-MONOMER_PHOSPHASERSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_37563_CDPDIGLYSYN-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000066_reaction_CDPDIGLYSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6116,7 +6091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6127,14 +6102,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN3O-349_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6142,11 +6117,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_CHEBI_15377_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_CHEBI_15377_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6161,11 +6136,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6176,25 +6151,25 @@
           <http://model.geneontology.org/YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_43474_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002333_YLR133W-MONOMER_CHOLINE-KINASE-RXN_controller_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_6a7f0829-0282-4e0c-aa50-9905dd719dc0_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6202,11 +6177,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002411_2.7.8.11-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002411_2.7.8.11-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6221,11 +6196,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_57856_RXN4FS-2_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_57856_RXN4FS-2_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6245,7 +6220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6253,14 +6228,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000066_reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_57856_RXN4FS-2_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6273,7 +6248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6285,11 +6260,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000066_reaction_RXN3O-349_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000066_reaction_RXN3O-349_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6300,14 +6275,28 @@
           <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_16749_2.7.8.11-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/87efaba4-5053-4dee-9885-cdf36515cc3a_CDPDIGLYSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6315,11 +6304,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002333_YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002333_YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6339,7 +6328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6351,11 +6340,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_05277f31-8d2d-4cb1-89db-0e9f40fa5050_CDPDIGLYSYN-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_05d1f440-1f08-4aac-9f22-efe7f6108711_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6363,7 +6352,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.8.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/05277f31-8d2d-4cb1-89db-0e9f40fa5050_CDPDIGLYSYN-RXN>
+          <http://model.geneontology.org/05d1f440-1f08-4aac-9f22-efe7f6108711_CDPDIGLYSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
@@ -6385,13 +6374,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYBiochemicalReaction38740> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PHOSPHASERDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004609> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6412,7 +6412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6424,11 +6424,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_30616_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_30616_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6443,11 +6443,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000066_reaction_2.1.1.71-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000066_reaction_2.1.1.71-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6462,11 +6462,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6477,25 +6477,14 @@
           <http://model.geneontology.org/CHEBI_59789_RXN3O-349>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_57876_2.7.7.14-RXN_SGD_YeastPathways_PHOS-PWY>
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_CHEBI_59789_RXN4FS-2_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6504,7 +6493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6512,11 +6501,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6536,7 +6525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6547,26 +6536,15 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002333_YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002333_YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6586,7 +6564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6598,11 +6576,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_57603_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_57603_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6622,7 +6600,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PGPPHOSPHA-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/2f4936b8-7db5-447d-bbf7-1f56dcf895d6_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> ;
+                <http://model.geneontology.org/5ba5f8c6-84e0-4951-b60e-c310d4348ad3_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -6630,24 +6608,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYBiochemicalReaction38993> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN4FS-2_SGD_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_PHOSPHASERDECARB-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -6658,7 +6625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6669,15 +6636,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_59789>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_17815_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_37563_2.7.7.14-RXN_SGD_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_37563_2.7.7.14-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6687,3 +6665,25 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_37563_2.7.7.14-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002333_YJR073C-MONOMER_RXN4FS-2_controller_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PHOSLIPSYN2-PWY-1.ttl
+++ b/models/YeastPathways_PHOSLIPSYN2-PWY-1.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_57856_RXN3O-349_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_57856_RXN3O-349_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -26,7 +26,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,11 +38,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,15 +53,32 @@
           <http://model.geneontology.org/CHEBI_15378_PHOSPHASERDECARB-RXN>
 ] .
 
+<http://model.geneontology.org/44bb8907-c764-417f-a5d0-512c08529040_2.1.1.71-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27206> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,54 +89,32 @@
           <http://model.geneontology.org/YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_64716_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_9f5fa7da-61e4-4c3f-9818-e05139c832cf_2.1.1.17-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_b0dbe14b-637c-4bd4-9432-e430a0fc387e_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -127,18 +122,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.17-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9f5fa7da-61e4-4c3f-9818-e05139c832cf_2.1.1.17-RXN>
+          <http://model.geneontology.org/b0dbe14b-637c-4bd4-9432-e430a0fc387e_2.1.1.17-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -149,15 +144,35 @@
           <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN>
 ] .
 
+<http://model.geneontology.org/reaction_2.1.1.17-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN3O-349_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -168,12 +183,14 @@
           <http://model.geneontology.org/YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1>
 ] .
 
-<http://model.geneontology.org/reaction_2.1.1.17-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -184,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -192,28 +209,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000066_reaction_PGPPHOSPHA-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15378_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002411_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_b0dbe14b-637c-4bd4-9432-e430a0fc387e_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -229,9 +246,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/7add0cd6-a7d6-431f-8e20-607d5dae42bd_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/244a7d90-5299-4da9-8a03-415a5ecfd2c4_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/bd44188a-339e-42b9-a953-2940a6ba0794_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/f9e09d37-9e64-48b5-938a-7c3a93d5007a_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -239,7 +256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -250,14 +267,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000066_reaction_RXN3O-349_location_lociGO_0005829_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000066_reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -265,11 +282,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -289,7 +306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -297,32 +314,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/7add0cd6-a7d6-431f-8e20-607d5dae42bd_PHOSPHAGLYPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27125> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,6 +333,17 @@
           <http://model.geneontology.org/YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000003834>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -340,11 +351,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -372,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -383,18 +394,15 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/14afb12f-8334-4176-a683-12a18e8f5202_2.1.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000066_reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000066_reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -405,28 +413,6 @@
           <http://model.geneontology.org/reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008654> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -434,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -445,15 +431,26 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000066_reaction_2.1.1.17-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000066_reaction_2.1.1.17-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -468,11 +465,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -483,36 +480,52 @@
           <http://model.geneontology.org/YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller>
 ] .
 
-<http://model.geneontology.org/bd44188a-339e-42b9-a953-2940a6ba0794_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
+<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002333_YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27024> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_26cab190-e758-474e-91c7-bd9885256a84_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57597>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16110>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -524,11 +537,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,26 +552,15 @@
           <http://model.geneontology.org/YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,26 +574,15 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_bd44188a-339e-42b9-a953-2940a6ba0794_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_7add0cd6-a7d6-431f-8e20-607d5dae42bd_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_244a7d90-5299-4da9-8a03-415a5ecfd2c4_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,22 +590,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7add0cd6-a7d6-431f-8e20-607d5dae42bd_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/244a7d90-5299-4da9-8a03-415a5ecfd2c4_PHOSPHAGLYPSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57856> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -625,7 +605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -640,7 +620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,14 +628,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/1ee9f9ad-dcac-4035-8820-802e4fb4d563_PHOSPHAGLYPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002333_YGR157W-MONOMER_2.1.1.17-RXN_controller_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_17754_CARDIOLIPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -668,7 +673,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/351d3c7a-bda4-4fa8-840b-5581764c778f_PHOSPHASERSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/26cab190-e758-474e-91c7-bd9885256a84_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -680,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -697,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -709,11 +714,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN3O-349_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN3O-349_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -724,18 +729,15 @@
           <http://model.geneontology.org/RXN3O-349>
 ] .
 
-<http://model.geneontology.org/09fe325c-57b5-4369-baf3-969b36d21041_2.1.1.17-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_14afb12f-8334-4176-a683-12a18e8f5202_2.1.1.71-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_26e24d24-6d1f-4243-b77c-09dfe5a89088_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,18 +745,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-349> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/14afb12f-8334-4176-a683-12a18e8f5202_2.1.1.71-RXN>
+          <http://model.geneontology.org/26e24d24-6d1f-4243-b77c-09dfe5a89088_2.1.1.71-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000066_reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000066_reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -772,11 +774,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_62237_CARDIOLIPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_62237_CARDIOLIPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -790,11 +792,30 @@
 <http://identifiers.org/sgd/S000005113>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/e9c36275-61f4-487d-8dd6-9ba2d5a67fc1_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://purl.obolibrary.org/obo/CHEBI_11750>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000066_reaction_2.1.1.17-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -806,11 +827,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15378_2.1.1.17-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15378_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -832,7 +853,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16038_PHOSPHASERDECARB-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/9f5fa7da-61e4-4c3f-9818-e05139c832cf_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
+                <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/b0dbe14b-637c-4bd4-9432-e430a0fc387e_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR157W-MONOMER_2.1.1.17-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -840,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -852,11 +873,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -867,23 +888,6 @@
           <http://model.geneontology.org/YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1>
 ] .
 
-<http://model.geneontology.org/351d3c7a-bda4-4fa8-840b-5581764c778f_PHOSPHASERSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27125> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_17754_CARDIOLIPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17754> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -893,7 +897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -905,11 +909,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_64716_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_64716_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -920,14 +924,14 @@
           <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002413_CARDIOLIPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_44bb8907-c764-417f-a5d0-512c08529040_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -936,20 +940,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_CHEBI_15377_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002411_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller>
+        a       <http://identifiers.org/sgd/S000002301> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "cardiolipin synthase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1Protein27109> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_62237_CARDIOLIPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_62237> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -960,7 +979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -968,20 +987,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller>
-        a       <http://identifiers.org/sgd/S000002301> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "cardiolipin synthase" ;
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000066_reaction_PGPPHOSPHA-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1Protein27109> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -992,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1000,25 +1015,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_7add0cd6-a7d6-431f-8e20-607d5dae42bd_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_15378_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002413_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1029,11 +1044,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_09fe325c-57b5-4369-baf3-969b36d21041_2.1.1.17-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_0338491a-0751-4df1-af2a-9a82dc81c304_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1041,18 +1056,29 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/09fe325c-57b5-4369-baf3-969b36d21041_2.1.1.17-RXN>
+          <http://model.geneontology.org/0338491a-0751-4df1-af2a-9a82dc81c304_2.1.1.17-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002411_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002411_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1063,25 +1089,14 @@
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000066_reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_64716_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1089,11 +1104,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_bd44188a-339e-42b9-a953-2940a6ba0794_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_f9e09d37-9e64-48b5-938a-7c3a93d5007a_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1101,33 +1116,50 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bd44188a-339e-42b9-a953-2940a6ba0794_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/f9e09d37-9e64-48b5-938a-7c3a93d5007a_PHOSPHAGLYPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000066_reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/f9e09d37-9e64-48b5-938a-7c3a93d5007a_PHOSPHAGLYPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27024> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1138,13 +1170,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27040> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1154,29 +1197,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000066_reaction_2.1.1.17-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_9f5fa7da-61e4-4c3f-9818-e05139c832cf_2.1.1.17-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1184,11 +1227,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002333_YJR073C-MONOMER_RXN3O-349_controller_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002333_YJR073C-MONOMER_RXN3O-349_controller_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1199,12 +1242,23 @@
           <http://model.geneontology.org/YJR073C-MONOMER_RXN3O-349_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1212,11 +1266,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1227,26 +1281,15 @@
           <http://model.geneontology.org/CHEBI_16038_PHOSPHASERDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_57856_RXN3O-349_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000066_reaction_PGPPHOSPHA-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000066_reaction_PGPPHOSPHA-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1257,28 +1300,6 @@
           <http://model.geneontology.org/reaction_PGPPHOSPHA-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_14afb12f-8334-4176-a683-12a18e8f5202_2.1.1.71-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_18631cd7-a77c-47b6-a8c5-8436f0ad91a4_2.1.1.71-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_11750> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1288,7 +1309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1303,11 +1324,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002333_YGR157W-MONOMER_2.1.1.17-RXN_controller_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002333_YGR157W-MONOMER_2.1.1.17-RXN_controller_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1318,15 +1339,26 @@
           <http://model.geneontology.org/YGR157W-MONOMER_2.1.1.17-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_351d3c7a-bda4-4fa8-840b-5581764c778f_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_26cab190-e758-474e-91c7-bd9885256a84_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1334,18 +1366,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/351d3c7a-bda4-4fa8-840b-5581764c778f_PHOSPHASERSYN-RXN>
+          <http://model.geneontology.org/26cab190-e758-474e-91c7-bd9885256a84_PHOSPHASERSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1356,17 +1388,6 @@
           <http://model.geneontology.org/reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_PHOSPHASERDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1376,7 +1397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1400,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1408,15 +1429,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://purl.obolibrary.org/obo/CHEBI_59789>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/RO_0002411>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_18631cd7-a77c-47b6-a8c5-8436f0ad91a4_2.1.1.71-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_44bb8907-c764-417f-a5d0-512c08529040_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1424,21 +1454,40 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/18631cd7-a77c-47b6-a8c5-8436f0ad91a4_2.1.1.71-RXN>
+          <http://model.geneontology.org/44bb8907-c764-417f-a5d0-512c08529040_2.1.1.71-RXN>
 ] .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002233_CHEBI_64716_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000066_reaction_RXN3O-349_location_lociGO_0005829_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000066_reaction_RXN3O-349_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1449,18 +1498,37 @@
           <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_59789>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_244a7d90-5299-4da9-8a03-415a5ecfd2c4_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1478,7 +1546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1486,18 +1554,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000066_reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002233_CHEBI_64716_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002233_CHEBI_64716_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1508,14 +1584,25 @@
           <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002413_CARDIOLIPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1523,11 +1610,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1538,14 +1625,14 @@
           <http://model.geneontology.org/CHEBI_16038_PHOSPHASERDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15378_2.1.1.17-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000066_reaction_2.1.1.71-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1553,11 +1640,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1572,11 +1659,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_e9c36275-61f4-487d-8dd6-9ba2d5a67fc1_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_1ee9f9ad-dcac-4035-8820-802e4fb4d563_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1584,7 +1671,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PGPPHOSPHA-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e9c36275-61f4-487d-8dd6-9ba2d5a67fc1_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/1ee9f9ad-dcac-4035-8820-802e4fb4d563_PHOSPHAGLYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller>
@@ -1594,13 +1681,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1Protein27304> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002413_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_59789_RXN3O-349>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59789> ;
@@ -1611,7 +1709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1619,36 +1717,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002333_YJR073C-MONOMER_RXN3O-349_controller_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1661,7 +1737,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/14afb12f-8334-4176-a683-12a18e8f5202_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
+                <http://model.geneontology.org/26e24d24-6d1f-4243-b77c-09dfe5a89088_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_57856_RXN3O-349> , <http://model.geneontology.org/CHEBI_16110_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1669,13 +1745,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1BiochemicalReaction27230> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_CHEBI_15377_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002411_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_64716>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1684,11 +1782,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000066_reaction_2.1.1.71-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000066_reaction_2.1.1.71-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1702,15 +1800,26 @@
 <http://purl.obolibrary.org/obo/GO_0004609>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002333_YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1721,26 +1830,15 @@
           <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1751,45 +1849,29 @@
           <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/b0dbe14b-637c-4bd4-9432-e430a0fc387e_2.1.1.17-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002233_CHEBI_64716_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27199> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002411_2.1.1.71-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1797,11 +1879,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_16110_RXN3O-349_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_16110_RXN3O-349_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1816,11 +1898,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1838,11 +1920,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002333_YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002333_YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1859,6 +1941,9 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/26e24d24-6d1f-4243-b77c-09dfe5a89088_2.1.1.71-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 <http://purl.obolibrary.org/obo/CHEBI_60377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1874,7 +1959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1882,19 +1967,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_15378_2.1.1.71-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000066_reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -1905,7 +2001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1917,11 +2013,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1941,7 +2037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1949,37 +2045,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002333_YER026C-MONOMER_PHOSPHASERSYN-RXN_controller_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002333_YGR157W-MONOMER_2.1.1.17-RXN_controller_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000066_reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000066_reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1990,37 +2064,15 @@
           <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000066_reaction_2.1.1.71-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" , "Provides Input For Rule. The relation '1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate + H<sub>2</sub>O &rarr; an L-1-phosphatidyl-<i>sn</i>-glycerol + phosphate' 'null' '2 an L-1-phosphatidyl-<i>sn</i>-glycerol &rarr; a cardiolipin + glycerol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002413_CARDIOLIPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002413_CARDIOLIPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2031,12 +2083,23 @@
           <http://model.geneontology.org/CARDIOLIPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_62237_CARDIOLIPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2049,7 +2112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2057,56 +2120,20 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_62237>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_17754>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_59789_2.1.1.71-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_1ee9f9ad-dcac-4035-8820-802e4fb4d563_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2114,11 +2141,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_15378_2.1.1.71-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_15378_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2129,26 +2156,18 @@
           <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_43474_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_17754>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" , "Provides Input For Rule. The relation 'a CDP-diacylglycerol + L-serine &harr; CMP + a 3-<i>O</i>-<i>sn</i>-phosphatidyl-L-serine + H<SUP>+</SUP>' 'null' 'a 3-<i>O</i>-<i>sn</i>-phosphatidyl-L-serine + H<SUP>+</SUP> &rarr; an L-1-phosphatidylethanolamine + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002413_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002413_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2168,7 +2187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2180,11 +2199,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002333_YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002333_YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2195,14 +2214,14 @@
           <http://model.geneontology.org/YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_09fe325c-57b5-4369-baf3-969b36d21041_2.1.1.17-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_26e24d24-6d1f-4243-b77c-09dfe5a89088_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2210,11 +2229,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2225,6 +2244,17 @@
           <http://model.geneontology.org/YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_0338491a-0751-4df1-af2a-9a82dc81c304_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57856_RXN3O-349>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57856> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2234,7 +2264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2242,11 +2272,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_59789_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0003882>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0008654>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002333_YJR073C-MONOMER_2.1.1.71-RXN_controller_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2257,7 +2317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2265,26 +2325,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0008654>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2304,7 +2356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2316,11 +2368,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2331,32 +2383,26 @@
           <http://model.geneontology.org/CHEBI_16526_PHOSPHASERDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/18631cd7-a77c-47b6-a8c5-8436f0ad91a4_2.1.1.71-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_f9e09d37-9e64-48b5-938a-7c3a93d5007a_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27206> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_CHEBI_15377_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_CHEBI_15377_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2377,7 +2423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2385,37 +2431,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_351d3c7a-bda4-4fa8-840b-5581764c778f_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/0338491a-0751-4df1-af2a-9a82dc81c304_2.1.1.17-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002411_2.1.1.71-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002411_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2430,11 +2457,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2452,11 +2479,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2467,50 +2494,45 @@
           <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000066_reaction_RXN3O-349_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002333_YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/26cab190-e758-474e-91c7-bd9885256a84_PHOSPHASERSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27125> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_62237_CARDIOLIPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_43474_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_16110_RXN3O-349_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2520,17 +2542,6 @@
 <http://identifiers.org/sgd/S000003402>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_17754_CARDIOLIPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YJR073C-MONOMER_RXN3O-349_controller>
         a       <http://identifiers.org/sgd/S000003834> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2538,7 +2549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2549,14 +2560,14 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2569,9 +2580,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.1.1.71-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/09fe325c-57b5-4369-baf3-969b36d21041_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> , <http://model.geneontology.org/0338491a-0751-4df1-af2a-9a82dc81c304_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> , <http://model.geneontology.org/18631cd7-a77c-47b6-a8c5-8436f0ad91a4_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> , <http://model.geneontology.org/44bb8907-c764-417f-a5d0-512c08529040_2.1.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YJR073C-MONOMER_2.1.1.71-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2579,7 +2590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2594,11 +2605,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002333_YJR073C-MONOMER_2.1.1.71-RXN_controller_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002333_YJR073C-MONOMER_2.1.1.71-RXN_controller_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2609,6 +2620,47 @@
           <http://model.geneontology.org/YJR073C-MONOMER_2.1.1.71-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_16110_RXN3O-349_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-349> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_59789_RXN3O-349>
+] .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16526_PHOSPHASERDECARB-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2618,7 +2670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2630,63 +2682,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-349> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_RXN3O-349>
-] .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHASERSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_e9c36275-61f4-487d-8dd6-9ba2d5a67fc1_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002333_YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2700,6 +2700,17 @@
 <http://purl.obolibrary.org/obo/GO_0008962>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16110_RXN3O-349>
         a       <http://purl.obolibrary.org/obo/CHEBI_16110> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2709,7 +2720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2721,11 +2732,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_17754_CARDIOLIPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_17754_CARDIOLIPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2736,28 +2747,6 @@
           <http://model.geneontology.org/CHEBI_17754_CARDIOLIPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002413_2.1.1.17-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2767,7 +2756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2784,7 +2773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2792,35 +2781,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_PGPPHOSPHA-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/244a7d90-5299-4da9-8a03-415a5ecfd2c4_PHOSPHAGLYPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27125> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2835,11 +2830,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a 3-<i>O</i>-<i>sn</i>-phosphatidyl-L-serine + H<SUP>+</SUP> &rarr; an L-1-phosphatidylethanolamine + CO<SUB>2</SUB>' 'null' '<i>S</i>-adenosyl-L-methionine + an L-1-phosphatidylethanolamine &rarr; a phosphatidyl-<i>N</i>-methylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002413_2.1.1.17-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002413_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2857,11 +2852,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_43474_PGPPHOSPHA-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_43474_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2872,54 +2867,76 @@
           <http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002333_YJR073C-MONOMER_RXN3O-349_controller_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_57856_RXN3O-349_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003389>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN3O-349_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000066_reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000000510>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_59789_2.1.1.71-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_59789_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2930,26 +2947,15 @@
           <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002333_YJR073C-MONOMER_2.1.1.71-RXN_controller_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002333_YER026C-MONOMER_PHOSPHASERSYN-RXN_controller_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002333_YER026C-MONOMER_PHOSPHASERSYN-RXN_controller_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2960,6 +2966,17 @@
           <http://model.geneontology.org/YER026C-MONOMER_PHOSPHASERSYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002333_YER026C-MONOMER_PHOSPHASERSYN-RXN_controller_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2969,7 +2986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phospholipid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2981,11 +2998,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2996,33 +3013,16 @@
           <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002413_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/9f5fa7da-61e4-4c3f-9818-e05139c832cf_2.1.1.17-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27199> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/PGPPHOSPHA-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0008962> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3033,7 +3033,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PGPPHOSPHA-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> , <http://model.geneontology.org/e9c36275-61f4-487d-8dd6-9ba2d5a67fc1_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/1ee9f9ad-dcac-4035-8820-802e4fb4d563_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3041,7 +3041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3054,7 +3054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3067,7 +3067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3094,7 +3094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PLPSAL-PWY.ttl
+++ b/models/YeastPathways_PLPSAL-PWY.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002234_CHEBI_597326_PNPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002234_CHEBI_597326_PNPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,26 +17,15 @@
           <http://model.geneontology.org/CHEBI_597326_PNPOXI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PNKIN-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_15379_PMPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_15379_PMPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -47,25 +36,36 @@
           <http://model.geneontology.org/CHEBI_15379_PMPOXI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002233_CHEBI_58589_PNKIN-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_15378_PNKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
+                "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002233_CHEBI_17310_PYRIDOXKIN-RXN_SGD_YeastPathways_PLPSAL-PWY>
+<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002333_YBR035C-MONOMER_PMPOXI-RXN_controller_SGD_PWY_YeastPathways_PLPSAL-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002233_CHEBI_30616_PYRAMKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -86,8 +86,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002233_CHEBI_16709_PNKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_PNKIN-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -109,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,37 +139,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002234_CHEBI_456216_PYRIDOXKIN-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002233_CHEBI_30616_PYRIDOXKIN-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002234_CHEBI_58451_PYRAMKIN-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002234_CHEBI_58451_PYRAMKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -162,11 +162,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_BFO_0000066_reaction_PNKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_BFO_0000066_reaction_PNKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -200,14 +200,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002333_CPLX3O-38_PYRIDOXKIN-RXN_controller_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PNPOXI-RXN_BFO_0000066_reaction_PNPOXI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002413_PNPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -215,11 +226,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002234_CHEBI_456216_PYRIDOXKIN-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002234_CHEBI_456216_PYRIDOXKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -234,11 +245,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,39 +260,6 @@
           <http://model.geneontology.org/YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PNKIN-RXN_BFO_0000066_reaction_PNKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PNPOXI-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002233_CHEBI_15379_PNPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -289,11 +267,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-38_PYRAMKIN-RXN_controller_BFO_0000051_SGD_S000000755_CPLX3O-38_component_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-38_PYRAMKIN-RXN_controller_BFO_0000051_SGD_S000000755_CPLX3O-38_component_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,28 +282,28 @@
           <http://model.geneontology.org/SGD_S000000755_CPLX3O-38_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_15379_PMPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY>
+<http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002234_CHEBI_597326_PNPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
+                "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000755>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002234_CHEBI_58451_PYRAMKIN-RXN_SGD_YeastPathways_PLPSAL-PWY>
+<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002234_CHEBI_597326_PMPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
+                "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -338,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -349,17 +327,6 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002234_CHEBI_597326_PMPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_17310_PYRIDOXKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17310> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -369,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -381,11 +348,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_BFO_0000066_reaction_PYRAMKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_BFO_0000066_reaction_PYRAMKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -405,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -422,7 +389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -430,14 +397,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_BFO_0000066_reaction_PYRIDOXKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PLPSAL-PWY>
+<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_BFO_0000066_reaction_PYRIDOXKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002233_CHEBI_15379_PNPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
+                "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -453,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -465,11 +443,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -487,11 +465,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_15378_PNKIN-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_15378_PNKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -524,7 +502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -535,14 +513,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_597326>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-38_PYRAMKIN-RXN_controller_BFO_0000051_SGD_S000000755_CPLX3O-38_component_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002413_PMPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
+                "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -555,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -567,11 +545,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002233_CHEBI_58589_PNKIN-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002233_CHEBI_58589_PNKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,11 +567,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_BFO_0000066_reaction_PMPOXI-RXN_location_lociGO_0005829_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_BFO_0000066_reaction_PMPOXI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,14 +582,14 @@
           <http://model.geneontology.org/reaction_PMPOXI-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002233_CHEBI_16709_PNKIN-RXN_SGD_YeastPathways_PLPSAL-PWY>
+<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002233_CHEBI_17310_PYRIDOXKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
+                "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -620,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -633,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pyridoxal 5'-phosphate salvage I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -648,11 +626,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002234_CHEBI_15378_PYRAMKIN-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002234_CHEBI_15378_PYRAMKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,11 +648,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002333_YBR035C-MONOMER_PMPOXI-RXN_controller_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002333_YBR035C-MONOMER_PMPOXI-RXN_controller_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -694,13 +672,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PLPSAL-PWYSmallMolecule36816> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PNKIN-RXN_BFO_0000066_reaction_PNKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -709,11 +709,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002233_CHEBI_30616_PYRIDOXKIN-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002233_CHEBI_30616_PYRIDOXKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -733,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -741,26 +741,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_456216_PNKIN-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002333_CPLX3O-38_PNKIN-RXN_controller_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002333_CPLX3O-38_PNKIN-RXN_controller_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -771,14 +760,14 @@
           <http://model.geneontology.org/CPLX3O-38_PNKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002333_CPLX3O-38_PNKIN-RXN_controller_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
+                "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -794,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -806,11 +795,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002333_YBR035C-MONOMER_PNPOXI-RXN_controller_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002333_YBR035C-MONOMER_PNPOXI-RXN_controller_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -821,15 +810,26 @@
           <http://model.geneontology.org/YBR035C-MONOMER_PNPOXI-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-38_PYRIDOXKIN-RXN_controller_BFO_0000051_SGD_S000000755_CPLX3O-38_component_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_58451_PYRAMKIN-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_58451_PYRAMKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -840,6 +840,17 @@
           <http://model.geneontology.org/CHEBI_58451_PYRAMKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002233_CHEBI_30616_PYRIDOXKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_PNKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -849,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -866,7 +877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -877,26 +888,15 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PNPOXI-RXN_BFO_0000066_reaction_PNPOXI-RXN_location_lociGO_0005829_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002333_CPLX3O-38_PYRAMKIN-RXN_controller_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002333_CPLX3O-38_PYRAMKIN-RXN_controller_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -907,26 +907,15 @@
           <http://model.geneontology.org/CPLX3O-38_PYRAMKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002413_PMPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002233_CHEBI_16709_PNKIN-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002233_CHEBI_16709_PNKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -936,6 +925,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16709_PNKIN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002234_CHEBI_28938_PMPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PYRIDOXKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008478> ;
@@ -954,13 +954,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PLPSAL-PWYBiochemicalReaction36593> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002234_CHEBI_16240_PNPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -974,28 +985,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_15378_PNKIN-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YBR035C-MONOMER_PNPOXI-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000239> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1003,7 +992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1018,11 +1007,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002234_CHEBI_597326_PYRIDOXKIN-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002234_CHEBI_597326_PYRIDOXKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1042,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1054,11 +1043,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_BFO_0000066_reaction_PNPOXI-RXN_location_lociGO_0005829_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_BFO_0000066_reaction_PNPOXI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1069,15 +1058,26 @@
           <http://model.geneontology.org/reaction_PNPOXI-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002233_CHEBI_58589_PNKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-38_PYRIDOXKIN-RXN_controller_BFO_0000051_SGD_S000000755_CPLX3O-38_component_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-38_PYRIDOXKIN-RXN_controller_BFO_0000051_SGD_S000000755_CPLX3O-38_component_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1091,62 +1091,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002234_CHEBI_15378_PYRIDOXKIN-RXN_SGD_YeastPathways_PLPSAL-PWY>
+<http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_456216_PNKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
+                "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57761>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002234_CHEBI_16240_PNPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002234_CHEBI_16240_PMPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002333_CPLX3O-38_PYRAMKIN-RXN_controller_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002233_CHEBI_30616_PYRAMKIN-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002233_CHEBI_30616_PYRAMKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1164,11 +1131,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002234_CHEBI_28938_PMPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002234_CHEBI_28938_PMPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1179,6 +1146,17 @@
           <http://model.geneontology.org/CHEBI_28938_PMPOXI-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_15377_PMPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-38_PYRIDOXKIN-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1188,7 +1166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1196,29 +1174,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-38_PYRIDOXKIN-RXN_controller_BFO_0000051_SGD_S000000755_CPLX3O-38_component_SGD_YeastPathways_PLPSAL-PWY>
+<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_BFO_0000066_reaction_PMPOXI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PLPSAL-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
+                "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002234_CHEBI_15378_PYRAMKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_BFO_0000066_reaction_PYRIDOXKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_BFO_0000066_reaction_PYRIDOXKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1229,15 +1218,26 @@
           <http://model.geneontology.org/reaction_PYRIDOXKIN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002233_CHEBI_30616_PNKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_456216_PNKIN-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_456216_PNKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1248,17 +1248,6 @@
           <http://model.geneontology.org/CHEBI_456216_PNKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002413_PNPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15379_PNPOXI-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1268,7 +1257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1276,14 +1265,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002333_YBR035C-MONOMER_PMPOXI-RXN_controller_SGD_YeastPathways_PLPSAL-PWY>
+<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002234_CHEBI_58451_PYRAMKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002333_CPLX3O-38_PYRAMKIN-RXN_controller_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1294,11 +1294,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002234_CHEBI_16240_PNPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002234_CHEBI_16240_PNPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1309,14 +1309,14 @@
           <http://model.geneontology.org/CHEBI_16240_PNPOXI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_YeastPathways_PLPSAL-PWY>
+<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002233_CHEBI_57761_PYRAMKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
+                "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1324,11 +1324,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_15377_PMPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_15377_PMPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1342,17 +1342,6 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002233_CHEBI_30616_PYRAMKIN-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_28938_PMPOXI-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_28938> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1362,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1370,14 +1359,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_15377_PMPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY>
+<http://model.geneontology.org/ev_w_id_CPLX3O-38_PYRAMKIN-RXN_controller_BFO_0000051_SGD_S000000755_CPLX3O-38_component_SGD_PWY_YeastPathways_PLPSAL-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002234_CHEBI_456216_PYRAMKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-38_PNKIN-RXN_controller_BFO_0000051_SGD_S000000755_CPLX3O-38_component_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1385,11 +1396,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002234_CHEBI_456216_PYRAMKIN-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002234_CHEBI_456216_PYRAMKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1409,7 +1420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1421,11 +1432,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1441,7 +1452,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002333_CPLX3O-38_PNKIN-RXN_controller_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_58589_PNKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1454,7 +1487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1462,30 +1495,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-38_PNKIN-RXN_controller_BFO_0000051_SGD_S000000755_CPLX3O-38_component_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002234_CHEBI_28938_PMPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YBR035C-MONOMER_PMPOXI-RXN_controller>
         a       <http://identifiers.org/sgd/S000000239> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1494,7 +1505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1502,26 +1513,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002233_CHEBI_30616_PNKIN-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002234_CHEBI_15378_PYRIDOXKIN-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002234_CHEBI_15378_PYRIDOXKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1536,11 +1536,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" , "Provides Input For Rule. The relation 'ATP + pyridoxine &rarr; ADP + pyridoxine 5'-phosphate + H<SUP>+</SUP>' 'null' 'pyridoxine 5'-phosphate + oxygen &rarr; hydrogen peroxide + pyridoxal 5'-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002413_PNPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002413_PNPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1560,7 +1560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1575,11 +1575,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-38_PNKIN-RXN_controller_BFO_0000051_SGD_S000000755_CPLX3O-38_component_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-38_PNKIN-RXN_controller_BFO_0000051_SGD_S000000755_CPLX3O-38_component_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1595,7 +1595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1618,7 +1618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1635,7 +1635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1643,18 +1643,73 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002234_CHEBI_16240_PMPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002333_CPLX3O-38_PYRIDOXKIN-RXN_controller_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002234_CHEBI_597326_PYRIDOXKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002234_CHEBI_15378_PYRIDOXKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1665,14 +1720,14 @@
           <http://model.geneontology.org/YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_58451_PYRAMKIN-RXN_SGD_YeastPathways_PLPSAL-PWY>
+<http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002333_YBR035C-MONOMER_PNPOXI-RXN_controller_SGD_PWY_YeastPathways_PLPSAL-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
+                "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1680,11 +1735,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002234_CHEBI_16240_PMPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002234_CHEBI_16240_PMPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1700,43 +1755,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_58589_PNKIN-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58589>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002234_CHEBI_456216_PYRAMKIN-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_YeastPathways_PLPSAL-PWY>
+<http://model.geneontology.org/ev_w_id_PNPOXI-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_PWY_YeastPathways_PLPSAL-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002234_CHEBI_456216_PYRIDOXKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1744,11 +1788,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" , "Provides Input For Rule. The relation 'ATP + pyridoxamine &rarr; ADP + pyridoxamine 5'-phosphate + H<SUP>+</SUP>' 'null' 'pyridoxamine 5'-phosphate + oxygen + H<sub>2</sub>O &rarr; ammonium + hydrogen peroxide + pyridoxal 5'-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002413_PMPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002413_PMPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1763,11 +1807,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002233_CHEBI_30616_PNKIN-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002233_CHEBI_30616_PNKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1790,14 +1834,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002234_CHEBI_15378_PYRAMKIN-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_BFO_0000066_reaction_PYRAMKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
+                "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1808,11 +1852,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002333_CPLX3O-38_PYRIDOXKIN-RXN_controller_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002333_CPLX3O-38_PYRIDOXKIN-RXN_controller_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1832,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1844,11 +1888,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002233_CHEBI_15379_PNPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002233_CHEBI_15379_PNPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1868,7 +1912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1880,11 +1924,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_BFO_0000050_YeastPathways_PLPSAL-PWY/YeastPathways_PLPSAL-PWY_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1898,17 +1942,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_17310>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_BFO_0000066_reaction_PYRAMKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_597326_PNPOXI-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_597326> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1918,7 +1951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1935,7 +1968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1960,7 +1993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1972,11 +2005,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002233_CHEBI_57761_PYRAMKIN-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002233_CHEBI_57761_PYRAMKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1987,6 +2020,17 @@
           <http://model.geneontology.org/CHEBI_57761_PYRAMKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_15379_PMPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_PYRAMKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1996,7 +2040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2008,11 +2052,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002234_CHEBI_597326_PMPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002234_CHEBI_597326_PMPOXI-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2022,28 +2066,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_597326_PMPOXI-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002234_CHEBI_597326_PNPOXI-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_BFO_0000066_reaction_PMPOXI-RXN_location_lociGO_0005829_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000239>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2056,29 +2078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PNPOXI-RXN_RO_0002333_YBR035C-MONOMER_PNPOXI-RXN_controller_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRAMKIN-RXN_RO_0002233_CHEBI_57761_PYRAMKIN-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2087,7 +2087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2095,11 +2095,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002233_CHEBI_17310_PYRIDOXKIN-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002233_CHEBI_17310_PYRIDOXKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2110,26 +2110,15 @@
           <http://model.geneontology.org/CHEBI_17310_PYRIDOXKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRIDOXKIN-RXN_RO_0002234_CHEBI_597326_PYRIDOXKIN-RXN_SGD_YeastPathways_PLPSAL-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PLPSAL-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_58589_PNKIN-RXN_SGD_YeastPathways_PLPSAL-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PNKIN-RXN_RO_0002234_CHEBI_58589_PNKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2149,10 +2138,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PLPSAL-PWYSmallMolecule36753> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PMPOXI-RXN_RO_0002233_CHEBI_58451_PYRAMKIN-RXN_SGD_PWY_YeastPathways_PLPSAL-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PLPSAL-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_POLYAMSYN-YEAST-PWY.ttl
+++ b/models/YeastPathways_POLYAMSYN-YEAST-PWY.ttl
@@ -1,14 +1,3 @@
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_17509_SPERMIDINESYN-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0006596> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -18,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -31,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -44,13 +33,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=POLYAMSYN-YEAST-PWYSmallMolecule27662> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002233_CHEBI_46911_ORNDECARBOX-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_SPERMIDINESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -69,15 +69,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57834_SPERMIDINESYN-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57834_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -91,26 +102,15 @@
 <http://identifiers.org/sgd/S000005412>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_326268_ORNDECARBOX-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002333_YOL052C-MONOMER_SAMDECARB-RXN_controller_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002333_YOL052C-MONOMER_SAMDECARB-RXN_controller_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -128,7 +128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -140,11 +140,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002234_CHEBI_16526_ORNDECARBOX-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002234_CHEBI_16526_ORNDECARBOX-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -155,26 +155,18 @@
           <http://model.geneontology.org/CHEBI_16526_ORNDECARBOX-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000066_reaction_SPERMINE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000066_reaction_SPERMINE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,22 +177,44 @@
           <http://model.geneontology.org/reaction_SPERMINE-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002333_YPR069C-MONOMER_SPERMIDINESYN-RXN_controller_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000066_reaction_SPERMIDINESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_17509_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000006273>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_SAMDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -211,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -219,8 +233,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000006273>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_16526_SAMDECARB-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_59789_SAMDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_59789> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -231,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -243,11 +265,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_15378_SPERMIDINESYN-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_15378_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -265,11 +287,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002411_SPERMIDINESYN-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002411_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -283,33 +305,33 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_45725_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57834_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/GO_0016768>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002333_YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000050_YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0016768>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YOL052C-MONOMER_SAMDECARB-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005412> ;
@@ -318,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -326,15 +348,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_45725_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -345,6 +378,17 @@
           <http://model.geneontology.org/CHEBI_57443_SAMDECARB-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_17509_SPERMINE-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17509> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -354,7 +398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -362,14 +406,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_57834_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -377,11 +421,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002233_CHEBI_46911_ORNDECARBOX-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002233_CHEBI_46911_ORNDECARBOX-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,6 +435,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_46911_ORNDECARBOX-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0016768> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -411,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -423,11 +478,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000050_YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000050_YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -441,33 +496,22 @@
 <http://purl.obolibrary.org/obo/CHEBI_57834>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_BFO_0000066_reaction_ORNDECARBOX-RXN_location_lociGO_0005829_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000066_reaction_SAMDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://identifiers.org/sgd/S000001667>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000050_YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -479,11 +523,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -499,7 +543,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002411_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -507,11 +562,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002333_YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002333_YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,17 +577,6 @@
           <http://model.geneontology.org/YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_BFO_0000050_YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_POLYAMSYN-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -542,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of polyamine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -550,15 +594,26 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002333_YKL184W-MONOMER_ORNDECARBOX-RXN_controller_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000066_reaction_SPERMIDINESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000066_reaction_SPERMIDINESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,26 +627,15 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000066_reaction_SPERMINE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000050_YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000050_YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -602,17 +646,6 @@
           <http://model.geneontology.org/YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -620,11 +653,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_16526_SAMDECARB-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_16526_SAMDECARB-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,11 +672,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002233_CHEBI_15378_ORNDECARBOX-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002233_CHEBI_15378_ORNDECARBOX-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,13 +696,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=POLYAMSYN-YEAST-PWYSmallMolecule27646> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002333_YOL052C-MONOMER_SAMDECARB-RXN_controller_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004136> ;
@@ -678,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -690,11 +734,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" , "Provides Input For Rule. The relation 'putrescine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermidine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' 'null' 'spermidine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -708,42 +752,31 @@
 <http://purl.obolibrary.org/obo/GO_0006596>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002333_YOL052C-MONOMER_SAMDECARB-RXN_controller_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002234_CHEBI_16526_ORNDECARBOX-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002233_CHEBI_15378_ORNDECARBOX-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_326268_ORNDECARBOX-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -751,11 +784,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_326268_ORNDECARBOX-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_326268_ORNDECARBOX-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,11 +803,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_45725_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_45725_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -785,44 +818,22 @@
           <http://model.geneontology.org/CHEBI_45725_SPERMINE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000050_YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002333_YKL184W-MONOMER_ORNDECARBOX-RXN_controller_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/ORNDECARBOX-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004586> ;
@@ -843,7 +854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -855,11 +866,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000050_YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000050_YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -874,11 +885,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" , "Provides Input For Rule. The relation 'L-ornithine + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + putrescine' 'null' 'putrescine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermidine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002413_SPERMIDINESYN-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002413_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -892,14 +903,36 @@
 <http://purl.obolibrary.org/obo/GO_0004014>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000066_reaction_SAMDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000066_reaction_SPERMINE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000050_YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002333_YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -907,11 +940,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_SAMDECARB-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_SAMDECARB-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,11 +959,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_BFO_0000066_reaction_ORNDECARBOX-RXN_location_lociGO_0005829_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_BFO_0000066_reaction_ORNDECARBOX-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -945,11 +978,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002333_YPR069C-MONOMER_SPERMIDINESYN-RXN_controller_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002333_YPR069C-MONOMER_SPERMIDINESYN-RXN_controller_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -960,6 +993,17 @@
           <http://model.geneontology.org/YPR069C-MONOMER_SPERMIDINESYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002234_CHEBI_326268_ORNDECARBOX-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57443_SAMDECARB-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57443> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -969,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -980,32 +1024,54 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://identifiers.org/sgd/S000004136>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002413_SPERMIDINESYN-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_BFO_0000050_YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004136>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,9 +1081,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_17509_SPERMINE-SYNTHASE-RXN>
 ] .
-
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/GO_0004766>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1034,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1042,33 +1105,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.org/dc/elements/1.1/date>
+<http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/YKL184W-MONOMER_ORNDECARBOX-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001667> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ornithine decarboxylase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=POLYAMSYN-YEAST-PWYProtein27601> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine' 'null' 'spermidine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1079,37 +1130,41 @@
           <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002233_CHEBI_15378_ORNDECARBOX-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_16526_SAMDECARB-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002234_CHEBI_16526_ORNDECARBOX-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/YKL184W-MONOMER_ORNDECARBOX-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001667> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ornithine decarboxylase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=POLYAMSYN-YEAST-PWYProtein27601> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002333_YKL184W-MONOMER_ORNDECARBOX-RXN_controller_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002333_YKL184W-MONOMER_ORNDECARBOX-RXN_controller_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1123,28 +1178,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_45725>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57834_SPERMIDINESYN-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002413_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1153,18 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000050_YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1177,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1189,11 +1233,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1208,11 +1252,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_BFO_0000050_YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_BFO_0000050_YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1230,11 +1274,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_57834_SPERMIDINESYN-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_57834_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1254,24 +1298,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=POLYAMSYN-YEAST-PWYSmallMolecule27578> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMIDINESYN-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1295,7 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1303,25 +1336,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_15378_SPERMIDINESYN-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/GO_0004586>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57834_SPERMIDINESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57834> ;
@@ -1332,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1340,57 +1359,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002411_SPERMIDINESYN-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000050_YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002234_CHEBI_326268_ORNDECARBOX-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SPERMINE-SYNTHASE-RXN>
-] .
+<http://purl.obolibrary.org/obo/GO_0004586>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/SPERMIDINESYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004766> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1411,13 +1392,54 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=POLYAMSYN-YEAST-PWYBiochemicalReaction27695> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_SPERMINE-SYNTHASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_SAMDECARB-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_ORNDECARBOX-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1428,7 +1450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1439,26 +1461,15 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_SAMDECARB-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine' 'null' 'putrescine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermidine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMIDINESYN-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1478,7 +1489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1491,7 +1502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1499,11 +1510,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002234_CHEBI_326268_ORNDECARBOX-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002234_CHEBI_326268_ORNDECARBOX-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1518,11 +1529,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1533,32 +1544,29 @@
           <http://model.geneontology.org/CHEBI_57443_SAMDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002233_CHEBI_46911_ORNDECARBOX-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
+<http://purl.obolibrary.org/obo/CHEBI_59789>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_BFO_0000066_reaction_ORNDECARBOX-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_59789>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000066_reaction_SAMDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000066_reaction_SAMDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1569,26 +1577,18 @@
           <http://model.geneontology.org/reaction_SAMDECARB-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000066_reaction_SPERMIDINESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_17509_SPERMIDINESYN-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_17509_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1599,6 +1599,17 @@
           <http://model.geneontology.org/CHEBI_17509_SPERMIDINESYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_SPERMINE-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1608,7 +1619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1616,27 +1627,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002333_YPR069C-MONOMER_SPERMIDINESYN-RXN_controller_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_15378_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_326268>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_57834_SPERMIDINESYN-RXN_SGD_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PROSYN-PWY.ttl
+++ b/models/YeastPathways_PROSYN-PWY.ttl
@@ -1,37 +1,26 @@
-<http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002333_YDR300C-MONOMER_GLUTKIN-RXN_controller_SGD_YeastPathways_PROSYN-PWY>
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_15378_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
+                "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002233_CHEBI_29985_GLUTKIN-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_15377_SPONTPRO-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_15377_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -42,15 +31,26 @@
           <http://model.geneontology.org/CHEBI_15377_SPONTPRO-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002413_GLUTSEMIALDEHYDROG-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002234_CHEBI_58066_GLUTSEMIALDEHYDROG-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002234_CHEBI_58066_GLUTSEMIALDEHYDROG-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,11 +65,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002234_CHEBI_456216_GLUTKIN-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002234_CHEBI_456216_GLUTKIN-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,6 +80,17 @@
           <http://model.geneontology.org/CHEBI_456216_GLUTKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_BFO_0000066_reaction_GLUTKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58349_GLUTSEMIALDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -89,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -97,18 +108,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -119,30 +127,11 @@
           <http://model.geneontology.org/reaction_SPONTPRO-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_60039_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002233_CHEBI_57783_GLUTSEMIALDEHYDROG-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YDR300C-MONOMER_GLUTKIN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002708> ;
@@ -151,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -159,47 +148,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_BFO_0000050_YeastPathways_PROSYN-PWY/YeastPathways_PROSYN-PWY_SGD_YeastPathways_PROSYN-PWY>
+<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002233_CHEBI_15378_GLUTSEMIALDEHYDROG-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
+                "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002333_YOR323C-MONOMER_GLUTSEMIALDEHYDROG-RXN_controller_SGD_YeastPathways_PROSYN-PWY>
+<http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_BFO_0000050_YeastPathways_PROSYN-PWY/YeastPathways_PROSYN-PWY_SGD_PWY_YeastPathways_PROSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_58066_GLUTSEMIALDEHYDROG-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000050_YeastPathways_PROSYN-PWY/YeastPathways_PROSYN-PWY_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
+                "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -212,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -241,11 +208,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_15378_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_15378_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -256,28 +223,28 @@
           <http://model.geneontology.org/CHEBI_15378_PYRROLINECARBREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_58066_GLUTSEMIALDEHYDROG-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_PYRROLINECARBREDUCT-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58274_GLUTKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58274> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -288,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -299,14 +266,14 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000050_YeastPathways_PROSYN-PWY/YeastPathways_PROSYN-PWY_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002233_CHEBI_57783_GLUTSEMIALDEHYDROG-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
+                "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -315,40 +282,40 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002234_CHEBI_456216_GLUTKIN-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002233_CHEBI_30616_GLUTKIN-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002234_CHEBI_58066_GLUTSEMIALDEHYDROG-RXN_SGD_YeastPathways_PROSYN-PWY>
+<http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002233_CHEBI_29985_GLUTKIN-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_17388_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002333_YER023W-MONOMER_PYRROLINECARBREDUCT-RXN_controller_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -367,24 +334,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-proline biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_17388_SPONTPRO-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004735>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -393,11 +349,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002234_CHEBI_43474_GLUTSEMIALDEHYDROG-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002234_CHEBI_43474_GLUTSEMIALDEHYDROG-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -412,11 +368,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002233_CHEBI_30616_GLUTKIN-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002233_CHEBI_30616_GLUTKIN-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,11 +387,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000050_YeastPathways_PROSYN-PWY/YeastPathways_PROSYN-PWY_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000050_YeastPathways_PROSYN-PWY/YeastPathways_PROSYN-PWY_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -446,17 +402,6 @@
           <http://model.geneontology.org/YeastPathways_PROSYN-PWY/YeastPathways_PROSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002413_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -466,19 +411,30 @@
 <http://purl.obolibrary.org/obo/CHEBI_60039>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002234_CHEBI_43474_GLUTSEMIALDEHYDROG-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002413_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
+                "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002234_CHEBI_58066_GLUTSEMIALDEHYDROG-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GLUTSEMIALDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004350> ;
@@ -499,7 +455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -510,14 +466,25 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_15378_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_17388_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002234_CHEBI_43474_GLUTSEMIALDEHYDROG-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -525,11 +492,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_13392_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_13392_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -545,7 +512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -561,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -569,26 +536,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_BFO_0000050_YeastPathways_PROSYN-PWY/YeastPathways_PROSYN-PWY_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000050_YeastPathways_PROSYN-PWY/YeastPathways_PROSYN-PWY_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000050_YeastPathways_PROSYN-PWY/YeastPathways_PROSYN-PWY_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -608,7 +564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -619,26 +575,15 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002333_YER023W-MONOMER_PYRROLINECARBREDUCT-RXN_controller_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_BFO_0000050_YeastPathways_PROSYN-PWY/YeastPathways_PROSYN-PWY_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_BFO_0000050_YeastPathways_PROSYN-PWY/YeastPathways_PROSYN-PWY_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -658,13 +603,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PROSYN-PWY" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_15378_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -676,11 +632,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002233_CHEBI_58274_GLUTKIN-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002233_CHEBI_58274_GLUTKIN-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -704,11 +660,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002233_CHEBI_29985_GLUTKIN-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002233_CHEBI_29985_GLUTKIN-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -723,11 +679,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002333_YER023W-MONOMER_PYRROLINECARBREDUCT-RXN_controller_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002333_YER023W-MONOMER_PYRROLINECARBREDUCT-RXN_controller_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -744,6 +700,17 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_BFO_0000066_reaction_GLUTSEMIALDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_13392>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -756,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -767,17 +734,6 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_13392_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000000825>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -785,11 +741,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000066_reaction_PYRROLINECARBREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000066_reaction_PYRROLINECARBREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -800,6 +756,17 @@
           <http://model.geneontology.org/reaction_PYRROLINECARBREDUCT-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_15377_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -807,11 +774,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>S</i>)-1-pyrroline-5-carboxylate + H<SUP>+</SUP> + H<sub>2</sub>O &harr; L-glutamate-5-semialdehyde' 'null' 'L-proline + NAD(P)<sup>+</sup> &larr; (<i>S</i>)-1-pyrroline-5-carboxylate + NAD(P)H + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002413_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002413_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -822,14 +789,14 @@
           <http://model.geneontology.org/PYRROLINECARBREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_13390_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002413_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
+                "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -845,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -857,11 +824,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" , "Provides Input For Rule. The relation 'L-glutamate-5-semialdehyde + NADP<sup>+</sup> + phosphate &larr; &gamma;-L-glutamyl 5-phosphate + NADPH + H<SUP>+</SUP>' 'null' '(<i>S</i>)-1-pyrroline-5-carboxylate + H<SUP>+</SUP> + H<sub>2</sub>O &harr; L-glutamate-5-semialdehyde' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002413_SPONTPRO-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002413_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -876,11 +843,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-glutamate + ATP &rarr; &gamma;-L-glutamyl 5-phosphate + ADP' 'null' 'L-glutamate-5-semialdehyde + NADP<sup>+</sup> + phosphate &larr; &gamma;-L-glutamyl 5-phosphate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002413_GLUTSEMIALDEHYDROG-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002413_GLUTSEMIALDEHYDROG-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -891,11 +858,44 @@
           <http://model.geneontology.org/GLUTSEMIALDEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000050_YeastPathways_PROSYN-PWY/YeastPathways_PROSYN-PWY_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58274>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002234_CHEBI_456216_GLUTKIN-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002333_YOR323C-MONOMER_GLUTSEMIALDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GLUTKIN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -916,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -924,15 +924,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_60039_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002233_CHEBI_57783_GLUTSEMIALDEHYDROG-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002233_CHEBI_57783_GLUTSEMIALDEHYDROG-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -952,7 +963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -964,11 +975,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_BFO_0000066_reaction_GLUTKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_BFO_0000066_reaction_GLUTKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -983,11 +994,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_60039_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_60039_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -997,50 +1008,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_60039_PYRROLINECARBREDUCT-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_15378_SPONTPRO-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_15377_SPONTPRO-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002234_CHEBI_58274_GLUTKIN-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_17388_SPONTPRO-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002708>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1055,11 +1022,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_17388_SPONTPRO-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_17388_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,6 +1037,28 @@
           <http://model.geneontology.org/CHEBI_17388_SPONTPRO-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_13392_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_BFO_0000050_YeastPathways_PROSYN-PWY/YeastPathways_PROSYN-PWY_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1077,11 +1066,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002333_YOR323C-MONOMER_GLUTSEMIALDEHYDROG-RXN_controller_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002333_YOR323C-MONOMER_GLUTSEMIALDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1104,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1116,11 +1105,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002333_YDR300C-MONOMER_GLUTKIN-RXN_controller_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002333_YDR300C-MONOMER_GLUTKIN-RXN_controller_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1140,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1155,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1183,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1194,15 +1183,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_58066>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002333_YDR300C-MONOMER_GLUTKIN-RXN_controller_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002233_CHEBI_15378_GLUTSEMIALDEHYDROG-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002233_CHEBI_15378_GLUTSEMIALDEHYDROG-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1222,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1234,11 +1234,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_BFO_0000050_YeastPathways_PROSYN-PWY/YeastPathways_PROSYN-PWY_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_BFO_0000050_YeastPathways_PROSYN-PWY/YeastPathways_PROSYN-PWY_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1253,11 +1253,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_13390_PYRROLINECARBREDUCT-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_13390_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1271,66 +1271,11 @@
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_13390>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_BFO_0000066_reaction_GLUTKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002413_SPONTPRO-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002233_CHEBI_58274_GLUTKIN-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000066_reaction_PYRROLINECARBREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_BFO_0000066_reaction_GLUTSEMIALDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_13390>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_SPONTPRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -1341,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1352,6 +1297,17 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_BFO_0000066_reaction_PYRROLINECARBREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58066_GLUTSEMIALDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58066> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1361,7 +1317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1369,29 +1325,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002234_CHEBI_58349_GLUTSEMIALDEHYDROG-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_13390_PYRROLINECARBREDUCT-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
+                "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_15378_SPONTPRO-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_15378_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1402,6 +1358,28 @@
           <http://model.geneontology.org/CHEBI_15378_SPONTPRO-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002234_CHEBI_58274_GLUTKIN-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002233_CHEBI_30616_GLUTKIN-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1409,11 +1387,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002234_CHEBI_58349_GLUTSEMIALDEHYDROG-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002234_CHEBI_58349_GLUTSEMIALDEHYDROG-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1424,26 +1402,15 @@
           <http://model.geneontology.org/CHEBI_58349_GLUTSEMIALDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002413_GLUTSEMIALDEHYDROG-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002234_CHEBI_58274_GLUTKIN-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002234_CHEBI_58274_GLUTKIN-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1454,26 +1421,15 @@
           <http://model.geneontology.org/CHEBI_58274_GLUTKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002233_CHEBI_15378_GLUTSEMIALDEHYDROG-RXN_SGD_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_58066_GLUTSEMIALDEHYDROG-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_58066_GLUTSEMIALDEHYDROG-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1493,7 +1449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1508,7 +1464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1525,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1536,15 +1492,26 @@
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000050_YeastPathways_PROSYN-PWY/YeastPathways_PROSYN-PWY_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_BFO_0000066_reaction_GLUTSEMIALDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_BFO_0000066_reaction_GLUTSEMIALDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1558,15 +1525,37 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002234_CHEBI_58349_GLUTSEMIALDEHYDROG-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_17388_SPONTPRO-RXN_SGD_YeastPathways_PROSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002233_CHEBI_17388_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1597,10 +1586,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROSYN-PWYBiochemicalReaction29006> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_GLUTSEMIALDEHYDROG-RXN_RO_0002233_CHEBI_58274_GLUTKIN-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PROUT-PWY.ttl
+++ b/models/YeastPathways_PROUT-PWY.ttl
@@ -1,14 +1,25 @@
 <http://purl.obolibrary.org/obo/GO_0004657>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002333_YLR142W-MONOMER_RXN-14903_controller_SGD_YeastPathways_PROUT-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_57540_RXN-14116_SGD_PWY_YeastPathways_PROUT-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
+                "SGD_PWY:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15378_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -21,7 +32,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -33,11 +44,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_6c81cfc5-da3a-4ac3-8183-cb62104a4ae3_RXN-14903_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_b4af2955-7936-4559-8eba-283db538ffd6_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,29 +56,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-14903> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6c81cfc5-da3a-4ac3-8183-cb62104a4ae3_RXN-14903>
+          <http://model.geneontology.org/b4af2955-7936-4559-8eba-283db538ffd6_RXN-14903>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_15378_RXN-14116_SGD_YeastPathways_PROUT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_58066_SPONTPRO-RXN_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_58066_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,80 +78,21 @@
           <http://model.geneontology.org/CHEBI_58066_SPONTPRO-RXN>
 ] .
 
-<http://model.geneontology.org/6c81cfc5-da3a-4ac3-8183-cb62104a4ae3_RXN-14903>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29059> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_58066_SPONTPRO-RXN_SGD_YeastPathways_PROUT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-14903_BFO_0000050_YeastPathways_PROUT-PWY/YeastPathways_PROUT-PWY_SGD_YeastPathways_PROUT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_6c81cfc5-da3a-4ac3-8183-cb62104a4ae3_RXN-14903_SGD_YeastPathways_PROUT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000050_YeastPathways_PROUT-PWY/YeastPathways_PROUT-PWY_SGD_YeastPathways_PROUT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_17388_RXN-14903_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_17388_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -161,6 +102,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_17388_RXN-14903>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_CHEBI_60039_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -173,40 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_58066_SPONTPRO-RXN_SGD_YeastPathways_PROUT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15377_SPONTPRO-RXN_SGD_YeastPathways_PROUT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000066_reaction_RXN-14116_location_lociGO_0005829_SGD_YeastPathways_PROUT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -225,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -233,26 +152,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000050_YeastPathways_PROUT-PWY/YeastPathways_PROUT-PWY_SGD_YeastPathways_PROUT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_17388_RXN-14903_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_17388_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,11 +175,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_57540_RXN-14116_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_57540_RXN-14116_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,28 +190,28 @@
           <http://model.geneontology.org/CHEBI_57540_RXN-14116>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15377>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/reaction_RXN-14903_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_BFO_0000066_reaction_RXN-14903_location_lociGO_0005829_SGD_YeastPathways_PROUT-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_57945_RXN-14116_SGD_PWY_YeastPathways_PROUT-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
+                "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YeastPathways_PROUT-PWY/YeastPathways_PROUT-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0010133> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -314,7 +222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -334,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-proline degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -356,7 +264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -367,11 +275,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15378_SPONTPRO-RXN_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15378_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -385,17 +293,6 @@
 <http://purl.obolibrary.org/obo/GO_0010133>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_15378_RXN-14903_SGD_YeastPathways_PROUT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000004132>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -403,11 +300,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -425,11 +322,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_BFO_0000050_YeastPathways_PROUT-PWY/YeastPathways_PROUT-PWY_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_BFO_0000050_YeastPathways_PROUT-PWY/YeastPathways_PROUT-PWY_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -447,7 +344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,17 +354,6 @@
 
 <http://purl.obolibrary.org/obo/GO_0003842>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_15377_RXN-14116_SGD_YeastPathways_PROUT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -479,11 +365,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_15378_RXN-14903_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_15378_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -498,11 +384,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_15377_RXN-14116_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_15377_RXN-14116_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,28 +399,17 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-14116>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_57945_RXN-14116_SGD_YeastPathways_PROUT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_SGD_YeastPathways_PROUT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_b4af2955-7936-4559-8eba-283db538ffd6_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
+                "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -545,11 +420,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15377_SPONTPRO-RXN_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15377_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -560,17 +435,6 @@
           <http://model.geneontology.org/CHEBI_15377_SPONTPRO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_17388_RXN-14903_SGD_YeastPathways_PROUT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_60039_RXN-14903>
         a       <http://purl.obolibrary.org/obo/CHEBI_60039> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -580,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -591,15 +455,30 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/54ee03ee-deb9-4f8f-87fe-3b07480dfb2b_RXN-14903>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinone" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29035> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000050_YeastPathways_PROUT-PWY/YeastPathways_PROUT-PWY_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000050_YeastPathways_PROUT-PWY/YeastPathways_PROUT-PWY_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -614,11 +493,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_57945_RXN-14116_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_57945_RXN-14116_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -629,6 +508,17 @@
           <http://model.geneontology.org/CHEBI_57945_RXN-14116>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57945_RXN-14116>
         a       <http://purl.obolibrary.org/obo/CHEBI_57945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -638,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -655,13 +545,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29087> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14903_BFO_0000050_YeastPathways_PROUT-PWY/YeastPathways_PROUT-PWY_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -670,11 +571,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_527e1b16-68ff-4475-8d16-26495de6b5b2_RXN-14903_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_54ee03ee-deb9-4f8f-87fe-3b07480dfb2b_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -682,18 +583,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-14903> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/527e1b16-68ff-4475-8d16-26495de6b5b2_RXN-14903>
+          <http://model.geneontology.org/54ee03ee-deb9-4f8f-87fe-3b07480dfb2b_RXN-14903>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000066_reaction_RXN-14116_location_lociGO_0005829_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000066_reaction_RXN-14116_location_lociGO_0005829_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,17 +608,61 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002333_YLR142W-MONOMER_RXN-14903_controller_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14903_BFO_0000066_reaction_RXN-14903_location_lociGO_0005829_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002413_RXN-14116_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_57540_RXN-14116_SGD_YeastPathways_PROUT-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_17388_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
+                "SGD_PWY:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_17388_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -733,13 +678,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29158> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_15378_RXN-14116_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002413_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -748,11 +715,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" , "Provides Input For Rule. The relation 'L-proline<SUB>[in]</SUB> + an electron-transfer quinone<SUB>[membrane]</SUB> &rarr; (<i>S</i>)-1-pyrroline-5-carboxylate<SUB>[in]</SUB> + an electron-transfer quinol<SUB>[membrane]</SUB> + H<SUP>+</SUP><SUB>[in]</SUB>' 'null' '(<i>S</i>)-1-pyrroline-5-carboxylate + H<SUP>+</SUP> + H<sub>2</sub>O &harr; L-glutamate-5-semialdehyde' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002413_SPONTPRO-RXN_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002413_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -772,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -780,15 +747,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_58066_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_29985_RXN-14116_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_29985_RXN-14116_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -808,15 +786,37 @@
 <http://purl.obolibrary.org/obo/CHEBI_58066>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000050_YeastPathways_PROUT-PWY/YeastPathways_PROUT-PWY_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000050_YeastPathways_PROUT-PWY/YeastPathways_PROUT-PWY_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_CHEBI_60039_RXN-14903_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_CHEBI_60039_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -836,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,11 +848,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000050_YeastPathways_PROUT-PWY/YeastPathways_PROUT-PWY_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000050_YeastPathways_PROUT-PWY/YeastPathways_PROUT-PWY_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -867,11 +867,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>S</i>)-1-pyrroline-5-carboxylate + H<SUP>+</SUP> + H<sub>2</sub>O &harr; L-glutamate-5-semialdehyde' 'null' 'L-glutamate-5-semialdehyde + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; L-glutamate + NADH + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002413_RXN-14116_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002413_RXN-14116_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -882,43 +882,17 @@
           <http://model.geneontology.org/RXN-14116>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002413_SPONTPRO-RXN_SGD_YeastPathways_PROUT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/527e1b16-68ff-4475-8d16-26495de6b5b2_RXN-14903>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinone" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29035> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_CHEBI_60039_RXN-14903_SGD_YeastPathways_PROUT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000066_reaction_RXN-14116_location_lociGO_0005829_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
+                "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -931,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -939,33 +913,59 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_17388_RXN-14903_SGD_YeastPathways_PROUT-PWY>
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15377_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROUT-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
+                "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15378_SPONTPRO-RXN_SGD_YeastPathways_PROUT-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_29985_RXN-14116_SGD_PWY_YeastPathways_PROUT-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
+                "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_15378_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/b4af2955-7936-4559-8eba-283db538ffd6_RXN-14903>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29059> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -974,11 +974,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002333_YLR142W-MONOMER_RXN-14903_controller_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002333_YLR142W-MONOMER_RXN-14903_controller_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -993,11 +993,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_15378_RXN-14116_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_15378_RXN-14116_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1017,24 +1017,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29072> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_29985_RXN-14116_SGD_YeastPathways_PROUT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-14903>
         a       <http://purl.obolibrary.org/obo/GO_0004657> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1045,9 +1034,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-14903_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/527e1b16-68ff-4475-8d16-26495de6b5b2_RXN-14903> , <http://model.geneontology.org/CHEBI_60039_RXN-14903> ;
+                <http://model.geneontology.org/54ee03ee-deb9-4f8f-87fe-3b07480dfb2b_RXN-14903> , <http://model.geneontology.org/CHEBI_60039_RXN-14903> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_RXN-14903> , <http://model.geneontology.org/6c81cfc5-da3a-4ac3-8183-cb62104a4ae3_RXN-14903> , <http://model.geneontology.org/CHEBI_17388_RXN-14903> ;
+                <http://model.geneontology.org/b4af2955-7936-4559-8eba-283db538ffd6_RXN-14903> , <http://model.geneontology.org/CHEBI_15378_RXN-14903> , <http://model.geneontology.org/CHEBI_17388_RXN-14903> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR142W-MONOMER_RXN-14903_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1055,13 +1044,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYBiochemicalReaction29030> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_58066_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58066_SPONTPRO-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58066> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1072,7 +1072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1087,11 +1087,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_BFO_0000066_reaction_RXN-14903_location_lociGO_0005829_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_BFO_0000066_reaction_RXN-14903_location_lociGO_0005829_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1114,7 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1122,26 +1122,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_527e1b16-68ff-4475-8d16-26495de6b5b2_RXN-14903_SGD_YeastPathways_PROUT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_58066_SPONTPRO-RXN_SGD_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002234_CHEBI_58066_SPONTPRO-RXN_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1151,17 +1140,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58066_SPONTPRO-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002413_RXN-14116_SGD_YeastPathways_PROUT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SPONTPRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
@@ -1180,10 +1158,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYBiochemicalReaction29098> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002233_CHEBI_15377_RXN-14116_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_54ee03ee-deb9-4f8f-87fe-3b07480dfb2b_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PRPP-PWY-1.ttl
+++ b/models/YeastPathways_PRPP-PWY-1.ttl
@@ -1,23 +1,12 @@
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,26 +17,15 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation '(<i>S</i>)-dihydroorotate + H<sub>2</sub>O &harr; <i>N</i>-carbamoyl-L-aspartate + H<SUP>+</SUP>' 'null' '(<i>S</i>)-dihydroorotate + fumarate &rarr; orotate + succinate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002413_RXN-9929_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002413_RXN-9929_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,14 +36,14 @@
           <http://model.geneontology.org/RXN-9929>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -73,11 +51,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' 'null' 'ATP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine &rarr; ADP + 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -95,24 +73,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1Protein40694> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_15378_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58457> ;
@@ -123,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -131,26 +98,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -160,17 +116,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57305_GLYRIBONUCSYN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GDPREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004748> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -191,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -203,11 +148,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -218,30 +163,52 @@
           <http://model.geneontology.org/CHEBI_58359_GMP-SYN-GLUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_78346_PRPPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001003>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001550>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -250,11 +217,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,24 +241,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule39619> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_15377_HISTCYCLOHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -305,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -323,11 +279,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,26 +294,15 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -371,17 +316,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_GUANYL-KIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -391,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -399,48 +333,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -451,36 +352,25 @@
           <http://model.geneontology.org/CHEBI_15378_ASPCARBTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -488,11 +378,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,15 +420,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000066_reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation '1-(5-phospho-&beta;-D-ribosyl)-ATP + diphosphate &larr; ATP + 5-phospho-&alpha;-D-ribose 1-diphosphate + H<SUP>+</SUP>' 'null' '1-(5-phospho-&beta;-D-ribosyl)-ATP + H<sub>2</sub>O &rarr; 1-(5-phospho-&beta;-D-ribosyl)-AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002413_HISTPRATPHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002413_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -553,11 +454,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'IMP + H<sub>2</sub>O &harr; 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' 'null' 'L-aspartate + IMP + GTP &rarr; adenylo-succinate + GDP + phosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -568,25 +469,14 @@
           <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002413_HISTPRATPHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -594,11 +484,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,11 +503,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15378_DIHYDROOROT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15378_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -634,15 +524,26 @@
 <http://purl.obolibrary.org/obo/GO_0004151>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -656,28 +557,6 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30839_RXN-9929_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -688,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -700,11 +579,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -715,25 +594,14 @@
           <http://model.geneontology.org/CHEBI_18413_FGAMSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_57538_OROPRIBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_15377_IMIDPHOSDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -749,7 +617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -761,11 +629,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -776,6 +644,17 @@
           <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58359_GMP-SYN-GLUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58359> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -785,7 +664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -793,19 +672,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000066_reaction_HISTPRATPHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_57667>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -814,11 +693,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -829,17 +708,6 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29991_ASPCARBTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -849,7 +717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -861,11 +729,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_64802_HISTOLDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_64802_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -876,6 +744,17 @@
           <http://model.geneontology.org/CHEBI_64802_HISTOLDEHYD-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58115_GMP-SYN-GLUT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58115> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -885,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -893,15 +772,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -931,7 +832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -942,14 +843,25 @@
 <http://identifiers.org/sgd/S000004351>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -957,11 +869,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -972,25 +884,14 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002413_IMIDPHOSDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1001,11 +902,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_30616_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_30616_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1020,11 +921,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1047,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1055,14 +956,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1070,11 +982,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,11 +1001,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1113,7 +1025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1124,14 +1036,14 @@
 <http://identifiers.org/sgd/S000000070>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002333_YER055C-MONOMER_ATPPHOSPHORIBOSYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1142,7 +1054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1172,7 +1084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1184,11 +1096,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002233_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002233_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1199,29 +1111,46 @@
           <http://model.geneontology.org/CHEBI_58435_HISTCYCLOHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_37563>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/6d1c36d3-bcc1-4358-bda3-92984bbdeed2_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40483> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1242,11 +1171,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1257,51 +1186,51 @@
           <http://model.geneontology.org/YKL067W-MONOMER_GDPKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YHL011C-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1312,14 +1241,25 @@
           <http://model.geneontology.org/CHEBI_58359_GLUTAMIDOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_29985_HISTAMINOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002234_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1330,7 +1270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1342,11 +1282,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1356,6 +1296,50 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_456215_AMPSYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002413_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ADENYL-KIN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004017> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1376,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1391,7 +1375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1403,11 +1387,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_57766_IMIDPHOSDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_57766_IMIDPHOSDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1418,14 +1402,25 @@
           <http://model.geneontology.org/CHEBI_57766_IMIDPHOSDEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002413_DIHYDROOROT-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1433,11 +1428,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000066_reaction_HISTIDPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000066_reaction_HISTIDPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1448,19 +1443,30 @@
           <http://model.geneontology.org/reaction_HISTIDPHOS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_29888_HISTPRATPHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003922>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1469,11 +1475,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_64802_HISTOLDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_64802_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1484,15 +1490,26 @@
           <http://model.geneontology.org/CHEBI_64802_HISTOLDEHYD-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1506,26 +1523,15 @@
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1545,7 +1551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1553,14 +1559,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1568,11 +1596,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1583,6 +1611,17 @@
           <http://model.geneontology.org/CHEBI_57865_OROTPDECARB-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29991> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1592,7 +1631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1605,7 +1644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1613,11 +1652,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation 'dADP + an oxidized thioredoxin + H<sub>2</sub>O &larr; ADP + a reduced thioredoxin' 'null' 'dADP + ATP &rarr; dATP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1628,15 +1667,26 @@
           <http://model.geneontology.org/DADPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_15378_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1654,11 +1704,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1673,11 +1723,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YBL068W-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YBL068W-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1688,14 +1738,14 @@
           <http://model.geneontology.org/YBL068W-MONOMER_PRPPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002234_CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1704,40 +1754,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1745,11 +1773,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1760,26 +1788,15 @@
           <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1794,11 +1811,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_RXN-12002_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_RXN-12002_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1813,11 +1830,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'phosphoribulosylformimino-AICAR-phosphate + L-glutamine &rarr; L-glutamate + D-erythro-imidazole-glycerol-phosphate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide + H<SUP>+</SUP>' 'null' 'D-erythro-imidazole-glycerol-phosphate &rarr; imidazole acetol-phosphate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002413_IMIDPHOSDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002413_IMIDPHOSDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1828,6 +1845,28 @@
           <http://model.geneontology.org/IMIDPHOSDEHYD-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58475_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29991_SAICARSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29991> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1837,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1845,14 +1884,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_57945_HISTOLDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30839_RXN-9929_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1860,11 +1899,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_59457_HISTPRATPHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_59457_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1875,14 +1914,14 @@
           <http://model.geneontology.org/CHEBI_59457_HISTPRATPHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1895,7 +1934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1903,40 +1942,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005654>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000066_reaction_HISTOLDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000066_reaction_HISTOLDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1947,6 +1975,17 @@
           <http://model.geneontology.org/reaction_HISTOLDEHYD-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_DIHYDROOROT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1956,7 +1995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1973,7 +2012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1985,11 +2024,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2004,11 +2043,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_29888_HISTPRATPHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_29888_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2019,71 +2058,27 @@
           <http://model.geneontology.org/CHEBI_29888_HISTPRATPHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000066_reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_DIHYDROOROT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002634>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2098,11 +2093,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2113,15 +2108,48 @@
           <http://model.geneontology.org/CHEBI_15377_IMP-DEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation '1-(5-phospho-&beta;-D-ribosyl)-5-[(5-phosphoribosylamino)methylideneamino]imidazole-4-carboxamide &rarr; phosphoribulosylformimino-AICAR-phosphate' 'null' 'phosphoribulosylformimino-AICAR-phosphate + L-glutamine &rarr; L-glutamate + D-erythro-imidazole-glycerol-phosphate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002413_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002413_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2139,11 +2167,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2154,15 +2182,37 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_RXN-12002_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_30616_PRPPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_30616_PRPPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2178,7 +2228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2186,11 +2236,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2210,7 +2260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2218,48 +2268,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_8ad8bf73-6d65-49e9-a162-810620121612_AICARTRANSFORM-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2287,7 +2304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2295,26 +2312,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2325,6 +2331,28 @@
           <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57699_HISTIDPHOS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57699> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2334,7 +2362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2346,11 +2374,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2366,18 +2394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002413_OROPRIBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2390,7 +2407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2402,11 +2419,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30839_RXN-9929_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30839_RXN-9929_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2417,15 +2434,26 @@
           <http://model.geneontology.org/CHEBI_30839_RXN-9929>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_UDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_UDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2436,28 +2464,6 @@
           <http://model.geneontology.org/CHEBI_46398_UDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58189> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2467,7 +2473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2484,7 +2490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2501,7 +2507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2513,11 +2519,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2528,15 +2534,48 @@
           <http://model.geneontology.org/CHEBI_456216_DADPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2557,7 +2596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2565,40 +2604,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002234_CHEBI_58525_PRIBFAICARPISOM-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://identifiers.org/sgd/S000005422>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_15377_HISTALDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000005422>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_57766_IMIDPHOSDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_57766_IMIDPHOSDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2609,59 +2637,15 @@
           <http://model.geneontology.org/CHEBI_57766_IMIDPHOSDEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2672,26 +2656,15 @@
           <http://model.geneontology.org/reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2706,11 +2679,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2721,14 +2694,14 @@
           <http://model.geneontology.org/YML056C-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57945_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2741,7 +2714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2749,26 +2722,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000066_reaction_IMIDPHOSDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide &harr; a tetrahydrofolate + 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' 'null' 'IMP + H<sub>2</sub>O &harr; 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2779,17 +2741,6 @@
           <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58595> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2799,13 +2750,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40285> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005164> ;
@@ -2814,7 +2776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2822,29 +2784,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_58359>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58359>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YKL181W-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YKL181W-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2859,11 +2821,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2883,7 +2845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2900,7 +2862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2915,11 +2877,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2939,24 +2901,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40208> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_SAICARSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2967,7 +2918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2979,11 +2930,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3003,7 +2954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3020,7 +2971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3035,7 +2986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3047,11 +2998,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3069,7 +3020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3081,11 +3032,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3099,14 +3050,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_58426>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_57766_IMIDPHOSDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3119,7 +3070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3134,7 +3085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3142,14 +3093,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3157,11 +3108,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3172,36 +3123,69 @@
           <http://model.geneontology.org/CHEBI_61429_DGDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_456215_PRPPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15378_DIHYDROOROT-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3209,11 +3193,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3227,15 +3211,26 @@
 <http://identifiers.org/sgd/S000004574>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002413_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3246,25 +3241,14 @@
           <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002413_OROPRIBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3272,11 +3256,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3287,28 +3271,6 @@
           <http://model.geneontology.org/CHEBI_456215_GMP-SYN-GLUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16526_AIRCARBOXY-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3318,7 +3280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3326,15 +3288,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + 2 H<SUP>+</SUP> &harr; 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + CO<SUB>2</SUB>' 'null' 'ATP + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + L-aspartate &rarr; ADP + 5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3348,6 +3321,17 @@
 <http://purl.obolibrary.org/obo/GO_0043727>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_78346_PRPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_78346> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3357,7 +3341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3365,25 +3349,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3391,11 +3364,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3406,14 +3379,25 @@
           <http://model.geneontology.org/CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3424,11 +3408,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3448,7 +3432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3456,15 +3440,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57699_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-aspartate + carbamoyl phosphate &harr; <i>N</i>-carbamoyl-L-aspartate + phosphate + H<SUP>+</SUP>' 'null' '(<i>S</i>)-dihydroorotate + H<sub>2</sub>O &harr; <i>N</i>-carbamoyl-L-aspartate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002413_DIHYDROOROT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002413_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3475,26 +3481,15 @@
           <http://model.geneontology.org/DIHYDROOROT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000066_reaction_RXN-9929_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3508,26 +3503,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3538,17 +3522,6 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3558,7 +3531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3566,26 +3539,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002233_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ATP + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + L-aspartate &rarr; ADP + 5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole + phosphate + H<SUP>+</SUP>' 'null' '5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole &harr; fumarate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3605,7 +3567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3617,11 +3579,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3632,14 +3594,14 @@
           <http://model.geneontology.org/YLR420W-MONOMER_DIHYDROOROT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000066_reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3647,11 +3609,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3665,14 +3627,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_43474_HISTIDPHOS-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3685,24 +3647,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40298> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CARBPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004088> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3723,7 +3674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3731,23 +3682,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002413_RXN-9929_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
         a       <http://identifiers.org/sgd/S000001328> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3755,11 +3706,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3770,25 +3721,47 @@
           <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3796,11 +3769,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3811,36 +3784,25 @@
           <http://model.geneontology.org/CHEBI_456216_GUANYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTPRATPHYD-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3849,7 +3811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3865,7 +3827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3877,11 +3839,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTALDEHYD-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTALDEHYD-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3891,17 +3853,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YCL030C-MONOMER_HISTALDEHYD-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_UDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/OROPRIBTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004588> ;
@@ -3922,7 +3873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3934,11 +3885,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3949,25 +3900,25 @@
           <http://model.geneontology.org/CHEBI_456216_AIRS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_ba163863-dd3e-4160-872d-1064a78367d2_AICARTRANSFORM-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3976,18 +3927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3996,7 +3936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4004,11 +3944,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4024,29 +3964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57540_HISTOLDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4054,11 +3972,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4078,7 +3996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4086,26 +4004,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002413_HISTOLDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002333_YER055C-MONOMER_ATPPHOSPHORIBOSYLTRANS-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002333_YER055C-MONOMER_ATPPHOSPHORIBOSYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4116,15 +4023,26 @@
           <http://model.geneontology.org/YER055C-MONOMER_ATPPHOSPHORIBOSYLTRANS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_57945_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4135,15 +4053,26 @@
           <http://model.geneontology.org/YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002333_YOR202W-MONOMER_IMIDPHOSDEHYD-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4161,11 +4090,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4185,7 +4114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4193,26 +4122,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4227,11 +4145,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4242,46 +4160,15 @@
           <http://model.geneontology.org/reaction_OROTPDECARB-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000066_reaction_HISTOLDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_AICARSYN-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4292,62 +4179,49 @@
           <http://model.geneontology.org/CHEBI_15378_FGAMSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_15378_HISTALDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/reaction_AICARSYN-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTALDEHYD-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002413_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004635>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_30616_PRPPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_093e01e4-f541-4860-badf-f36f7413146e_GART-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_1c61bc1e-7c10-4e09-9602-c9a9db95844c_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4355,7 +4229,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/093e01e4-f541-4860-badf-f36f7413146e_GART-RXN>
+          <http://model.geneontology.org/1c61bc1e-7c10-4e09-9602-c9a9db95844c_GART-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58475_GLUTAMIDOTRANS-RXN>
@@ -4367,7 +4241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4384,13 +4258,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40395> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_HISTAMINOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4401,7 +4286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4409,25 +4294,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4435,11 +4309,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4453,15 +4327,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_58228>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4472,36 +4357,14 @@
           <http://model.geneontology.org/GUANYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_16810_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4510,7 +4373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4518,11 +4381,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_57540_HISTALDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_57540_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4537,11 +4400,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'AMP + ATP &harr; 2 ADP' 'null' 'dADP + an oxidized thioredoxin + H<sub>2</sub>O &larr; ADP + a reduced thioredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4552,17 +4415,6 @@
           <http://model.geneontology.org/ADPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16526_OROTPDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4572,7 +4424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4585,7 +4437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4594,7 +4446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4605,7 +4457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4617,11 +4469,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-histidinol phosphate + 2-oxoglutarate &larr; imidazole acetol-phosphate + L-glutamate' 'null' 'L-histidinol phosphate + H<sub>2</sub>O &rarr; histidinol + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002413_HISTIDPHOS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002413_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4632,29 +4484,51 @@
           <http://model.geneontology.org/HISTIDPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
+<http://purl.obolibrary.org/obo/GO_0004550>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_PRPPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0004550>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_57699_HISTIDPHOS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_57699_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4669,11 +4543,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_15378_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_15378_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4688,11 +4562,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4722,7 +4596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4730,16 +4604,46 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_1c61bc1e-7c10-4e09-9602-c9a9db95844c_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CARBPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_CARBPSYN-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_29985_GMP-SYN-GLUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
@@ -4750,7 +4654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4762,41 +4666,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CARBPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_CARBPSYN-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_57538_OROPRIBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4807,6 +4681,17 @@
           <http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_ae218896-da4c-4082-a729-8e8537eff988_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_RXN0-746>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4816,7 +4701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4831,7 +4716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4843,11 +4728,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-aspartate + IMP + GTP &rarr; adenylo-succinate + GDP + phosphate + 2 H<SUP>+</SUP>' 'null' 'adenylo-succinate &harr; fumarate + AMP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4862,11 +4747,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000066_reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000066_reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4877,15 +4762,26 @@
           <http://model.geneontology.org/reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4903,11 +4799,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4918,6 +4814,28 @@
           <http://model.geneontology.org/YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_15377_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004643>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -4925,11 +4843,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4952,7 +4870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of histidine, purine, and pyrimidine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -4960,14 +4878,14 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_BFO_0000066_reaction_ATPPHOSPHORIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4975,11 +4893,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000066_reaction_GLUTAMIDOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000066_reaction_GLUTAMIDOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4990,12 +4908,34 @@
           <http://model.geneontology.org/reaction_GLUTAMIDOTRANS-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000066_reaction_RXN-9929_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5008,7 +4948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5016,37 +4956,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_093e01e4-f541-4860-badf-f36f7413146e_GART-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5057,15 +4975,26 @@
           <http://model.geneontology.org/CHEBI_30616_ADENYL-KIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_58017_PRPPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_29985_HISTAMINOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_29985_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5076,6 +5005,17 @@
           <http://model.geneontology.org/CHEBI_29985_HISTAMINOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_AIRS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5085,7 +5025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5093,71 +5033,49 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_29888_OROPRIBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004830>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5168,36 +5086,25 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002333_YBR248C-MONOMER_GLUTAMIDOTRANS-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_29888_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5210,7 +5117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5218,15 +5125,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_15378_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_57945_HISTOLDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_57945_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5237,17 +5155,6 @@
           <http://model.geneontology.org/CHEBI_57945_HISTOLDEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5257,7 +5164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5270,7 +5177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5281,7 +5188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5292,26 +5199,15 @@
 <http://purl.obolibrary.org/obo/GO_0004749>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002413_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5322,15 +5218,26 @@
           <http://model.geneontology.org/CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5341,14 +5248,14 @@
           <http://model.geneontology.org/CHEBI_16526_OROTPDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5356,11 +5263,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5371,6 +5278,17 @@
           <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5380,7 +5298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5391,26 +5309,15 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002413_AIRCARBOXY-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5425,11 +5332,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_58017_PRPPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_58017_PRPPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5445,18 +5352,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5464,11 +5371,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5488,7 +5395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5496,14 +5403,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_b1f621c1-d76d-4313-a178-3d9b6a8a3105_GART-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5511,11 +5418,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5530,11 +5437,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5545,26 +5452,15 @@
           <http://model.geneontology.org/CHEBI_30616_UDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation 'phosphoribulosylformimino-AICAR-phosphate + L-glutamine &rarr; L-glutamate + D-erythro-imidazole-glycerol-phosphate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide + H<SUP>+</SUP>' 'null' 'a 10-formyltetrahydrofolate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide &harr; a tetrahydrofolate + 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5575,28 +5471,61 @@
           <http://model.geneontology.org/AICARTRANSFORM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_64802_HISTOLDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004424>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57699_HISTIDPHOS-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5619,13 +5548,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1BiochemicalReaction40312> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002413_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58564>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5634,11 +5585,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5652,6 +5603,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_57699_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YGR061C-MONOMER_FGAMSYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003293> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -5659,7 +5621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5667,14 +5629,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_58017_PRPPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5686,7 +5648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5694,11 +5656,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_15378_HISTPRATPHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_15378_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5709,6 +5671,28 @@
           <http://model.geneontology.org/CHEBI_15378_HISTPRATPHYD-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_57540_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_ATPPHOSPHORIBOSYLTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5718,7 +5702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5726,15 +5710,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5749,11 +5744,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5767,14 +5762,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5782,11 +5788,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation '5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole &harr; fumarate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide' 'null' 'a 10-formyltetrahydrofolate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide &harr; a tetrahydrofolate + 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5797,37 +5803,15 @@
           <http://model.geneontology.org/AICARTRANSFORM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002413_HISTAMINOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000066_reaction_PRPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000066_reaction_PRPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5838,14 +5822,25 @@
           <http://model.geneontology.org/reaction_PRPPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002333_YIL020C-MONOMER_PRIBFAICARPISOM-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5853,11 +5848,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5868,14 +5863,14 @@
           <http://model.geneontology.org/CHEBI_16526_AIRCARBOXY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_15378_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5888,7 +5883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5898,13 +5893,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation 'D-ribose 5-phosphate + ATP &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + AMP + H<SUP>+</SUP>' 'null' '5-phospho-&beta;-D-ribosylamine + L-glutamate + diphosphate &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + L-glutamine + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Provides Input For Rule. The relation 'D-ribose 5-phosphate + ATP &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + AMP + H<SUP>+</SUP>' 'null' '5-phospho-&beta;-D-ribosylamine + L-glutamate + diphosphate &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + L-glutamine + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002413_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002413_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5919,11 +5914,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5938,11 +5933,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_15378_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_15378_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5962,7 +5957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5974,11 +5969,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30031_RXN-9929_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30031_RXN-9929_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5993,11 +5988,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6008,14 +6003,36 @@
           <http://model.geneontology.org/CHEBI_30616_CTPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6023,11 +6040,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6038,25 +6055,25 @@
           <http://model.geneontology.org/CHEBI_57667_ADPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6068,18 +6085,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6090,11 +6107,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'histidinol + NAD<sup>+</sup> &rarr; histidinal + NADH + H<SUP>+</SUP>' 'null' 'histidinal + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; L-histidine + NADH + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002413_HISTALDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002413_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6105,23 +6122,45 @@
           <http://model.geneontology.org/HISTALDEHYD-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_ADPREDUCT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002333_YBR248C-MONOMER_GLUTAMIDOTRANS-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6130,19 +6169,52 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004018>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_HISTIDPHOS-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6150,11 +6222,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_15377_IMIDPHOSDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_15377_IMIDPHOSDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6175,11 +6247,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6190,14 +6262,14 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002413_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6205,11 +6277,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6220,26 +6292,15 @@
           <http://model.geneontology.org/reaction_AICARSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6250,14 +6311,14 @@
           <http://model.geneontology.org/YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_15378_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6270,7 +6331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6278,15 +6339,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6296,17 +6379,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GLYRIBONUCSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004637> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6327,7 +6399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6339,11 +6411,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YHL011C-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YHL011C-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6354,17 +6426,6 @@
           <http://model.geneontology.org/YHL011C-MONOMER_PRPPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTPRATPHYD-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_FGAMSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6374,7 +6435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6386,11 +6447,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6401,14 +6462,14 @@
           <http://model.geneontology.org/CHEBI_30616_AIRS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6416,11 +6477,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ATP + UMP &rarr; ADP + UDP' 'null' 'UDP + ATP &rarr; UTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6435,11 +6496,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6450,26 +6511,15 @@
           <http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'adenylo-succinate &harr; fumarate + AMP' 'null' 'AMP + ATP &harr; 2 ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6489,7 +6539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6506,7 +6556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6518,11 +6568,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6540,7 +6590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6552,11 +6602,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6566,17 +6616,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YBL039C-MONOMER_CTPSYN-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000066_reaction_GLUTAMIDOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_32814>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6600,7 +6639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6613,7 +6652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6621,11 +6660,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6640,11 +6679,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6655,23 +6694,6 @@
           <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ba163863-dd3e-4160-872d-1064a78367d2_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40483> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_58443_SAICARSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58443> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6681,46 +6703,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40524> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_PRPPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002333_YIL116W-MONOMER_HISTAMINOTRANS-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GART-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004644> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6731,9 +6720,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/b1f621c1-d76d-4313-a178-3d9b6a8a3105_GART-RXN> , <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> , <http://model.geneontology.org/6d1c36d3-bcc1-4358-bda3-92984bbdeed2_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/093e01e4-f541-4860-badf-f36f7413146e_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> , <http://model.geneontology.org/1c61bc1e-7c10-4e09-9602-c9a9db95844c_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -6741,7 +6730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6749,15 +6738,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000066_reaction_HISTIDPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6768,14 +6768,14 @@
           <http://model.geneontology.org/CHEBI_15377_FGAMSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTCYCLOHYD-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000066_reaction_HISTCYCLOHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6788,7 +6788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6805,7 +6805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6813,25 +6813,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6842,7 +6831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6854,11 +6843,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6873,11 +6862,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6897,7 +6886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6905,14 +6894,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002413_PRIBFAICARPISOM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6920,11 +6909,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6935,39 +6924,17 @@
           <http://model.geneontology.org/CHEBI_29985_GMP-SYN-GLUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000001259>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6975,11 +6942,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'dGDP + an oxidized thioredoxin + H<sub>2</sub>O &larr; GDP + a reduced thioredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6994,11 +6961,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7009,25 +6976,25 @@
           <http://model.geneontology.org/YOR128C-MONOMER_AIRCARBOXY-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7038,7 +7005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7046,15 +7013,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YKL181W-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7065,6 +7043,28 @@
           <http://model.geneontology.org/reaction_AMPSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57540_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_CARBPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7074,7 +7074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7082,26 +7082,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation '(<i>S</i>)-dihydroorotate + fumarate &rarr; orotate + succinate' 'null' 'orotidine 5'-phosphate + diphosphate &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + orotate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002413_OROPRIBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002413_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7117,7 +7106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7130,7 +7119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7142,11 +7131,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7157,26 +7146,15 @@
           <http://model.geneontology.org/YJL130C-MONOMER_ASPCARBTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7187,26 +7165,15 @@
           <http://model.geneontology.org/CHEBI_37565_GDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7221,11 +7188,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7236,17 +7203,6 @@
           <http://model.geneontology.org/reaction_OROPRIBTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58475> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7256,7 +7212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7264,14 +7220,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_15377_HISTIDPHOS-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7279,11 +7246,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7301,11 +7268,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_30864_DIHYDROOROT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7315,6 +7282,39 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_59457_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -7328,7 +7328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7336,14 +7336,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7351,11 +7351,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7385,13 +7385,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1BiochemicalReaction40592> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_59457_HISTPRATPHYD-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59457> ;
@@ -7402,7 +7413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7413,28 +7424,61 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004639>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7450,7 +7494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7462,11 +7506,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7484,7 +7528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7500,7 +7544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7513,13 +7557,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule39619> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YBL068W-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ADPREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004748> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7540,7 +7595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7552,11 +7607,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7567,14 +7622,25 @@
           <http://model.geneontology.org/CHEBI_58115_GMP-SYN-GLUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7597,7 +7663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7605,40 +7671,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000452>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57945_HISTALDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57945_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7656,7 +7711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7664,14 +7719,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7679,11 +7734,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7703,7 +7758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7721,13 +7776,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1Protein40009> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -7751,7 +7817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7759,26 +7825,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002234_CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002234_CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7789,15 +7844,26 @@
           <http://model.geneontology.org/CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_15378_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7817,7 +7883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7834,7 +7900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7846,11 +7912,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7861,15 +7927,37 @@
           <http://model.geneontology.org/CHEBI_58564_AIRCARBOXY-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002413_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7880,15 +7968,37 @@
           <http://model.geneontology.org/CHEBI_58228_CARBPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002333_YFR025C-MONOMER_HISTIDPHOS-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7899,26 +8009,32 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000066_reaction_HISTALDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/27cef36d-dad3-4424-ab27-c69edad9ec44_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40483> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7948,7 +8064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7956,12 +8072,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_IMIDPHOSDEHYD-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7974,7 +8101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7982,18 +8109,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_58467>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8004,16 +8128,8 @@
           <http://model.geneontology.org/CHEBI_58426_GART-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YBL068W-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_58467>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15377_PRPPAMIDOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -8024,7 +8140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8041,7 +8157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8049,25 +8165,47 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_30839_RXN-9929_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8075,11 +8213,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8090,6 +8228,17 @@
           <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29888_PRPPAMIDOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8099,13 +8248,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule39973> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_30616_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_IMPCYCLOHYDROLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -8116,7 +8276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8124,14 +8284,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57945_HISTALDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8139,11 +8310,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_15377_HISTALDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_15377_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8154,17 +8325,6 @@
           <http://model.geneontology.org/CHEBI_15377_HISTALDEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YER099C-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000005164>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -8172,11 +8332,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8187,6 +8347,17 @@
           <http://model.geneontology.org/YER170W-MONOMER_ADENYL-KIN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_RXN-12002>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8196,7 +8367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8223,7 +8394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8235,11 +8406,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002333_YIL116W-MONOMER_HISTAMINOTRANS-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002333_YIL116W-MONOMER_HISTAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8250,32 +8421,37 @@
           <http://model.geneontology.org/YIL116W-MONOMER_HISTAMINOTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/CHEBI_15378_CTPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_30616_PRPPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule39619> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000066_reaction_HISTALDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_43474_HISTIDPHOS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_43474_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8289,26 +8465,32 @@
 <http://purl.obolibrary.org/obo/CHEBI_46398>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_15378_CTPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule39619> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_BFO_0000066_reaction_ATPPHOSPHORIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_BFO_0000066_reaction_ATPPHOSPHORIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8322,25 +8504,14 @@
 <http://identifiers.org/sgd/S000001507>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000066_reaction_HISTPRATPHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8353,7 +8524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8365,11 +8536,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8384,11 +8555,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_29888_OROPRIBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8408,7 +8579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8416,26 +8587,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8452,26 +8612,15 @@
 <http://purl.obolibrary.org/obo/GO_0004588>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8486,11 +8635,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8501,14 +8650,14 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8516,11 +8665,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8531,29 +8680,51 @@
           <http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_15378_PRPPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004642>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8576,7 +8747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8584,26 +8755,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8629,13 +8789,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1BiochemicalReaction40304> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002413_RXN-9929_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YCL030C-MONOMER_HISTCYCLOHYD-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000535> ;
@@ -8644,7 +8815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8656,11 +8827,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8680,7 +8851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8692,11 +8863,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'UDP + ATP &rarr; UTP + ADP' 'null' 'L-glutamine + UTP + ATP + H<sub>2</sub>O &rarr; ADP + CTP + L-glutamate + phosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8716,7 +8887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8733,7 +8904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8745,11 +8916,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8763,17 +8934,6 @@
 <http://identifiers.org/sgd/S000003666>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000066_reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_HISTPRATPHYD-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8783,7 +8943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8791,23 +8951,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN-12002_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8815,11 +8964,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000066_reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000066_reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8830,17 +8979,6 @@
           <http://model.geneontology.org/reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_HISTPRATPHYD-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8850,7 +8988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8861,14 +8999,36 @@
 <http://purl.obolibrary.org/obo/CHEBI_57980>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTCYCLOHYD-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_64802_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8881,7 +9041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8896,11 +9056,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation '1-(5-phospho-&beta;-D-ribosyl)-AMP + H<sub>2</sub>O &rarr; 1-(5-phospho-&beta;-D-ribosyl)-5-[(5-phosphoribosylamino)methylideneamino]imidazole-4-carboxamide' 'null' '1-(5-phospho-&beta;-D-ribosyl)-5-[(5-phosphoribosylamino)methylideneamino]imidazole-4-carboxamide &rarr; phosphoribulosylformimino-AICAR-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002413_PRIBFAICARPISOM-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002413_PRIBFAICARPISOM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8918,7 +9078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8926,14 +9086,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8942,44 +9102,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003879>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_15378_HISTOLDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_15378_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8990,6 +9139,17 @@
           <http://model.geneontology.org/CHEBI_15378_HISTOLDEHYD-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30031_RXN-9929_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004748>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -8997,11 +9157,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9021,7 +9181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9033,11 +9193,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation '1-(5-phospho-&beta;-D-ribosyl)-ATP + H<sub>2</sub>O &rarr; 1-(5-phospho-&beta;-D-ribosyl)-AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' '1-(5-phospho-&beta;-D-ribosyl)-AMP + H<sub>2</sub>O &rarr; 1-(5-phospho-&beta;-D-ribosyl)-5-[(5-phosphoribosylamino)methylideneamino]imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002413_HISTCYCLOHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002413_HISTCYCLOHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9048,6 +9208,17 @@
           <http://model.geneontology.org/HISTCYCLOHYD-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002234_CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57766>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -9055,11 +9226,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9074,11 +9245,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9089,6 +9260,17 @@
           <http://model.geneontology.org/Red-Thioredoxin_ADPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -9096,11 +9278,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9111,6 +9293,17 @@
           <http://model.geneontology.org/CHEBI_15377_PRPPAMIDOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTALDEHYD-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_RXN0-745>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9120,7 +9313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9132,11 +9325,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_ba163863-dd3e-4160-872d-1064a78367d2_AICARTRANSFORM-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_27cef36d-dad3-4424-ab27-c69edad9ec44_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9144,40 +9337,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ba163863-dd3e-4160-872d-1064a78367d2_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/27cef36d-dad3-4424-ab27-c69edad9ec44_AICARTRANSFORM-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_456215_PRPPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_456215_PRPPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9188,6 +9359,17 @@
           <http://model.geneontology.org/CHEBI_456215_PRPPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58189>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -9195,11 +9377,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9214,11 +9396,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_OROTPDECARB-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9229,14 +9411,25 @@
           <http://model.geneontology.org/CHEBI_57865_OROTPDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YOL061W-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9244,11 +9437,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9259,14 +9452,25 @@
           <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002233_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9277,11 +9481,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9299,7 +9503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9311,11 +9515,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002333_YBR248C-MONOMER_GLUTAMIDOTRANS-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002333_YBR248C-MONOMER_GLUTAMIDOTRANS-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9329,26 +9533,15 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9362,25 +9555,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_18413>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58525_PRIBFAICARPISOM-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9388,11 +9570,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-histidinol phosphate + H<sub>2</sub>O &rarr; histidinol + phosphate' 'null' 'histidinol + NAD<sup>+</sup> &rarr; histidinal + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002413_HISTOLDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002413_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9403,48 +9585,15 @@
           <http://model.geneontology.org/HISTOLDEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9464,7 +9613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9472,26 +9621,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9502,15 +9640,26 @@
           <http://model.geneontology.org/reaction_ADPREDUCT-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000066_reaction_HISTOLDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9520,6 +9669,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004044>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -9531,7 +9691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9546,11 +9706,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9561,25 +9721,14 @@
           <http://model.geneontology.org/YLR359W-MONOMER_AICARSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9587,11 +9736,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9611,7 +9760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9623,11 +9772,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9638,17 +9787,6 @@
           <http://model.geneontology.org/CHEBI_137981_AIRS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57945_IMP-DEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9658,7 +9796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9671,7 +9809,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_UDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9679,11 +9839,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-ribose 5-phosphate + ATP &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + AMP + H<SUP>+</SUP>' 'null' 'orotidine 5'-phosphate + diphosphate &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + orotate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002413_OROPRIBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002413_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9701,11 +9861,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation '2 ATP + L-glutamine + hydrogencarbonate + H<sub>2</sub>O &rarr; L-glutamate + carbamoyl phosphate + 2 ADP + phosphate + 2 H<SUP>+</SUP>' 'null' 'L-aspartate + carbamoyl phosphate &harr; <i>N</i>-carbamoyl-L-aspartate + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9716,17 +9876,6 @@
           <http://model.geneontology.org/ASPCARBTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -9734,11 +9883,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9753,11 +9902,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9773,40 +9922,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/093e01e4-f541-4860-badf-f36f7413146e_GART-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40505> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004018> ;
@@ -9815,7 +9936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9827,11 +9948,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9851,7 +9972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9878,7 +9999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9886,14 +10007,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9904,7 +10025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9912,25 +10033,58 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57595_HISTALDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9943,7 +10097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9951,25 +10105,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002413_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9977,11 +10131,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002233_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002233_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9991,6 +10145,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58278_GLUTAMIDOTRANS-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000066_reaction_GLUTAMIDOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CTPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003883> ;
@@ -10009,7 +10174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10017,15 +10182,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation 'ATP + 5-phospho-&beta;-D-ribosylamine + glycine &rarr; ADP + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + phosphate + H<SUP>+</SUP>' 'null' 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10036,25 +10212,25 @@
           <http://model.geneontology.org/GART-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15377_DIHYDROOROT-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002413_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10062,11 +10238,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10077,37 +10253,15 @@
           <http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58475_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10118,19 +10272,30 @@
           <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller>
 ] .
 
-<http://identifiers.org/sgd/S000004884>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004884>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_456216_GLYRIBONUCSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -10141,7 +10306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10153,11 +10318,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10168,25 +10333,25 @@
           <http://model.geneontology.org/CHEBI_18413_FGAMSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_57540_HISTALDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_BFO_0000066_reaction_ATPPHOSPHORIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTOLDEHYD-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10194,11 +10359,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10212,6 +10377,17 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002413_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57980_HISTAMINOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57980> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -10221,7 +10397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10229,15 +10405,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_15377_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10248,26 +10435,32 @@
           <http://model.geneontology.org/YLR359W-MONOMER_AMPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ae218896-da4c-4082-a729-8e8537eff988_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40505> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10285,11 +10478,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10300,25 +10493,14 @@
           <http://model.geneontology.org/CHEBI_456216_CTPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_15377_HISTPRATPHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10326,11 +10508,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10345,11 +10527,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10360,6 +10542,17 @@
           <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_DIHYDROOROT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -10369,7 +10562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10377,25 +10570,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10403,11 +10585,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10418,47 +10600,25 @@
           <http://model.geneontology.org/reaction_FGAMSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_15378_HISTPRATPHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000066_reaction_PRPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002333_YIL020C-MONOMER_PRIBFAICARPISOM-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10466,11 +10626,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10488,7 +10648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10496,26 +10656,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10526,14 +10675,25 @@
           <http://model.geneontology.org/CHEBI_57540_IMP-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10541,11 +10701,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10563,7 +10723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10580,7 +10740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10588,37 +10748,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_30839_RXN-9929_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YKL181W-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'GDP + ATP &rarr; GTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10634,7 +10772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10642,11 +10780,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10657,14 +10795,36 @@
           <http://model.geneontology.org/CHEBI_58564_AIRCARBOXY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10687,24 +10847,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1BiochemicalReaction40825> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002234_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9929>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_1990663> ;
@@ -10725,7 +10874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10733,15 +10882,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10752,25 +10912,25 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10783,7 +10943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10798,11 +10958,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10813,12 +10973,23 @@
           <http://model.geneontology.org/YKL216W-MONOMER_RXN-9929_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_HISTOLDEHYD-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10831,7 +11002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10843,11 +11014,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10867,7 +11038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10887,7 +11058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10902,11 +11073,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10921,11 +11092,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10936,15 +11107,26 @@
           <http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10955,17 +11137,6 @@
           <http://model.geneontology.org/reaction_CARBPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16810_HISTAMINOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16810> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -10975,7 +11146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10987,11 +11158,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11002,17 +11173,6 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/AICARTRANSFORM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004643> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -11022,9 +11182,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/ba163863-dd3e-4160-872d-1064a78367d2_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
+                <http://model.geneontology.org/27cef36d-dad3-4424-ab27-c69edad9ec44_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/8ad8bf73-6d65-49e9-a162-810620121612_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/ae218896-da4c-4082-a729-8e8537eff988_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -11032,7 +11192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11044,11 +11204,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11063,11 +11223,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15377_DIHYDROOROT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15377_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11085,7 +11245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11093,30 +11253,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58525_PRIBFAICARPISOM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YKL024C-MONOMER_RXN-12002_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001507> ;
@@ -11125,7 +11274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11133,15 +11282,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11152,25 +11312,47 @@
           <http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_43474_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_15378_PRPPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11178,11 +11360,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11193,6 +11375,17 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_46398_UDPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_46398> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -11202,7 +11395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11214,11 +11407,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11232,15 +11425,32 @@
 <http://purl.obolibrary.org/obo/CHEBI_58053>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule39799> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11251,71 +11461,43 @@
           <http://model.geneontology.org/CHEBI_30616_GUANYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule39799> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58525>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002413_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_32814_ASPCARBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57595_HISTALDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57595_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11326,15 +11508,26 @@
           <http://model.geneontology.org/CHEBI_57595_HISTALDEHYD-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_15377_HISTCYCLOHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_15377_HISTCYCLOHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11354,7 +11547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11366,11 +11559,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11381,12 +11574,45 @@
           <http://model.geneontology.org/reaction_ASPCARBTRANS-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_ATPPHOSPHORIBOSYLTRANS-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11399,7 +11625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11414,7 +11640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11422,14 +11648,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_15377_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11438,7 +11686,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11449,11 +11708,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11473,7 +11732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11485,11 +11744,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11509,7 +11768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11517,32 +11776,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/b1f621c1-d76d-4313-a178-3d9b6a8a3105_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40483> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11556,14 +11798,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_29991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002413_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11571,11 +11813,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11590,11 +11832,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation 'orotidine 5'-phosphate + diphosphate &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + orotate' 'null' 'orotidine 5'-phosphate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + UMP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002413_OROTPDECARB-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002413_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11613,7 +11855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11621,11 +11863,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11640,11 +11882,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002333_YIL020C-MONOMER_PRIBFAICARPISOM-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002333_YIL020C-MONOMER_PRIBFAICARPISOM-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11664,7 +11906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11681,7 +11923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11692,17 +11934,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_64802>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_37565>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -11710,11 +11941,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11730,7 +11961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11741,7 +11972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11758,7 +11989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11766,14 +11997,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30031_RXN-9929_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_29985_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11781,11 +12012,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11796,17 +12027,6 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002333_YFR025C-MONOMER_HISTIDPHOS-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_AIRS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -11816,35 +12036,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule39715> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002413_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YMR271C-MONOMER_OROPRIBTRANS-RXN_controller>
         a       <http://identifiers.org/sgd/S000004884> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -11853,7 +12051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11861,14 +12059,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11876,11 +12074,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000066_reaction_HISTALDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000066_reaction_HISTALDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11891,15 +12089,26 @@
           <http://model.geneontology.org/reaction_HISTALDEHYD-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11917,7 +12126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11934,7 +12143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11961,7 +12170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11969,26 +12178,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11999,26 +12197,15 @@
           <http://model.geneontology.org/CHEBI_57980_HISTAMINOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12029,25 +12216,25 @@
           <http://model.geneontology.org/CHEBI_57980_HISTAMINOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12055,11 +12242,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12074,11 +12261,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_58017_PRPPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_58017_PRPPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12089,15 +12276,26 @@
           <http://model.geneontology.org/CHEBI_58017_PRPPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_57595_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12108,12 +12306,23 @@
           <http://model.geneontology.org/CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003870> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12124,11 +12333,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'orotidine 5'-phosphate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + UMP' 'null' 'ATP + UMP &rarr; ADP + UDP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12139,25 +12348,14 @@
           <http://model.geneontology.org/RXN-12002>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002413_PRIBFAICARPISOM-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002413_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12170,7 +12368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12185,11 +12383,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12200,17 +12398,6 @@
           <http://model.geneontology.org/CHEBI_29985_PRPPAMIDOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YER055C-MONOMER_ATPPHOSPHORIBOSYLTRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000857> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -12218,7 +12405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12229,14 +12416,14 @@
 <http://purl.obolibrary.org/obo/GO_0004641>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12244,11 +12431,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12278,7 +12465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12305,7 +12492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12313,14 +12500,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12333,7 +12520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12341,40 +12528,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004401>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation 'dGDP + an oxidized thioredoxin + H<sub>2</sub>O &larr; GDP + a reduced thioredoxin' 'null' 'dGDP + ATP &rarr; dGTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12400,7 +12565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12411,26 +12576,15 @@
 <http://identifiers.org/sgd/S000000872>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12445,11 +12599,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12469,7 +12623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12477,26 +12631,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002413_OROTPDECARB-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12516,7 +12659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12536,7 +12679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12544,17 +12687,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000001282>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001282>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12562,11 +12716,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTCYCLOHYD-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTCYCLOHYD-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12586,7 +12740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12594,19 +12748,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_78346>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_78346>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YBL039C-MONOMER_CTPSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000000135> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -12615,7 +12769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12623,26 +12777,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57699_HISTIDPHOS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57699_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12653,14 +12796,25 @@
           <http://model.geneontology.org/CHEBI_57699_HISTIDPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YHL011C-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12673,7 +12827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12685,11 +12839,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12704,11 +12858,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTPRATPHYD-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTPRATPHYD-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12722,37 +12876,15 @@
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12763,48 +12895,15 @@
           <http://model.geneontology.org/CHEBI_57667_ADPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002234_CHEBI_57699_HISTIDPHOS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12815,26 +12914,15 @@
           <http://model.geneontology.org/reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12845,32 +12933,70 @@
           <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_15378_ASPCARBTRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule39619> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_15378_PRPPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_15378_PRPPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12890,7 +13016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12898,16 +13024,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_15378_ASPCARBTRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule39619> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57538>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -12919,7 +13051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12946,7 +13078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12954,26 +13086,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12984,15 +13105,26 @@
           <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13007,11 +13139,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13022,26 +13154,15 @@
           <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58475_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58475_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13052,37 +13173,15 @@
           <http://model.geneontology.org/CHEBI_58475_GLUTAMIDOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_RXN-12002_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13093,6 +13192,17 @@
           <http://model.geneontology.org/CHEBI_15378_CTPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57464> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -13102,7 +13212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13113,15 +13223,26 @@
 <http://identifiers.org/sgd/S000005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002333_YFR025C-MONOMER_HISTIDPHOS-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002333_YFR025C-MONOMER_HISTIDPHOS-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13132,6 +13253,17 @@
           <http://model.geneontology.org/YFR025C-MONOMER_HISTIDPHOS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_ADPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -13141,7 +13273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13149,25 +13281,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002413_HISTIDPHOS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13175,11 +13296,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_15377_HISTPRATPHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_15377_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13190,25 +13311,47 @@
           <http://model.geneontology.org/CHEBI_15377_HISTPRATPHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRS-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13222,7 +13365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13234,11 +13377,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13249,15 +13392,26 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation 'D-erythro-imidazole-glycerol-phosphate &rarr; imidazole acetol-phosphate + H<sub>2</sub>O' 'null' 'L-histidinol phosphate + 2-oxoglutarate &larr; imidazole acetol-phosphate + L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002413_HISTAMINOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002413_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13271,14 +13425,14 @@
 <http://purl.obolibrary.org/obo/GO_0004590>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15378_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13286,11 +13440,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13305,11 +13459,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13327,11 +13481,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '5-phospho-&beta;-D-ribosylamine + L-glutamate + diphosphate &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + L-glutamine + H<sub>2</sub>O' 'null' 'ATP + 5-phospho-&beta;-D-ribosylamine + glycine &rarr; ADP + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13351,7 +13505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13359,37 +13513,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YOL061W-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13400,16 +13532,22 @@
           <http://model.geneontology.org/reaction_AIRCARBOXY-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/1c61bc1e-7c10-4e09-9602-c9a9db95844c_GART-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40505> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/DGDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004550> ;
@@ -13428,7 +13566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13440,11 +13578,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-ribose 5-phosphate + ATP &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + AMP + H<SUP>+</SUP>' 'null' '1-(5-phospho-&beta;-D-ribosyl)-ATP + diphosphate &larr; ATP + 5-phospho-&alpha;-D-ribose 1-diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002413_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002413_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13459,11 +13597,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13483,7 +13621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13495,11 +13633,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13510,25 +13648,36 @@
           <http://model.geneontology.org/CHEBI_43474_AIRS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000066_reaction_HISTIDPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13536,11 +13685,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13555,11 +13704,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13570,17 +13719,6 @@
           <http://model.geneontology.org/reaction_CTPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_PRPPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -13590,7 +13728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13601,14 +13739,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_30839>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13617,7 +13755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13625,11 +13763,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13640,6 +13778,17 @@
           <http://model.geneontology.org/CHEBI_61404_RXN0-745>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002234_CHEBI_58525_PRIBFAICARPISOM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_DADPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -13649,7 +13798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13661,11 +13810,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13676,14 +13825,36 @@
           <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13696,7 +13867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13704,26 +13875,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13734,25 +13894,36 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13765,7 +13936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13773,25 +13944,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13804,7 +13975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13816,11 +13987,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000066_reaction_IMIDPHOSDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000066_reaction_IMIDPHOSDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13831,17 +14002,6 @@
           <http://model.geneontology.org/reaction_IMIDPHOSDEHYD-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57945_HISTALDEHYD-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -13851,13 +14011,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40395> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58435_HISTCYCLOHYD-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58435> ;
@@ -13868,7 +14050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13876,35 +14058,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_AIRCARBOXY-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13915,14 +14077,12 @@
           <http://model.geneontology.org/YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_456215_PRPPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/reaction_AIRCARBOXY-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13933,11 +14093,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13948,6 +14108,17 @@
           <http://model.geneontology.org/CHEBI_57945_IMP-DEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15740_RXN0-746>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15740> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -13957,7 +14128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13965,26 +14136,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002413_HISTCYCLOHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13999,11 +14159,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_8ad8bf73-6d65-49e9-a162-810620121612_AICARTRANSFORM-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_ae218896-da4c-4082-a729-8e8537eff988_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14011,30 +14171,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8ad8bf73-6d65-49e9-a162-810620121612_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/ae218896-da4c-4082-a729-8e8537eff988_AICARTRANSFORM-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003937> ;
@@ -14055,7 +14193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14067,11 +14205,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14091,7 +14229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14103,11 +14241,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14130,7 +14268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14138,37 +14276,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14179,14 +14295,14 @@
           <http://model.geneontology.org/CHEBI_456215_AMPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14194,11 +14310,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14216,11 +14332,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14231,14 +14347,14 @@
           <http://model.geneontology.org/CHEBI_43474_CTPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000066_reaction_PRPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14259,7 +14375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14271,11 +14387,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14286,14 +14402,14 @@
           <http://model.geneontology.org/CHEBI_61429_RXN0-746>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14301,11 +14417,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14316,14 +14432,14 @@
           <http://model.geneontology.org/CHEBI_30616_DGDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14336,7 +14452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14344,14 +14460,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_59457_HISTPRATPHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000066_reaction_IMIDPHOSDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14359,11 +14475,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14379,7 +14495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14387,11 +14503,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14402,41 +14518,19 @@
           <http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_59457_HISTPRATPHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000135>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PRPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004749> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -14457,7 +14551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14469,11 +14563,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14489,18 +14583,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_78346_PRPPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002413_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14516,7 +14621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14529,7 +14634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14542,7 +14647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14557,7 +14662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14569,11 +14674,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14584,28 +14689,6 @@
           <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_43474_HISTIDPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -14615,7 +14698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14623,26 +14706,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ATP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine &rarr; ADP + 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + phosphate + H<SUP>+</SUP>' 'null' '5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + 2 H<SUP>+</SUP> &harr; 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002413_AIRCARBOXY-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002413_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14653,35 +14725,40 @@
           <http://model.geneontology.org/AIRCARBOXY-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_456216>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/8ad8bf73-6d65-49e9-a162-810620121612_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40505> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_456216>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14698,6 +14775,17 @@
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
         a       <http://identifiers.org/sgd/S000001550> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -14705,7 +14793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14722,7 +14810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14730,26 +14818,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14760,15 +14837,37 @@
           <http://model.geneontology.org/CHEBI_15378_RXN0-746>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15377_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_15377_HISTCYCLOHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14779,15 +14878,26 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'IMP + H<sub>2</sub>O &harr; 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' 'null' 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14798,28 +14908,6 @@
           <http://model.geneontology.org/IMP-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_15378_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000004424>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -14827,11 +14915,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14846,11 +14934,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_32814_ASPCARBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14880,7 +14968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14900,7 +14988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14915,7 +15003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14927,11 +15015,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14945,26 +15033,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_58457>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004637>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004637>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14972,11 +15060,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' 'null' 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14987,6 +15075,17 @@
           <http://model.geneontology.org/FGAMSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_PRPPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -14996,7 +15095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15013,7 +15112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15040,7 +15139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15057,7 +15156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15069,11 +15168,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15084,14 +15183,14 @@
           <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTOLDEHYD-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -15114,7 +15213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15122,15 +15221,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002413_IMIDPHOSDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_15378_HISTALDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002234_CHEBI_15378_HISTALDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15141,28 +15251,6 @@
           <http://model.geneontology.org/CHEBI_15378_HISTALDEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58228_CARBPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58228> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -15172,7 +15260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15184,11 +15272,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000066_reaction_HISTCYCLOHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000066_reaction_HISTCYCLOHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15199,14 +15287,14 @@
           <http://model.geneontology.org/reaction_HISTCYCLOHYD-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -15214,11 +15302,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15229,6 +15317,17 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58223_RXN-12002>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58223> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -15238,7 +15337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15246,14 +15345,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -15264,11 +15374,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_PRPPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_PRPPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15283,11 +15393,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15315,7 +15425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15323,14 +15433,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -15341,11 +15451,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15356,17 +15466,6 @@
           <http://model.geneontology.org/CHEBI_29991_SAICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_GLYRIBONUCSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -15376,7 +15475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15388,11 +15487,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15403,26 +15502,15 @@
           <http://model.geneontology.org/CHEBI_43474_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15432,28 +15520,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YMR271C-MONOMER_OROPRIBTRANS-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/DIHYDROOROT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004151> ;
@@ -15474,7 +15540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15494,7 +15560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15506,11 +15572,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15521,23 +15587,12 @@
           <http://model.geneontology.org/CHEBI_30616_FGAMSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002413_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -15545,11 +15600,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002234_CHEBI_58525_PRIBFAICARPISOM-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002234_CHEBI_58525_PRIBFAICARPISOM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15560,14 +15615,14 @@
           <http://model.geneontology.org/CHEBI_58525_PRIBFAICARPISOM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -15575,11 +15630,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_b1f621c1-d76d-4313-a178-3d9b6a8a3105_GART-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_6d1c36d3-bcc1-4358-bda3-92984bbdeed2_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15587,7 +15642,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b1f621c1-d76d-4313-a178-3d9b6a8a3105_GART-RXN>
+          <http://model.geneontology.org/6d1c36d3-bcc1-4358-bda3-92984bbdeed2_GART-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_137981_AIRS-RXN>
@@ -15599,7 +15654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15611,11 +15666,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Provides Input For Rule. The relation 'GDP + ATP &rarr; GTP + ADP' 'null' 'formate + GTP + H<SUP>+</SUP> &rarr; dGTP + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15626,17 +15681,6 @@
           <http://model.geneontology.org/RXN0-746>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57540_HISTOLDEHYD-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -15646,7 +15690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15663,7 +15707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15690,7 +15734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15698,15 +15742,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58525_PRIBFAICARPISOM-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002233_CHEBI_58525_PRIBFAICARPISOM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15717,6 +15772,17 @@
           <http://model.geneontology.org/CHEBI_58525_PRIBFAICARPISOM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_37565> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -15726,7 +15792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15738,11 +15804,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15757,11 +15823,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15772,29 +15838,29 @@
           <http://model.geneontology.org/CHEBI_456216_ADENYL-KIN-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000000164>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002333_YOR202W-MONOMER_IMIDPHOSDEHYD-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000164>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_16810_HISTAMINOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_16810_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15814,7 +15880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15822,14 +15888,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002233_CHEBI_30616_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -15837,11 +15903,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_15377_HISTIDPHOS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_15377_HISTIDPHOS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15871,24 +15937,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1BiochemicalReaction40417> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_57766_IMIDPHOSDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29888_HISTPRATPHYD-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
@@ -15899,7 +15954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15907,26 +15962,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_OROTPDECARB-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTOLDEHYD-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTOLDEHYD-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15946,13 +15990,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule39606> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PRPPAMIDOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004044> ;
@@ -15973,7 +16028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15985,11 +16040,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16004,11 +16059,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_30839_RXN-9929_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_30839_RXN-9929_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16019,15 +16074,26 @@
           <http://model.geneontology.org/CHEBI_30839_RXN-9929>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16047,7 +16113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16055,15 +16121,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16074,26 +16151,15 @@
           <http://model.geneontology.org/YEL021W-MONOMER_OROTPDECARB-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16111,11 +16177,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16135,7 +16201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16143,15 +16209,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16162,14 +16250,14 @@
           <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_15377_IMIDPHOSDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16177,11 +16265,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YER099C-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YER099C-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16192,14 +16280,14 @@
           <http://model.geneontology.org/YER099C-MONOMER_PRPPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_15378_HISTOLDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16210,11 +16298,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16225,37 +16313,15 @@
           <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16270,11 +16336,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16285,48 +16351,15 @@
           <http://model.geneontology.org/CHEBI_456216_UDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_58017_PRPPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16344,7 +16377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16355,19 +16388,19 @@
 <http://identifiers.org/sgd/S000001699>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000004520>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002234_CHEBI_64802_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004520>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_43474_ASPCARBTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -16378,13 +16411,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule39799> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -16395,7 +16439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16403,14 +16447,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16421,11 +16465,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002234_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002234_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16436,25 +16480,36 @@
           <http://model.geneontology.org/CHEBI_58435_HISTCYCLOHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002233_CHEBI_64802_HISTOLDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16462,11 +16517,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57540_HISTOLDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002233_CHEBI_57540_HISTOLDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16482,7 +16537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16493,11 +16548,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16508,15 +16563,26 @@
           <http://model.geneontology.org/CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_59457_HISTPRATPHYD-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_59457_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16530,36 +16596,14 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_58017_PRPPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16567,11 +16611,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16589,35 +16633,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1Protein40469> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller>
         a       <http://identifiers.org/sgd/S000004830> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -16626,35 +16648,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1Protein40362> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_CTPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -16665,7 +16665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16677,11 +16677,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16699,7 +16699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16711,11 +16711,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16726,25 +16726,14 @@
           <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16752,11 +16741,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_78346_PRPPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_78346_PRPPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16767,47 +16756,36 @@
           <http://model.geneontology.org/CHEBI_78346_PRPPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16815,11 +16793,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16834,11 +16812,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16849,36 +16827,14 @@
           <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16886,11 +16842,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16901,25 +16857,47 @@
           <http://model.geneontology.org/CHEBI_58278_GLUTAMIDOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002233_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002413_HISTCYCLOHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16927,11 +16905,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16945,25 +16923,25 @@
 <http://purl.obolibrary.org/obo/GO_0004127>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_59457_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_16810_HISTAMINOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002333_YIL116W-MONOMER_HISTAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16971,11 +16949,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000066_reaction_HISTPRATPHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000066_reaction_HISTPRATPHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16986,39 +16964,6 @@
           <http://model.geneontology.org/reaction_HISTPRATPHYD-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_RO_0002413_HISTALDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002233_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -17026,11 +16971,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002333_YOR202W-MONOMER_IMIDPHOSDEHYD-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002333_YOR202W-MONOMER_IMIDPHOSDEHYD-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17048,7 +16993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17062,34 +17007,12 @@
 <http://identifiers.org/sgd/S000003293>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_PRPPSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -17097,11 +17020,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17116,11 +17039,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17131,12 +17054,23 @@
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
         a       <http://identifiers.org/sgd/S000003563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -17149,7 +17083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17161,11 +17095,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17176,14 +17110,14 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YER099C-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -17191,11 +17125,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YOL061W-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YOL061W-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17206,14 +17140,14 @@
           <http://model.geneontology.org/YOL061W-MONOMER_PRPPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002333_YER055C-MONOMER_ATPPHOSPHORIBOSYLTRANS-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -17221,11 +17155,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17245,7 +17179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17253,14 +17187,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -17268,11 +17202,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000066_reaction_RXN-9929_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000066_reaction_RXN-9929_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17292,7 +17226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17304,11 +17238,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17322,37 +17256,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_30864_DIHYDROOROT-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17367,11 +17279,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17388,6 +17300,17 @@
 <http://identifiers.org/sgd/S000001921>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_57766_IMIDPHOSDEHYD-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -17397,7 +17320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17405,14 +17328,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -17423,7 +17346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17431,14 +17354,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -17446,11 +17369,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17461,14 +17384,36 @@
           <http://model.geneontology.org/YKL067W-MONOMER_DGDPKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_27cef36d-dad3-4424-ab27-c69edad9ec44_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -17478,14 +17423,25 @@
 <http://identifiers.org/sgd/S000004727>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -17496,7 +17452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17511,7 +17467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -17523,11 +17479,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17545,11 +17501,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17560,29 +17516,29 @@
           <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57945>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57945>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17596,14 +17552,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_58595>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000066_reaction_HISTCYCLOHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -17616,7 +17572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17628,11 +17584,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17643,14 +17599,14 @@
           <http://model.geneontology.org/CHEBI_58115_GMP-SYN-GLUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -17658,11 +17614,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17678,7 +17634,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -17704,7 +17671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17716,11 +17683,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17731,6 +17698,28 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29888_ATPPHOSPHORIBOSYLTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -17740,7 +17729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17752,11 +17741,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17779,7 +17768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17787,14 +17776,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002234_CHEBI_57766_IMIDPHOSDEHYD-RXN_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_6d1c36d3-bcc1-4358-bda3-92984bbdeed2_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -17802,11 +17791,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17824,7 +17813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17832,14 +17821,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -17847,11 +17858,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17865,26 +17876,15 @@
 <http://identifiers.org/sgd/S000001328>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17899,11 +17899,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17914,14 +17914,14 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
+                "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -17929,11 +17929,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17948,11 +17948,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY-1801-1.ttl
+++ b/models/YeastPathways_PWY-1801-1.ttl
@@ -1,3 +1,14 @@
+<http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002233_CHEBI_57540_1.2.1.2-RXN_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0008863>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -10,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -18,58 +29,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002333_YDL168W-MONOMER_RXN-2962_controller_SGD_YeastPathways_PWY-1801-1>
+<http://model.geneontology.org/ev_w_id_RXN-2961_RO_0002234_CHEBI_58758_RXN-2961_SGD_PWY_YeastPathways_PWY-1801-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
+                "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-2961_RO_0002233_CHEBI_57925_RXN-2961_SGD_YeastPathways_PWY-1801-1>
+<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_13392_RXN-2962_SGD_PWY_YeastPathways_PWY-1801-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-2961_RO_0002413_RXN-2962_SGD_YeastPathways_PWY-1801-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002234_CHEBI_16526_1.2.1.2-RXN_SGD_YeastPathways_PWY-1801-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY-1801-1/YeastPathways_PWY-1801-1_SGD_YeastPathways_PWY-1801-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
+                "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -77,11 +55,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002234_CHEBI_57945_1.2.1.2-RXN_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002234_CHEBI_57945_1.2.1.2-RXN_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -92,48 +70,15 @@
           <http://model.geneontology.org/CHEBI_57945_1.2.1.2-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002413_1.2.1.2-RXN_SGD_YeastPathways_PWY-1801-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-2961_RO_0002234_CHEBI_58758_RXN-2961_SGD_YeastPathways_PWY-1801-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002233_CHEBI_13390_RXN-2962_SGD_YeastPathways_PWY-1801-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" , "Provides Input For Rule. The relation '<i>S</i>-(hydroxymethyl)glutathione + NAD(P)<sup>+</sup> &rarr; <i>S</i>-formylglutathione + NAD(P)H + H<SUP>+</SUP>' 'null' '<i>S</i>-formylglutathione + H<sub>2</sub>O &rarr; formate + glutathione + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002413_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002413_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -144,25 +89,14 @@
           <http://model.geneontology.org/S-FORMYLGLUTATHIONE-HYDROLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002233_CHEBI_15740_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_YeastPathways_PWY-1801-1>
+<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_15378_RXN-2962_SGD_PWY_YeastPathways_PWY-1801-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_BFO_0000066_reaction_1.2.1.2-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-1801-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
+                "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -170,11 +104,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-2961_RO_0002234_CHEBI_58758_RXN-2961_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-2961_RO_0002234_CHEBI_58758_RXN-2961_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -192,11 +126,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002233_CHEBI_57540_1.2.1.2-RXN_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002233_CHEBI_57540_1.2.1.2-RXN_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -213,48 +147,15 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-2962_BFO_0000050_YeastPathways_PWY-1801-1/YeastPathways_PWY-1801-1_SGD_YeastPathways_PWY-1801-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_57688_RXN-2962_SGD_YeastPathways_PWY-1801-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-2961_RO_0002233_CHEBI_16842_RXN-2961_SGD_YeastPathways_PWY-1801-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002234_CHEBI_57925_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002234_CHEBI_57925_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -291,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -302,25 +203,14 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002233_CHEBI_57688_RXN-2962_SGD_YeastPathways_PWY-1801-1>
+<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002234_CHEBI_57925_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-1801-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002234_CHEBI_57925_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_YeastPathways_PWY-1801-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
+                "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -329,36 +219,58 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_16842>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002233_CHEBI_57540_1.2.1.2-RXN_SGD_YeastPathways_PWY-1801-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002234_CHEBI_57945_1.2.1.2-RXN_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
+                "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_BFO_0000050_YeastPathways_PWY-1801-1/YeastPathways_PWY-1801-1_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-2961_BFO_0000066_reaction_RXN-2961_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16842>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002333_YDL168W-MONOMER_RXN-2962_controller_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002333_YDL168W-MONOMER_RXN-2962_controller_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,18 +281,26 @@
           <http://model.geneontology.org/YDL168W-MONOMER_RXN-2962_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15377>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY-1801-1/YeastPathways_PWY-1801-1_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-2961_RO_0002233_CHEBI_57925_RXN-2961_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-2961_RO_0002233_CHEBI_57925_RXN-2961_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,25 +311,14 @@
           <http://model.geneontology.org/CHEBI_57925_RXN-2961>
 ] .
 
-<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002233_CHEBI_15377_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_YeastPathways_PWY-1801-1>
+<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002233_CHEBI_58758_RXN-2961_SGD_PWY_YeastPathways_PWY-1801-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_BFO_0000066_reaction_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-1801-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
+                "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -417,11 +326,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002233_CHEBI_15740_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002233_CHEBI_15740_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -432,23 +341,15 @@
           <http://model.geneontology.org/CHEBI_15740_S-FORMYLGLUTATHIONE-HYDROLASE-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/reaction_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_15378_RXN-2962_SGD_YeastPathways_PWY-1801-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -461,12 +362,23 @@
 <http://identifiers.org/sgd/S000003604>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002233_CHEBI_15377_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-2962_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -479,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -490,15 +402,26 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002234_CHEBI_15740_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002234_CHEBI_15740_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002234_CHEBI_15740_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,22 +432,33 @@
           <http://model.geneontology.org/CHEBI_15740_S-FORMYLGLUTATHIONE-HYDROLASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0018738>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://identifiers.org/sgd/S000005915>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-2962_BFO_0000066_reaction_RXN-2962_location_lociGO_0005829_SGD_YeastPathways_PWY-1801-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002233_CHEBI_13390_RXN-2962_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
+                "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0018738>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_BFO_0000066_reaction_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000005915>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/1.2.1.2-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008863> ;
@@ -543,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -555,11 +489,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002233_CHEBI_57688_RXN-2962_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002233_CHEBI_57688_RXN-2962_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -577,11 +511,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002233_CHEBI_13390_RXN-2962_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002233_CHEBI_13390_RXN-2962_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -591,17 +525,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_13390_RXN-2962>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002413_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_YeastPathways_PWY-1801-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57688>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -615,7 +538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -630,11 +553,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_57688_RXN-2962_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_57688_RXN-2962_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -649,11 +572,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-2961_RO_0002233_CHEBI_16842_RXN-2961_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-2961_RO_0002233_CHEBI_16842_RXN-2961_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,11 +591,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_BFO_0000066_reaction_1.2.1.2-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_BFO_0000066_reaction_1.2.1.2-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -683,19 +606,19 @@
           <http://model.geneontology.org/reaction_1.2.1.2-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_13392_RXN-2962_SGD_YeastPathways_PWY-1801-1>
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-2961_RO_0002233_CHEBI_57925_RXN-2961_SGD_PWY_YeastPathways_PWY-1801-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
+                "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_13392>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -709,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -720,14 +643,14 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002234_CHEBI_15740_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_YeastPathways_PWY-1801-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-2961_BFO_0000050_YeastPathways_PWY-1801-1/YeastPathways_PWY-1801-1_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
+                "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -735,11 +658,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002234_CHEBI_15378_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002234_CHEBI_15378_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -762,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -776,15 +699,26 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002234_CHEBI_15378_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002233_CHEBI_15377_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002233_CHEBI_15377_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,11 +733,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-2962_BFO_0000066_reaction_RXN-2962_location_lociGO_0005829_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-2962_BFO_0000066_reaction_RXN-2962_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,6 +747,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN-2962_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_57688_RXN-2962_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-2961_RO_0002413_RXN-2962_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/S-FORMYLGLUTATHIONE-HYDROLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0018738> ;
@@ -833,35 +789,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-1801-1BiochemicalReaction62268> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002333_YOR388C-MONOMER_1.2.1.2-RXN_controller_SGD_YeastPathways_PWY-1801-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002234_CHEBI_15378_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_YeastPathways_PWY-1801-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_S-FORMYLGLUTATHIONE-HYDROLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -872,7 +806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -899,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -914,11 +848,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_15378_RXN-2962_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_15378_RXN-2962_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -933,11 +867,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-2961_BFO_0000066_reaction_RXN-2961_location_lociGO_0005829_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-2961_BFO_0000066_reaction_RXN-2961_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -955,11 +889,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_BFO_0000050_YeastPathways_PWY-1801-1/YeastPathways_PWY-1801-1_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_BFO_0000050_YeastPathways_PWY-1801-1/YeastPathways_PWY-1801-1_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,17 +903,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY-1801-1/YeastPathways_PWY-1801-1>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-2961_BFO_0000050_YeastPathways_PWY-1801-1/YeastPathways_PWY-1801-1_SGD_YeastPathways_PWY-1801-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -993,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1011,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1028,26 +951,15 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002234_CHEBI_57945_1.2.1.2-RXN_SGD_YeastPathways_PWY-1801-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_BFO_0000066_reaction_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_BFO_0000066_reaction_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,11 +977,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-2962_BFO_0000050_YeastPathways_PWY-1801-1/YeastPathways_PWY-1801-1_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-2962_BFO_0000050_YeastPathways_PWY-1801-1/YeastPathways_PWY-1801-1_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,6 +1001,17 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002233_CHEBI_15740_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YDL168W-MONOMER_RXN-2962_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002327> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1096,13 +1019,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-1801-1Protein62231> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/CHEBI_13390_RXN-2962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_13390> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD(P)<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-1801-1SmallMolecule62190> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN-2961>
         a       <http://purl.obolibrary.org/obo/GO_0051907> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1121,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1129,32 +1069,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/CHEBI_13390_RXN-2962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_13390> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD(P)<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-1801-1SmallMolecule62190> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_13392_RXN-2962_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_13392_RXN-2962_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1165,12 +1088,23 @@
           <http://model.geneontology.org/CHEBI_13392_RXN-2962>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002413_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-2961_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1178,11 +1112,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-2961_BFO_0000050_YeastPathways_PWY-1801-1/YeastPathways_PWY-1801-1_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-2961_BFO_0000050_YeastPathways_PWY-1801-1/YeastPathways_PWY-1801-1_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1202,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1214,11 +1148,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>S</i>-formylglutathione + H<sub>2</sub>O &rarr; formate + glutathione + H<SUP>+</SUP>' 'null' 'formate + NAD<sup>+</sup> &rarr; CO<SUB>2</SUB> + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002413_1.2.1.2-RXN_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002413_1.2.1.2-RXN_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1238,14 +1172,14 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-2961_BFO_0000066_reaction_RXN-2961_location_lociGO_0005829_SGD_YeastPathways_PWY-1801-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002333_YOR388C-MONOMER_1.2.1.2-RXN_controller_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
+                "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1258,7 +1192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1266,18 +1200,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002333_YDL168W-MONOMER_RXN-2962_controller_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-2961_RO_0002233_CHEBI_16842_RXN-2961_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-2962_BFO_0000066_reaction_RXN-2962_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002333_YOR388C-MONOMER_1.2.1.2-RXN_controller_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002333_YOR388C-MONOMER_1.2.1.2-RXN_controller_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1288,8 +1255,16 @@
           <http://model.geneontology.org/YOR388C-MONOMER_1.2.1.2-RXN_controller>
 ] .
 
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_BFO_0000066_reaction_1.2.1.2-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57925_RXN-2961>
         a       <http://purl.obolibrary.org/obo/CHEBI_57925> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1300,13 +1275,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-1801-1SmallMolecule62264> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YeastPathways_PWY-1801-1>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -1317,24 +1295,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "formaldehyde oxidation II (glutathione-dependent) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002233_CHEBI_58758_RXN-2961_SGD_YeastPathways_PWY-1801-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YJL068C-MONOMER_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003604> ;
@@ -1343,7 +1310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1360,7 +1327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1372,11 +1339,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY-1801-1/YeastPathways_PWY-1801-1_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY-1801-1/YeastPathways_PWY-1801-1_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1396,7 +1363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1408,11 +1375,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" , "Provides Input For Rule. The relation '<i>S</i>-(hydroxymethyl)glutathione &larr; formaldehyde + glutathione' 'null' '<i>S</i>-(hydroxymethyl)glutathione + NAD(P)<sup>+</sup> &rarr; <i>S</i>-formylglutathione + NAD(P)H + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-2961_RO_0002413_RXN-2962_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-2961_RO_0002413_RXN-2962_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1427,11 +1394,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002234_CHEBI_16526_1.2.1.2-RXN_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002234_CHEBI_16526_1.2.1.2-RXN_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1442,14 +1409,25 @@
           <http://model.geneontology.org/CHEBI_16526_1.2.1.2-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_BFO_0000050_YeastPathways_PWY-1801-1/YeastPathways_PWY-1801-1_SGD_YeastPathways_PWY-1801-1>
+<http://model.geneontology.org/ev_w_id_1.2.1.2-RXN_RO_0002234_CHEBI_16526_1.2.1.2-RXN_SGD_PWY_YeastPathways_PWY-1801-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
+                "SGD_PWY:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002413_1.2.1.2-RXN_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1457,11 +1435,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002233_CHEBI_58758_RXN-2961_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002233_CHEBI_58758_RXN-2961_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1472,6 +1450,17 @@
           <http://model.geneontology.org/CHEBI_58758_RXN-2961>
 ] .
 
+<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002233_CHEBI_57688_RXN-2962_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1479,11 +1468,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002333_YJL068C-MONOMER_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_controller_SGD_YeastPathways_PWY-1801-1> ;
+          <http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002333_YJL068C-MONOMER_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_controller_SGD_PWY_YeastPathways_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1494,13 +1483,24 @@
           <http://model.geneontology.org/YJL068C-MONOMER_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002333_YJL068C-MONOMER_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_controller_SGD_YeastPathways_PWY-1801-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-2962_BFO_0000050_YeastPathways_PWY-1801-1/YeastPathways_PWY-1801-1_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
+                "SGD_PWY:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002333_YJL068C-MONOMER_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_controller_SGD_PWY_YeastPathways_PWY-1801-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-2201.ttl
+++ b/models/YeastPathways_PWY-2201.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,41 +17,8 @@
           <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_ce8338e7-aee4-4fbb-83a9-ebf485fbcdd5_2.1.1.19-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000003093>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_CHEBI_15377_FORMYLTHFDEFORMYL-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004372>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -60,11 +27,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,6 +45,20 @@
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/94dd851d-9307-4fb4-9907-6b086fd3a5c5_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/Apo-Ferredoxins_RXN-5061>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -87,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,26 +76,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_47c36fee-8a5a-42f6-8d43-cee115185d86_RXN-5061_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -125,51 +95,29 @@
           <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_CHEBI_17434_2.1.1.19-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_CHEBI_17434_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -184,11 +132,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -208,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -220,11 +168,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_CHEBI_57844_HOMOCYSMETB12-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_CHEBI_57844_HOMOCYSMETB12-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -238,15 +186,18 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/9346407b-b052-414b-9b71-7fda69fc7598_2.1.1.19-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_3ffe474a-4ec0-4ac7-b663-fe1d48b2f5c7_FORMYLTHFDEFORMYL-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_1462aa25-c1ef-4ce0-8eab-b16aca2c6726_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,28 +205,28 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3ffe474a-4ec0-4ac7-b663-fe1d48b2f5c7_FORMYLTHFDEFORMYL-RXN>
+          <http://model.geneontology.org/1462aa25-c1ef-4ce0-8eab-b16aca2c6726_FORMYLTHFDEFORMYL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_RXN-5061_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_CHEBI_57844_HOMOCYSMETB12-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -283,11 +234,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002333_YER183C-MONOMER_5-FORMYL-THF-CYCLO-LIGASE-RXN_controller_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002333_YER183C-MONOMER_5-FORMYL-THF-CYCLO-LIGASE-RXN_controller_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -302,11 +253,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57540_1.5.1.20-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57540_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,11 +272,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -341,7 +292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -353,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -361,11 +312,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -379,14 +330,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YPL023C-MONOMER_1.5.1.20-RXN_controller_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -394,11 +345,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'glycine + a tetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methylenetetrahydrofolate + ammonium + CO<SUB>2</SUB> + NADH' 'null' 'a 5-methyltetrahydrofolate + NAD<sup>+</sup> &larr; a 5,10-methylenetetrahydrofolate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_1.5.1.20-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,30 +360,25 @@
           <http://model.geneontology.org/1.5.1.20-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/bd814a43-3d8f-4ee1-90bf-eb2a8e580a88_1.5.1.20-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000004801>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_2.1.1.19-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -443,7 +389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -455,11 +401,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_1c518425-e560-4a6f-83af-0c99a81e17ea_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_2e58b3a5-dc45-4359-886b-30e53e87ed1c_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -467,8 +413,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-5061> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1c518425-e560-4a6f-83af-0c99a81e17ea_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/2e58b3a5-dc45-4359-886b-30e53e87ed1c_GLYOHMETRANS-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008864>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -480,7 +437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -488,32 +445,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/Reduced-ferredoxins_RXN-5061>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an oxidized ferredoxin [iron-sulfur] cluster" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201Protein67354> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.15-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -524,14 +464,31 @@
           <http://model.geneontology.org/1.5.1.15-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_81402844-e478-462f-bcca-91c5f3e05ce6_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/Reduced-ferredoxins_RXN-5061>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an oxidized ferredoxin [iron-sulfur] cluster" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201Protein67354> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -542,11 +499,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -561,11 +518,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -585,15 +542,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-5061_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/Apo-Ferredoxins_RXN-5061> , <http://model.geneontology.org/1c518425-e560-4a6f-83af-0c99a81e17ea_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15378_RXN-5061> ;
+                <http://model.geneontology.org/Apo-Ferredoxins_RXN-5061> , <http://model.geneontology.org/2e58b3a5-dc45-4359-886b-30e53e87ed1c_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15378_RXN-5061> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/Reduced-ferredoxins_RXN-5061> , <http://model.geneontology.org/47c36fee-8a5a-42f6-8d43-cee115185d86_RXN-5061> ;
+                <http://model.geneontology.org/Reduced-ferredoxins_RXN-5061> , <http://model.geneontology.org/d898a63e-b68f-480d-9cbc-9fd461ab6ac4_RXN-5061> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
                 <http://model.geneontology.org/HOMOCYSMETB12-RXN> , <http://model.geneontology.org/2.1.1.19-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -601,31 +558,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/d12eb17a-ea4b-4231-8097-b941dfd24e06_1.5.1.15-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5061_BFO_0000066_reaction_RXN-5061_location_lociGO_0005829_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -634,46 +574,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/5e7a5b6f-4a9b-4dfb-bff1-c75688c71cb2_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_95a6cd5f-ce6d-4b73-9154-37c44bc289d6_2.1.1.19-RXN_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -684,30 +596,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,11 +615,41 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -736,6 +659,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -749,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -757,22 +691,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/2af6329e-4093-4262-ade8-fe59e90bd6a3_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
+<http://purl.obolibrary.org/obo/GO_0004487>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_d898a63e-b68f-480d-9cbc-9fd461ab6ac4_RXN-5061_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
         a       <http://identifiers.org/sgd/S000003436> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -781,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -793,11 +724,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -808,17 +739,36 @@
           <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002426> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0004487>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_15378_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000288> ;
@@ -827,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -835,15 +785,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_0a2c0d03-fa2e-4ac9-8d84-45eaa17420b4_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -854,39 +815,6 @@
           <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_2af6329e-4093-4262-ade8-fe59e90bd6a3_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -896,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -904,14 +832,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_BFO_0000066_reaction_2.1.1.19-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002411_HOMOCYSMETB12-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_BFO_0000066_reaction_FORMYLTHFDEFORMYL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -924,7 +874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -932,15 +882,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -951,53 +912,31 @@
           <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN>
 ] .
 
-<http://model.geneontology.org/bce8f210-1eb2-4bfe-83cb-39559f294abf_5-FORMYL-THF-CYCLO-LIGASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001876>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_81402844-e478-462f-bcca-91c5f3e05ce6_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/81402844-e478-462f-bcca-91c5f3e05ce6_GLYOHMETRANS-RXN>
-] .
+<http://model.geneontology.org/2e58b3a5-dc45-4359-886b-30e53e87ed1c_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_CHEBI_58199_HOMOCYSMETB12-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_bddddb7e-573d-4af0-a850-b029bb1efb00_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1005,11 +944,52 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_c998a199-46a0-4720-8525-0f225746be07_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_bddddb7e-573d-4af0-a850-b029bb1efb00_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/bddddb7e-573d-4af0-a850-b029bb1efb00_GLYOHMETRANS-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_0662b20e-0b2e-44d1-95b2-7a24a7070447_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1017,11 +997,28 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c998a199-46a0-4720-8525-0f225746be07_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/0662b20e-0b2e-44d1-95b2-7a24a7070447_FORMATETHFLIG-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58349>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/FORMATETHFLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004329> ;
@@ -1032,9 +1029,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/ce8338e7-aee4-4fbb-83a9-ebf485fbcdd5_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/ce0541ae-13fe-4eaa-90cd-6e13662be5a6_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/c998a199-46a0-4720-8525-0f225746be07_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/0662b20e-0b2e-44d1-95b2-7a24a7070447_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1042,7 +1039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1050,38 +1047,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_362f9aa3-7970-4eae-80a3-ef21a881d97f_1.5.1.20-RXN_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_Reduced-ferredoxins_RXN-5061_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_95a6cd5f-ce6d-4b73-9154-37c44bc289d6_2.1.1.19-RXN_SGD_YeastPathways_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.19-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/95a6cd5f-ce6d-4b73-9154-37c44bc289d6_2.1.1.19-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1092,7 +1067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1109,7 +1084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1121,11 +1096,30 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_c42d4043-e0a3-4ef1-91ec-f3afdc7e1218_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.19-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/c42d4043-e0a3-4ef1-91ec-f3afdc7e1218_2.1.1.19-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1136,28 +1130,28 @@
           <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ce0541ae-13fe-4eaa-90cd-6e13662be5a6_2.1.1.19-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_58349>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1168,11 +1162,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_eec788f8-4455-4556-b0fd-fcd450c9052e_HOMOCYSMETB12-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_d29252c4-1940-4f8a-966d-03631e249f8c_HOMOCYSMETB12-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1180,8 +1174,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOCYSMETB12-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/eec788f8-4455-4556-b0fd-fcd450c9052e_HOMOCYSMETB12-RXN>
+          <http://model.geneontology.org/d29252c4-1940-4f8a-966d-03631e249f8c_HOMOCYSMETB12-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_CHEBI_15377_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1192,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1209,7 +1214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1217,26 +1222,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57540_1.5.1.20-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1247,30 +1241,8 @@
           <http://model.geneontology.org/GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15740>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_6de8b433-11b1-4900-b3f9-fdc5b41e0b01_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1278,33 +1250,14 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_877d3f10-a4da-4f71-9aef-85c904a8add8_1.5.1.20-RXN_SGD_YeastPathways_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.5.1.20-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/877d3f10-a4da-4f71-9aef-85c904a8add8_1.5.1.20-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_BFO_0000066_reaction_2.1.1.19-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1312,11 +1265,41 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_bd814a43-3d8f-4ee1-90bf-eb2a8e580a88_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.5.1.20-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/bd814a43-3d8f-4ee1-90bf-eb2a8e580a88_1.5.1.20-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_RXN-5061_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1327,37 +1310,18 @@
           <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_d12eb17a-ea4b-4231-8097-b941dfd24e06_1.5.1.15-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_GCVMULTI-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/3ac7201d-b44a-46d8-af7c-d476dff1cca6_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1380,9 +1344,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/9b58bf00-c25f-409b-ab9d-143bf5a533fb_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/fde4e683-e413-4a0d-9435-e31ff7976df6_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/2af6329e-4093-4262-ade8-fe59e90bd6a3_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/295f5d5a-6021-49e9-96d5-d14359b94cbf_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1390,7 +1354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1402,11 +1366,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1417,6 +1381,17 @@
           <http://model.geneontology.org/YeastPathways_PWY-2201/YeastPathways_PWY-2201>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1426,7 +1401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1434,30 +1409,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_6f7b502f-fcca-490f-91b7-b2d4fc577f70_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1466,11 +1430,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_Reduced-ferredoxins_RXN-5061_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_Reduced-ferredoxins_RXN-5061_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1481,29 +1445,35 @@
           <http://model.geneontology.org/Reduced-ferredoxins_RXN-5061>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002333_YER183C-MONOMER_5-FORMYL-THF-CYCLO-LIGASE-RXN_controller_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/d898a63e-b68f-480d-9cbc-9fd461ab6ac4_RXN-5061>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1514,26 +1484,15 @@
           <http://model.geneontology.org/1.5.1.20-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_BFO_0000066_reaction_FORMYLTHFDEFORMYL-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_BFO_0000066_reaction_FORMYLTHFDEFORMYL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1548,11 +1507,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_BFO_0000066_reaction_2.1.1.19-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_BFO_0000066_reaction_2.1.1.19-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1567,11 +1526,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_47c36fee-8a5a-42f6-8d43-cee115185d86_RXN-5061_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_d898a63e-b68f-480d-9cbc-9fd461ab6ac4_RXN-5061_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1579,32 +1538,29 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-5061> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/47c36fee-8a5a-42f6-8d43-cee115185d86_RXN-5061>
+          <http://model.geneontology.org/d898a63e-b68f-480d-9cbc-9fd461ab6ac4_RXN-5061>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_GCVMULTI-RXN_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_HOMOCYSMETB12-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/83dfc6dd-08d7-401c-a235-9dfd4e25bb3a_2.1.1.19-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1620,41 +1576,69 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_BFO_0000066_reaction_5-FORMYL-THF-CYCLO-LIGASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57540_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/c42d4043-e0a3-4ef1-91ec-f3afdc7e1218_2.1.1.19-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_CHEBI_15377_FORMYLTHFDEFORMYL-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_CHEBI_15377_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1665,14 +1649,25 @@
           <http://model.geneontology.org/CHEBI_15377_FORMYLTHFDEFORMYL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_CHEBI_43474_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1680,11 +1675,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_6de8b433-11b1-4900-b3f9-fdc5b41e0b01_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_0a2c0d03-fa2e-4ac9-8d84-45eaa17420b4_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1692,18 +1687,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6de8b433-11b1-4900-b3f9-fdc5b41e0b01_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+          <http://model.geneontology.org/0a2c0d03-fa2e-4ac9-8d84-45eaa17420b4_5-FORMYL-THF-CYCLO-LIGASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1714,14 +1709,14 @@
           <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1734,15 +1729,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/1244805a-17a6-4916-998b-434eda648924_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/6f7b502f-fcca-490f-91b7-b2d4fc577f70_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/5e7a5b6f-4a9b-4dfb-bff1-c75688c71cb2_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/eb7de80b-10d9-4db2-9ba1-31e583c76710_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1750,25 +1745,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_5e7a5b6f-4a9b-4dfb-bff1-c75688c71cb2_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_1244805a-17a6-4916-998b-434eda648924_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1776,11 +1760,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_5e7a5b6f-4a9b-4dfb-bff1-c75688c71cb2_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_eb7de80b-10d9-4db2-9ba1-31e583c76710_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1788,18 +1772,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5e7a5b6f-4a9b-4dfb-bff1-c75688c71cb2_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/eb7de80b-10d9-4db2-9ba1-31e583c76710_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1815,33 +1799,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_BFO_0000066_reaction_HOMOCYSMETB12-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1852,41 +1847,74 @@
           <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/a67757be-061e-48f2-b690-f0690aa67ef9_FORMATETHFLIG-RXN>
+<http://model.geneontology.org/fde4e683-e413-4a0d-9435-e31ff7976df6_GLYOHMETRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ed58414b-a8c5-4284-89b8-27a71294ee78_2.1.1.19-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57844>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/928f87a1-0e6e-4d3d-8f45-81118944e32f_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/47c36fee-8a5a-42f6-8d43-cee115185d86_RXN-5061>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://model.geneontology.org/1462aa25-c1ef-4ce0-8eab-b16aca2c6726_FORMYLTHFDEFORMYL-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
+                "a tetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5061_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1897,17 +1925,6 @@
           <http://model.geneontology.org/YeastPathways_PWY-2201/YeastPathways_PWY-2201>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_CHEBI_15378_2.1.1.19-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_17434_2.1.1.19-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17434> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1917,7 +1934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1925,48 +1942,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_1c518425-e560-4a6f-83af-0c99a81e17ea_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.15-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1980,14 +1964,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_58199>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_CHEBI_15740_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1995,11 +1990,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2009,17 +2004,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002426>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2033,7 +2017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2044,26 +2028,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_2.1.1.19-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2078,11 +2051,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_4019783e-7300-4723-b23e-7c202d49c2f4_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_94dd851d-9307-4fb4-9907-6b086fd3a5c5_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2090,20 +2063,31 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4019783e-7300-4723-b23e-7c202d49c2f4_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/94dd851d-9307-4fb4-9907-6b086fd3a5c5_GLYOHMETRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_0662b20e-0b2e-44d1-95b2-7a24a7070447_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2111,11 +2095,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2126,20 +2110,31 @@
           <http://model.geneontology.org/FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/c0234821-1d1d-46f9-91bd-efe3e4c0c266_GCVMULTI-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ca399521-de2c-4a92-8303-26a39ffb8c8c_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2150,11 +2145,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2169,11 +2164,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_GCVMULTI-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2184,32 +2179,32 @@
           <http://model.geneontology.org/GCVMULTI-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000004048>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YGL125W-MONOMER_1.5.1.20-RXN_controller_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YGL125W-MONOMER_1.5.1.20-RXN_controller_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2227,11 +2222,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2242,15 +2237,37 @@
           <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_aa8ee7f8-79fe-4187-b471-59584b9c0cf1_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_d29252c4-1940-4f8a-966d-03631e249f8c_HOMOCYSMETB12-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_9b58bf00-c25f-409b-ab9d-143bf5a533fb_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_fde4e683-e413-4a0d-9435-e31ff7976df6_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2258,18 +2275,46 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9b58bf00-c25f-409b-ab9d-143bf5a533fb_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/fde4e683-e413-4a0d-9435-e31ff7976df6_GLYOHMETRANS-RXN>
 ] .
+
+<http://model.geneontology.org/295f5d5a-6021-49e9-96d5-d14359b94cbf_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2283,17 +2328,39 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_BFO_0000066_reaction_HOMOCYSMETB12-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0035999>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_c998a199-46a0-4720-8525-0f225746be07_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_CHEBI_17434_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2306,15 +2373,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_5-FORMYL-THF-CYCLO-LIGASE-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/6de8b433-11b1-4900-b3f9-fdc5b41e0b01_5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
+                <http://model.geneontology.org/CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/0a2c0d03-fa2e-4ac9-8d84-45eaa17420b4_5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/bce8f210-1eb2-4bfe-83cb-39559f294abf_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_456216_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_43474_5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
+                <http://model.geneontology.org/CHEBI_456216_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/ca399521-de2c-4a92-8303-26a39ffb8c8c_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_43474_5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YER183C-MONOMER_5-FORMYL-THF-CYCLO-LIGASE-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2331,41 +2398,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67541> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/c998a199-46a0-4720-8525-0f225746be07_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67744> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58199_HOMOCYSMETB12-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58199> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2376,24 +2415,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67559> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY-2201/YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0035999> ;
@@ -2402,7 +2430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2417,30 +2445,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002411_HOMOCYSMETB12-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_CHEBI_15378_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5061> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/HOMOCYSMETB12-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_CHEBI_15378_2.1.1.19-RXN_SGD_YeastPathways_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2451,16 +2460,24 @@
           <http://model.geneontology.org/CHEBI_15378_2.1.1.19-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_CHEBI_17437_2.1.1.19-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002411_HOMOCYSMETB12-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-5061> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/HOMOCYSMETB12-RXN>
+] .
 
 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller>
         a       <http://identifiers.org/sgd/S000003436> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2469,7 +2486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2477,14 +2494,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_CHEBI_456216_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2492,11 +2520,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_BFO_0000066_reaction_HOMOCYSMETB12-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_BFO_0000066_reaction_HOMOCYSMETB12-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2507,30 +2535,33 @@
           <http://model.geneontology.org/reaction_HOMOCYSMETB12-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/3fc96e1e-191a-4659-b874-33bf2f6cfc0c_1.5.1.20-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_3fc96e1e-191a-4659-b874-33bf2f6cfc0c_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004477>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_HOMOCYSMETB12-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2544,24 +2575,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "folate transformations I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_83dfc6dd-08d7-401c-a235-9dfd4e25bb3a_2.1.1.19-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0033738>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2570,11 +2590,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_a67757be-061e-48f2-b690-f0690aa67ef9_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_3ac7201d-b44a-46d8-af7c-d476dff1cca6_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2582,7 +2602,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a67757be-061e-48f2-b690-f0690aa67ef9_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/3ac7201d-b44a-46d8-af7c-d476dff1cca6_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
@@ -2590,7 +2610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2598,11 +2618,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_CHEBI_43474_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_CHEBI_43474_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2617,11 +2637,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_15378_1.5.1.20-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_15378_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2641,9 +2661,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/f45f90c9-38aa-478c-9c39-6518208bf63a_2.1.1.19-RXN> ;
+                <http://model.geneontology.org/ed58414b-a8c5-4284-89b8-27a71294ee78_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/81402844-e478-462f-bcca-91c5f3e05ce6_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/bddddb7e-573d-4af0-a850-b029bb1efb00_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2651,13 +2671,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201BiochemicalReaction67696> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_2f5c7704-ffa6-4ace-aa2f-c0a1f428a73f_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2668,7 +2699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2676,15 +2707,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2704,15 +2746,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_HOMOCYSMETB12-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58199_HOMOCYSMETB12-RXN> , <http://model.geneontology.org/362f9aa3-7970-4eae-80a3-ef21a881d97f_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/3fc96e1e-191a-4659-b874-33bf2f6cfc0c_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_58199_HOMOCYSMETB12-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57844_HOMOCYSMETB12-RXN> , <http://model.geneontology.org/eec788f8-4455-4556-b0fd-fcd450c9052e_HOMOCYSMETB12-RXN> ;
+                <http://model.geneontology.org/CHEBI_57844_HOMOCYSMETB12-RXN> , <http://model.geneontology.org/d29252c4-1940-4f8a-966d-03631e249f8c_HOMOCYSMETB12-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
                 <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2720,26 +2762,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_f45f90c9-38aa-478c-9c39-6518208bf63a_2.1.1.19-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2750,40 +2781,18 @@
           <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004489>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_3ffe474a-4ec0-4ac7-b663-fe1d48b2f5c7_FORMYLTHFDEFORMYL-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2794,36 +2803,14 @@
           <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_1.5.1.20-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_CHEBI_15378_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_13053ed2-6495-4095-bfff-fcc76cddb313_1.5.1.20-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2833,14 +2820,25 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_CHEBI_15378_RXN-5061_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2848,11 +2846,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_BFO_0000066_reaction_RXN-5061_location_lociGO_0005829_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5061_BFO_0000066_reaction_RXN-5061_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2863,25 +2861,25 @@
           <http://model.geneontology.org/reaction_RXN-5061_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2889,11 +2887,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2904,14 +2902,14 @@
           <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-5061_BFO_0000066_reaction_RXN-5061_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2924,7 +2922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2936,11 +2934,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2960,7 +2958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2968,36 +2966,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3005,11 +2981,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3020,6 +2996,17 @@
           <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3029,7 +3016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3037,14 +3024,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_bce8f210-1eb2-4bfe-83cb-39559f294abf_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/aa8ee7f8-79fe-4187-b471-59584b9c0cf1_1.5.1.15-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3052,11 +3056,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3070,52 +3074,14 @@
 <http://identifiers.org/sgd/S000000467>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.19-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN-5061_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/6de8b433-11b1-4900-b3f9-fdc5b41e0b01_5-FORMYL-THF-CYCLO-LIGASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (6<i>S</i>)-5-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67387> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003093> ;
@@ -3124,7 +3090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3136,11 +3102,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3151,12 +3117,33 @@
           <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.19-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3169,9 +3156,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/4019783e-7300-4723-b23e-7c202d49c2f4_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/94dd851d-9307-4fb4-9907-6b086fd3a5c5_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/d12eb17a-ea4b-4231-8097-b941dfd24e06_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/aa8ee7f8-79fe-4187-b471-59584b9c0cf1_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3179,7 +3166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3187,15 +3174,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/d29252c4-1940-4f8a-966d-03631e249f8c_HOMOCYSMETB12-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YPL023C-MONOMER_1.5.1.20-RXN_controller_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YPL023C-MONOMER_1.5.1.20-RXN_controller_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3210,11 +3214,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3225,18 +3229,26 @@
           <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
 ] .
 
-<http://model.geneontology.org/1c518425-e560-4a6f-83af-0c99a81e17ea_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_ed58414b-a8c5-4284-89b8-27a71294ee78_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3247,23 +3259,23 @@
           <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YPL023C-MONOMER_1.5.1.20-RXN_controller_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3274,7 +3286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3286,11 +3298,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3301,36 +3313,25 @@
           <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_CHEBI_15378_FORMYLTHFDEFORMYL-RXN_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_CHEBI_15378_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_BFO_0000066_reaction_5-FORMYL-THF-CYCLO-LIGASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_FORMYLTHFDEFORMYL-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3338,11 +3339,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_2af6329e-4093-4262-ade8-fe59e90bd6a3_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_295f5d5a-6021-49e9-96d5-d14359b94cbf_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3350,7 +3351,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2af6329e-4093-4262-ade8-fe59e90bd6a3_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/295f5d5a-6021-49e9-96d5-d14359b94cbf_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
@@ -3360,13 +3361,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201Protein67730> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002411_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3378,11 +3390,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_f45f90c9-38aa-478c-9c39-6518208bf63a_2.1.1.19-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_ed58414b-a8c5-4284-89b8-27a71294ee78_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3390,21 +3402,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f45f90c9-38aa-478c-9c39-6518208bf63a_2.1.1.19-RXN>
+          <http://model.geneontology.org/ed58414b-a8c5-4284-89b8-27a71294ee78_2.1.1.19-RXN>
 ] .
-
-<http://model.geneontology.org/f45f90c9-38aa-478c-9c39-6518208bf63a_2.1.1.19-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_ce8338e7-aee4-4fbb-83a9-ebf485fbcdd5_2.1.1.19-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_ce0541ae-13fe-4eaa-90cd-6e13662be5a6_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3412,30 +3421,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ce8338e7-aee4-4fbb-83a9-ebf485fbcdd5_2.1.1.19-RXN>
+          <http://model.geneontology.org/ce0541ae-13fe-4eaa-90cd-6e13662be5a6_2.1.1.19-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_4019783e-7300-4723-b23e-7c202d49c2f4_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57305> ;
@@ -3446,7 +3433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3458,11 +3445,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_CHEBI_17437_2.1.1.19-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_CHEBI_17437_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3477,11 +3464,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002411_2.1.1.19-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002411_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3495,14 +3482,25 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YGL125W-MONOMER_1.5.1.20-RXN_controller_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_CHEBI_15378_RXN-5061_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3513,11 +3511,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_CHEBI_58199_HOMOCYSMETB12-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_CHEBI_58199_HOMOCYSMETB12-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3534,39 +3532,6 @@
 <http://identifiers.org/sgd/S000005944>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002411_HOMOCYSMETB12-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_CHEBI_57844_HOMOCYSMETB12-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3576,7 +3541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3588,11 +3553,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_CHEBI_15378_FORMYLTHFDEFORMYL-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_CHEBI_15378_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3603,40 +3568,15 @@
           <http://model.geneontology.org/CHEBI_15378_FORMYLTHFDEFORMYL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/9b58bf00-c25f-409b-ab9d-143bf5a533fb_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_eec788f8-4455-4556-b0fd-fcd450c9052e_HOMOCYSMETB12-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_CHEBI_456216_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_CHEBI_456216_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3651,11 +3591,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_GCVMULTI-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3666,29 +3606,46 @@
           <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_Apo-Ferredoxins_RXN-5061_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_CHEBI_58199_HOMOCYSMETB12-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002411>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/e85f3c0a-1891-4428-a938-1a81de9823da_GCVMULTI-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3699,26 +3656,15 @@
           <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_c0234821-1d1d-46f9-91bd-efe3e4c0c266_GCVMULTI-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_e85f3c0a-1891-4428-a938-1a81de9823da_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3726,28 +3672,61 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c0234821-1d1d-46f9-91bd-efe3e4c0c266_GCVMULTI-RXN>
+          <http://model.geneontology.org/e85f3c0a-1891-4428-a938-1a81de9823da_GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_9b58bf00-c25f-409b-ab9d-143bf5a533fb_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_Apo-Ferredoxins_RXN-5061_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_ca399521-de2c-4a92-8303-26a39ffb8c8c_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3759,24 +3738,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/877d3f10-a4da-4f71-9aef-85c904a8add8_1.5.1.20-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://model.geneontology.org/0a2c0d03-fa2e-4ac9-8d84-45eaa17420b4_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
+                "a (6<i>S</i>)-5-formyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67387> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3787,11 +3766,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_Apo-Ferredoxins_RXN-5061_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_Apo-Ferredoxins_RXN-5061_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3811,7 +3790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3819,15 +3798,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3838,6 +3828,17 @@
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000467> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3845,7 +3846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3857,11 +3858,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_FORMYLTHFDEFORMYL-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3876,11 +3877,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_HOMOCYSMETB12-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_HOMOCYSMETB12-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3891,15 +3892,37 @@
           <http://model.geneontology.org/HOMOCYSMETB12-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_bd814a43-3d8f-4ee1-90bf-eb2a8e580a88_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_eb7de80b-10d9-4db2-9ba1-31e583c76710_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_d12eb17a-ea4b-4231-8097-b941dfd24e06_1.5.1.15-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_aa8ee7f8-79fe-4187-b471-59584b9c0cf1_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3907,21 +3930,43 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d12eb17a-ea4b-4231-8097-b941dfd24e06_1.5.1.15-RXN>
+          <http://model.geneontology.org/aa8ee7f8-79fe-4187-b471-59584b9c0cf1_1.5.1.15-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17437>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3932,23 +3977,23 @@
           <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-5061_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3957,18 +4002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_a67757be-061e-48f2-b690-f0690aa67ef9_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3976,11 +4010,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3995,11 +4029,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4010,40 +4044,26 @@
           <http://model.geneontology.org/YeastPathways_PWY-2201/YeastPathways_PWY-2201>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002333_YER183C-MONOMER_5-FORMYL-THF-CYCLO-LIGASE-RXN_controller_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/4019783e-7300-4723-b23e-7c202d49c2f4_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4054,25 +4074,58 @@
           <http://model.geneontology.org/SGD_S000001788_CPLX3O-317_component>
 ] .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/81402844-e478-462f-bcca-91c5f3e05ce6_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://model.geneontology.org/eb7de80b-10d9-4db2-9ba1-31e583c76710_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
+                "a 5,10-methenyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_CHEBI_17437_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_28938> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4083,7 +4136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4100,35 +4153,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67438> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_c0234821-1d1d-46f9-91bd-efe3e4c0c266_GCVMULTI-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -4142,9 +4173,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/83dfc6dd-08d7-401c-a235-9dfd4e25bb3a_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/9346407b-b052-414b-9b71-7fda69fc7598_2.1.1.19-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> , <http://model.geneontology.org/c0234821-1d1d-46f9-91bd-efe3e4c0c266_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/e85f3c0a-1891-4428-a938-1a81de9823da_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -4152,7 +4183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4160,15 +4191,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_3ac7201d-b44a-46d8-af7c-d476dff1cca6_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4188,15 +4230,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.1.1.19-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/13053ed2-6495-4095-bfff-fcc76cddb313_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_17437_2.1.1.19-RXN> ;
+                <http://model.geneontology.org/d9d483ea-ef26-4f9f-943e-507b448a9557_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_17437_2.1.1.19-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/95a6cd5f-ce6d-4b73-9154-37c44bc289d6_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_17434_2.1.1.19-RXN> ;
+                <http://model.geneontology.org/c42d4043-e0a3-4ef1-91ec-f3afdc7e1218_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_17434_2.1.1.19-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
                 <http://model.geneontology.org/GCVMULTI-RXN> , <http://model.geneontology.org/FORMATETHFLIG-RXN> , <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4211,7 +4253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4219,14 +4261,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_RXN-5061_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4234,11 +4276,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4249,6 +4291,17 @@
           <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_c42d4043-e0a3-4ef1-91ec-f3afdc7e1218_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -4256,11 +4309,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4271,6 +4324,50 @@
           <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_CHEBI_456216_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_d9d483ea-ef26-4f9f-943e-507b448a9557_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_43474_5-FORMYL-THF-CYCLO-LIGASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4280,13 +4377,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67438> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_2e58b3a5-dc45-4359-886b-30e53e87ed1c_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_FORMYLTHFDEFORMYL-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -4297,7 +4405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4309,11 +4417,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_13053ed2-6495-4095-bfff-fcc76cddb313_1.5.1.20-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_d9d483ea-ef26-4f9f-943e-507b448a9557_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4321,18 +4429,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/13053ed2-6495-4095-bfff-fcc76cddb313_1.5.1.20-RXN>
+          <http://model.geneontology.org/d9d483ea-ef26-4f9f-943e-507b448a9557_1.5.1.20-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4343,46 +4451,29 @@
           <http://model.geneontology.org/YeastPathways_PWY-2201/YeastPathways_PWY-2201>
 ] .
 
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/3ffe474a-4ec0-4ac7-b663-fe1d48b2f5c7_FORMYLTHFDEFORMYL-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_362f9aa3-7970-4eae-80a3-ef21a881d97f_1.5.1.20-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_3fc96e1e-191a-4659-b874-33bf2f6cfc0c_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4390,29 +4481,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOCYSMETB12-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/362f9aa3-7970-4eae-80a3-ef21a881d97f_1.5.1.20-RXN>
+          <http://model.geneontology.org/3fc96e1e-191a-4659-b874-33bf2f6cfc0c_1.5.1.20-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_CHEBI_15740_FORMYLTHFDEFORMYL-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_CHEBI_15740_FORMYLTHFDEFORMYL-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_CHEBI_15740_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4423,22 +4503,16 @@
           <http://model.geneontology.org/CHEBI_15740_FORMYLTHFDEFORMYL-RXN>
 ] .
 
-<http://model.geneontology.org/eec788f8-4455-4556-b0fd-fcd450c9052e_HOMOCYSMETB12-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_9346407b-b052-414b-9b71-7fda69fc7598_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57844_HOMOCYSMETB12-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57844> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4449,7 +4523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4460,27 +4534,41 @@
 <http://identifiers.org/sgd/S000003436>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/0662b20e-0b2e-44d1-95b2-7a24a7070447_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67744> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/reaction_FORMYLTHFDEFORMYL-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/13053ed2-6495-4095-bfff-fcc76cddb313_1.5.1.20-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_bce8f210-1eb2-4bfe-83cb-39559f294abf_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_ca399521-de2c-4a92-8303-26a39ffb8c8c_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4488,18 +4576,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bce8f210-1eb2-4bfe-83cb-39559f294abf_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+          <http://model.geneontology.org/ca399521-de2c-4a92-8303-26a39ffb8c8c_5-FORMYL-THF-CYCLO-LIGASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_928f87a1-0e6e-4d3d-8f45-81118944e32f_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_2f5c7704-ffa6-4ace-aa2f-c0a1f428a73f_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4507,7 +4595,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/928f87a1-0e6e-4d3d-8f45-81118944e32f_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/2f5c7704-ffa6-4ace-aa2f-c0a1f428a73f_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
@@ -4515,18 +4603,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_fde4e683-e413-4a0d-9435-e31ff7976df6_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4539,9 +4638,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/928f87a1-0e6e-4d3d-8f45-81118944e32f_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/2f5c7704-ffa6-4ace-aa2f-c0a1f428a73f_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/877d3f10-a4da-4f71-9aef-85c904a8add8_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/bd814a43-3d8f-4ee1-90bf-eb2a8e580a88_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller> , <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -4549,7 +4648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4557,26 +4656,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4594,7 +4682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4609,7 +4697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4622,7 +4710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4635,15 +4723,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMYLTHFDEFORMYL-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/a67757be-061e-48f2-b690-f0690aa67ef9_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/3ac7201d-b44a-46d8-af7c-d476dff1cca6_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/CHEBI_15740_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/3ffe474a-4ec0-4ac7-b663-fe1d48b2f5c7_FORMYLTHFDEFORMYL-RXN> ;
+                <http://model.geneontology.org/1462aa25-c1ef-4ce0-8eab-b16aca2c6726_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/CHEBI_15378_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/CHEBI_15740_FORMYLTHFDEFORMYL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
                 <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4660,7 +4748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4668,15 +4756,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_ce0541ae-13fe-4eaa-90cd-6e13662be5a6_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4687,66 +4786,30 @@
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller>
 ] .
 
-<http://model.geneontology.org/1244805a-17a6-4916-998b-434eda648924_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_Reduced-ferredoxins_RXN-5061_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_928f87a1-0e6e-4d3d-8f45-81118944e32f_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_CHEBI_15378_RXN-5061_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_CHEBI_15378_RXN-5061_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4757,17 +4820,6 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-5061>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YGL125W-MONOMER_1.5.1.20-RXN_controller_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_RXN-5061>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4777,7 +4829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4785,26 +4837,42 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_43474>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_15378_1.5.1.20-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_94dd851d-9307-4fb4-9907-6b086fd3a5c5_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/reaction_5-FORMYL-THF-CYCLO-LIGASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_e85f3c0a-1891-4428-a938-1a81de9823da_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/d9d483ea-ef26-4f9f-943e-507b448a9557_1.5.1.20-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://purl.obolibrary.org/obo/CHEBI_43474>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4812,11 +4880,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_RXN-5061_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_RXN-5061_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4827,25 +4895,34 @@
           <http://model.geneontology.org/RXN-5061>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/reaction_5-FORMYL-THF-CYCLO-LIGASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_877d3f10-a4da-4f71-9aef-85c904a8add8_1.5.1.20-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4858,7 +4935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4870,11 +4947,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4889,11 +4966,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_2.1.1.19-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4904,26 +4981,18 @@
           <http://model.geneontology.org/2.1.1.19-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/2f5c7704-ffa6-4ace-aa2f-c0a1f428a73f_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4934,14 +5003,25 @@
           <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_CHEBI_17434_2.1.1.19-RXN_SGD_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_295f5d5a-6021-49e9-96d5-d14359b94cbf_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4954,7 +5034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4969,11 +5049,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4984,65 +5064,46 @@
           <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/95a6cd5f-ce6d-4b73-9154-37c44bc289d6_2.1.1.19-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/bddddb7e-573d-4af0-a850-b029bb1efb00_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+                "a 5,10-methylenetetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/6f7b502f-fcca-490f-91b7-b2d4fc577f70_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5057,11 +5118,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_BFO_0000066_reaction_5-FORMYL-THF-CYCLO-LIGASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_BFO_0000066_reaction_5-FORMYL-THF-CYCLO-LIGASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5076,11 +5137,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5094,37 +5155,15 @@
 <http://purl.obolibrary.org/obo/GO_0004329>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_CHEBI_43474_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_1244805a-17a6-4916-998b-434eda648924_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_6f7b502f-fcca-490f-91b7-b2d4fc577f70_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5132,7 +5171,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1244805a-17a6-4916-998b-434eda648924_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/6f7b502f-fcca-490f-91b7-b2d4fc577f70_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller>
@@ -5144,7 +5183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5164,7 +5203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5176,11 +5215,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5191,14 +5230,14 @@
           <http://model.geneontology.org/YeastPathways_PWY-2201/YeastPathways_PWY-2201>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_1462aa25-c1ef-4ce0-8eab-b16aca2c6726_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5211,7 +5250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5223,11 +5262,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_83dfc6dd-08d7-401c-a235-9dfd4e25bb3a_2.1.1.19-RXN_SGD_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_9346407b-b052-414b-9b71-7fda69fc7598_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5235,41 +5274,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/83dfc6dd-08d7-401c-a235-9dfd4e25bb3a_2.1.1.19-RXN>
+          <http://model.geneontology.org/9346407b-b052-414b-9b71-7fda69fc7598_2.1.1.19-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_BFO_0000066_reaction_FORMYLTHFDEFORMYL-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002411_2.1.1.19-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33384> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5280,16 +5286,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67709> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ce8338e7-aee4-4fbb-83a9-ebf485fbcdd5_2.1.1.19-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/362f9aa3-7970-4eae-80a3-ef21a881d97f_1.5.1.20-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .

--- a/models/YeastPathways_PWY-2301.ttl
+++ b/models/YeastPathways_PWY-2301.ttl
@@ -7,24 +7,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2301SmallMolecule29753> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-29_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_controller_BFO_0000051_SGD_S000003689_CPLX3O-29_component_SGD_YeastPathways_PWY-2301>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2301" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -35,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -47,11 +36,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002333_YHR046C-MONOMER_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller_SGD_YeastPathways_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002333_YHR046C-MONOMER_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,26 +51,15 @@
           <http://model.geneontology.org/YHR046C-MONOMER_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002234_CHEBI_17268_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_YeastPathways_PWY-2301>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2301" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002234_CHEBI_58401_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002234_CHEBI_58401_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -112,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,39 +98,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002333_CPLX3O-29_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY-2301>
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002333_CPLX3O-29_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY-2301>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2301" ;
+                "SGD_PWY:PWY-2301" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/BFO_0000051>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002233_CHEBI_4170_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-2301>
+<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-2301/YeastPathways_PWY-2301_SGD_PWY_YeastPathways_PWY-2301>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2301" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002233_CHEBI_58401_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-2301>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2301" ;
+                "SGD_PWY:PWY-2301" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -175,11 +142,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002333_MONOMER3O-11_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller_SGD_YeastPathways_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002333_MONOMER3O-11_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -194,11 +161,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002233_CHEBI_4170_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002233_CHEBI_4170_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -239,13 +206,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2301SmallMolecule29739> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_BFO_0000050_YeastPathways_PWY-2301/YeastPathways_PWY-2301_SGD_PWY_YeastPathways_PWY-2301>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2301" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002333_YHR046C-MONOMER_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_PWY-2301>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2301" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -260,11 +249,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_BFO_0000066_reaction_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_BFO_0000066_reaction_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,6 +263,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002413_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY-2301>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2301" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -285,11 +285,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002234_CHEBI_43474_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_YeastPathways_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002234_CHEBI_43474_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,11 +304,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_BFO_0000066_reaction_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_BFO_0000066_reaction_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -322,28 +322,17 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002413_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_YeastPathways_PWY-2301>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2301" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_BFO_0000066_reaction_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2301>
+<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002234_CHEBI_58401_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-2301>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2301" ;
+                "SGD_PWY:PWY-2301" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -369,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -381,11 +370,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_BFO_0000050_YeastPathways_PWY-2301/YeastPathways_PWY-2301_SGD_YeastPathways_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_BFO_0000050_YeastPathways_PWY-2301/YeastPathways_PWY-2301_SGD_PWY_YeastPathways_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -396,6 +385,17 @@
           <http://model.geneontology.org/YeastPathways_PWY-2301/YeastPathways_PWY-2301>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_BFO_0000066_reaction_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2301>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2301" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY-2301/YeastPathways_PWY-2301>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0006021> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -403,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -415,11 +415,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002234_CHEBI_17268_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_YeastPathways_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002234_CHEBI_17268_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -434,11 +434,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-2301/YeastPathways_PWY-2301_SGD_YeastPathways_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-2301/YeastPathways_PWY-2301_SGD_PWY_YeastPathways_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -469,30 +469,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002333_MONOMER3O-11_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller_SGD_YeastPathways_PWY-2301>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2301" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_BFO_0000066_reaction_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-2301>
+<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_BFO_0000066_reaction_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2301>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2301" ;
+                "SGD_PWY:PWY-2301" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0006021>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002234_CHEBI_43474_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY-2301>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2301" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -512,8 +512,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002233_CHEBI_15377_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY-2301>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2301" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002234_CHEBI_17268_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY-2301>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2301" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-29_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -524,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -536,11 +558,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-glucopyranose 6-phosphate &rarr; 1D-<i>myo</i>-inositol 3-monophosphate' 'null' '1D-<i>myo</i>-inositol 3-monophosphate + H<sub>2</sub>O &rarr; <I>myo</I>-inositol + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002413_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_YeastPathways_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002413_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -563,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -577,26 +599,15 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-2301/YeastPathways_PWY-2301_SGD_YeastPathways_PWY-2301>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2301" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002233_CHEBI_58401_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002233_CHEBI_58401_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,26 +618,15 @@
           <http://model.geneontology.org/CHEBI_58401_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002234_CHEBI_43474_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_YeastPathways_PWY-2301>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2301" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-29_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_controller_BFO_0000051_SGD_S000003689_CPLX3O-29_component_SGD_YeastPathways_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-29_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_controller_BFO_0000051_SGD_S000003689_CPLX3O-29_component_SGD_PWY_YeastPathways_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -645,12 +645,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-29_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_controller_BFO_0000051_SGD_S000003689_CPLX3O-29_component_SGD_PWY_YeastPathways_PWY-2301>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2301" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -662,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -673,18 +684,51 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002233_CHEBI_4170_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-2301>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2301" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002333_MONOMER3O-11_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_PWY-2301>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2301" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002233_CHEBI_58401_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-2301>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2301" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002333_CPLX3O-29_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002333_CPLX3O-29_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -695,34 +739,12 @@
           <http://model.geneontology.org/CPLX3O-29_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002333_YHR046C-MONOMER_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_controller_SGD_YeastPathways_PWY-2301>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2301" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_BFO_0000050_YeastPathways_PWY-2301/YeastPathways_PWY-2301_SGD_YeastPathways_PWY-2301>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2301" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -730,11 +752,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002233_CHEBI_15377_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_YeastPathways_PWY-2301> ;
+          <http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002233_CHEBI_15377_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY-2301> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -748,9 +770,6 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_43474>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/YeastPathways_PWY-2301>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -760,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "<i>myo</i>-inositol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -768,24 +787,5 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_RO_0002234_CHEBI_58401_MYO-INOSITOL-1-PHOSPHATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-2301>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2301" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_RO_0002233_CHEBI_15377_MYO-INOSITOL-1OR-4-MONOPHOSPHATASE-RXN_SGD_YeastPathways_PWY-2301>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2301" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_43474>
+        a       <http://www.w3.org/2002/07/owl#Class> .

--- a/models/YeastPathways_PWY-3322.ttl
+++ b/models/YeastPathways_PWY-3322.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -32,14 +32,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_16810_GLUTAMATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-3322>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_16810_GLUTAMATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-3322>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-3322" ;
+                "SGD_PWY:PWY-3322" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -47,11 +47,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_GLUTAMATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-3322> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_GLUTAMATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-3322> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -83,33 +83,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_GLUTAMATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-3322>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15377_GLUTAMATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-3322>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-3322" ;
+                "SGD_PWY:PWY-3322" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY-3322/YeastPathways_PWY-3322_SGD_YeastPathways_PWY-3322>
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002333_YDL215C-MONOMER_GLUTAMATE-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY-3322>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-3322" ;
+                "SGD_PWY:PWY-3322" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_15377_GLUTAMATE-DEHYDROGENASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -128,15 +128,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_GLUTAMATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-3322>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-3322" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_29985_GLUTAMATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-3322> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_29985_GLUTAMATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-3322> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,22 +164,33 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_GLUTAMATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-3322>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-3322" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://identifiers.org/sgd/S000002374>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_GLUTAMATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-3322>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-3322" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY-3322/YeastPathways_PWY-3322_SGD_PWY_YeastPathways_PWY-3322>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-3322" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -177,11 +199,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_GLUTAMATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-3322> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_GLUTAMATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-3322> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -199,11 +221,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15377_GLUTAMATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-3322> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15377_GLUTAMATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-3322> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -225,29 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002333_YDL215C-MONOMER_GLUTAMATE-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PWY-3322>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-3322" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_29985_GLUTAMATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-3322>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-3322" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -258,11 +258,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_28938_GLUTAMATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-3322> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_28938_GLUTAMATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-3322> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,13 +282,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-3322SmallMolecule29883> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_BFO_0000066_reaction_GLUTAMATE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-3322>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-3322" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GLUTAMATE-DEHYDROGENASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004352> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -307,7 +318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -324,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -339,11 +350,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_BFO_0000066_reaction_GLUTAMATE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-3322> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_BFO_0000066_reaction_GLUTAMATE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-3322> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,14 +368,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_BFO_0000066_reaction_GLUTAMATE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-3322>
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_28938_GLUTAMATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-3322>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-3322" ;
+                "SGD_PWY:PWY-3322" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -381,11 +392,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_16810_GLUTAMATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-3322> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_16810_GLUTAMATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-3322> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -411,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -428,7 +439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutamate degradation IX - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -436,15 +447,26 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_29985_GLUTAMATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-3322>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-3322" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY-3322/YeastPathways_PWY-3322_SGD_YeastPathways_PWY-3322> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY-3322/YeastPathways_PWY-3322_SGD_PWY_YeastPathways_PWY-3322> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,30 +483,8 @@
 <http://purl.obolibrary.org/obo/GO_0006538>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_28938_GLUTAMATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-3322>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-3322" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15377_GLUTAMATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-3322>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-3322" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -496,11 +496,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_GLUTAMATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-3322> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_GLUTAMATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-3322> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -520,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -538,11 +538,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002333_YDL215C-MONOMER_GLUTAMATE-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PWY-3322> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002333_YDL215C-MONOMER_GLUTAMATE-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY-3322> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -562,7 +562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -570,14 +570,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_GLUTAMATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-3322>
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_GLUTAMATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-3322>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-3322" ;
+                "SGD_PWY:PWY-3322" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 

--- a/models/YeastPathways_PWY-46.ttl
+++ b/models/YeastPathways_PWY-46.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002234_CHEBI_16526_ORNDECARBOX-RXN_SGD_YeastPathways_PWY-46> ;
+          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002234_CHEBI_16526_ORNDECARBOX-RXN_SGD_PWY_YeastPathways_PWY-46> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16,17 +16,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16526_ORNDECARBOX-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002234_CHEBI_326268_ORNDECARBOX-RXN_SGD_YeastPathways_PWY-46>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-46" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -40,14 +29,25 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_BFO_0000066_reaction_ORNDECARBOX-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-46>
+<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002233_CHEBI_15378_ORNDECARBOX-RXN_SGD_PWY_YeastPathways_PWY-46>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-46" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_BFO_0000066_reaction_ORNDECARBOX-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-46>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-46" ;
+                "SGD_PWY:PWY-46" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -55,11 +55,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002233_CHEBI_46911_ORNDECARBOX-RXN_SGD_YeastPathways_PWY-46> ;
+          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002233_CHEBI_46911_ORNDECARBOX-RXN_SGD_PWY_YeastPathways_PWY-46> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -76,14 +76,25 @@
 <http://identifiers.org/sgd/S000001667>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002333_YKL184W-MONOMER_ORNDECARBOX-RXN_controller_SGD_YeastPathways_PWY-46>
+<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002234_CHEBI_16526_ORNDECARBOX-RXN_SGD_PWY_YeastPathways_PWY-46>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-46" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002333_YKL184W-MONOMER_ORNDECARBOX-RXN_controller_SGD_PWY_YeastPathways_PWY-46>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-46" ;
+                "SGD_PWY:PWY-46" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -95,23 +106,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_BFO_0000050_YeastPathways_PWY-46/YeastPathways_PWY-46_SGD_YeastPathways_PWY-46>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-46" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002233_CHEBI_46911_ORNDECARBOX-RXN_SGD_PWY_YeastPathways_PWY-46>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-46" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0009446>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -123,11 +134,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002233_CHEBI_15378_ORNDECARBOX-RXN_SGD_YeastPathways_PWY-46> ;
+          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002233_CHEBI_15378_ORNDECARBOX-RXN_SGD_PWY_YeastPathways_PWY-46> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -141,14 +152,14 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002233_CHEBI_15378_ORNDECARBOX-RXN_SGD_YeastPathways_PWY-46>
+<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_BFO_0000050_YeastPathways_PWY-46/YeastPathways_PWY-46_SGD_PWY_YeastPathways_PWY-46>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-46" ;
+                "SGD_PWY:PWY-46" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -175,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -187,11 +198,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_BFO_0000066_reaction_ORNDECARBOX-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-46> ;
+          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_BFO_0000066_reaction_ORNDECARBOX-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-46> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -209,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -219,6 +230,17 @@
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002234_CHEBI_326268_ORNDECARBOX-RXN_SGD_PWY_YeastPathways_PWY-46>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-46" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_46911>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -232,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -250,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -262,11 +284,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002333_YKL184W-MONOMER_ORNDECARBOX-RXN_controller_SGD_YeastPathways_PWY-46> ;
+          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002333_YKL184W-MONOMER_ORNDECARBOX-RXN_controller_SGD_PWY_YeastPathways_PWY-46> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -280,17 +302,6 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002234_CHEBI_16526_ORNDECARBOX-RXN_SGD_YeastPathways_PWY-46>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-46" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -303,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "putrescine biosynthesis III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -320,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -332,11 +343,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_BFO_0000050_YeastPathways_PWY-46/YeastPathways_PWY-46_SGD_YeastPathways_PWY-46> ;
+          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_BFO_0000050_YeastPathways_PWY-46/YeastPathways_PWY-46_SGD_PWY_YeastPathways_PWY-46> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -388,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -396,26 +407,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002233_CHEBI_46911_ORNDECARBOX-RXN_SGD_YeastPathways_PWY-46>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-46" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002234_CHEBI_326268_ORNDECARBOX-RXN_SGD_YeastPathways_PWY-46> ;
+          <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002234_CHEBI_326268_ORNDECARBOX-RXN_SGD_PWY_YeastPathways_PWY-46> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY-5041.ttl
+++ b/models/YeastPathways_PWY-5041.ttl
@@ -1,14 +1,3 @@
-<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002413_ADENOSYLHOMOCYSTEINASE-RXN_SGD_YeastPathways_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004478>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -21,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -32,14 +21,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_57856>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_YeastPathways_PWY-5041>
+<http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002413_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002234_CHEBI_16335_ADENOSYLHOMOCYSTEINASE-RXN_SGD_PWY_YeastPathways_PWY-5041>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
+                "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -47,11 +47,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,11 +71,39 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30405> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_BFO_0000066_reaction_ADENOSYLHOMOCYSTEINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_58140_HOMOCYSMET-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58140> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "tetrahydropteroyl tri-L-glutamate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30342> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -88,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -96,32 +124,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CHEBI_58140_HOMOCYSMET-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58140> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "tetrahydropteroyl tri-L-glutamate" ;
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30342> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -136,11 +158,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002234_CHEBI_16335_ADENOSYLHOMOCYSTEINASE-RXN_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002234_CHEBI_16335_ADENOSYLHOMOCYSTEINASE-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,11 +180,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -193,30 +215,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_7d8fcb73-c34d-4fdd-977f-a98cd11b1521_RXN-7605_SGD_YeastPathways_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57856_RXN-7605>
         a       <http://purl.obolibrary.org/obo/CHEBI_57856> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -227,7 +227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -239,11 +239,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_CHEBI_57856_RXN-7605_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_CHEBI_57856_RXN-7605_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -273,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -281,26 +281,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002413_RXN-7605_SGD_YeastPathways_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ATP + L-methionine + H<sub>2</sub>O &rarr; <i>S</i>-adenosyl-L-methionine + phosphate + diphosphate' 'null' '<i>S</i>-adenosyl-L-methionine + a demethylated methyl donor &rarr; <i>S</i>-adenosyl-L-homocysteine + a methylated methyl donor + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002413_RXN-7605_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002413_RXN-7605_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -317,6 +306,17 @@
 <http://purl.obolibrary.org/obo/GO_0033353>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58199_ADENOSYLHOMOCYSTEINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58199> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -326,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -346,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "<i>S</i>-adenosyl-L-methionine cycle II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -361,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -375,26 +375,65 @@
 <http://purl.obolibrary.org/obo/CHEBI_58207>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-5041>
+<http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002233_CHEBI_15377_ADENOSYLHOMOCYSTEINASE-RXN_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-5041>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
+                "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_PWY-5041/YeastPathways_PWY-5041_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/4889558f-1065-449f-b84a-e7b56504cc28_RXN-7605>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a methylated methyl donor" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30392> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -405,25 +444,14 @@
           <http://model.geneontology.org/CHEBI_58140_HOMOCYSMET-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002233_CHEBI_15377_ADENOSYLHOMOCYSTEINASE-RXN_SGD_YeastPathways_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002233_CHEBI_57856_RXN-7605_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
+                "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -431,11 +459,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002233_CHEBI_57856_RXN-7605_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002233_CHEBI_57856_RXN-7605_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -446,37 +474,15 @@
           <http://model.geneontology.org/CHEBI_57856_RXN-7605>
 ] .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_YeastPathways_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_CHEBI_59789_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -502,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -516,17 +522,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002234_CHEBI_16335_ADENOSYLHOMOCYSTEINASE-RXN_SGD_YeastPathways_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -534,11 +529,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_CHEBI_15378_RXN-7605_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_CHEBI_15378_RXN-7605_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -561,15 +556,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-7605_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN> , <http://model.geneontology.org/5911cf67-4f2c-427a-b13c-a7f994d26be5_RXN-7605> ;
+                <http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN> , <http://model.geneontology.org/15b3ba84-75cd-48f2-81fb-87d4ccec1eb7_RXN-7605> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/7d8fcb73-c34d-4fdd-977f-a98cd11b1521_RXN-7605> , <http://model.geneontology.org/CHEBI_57856_RXN-7605> , <http://model.geneontology.org/CHEBI_15378_RXN-7605> ;
+                <http://model.geneontology.org/4889558f-1065-449f-b84a-e7b56504cc28_RXN-7605> , <http://model.geneontology.org/CHEBI_57856_RXN-7605> , <http://model.geneontology.org/CHEBI_15378_RXN-7605> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/ADENOSYLHOMOCYSTEINASE-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -582,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -590,11 +585,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -605,14 +600,47 @@
           <http://model.geneontology.org/YLR180W-MONOMER_S-ADENMETSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002333_YER043C-MONOMER_ADENOSYLHOMOCYSTEINASE-RXN_controller_SGD_YeastPathways_PWY-5041>
+<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_CHEBI_15378_RXN-7605_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_YeastPathways_PWY-5041/YeastPathways_PWY-5041_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002234_CHEBI_58199_ADENOSYLHOMOCYSTEINASE-RXN_SGD_PWY_YeastPathways_PWY-5041>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -620,11 +648,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_CHEBI_59789_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_CHEBI_59789_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -642,11 +670,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_PWY-5041/YeastPathways_PWY-5041_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_PWY-5041/YeastPathways_PWY-5041_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -657,46 +685,46 @@
           <http://model.geneontology.org/YeastPathways_PWY-5041/YeastPathways_PWY-5041>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002413_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
+                "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/7d8fcb73-c34d-4fdd-977f-a98cd11b1521_RXN-7605>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/15b3ba84-75cd-48f2-81fb-87d4ccec1eb7_RXN-7605>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a methylated methyl donor" ;
+                "a demethylated methyl donor" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30392> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30372> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,26 +735,15 @@
           <http://model.geneontology.org/CHEBI_57844_HOMOCYSMET-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002233_CHEBI_15377_ADENOSYLHOMOCYSTEINASE-RXN_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002233_CHEBI_15377_ADENOSYLHOMOCYSTEINASE-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -737,26 +754,15 @@
           <http://model.geneontology.org/CHEBI_15377_ADENOSYLHOMOCYSTEINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -772,23 +778,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002233_CHEBI_57856_RXN-7605_SGD_YeastPathways_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -797,11 +792,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_5911cf67-4f2c-427a-b13c-a7f994d26be5_RXN-7605_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_15b3ba84-75cd-48f2-81fb-87d4ccec1eb7_RXN-7605_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -809,17 +804,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7605> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5911cf67-4f2c-427a-b13c-a7f994d26be5_RXN-7605>
+          <http://model.geneontology.org/15b3ba84-75cd-48f2-81fb-87d4ccec1eb7_RXN-7605>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_CHEBI_15378_RXN-7605_SGD_YeastPathways_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
+                "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -830,11 +825,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -845,18 +840,40 @@
           <http://model.geneontology.org/MONOMER3O-1014_S-ADENMETSYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_CHEBI_57856_RXN-7605_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7605_BFO_0000066_reaction_RXN-7605_location_lociGO_0005829_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7605_BFO_0000066_reaction_RXN-7605_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -867,26 +884,15 @@
           <http://model.geneontology.org/reaction_RXN-7605_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_YeastPathways_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" , "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-homocysteine + H<sub>2</sub>O &rarr; L-homocysteine + adenosine' 'null' 'L-homocysteine + 5-methyltetrahydropteroyl tri-L-glutamate &harr; L-methionine + tetrahydropteroyl tri-L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002413_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002413_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -909,7 +915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -917,40 +923,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000845>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_5911cf67-4f2c-427a-b13c-a7f994d26be5_RXN-7605_SGD_YeastPathways_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -961,15 +967,26 @@
           <http://model.geneontology.org/CHEBI_58207_HOMOCYSMET-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002413_ADENOSYLHOMOCYSTEINASE-RXN_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_BFO_0000066_reaction_ADENOSYLHOMOCYSTEINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_BFO_0000066_reaction_ADENOSYLHOMOCYSTEINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -984,11 +1001,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_YeastPathways_PWY-5041/YeastPathways_PWY-5041_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_YeastPathways_PWY-5041/YeastPathways_PWY-5041_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -999,14 +1016,14 @@
           <http://model.geneontology.org/YeastPathways_PWY-5041/YeastPathways_PWY-5041>
 ] .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_ADENOSYLHOMOCYSTEINASE-RXN_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
+                "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1017,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1031,17 +1048,6 @@
 <http://identifiers.org/sgd/S000000893>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_BFO_0000066_reaction_ADENOSYLHOMOCYSTEINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1049,11 +1055,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1064,54 +1070,15 @@
           <http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN>
 ] .
 
-<http://model.geneontology.org/5911cf67-4f2c-427a-b13c-a7f994d26be5_RXN-7605>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a demethylated methyl donor" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30372> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_PWY-5041/YeastPathways_PWY-5041_SGD_YeastPathways_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002413_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_HOMOCYSMET-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1119,11 +1086,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7605_BFO_0000050_YeastPathways_PWY-5041/YeastPathways_PWY-5041_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7605_BFO_0000050_YeastPathways_PWY-5041/YeastPathways_PWY-5041_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1134,18 +1101,15 @@
           <http://model.geneontology.org/YeastPathways_PWY-5041/YeastPathways_PWY-5041>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002333_YER043C-MONOMER_ADENOSYLHOMOCYSTEINASE-RXN_controller_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002333_YER043C-MONOMER_ADENOSYLHOMOCYSTEINASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1156,22 +1120,25 @@
           <http://model.geneontology.org/YER043C-MONOMER_ADENOSYLHOMOCYSTEINASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7605_BFO_0000066_reaction_RXN-7605_location_lociGO_0005829_SGD_YeastPathways_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/GO_0004013>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-7605_BFO_0000066_reaction_RXN-7605_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-1014_S-ADENMETSYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002910> ;
@@ -1180,7 +1147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1188,24 +1155,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_ADENOSYLHOMOCYSTEINASE-RXN_SGD_YeastPathways_PWY-5041> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOCYSMET-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58199_ADENOSYLHOMOCYSTEINASE-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_S-ADENMETSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1216,13 +1175,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30477> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_ADENOSYLHOMOCYSTEINASE-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HOMOCYSMET-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58199_ADENOSYLHOMOCYSTEINASE-RXN>
+] .
 
 <http://model.geneontology.org/YER091C-MONOMER_HOMOCYSMET-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000893> ;
@@ -1231,7 +1209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1243,11 +1221,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_BFO_0000050_YeastPathways_PWY-5041/YeastPathways_PWY-5041_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_BFO_0000050_YeastPathways_PWY-5041/YeastPathways_PWY-5041_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1262,11 +1240,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" , "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + a demethylated methyl donor &rarr; <i>S</i>-adenosyl-L-homocysteine + a methylated methyl donor + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-homocysteine + H<sub>2</sub>O &rarr; L-homocysteine + adenosine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002413_ADENOSYLHOMOCYSTEINASE-RXN_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002413_ADENOSYLHOMOCYSTEINASE-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1280,8 +1258,16 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_58199>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN-7605_BFO_0000050_YeastPathways_PWY-5041/YeastPathways_PWY-5041_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/HOMOCYSMET-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003871> ;
@@ -1302,7 +1288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1310,16 +1296,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_YeastPathways_PWY-5041/YeastPathways_PWY-5041_SGD_YeastPathways_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_58199>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_29888_S-ADENMETSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
@@ -1330,7 +1308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1341,19 +1319,19 @@
 <http://purl.obolibrary.org/obo/CHEBI_57844>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002234_CHEBI_58199_ADENOSYLHOMOCYSTEINASE-RXN_SGD_YeastPathways_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002413_RXN-7605_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
+                "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/ADENOSYLHOMOCYSTEINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004013> ;
@@ -1374,7 +1352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1382,35 +1360,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_59789> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "SAM" ;
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30366> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1421,29 +1404,54 @@
           <http://model.geneontology.org/CHEBI_43474_S-ADENMETSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_BFO_0000050_YeastPathways_PWY-5041/YeastPathways_PWY-5041_SGD_YeastPathways_PWY-5041>
+<http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_59789> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "SAM" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30366> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_CHEBI_59789_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-5041>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
+                "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://identifiers.org/sgd/S000004170>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_BFO_0000050_YeastPathways_PWY-5041/YeastPathways_PWY-5041_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN-7605_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1451,11 +1459,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" , "Provides Input For Rule. The relation 'L-homocysteine + 5-methyltetrahydropteroyl tri-L-glutamate &harr; L-methionine + tetrahydropteroyl tri-L-glutamate' 'null' 'ATP + L-methionine + H<sub>2</sub>O &rarr; <i>S</i>-adenosyl-L-methionine + phosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002413_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002413_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1466,26 +1474,15 @@
           <http://model.geneontology.org/S-ADENMETSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002234_CHEBI_58199_ADENOSYLHOMOCYSTEINASE-RXN_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002234_CHEBI_58199_ADENOSYLHOMOCYSTEINASE-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1496,27 +1493,8 @@
           <http://model.geneontology.org/CHEBI_58199_ADENOSYLHOMOCYSTEINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_CHEBI_57856_RXN-7605_SGD_YeastPathways_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_ADENOSYLHOMOCYSTEINASE-RXN_SGD_YeastPathways_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000004170>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YeastPathways_PWY-5041/YeastPathways_PWY-5041>
         a       <http://purl.obolibrary.org/obo/GO_0033353> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1525,7 +1503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1537,11 +1515,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1552,14 +1530,14 @@
           <http://model.geneontology.org/CHEBI_57844_HOMOCYSMET-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-5041>
+<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_15b3ba84-75cd-48f2-81fb-87d4ccec1eb7_RXN-7605_SGD_PWY_YeastPathways_PWY-5041>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
+                "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1568,28 +1546,6 @@
 
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-7605_BFO_0000050_YeastPathways_PWY-5041/YeastPathways_PWY-5041_SGD_YeastPathways_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16335_ADENOSYLHOMOCYSTEINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16335> ;
@@ -1600,7 +1556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1608,15 +1564,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1627,17 +1586,25 @@
           <http://model.geneontology.org/reaction_HOMOCYSMET-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5041>
+<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_4889558f-1065-449f-b84a-e7b56504cc28_RXN-7605_SGD_PWY_YeastPathways_PWY-5041>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1645,11 +1612,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_7d8fcb73-c34d-4fdd-977f-a98cd11b1521_RXN-7605_SGD_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_4889558f-1065-449f-b84a-e7b56504cc28_RXN-7605_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1657,8 +1624,41 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7605> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7d8fcb73-c34d-4fdd-977f-a98cd11b1521_RXN-7605>
+          <http://model.geneontology.org/4889558f-1065-449f-b84a-e7b56504cc28_RXN-7605>
 ] .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002413_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002333_YER043C-MONOMER_ADENOSYLHOMOCYSTEINASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-5080-1.ttl
+++ b/models/YeastPathways_PWY-5080-1.ttl
@@ -1,28 +1,25 @@
-<http://model.geneontology.org/f8c2d8c4-c2fd-4c5f-b663-1b3607c19614_RXN3O-9812>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_RXN3O-9813_BFO_0000066_reaction_RXN3O-9813_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_26d8886f-5d5e-459f-aa88-fff8b89813be_RXN3O-9812_SGD_YeastPathways_PWY-5080-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_6b94ccc8-763c-4901-8202-082c904fc57a_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9814_BFO_0000050_YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1_SGD_YeastPathways_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
+                "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -30,11 +27,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_CHEBI_57783_RXN3O-9814_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_CHEBI_57783_RXN3O-9814_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,14 +42,25 @@
           <http://model.geneontology.org/CHEBI_57783_RXN3O-9814>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002411_RXN3O-9813_SGD_YeastPathways_PWY-5080-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002233_CHEBI_15378_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_7401a812-baf9-425d-8c4e-b8f4e219b0f0_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -60,11 +68,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002233_CHEBI_57783_RXN3O-9812_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002233_CHEBI_57783_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,15 +83,26 @@
           <http://model.geneontology.org/CHEBI_57783_RXN3O-9812>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002333_MONOMER3O-101_RXN3O-9814_controller_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002234_CHEBI_15489_RXN3O-9811_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002234_CHEBI_15489_RXN3O-9811_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -97,26 +116,18 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_8fa80271-c815-4be4-9495-f25106121ccd_RXN3O-9813_SGD_YeastPathways_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9814_BFO_0000066_reaction_RXN3O-9814_location_lociGO_0005829_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9814_BFO_0000066_reaction_RXN3O-9814_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -127,8 +138,16 @@
           <http://model.geneontology.org/reaction_RXN3O-9814_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_CHEBI_15378_RXN3O-9814_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-101_RXN3O-9814_controller>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -137,24 +156,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1Protein75535> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9812_BFO_0000050_YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1_SGD_YeastPathways_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-9812>
         a       <http://purl.obolibrary.org/obo/GO_0018454> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -167,7 +175,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57783_RXN3O-9812> , <http://model.geneontology.org/CHEBI_15489_RXN3O-9811> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9812> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/26d8886f-5d5e-459f-aa88-fff8b89813be_RXN3O-9812> , <http://model.geneontology.org/CHEBI_58349_RXN3O-9812> ;
+                <http://model.geneontology.org/CHEBI_58349_RXN3O-9812> , <http://model.geneontology.org/7401a812-baf9-425d-8c4e-b8f4e219b0f0_RXN3O-9812> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-79_RXN3O-9812_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -175,7 +183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -183,14 +191,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9813_BFO_0000066_reaction_RXN3O-9813_location_lociGO_0005829_SGD_YeastPathways_PWY-5080-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002233_5871b142-e49f-43f1-83da-a50512067ef1_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002233_CHEBI_33184_RXN3O-9811_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -204,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,18 +236,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002233_CHEBI_57783_RXN3O-9812_SGD_YeastPathways_PWY-5080-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002233_CHEBI_57384_RXN3O-9811_SGD_PWY_YeastPathways_PWY-5080-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9814_BFO_0000050_YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -236,11 +266,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002233_f8c2d8c4-c2fd-4c5f-b663-1b3607c19614_RXN3O-9812_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002233_5871b142-e49f-43f1-83da-a50512067ef1_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -248,7 +278,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9813> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f8c2d8c4-c2fd-4c5f-b663-1b3607c19614_RXN3O-9812>
+          <http://model.geneontology.org/5871b142-e49f-43f1-83da-a50512067ef1_RXN3O-9812>
 ] .
 
 <http://model.geneontology.org/CHEBI_58349_RXN3O-9812>
@@ -260,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -277,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -291,36 +321,11 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/8fa80271-c815-4be4-9495-f25106121ccd_RXN3O-9813>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://purl.obolibrary.org/obo/CHEBI_57384>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_CHEBI_15377_RXN3O-9813_SGD_YeastPathways_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002333_YCR034W-MONOMER_RXN3O-9811_controller_SGD_YeastPathways_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -328,14 +333,14 @@
 <http://purl.obolibrary.org/obo/GO_0102758>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002234_CHEBI_16526_RXN3O-9811_SGD_YeastPathways_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002233_CHEBI_15489_RXN3O-9811_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
+                "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -343,11 +348,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002233_CHEBI_15489_RXN3O-9811_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002233_CHEBI_15489_RXN3O-9811_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -365,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -380,11 +385,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002233_CHEBI_57384_RXN3O-9811_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002233_CHEBI_57384_RXN3O-9811_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -402,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -410,26 +415,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_9bff6858-e4db-4041-9dc1-2c5879b01883_RXN3O-9813_SGD_YeastPathways_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9814_BFO_0000050_YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9814_BFO_0000050_YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -449,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -469,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -496,7 +490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -510,22 +504,8 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002233_CHEBI_33184_RXN3O-9811_SGD_YeastPathways_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9813>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -536,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -544,26 +524,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9811_BFO_0000066_reaction_RXN3O-9811_location_lociGO_0005829_SGD_YeastPathways_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9813_BFO_0000066_reaction_RXN3O-9813_location_lociGO_0005829_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9813_BFO_0000066_reaction_RXN3O-9813_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,23 +546,12 @@
           <http://model.geneontology.org/reaction_RXN3O-9813_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_CHEBI_58349_RXN3O-9812_SGD_YeastPathways_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-9812_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -598,11 +559,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002333_MONOMER3O-101_RXN3O-9814_controller_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002333_MONOMER3O-101_RXN3O-9814_controller_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,26 +574,15 @@
           <http://model.geneontology.org/MONOMER3O-101_RXN3O-9814_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002333_MONOMER3O-79_RXN3O-9812_controller_SGD_YeastPathways_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002411_RXN3O-9813_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002411_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -650,11 +600,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002333_YCR034W-MONOMER_RXN3O-9811_controller_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002333_YCR034W-MONOMER_RXN3O-9811_controller_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,14 +615,42 @@
           <http://model.geneontology.org/YCR034W-MONOMER_RXN3O-9811_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002234_CHEBI_33184_RXN3O-9814_SGD_YeastPathways_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/0ef64807-fcaf-40f8-8e86-d96caaf2e19e_RXN3O-9813>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a <i>trans</i>-2-enoyl-CoA" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75474> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9813_BFO_0000050_YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9814_BFO_0000066_reaction_RXN3O-9814_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -683,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -694,15 +672,26 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9811_BFO_0000050_YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002233_CHEBI_15378_RXN3O-9812_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002233_CHEBI_15378_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -737,11 +726,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002233_CHEBI_33184_RXN3O-9811_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002233_CHEBI_33184_RXN3O-9811_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -752,26 +741,15 @@
           <http://model.geneontology.org/CHEBI_33184_RXN3O-9811>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_CHEBI_15378_RXN3O-9814_SGD_YeastPathways_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002411_RXN3O-9814_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002411_RXN3O-9814_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -781,17 +759,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN3O-9814>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002233_f8c2d8c4-c2fd-4c5f-b663-1b3607c19614_RXN3O-9812_SGD_YeastPathways_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -805,7 +772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -822,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "very long chain fatty acid biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -833,15 +800,26 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002234_CHEBI_16526_RXN3O-9811_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9813_BFO_0000050_YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9813_BFO_0000050_YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -852,6 +830,17 @@
           <http://model.geneontology.org/YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002234_CHEBI_15489_RXN3O-9811_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER3O-79_RXN3O-9812_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000363> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -859,7 +848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -867,15 +856,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/7401a812-baf9-425d-8c4e-b8f4e219b0f0_RXN3O-9812>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 3-hydroxyacyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75543> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002234_CHEBI_58349_RXN3O-9814_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002234_CHEBI_58349_RXN3O-9814_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -886,21 +892,68 @@
           <http://model.geneontology.org/CHEBI_58349_RXN3O-9814>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002333_MONOMER3O-70_RXN3O-9811_controller_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002411_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002411_RXN3O-9814_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_33184>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_CHEBI_58349_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002333_MONOMER3O-79_RXN3O-9812_controller_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002333_MONOMER3O-79_RXN3O-9812_controller_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -911,18 +964,26 @@
           <http://model.geneontology.org/MONOMER3O-79_RXN3O-9812_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_33184>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002234_CHEBI_33184_RXN3O-9814_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002333_MONOMER3O-70_RXN3O-9811_controller_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002333_MONOMER3O-70_RXN3O-9811_controller_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -933,65 +994,32 @@
           <http://model.geneontology.org/MONOMER3O-70_RXN3O-9811_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002233_CHEBI_57384_RXN3O-9811_SGD_YeastPathways_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9813_BFO_0000050_YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1_SGD_YeastPathways_PWY-5080-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002234_CHEBI_58349_RXN3O-9814_SGD_PWY_YeastPathways_PWY-5080-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
+                "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002233_CHEBI_15378_RXN3O-9812_SGD_YeastPathways_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000004364>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0102756>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9812_BFO_0000066_reaction_RXN3O-9812_location_lociGO_0005829_SGD_YeastPathways_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000004364>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9812_BFO_0000066_reaction_RXN3O-9812_location_lociGO_0005829_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9812_BFO_0000066_reaction_RXN3O-9812_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1011,7 +1039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1023,11 +1051,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9811_BFO_0000066_reaction_RXN3O-9811_location_lociGO_0005829_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9811_BFO_0000066_reaction_RXN3O-9811_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1041,20 +1069,20 @@
 <http://purl.obolibrary.org/obo/GO_0004300>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/26d8886f-5d5e-459f-aa88-fff8b89813be_RXN3O-9812>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://model.geneontology.org/CHEBI_57783_RXN3O-9812>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 3-hydroxyacyl-CoA" ;
+                "NADPH" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75543> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75491> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1062,11 +1090,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002333_MONOMER3O-85_RXN3O-9813_controller_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002333_MONOMER3O-85_RXN3O-9813_controller_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1077,36 +1105,74 @@
           <http://model.geneontology.org/MONOMER3O-85_RXN3O-9813_controller>
 ] .
 
-<http://model.geneontology.org/CHEBI_57783_RXN3O-9812>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NADPH" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9812_BFO_0000066_reaction_RXN3O-9812_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75491> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9814_BFO_0000066_reaction_RXN3O-9814_location_lociGO_0005829_SGD_YeastPathways_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
+                "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002233_CHEBI_57783_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002413_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_CHEBI_15377_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002333_YCR034W-MONOMER_RXN3O-9811_controller_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_CHEBI_57783_RXN3O-9814_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1120,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1132,11 +1198,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002234_CHEBI_33184_RXN3O-9814_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002234_CHEBI_33184_RXN3O-9814_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1150,40 +1216,18 @@
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002413_RXN3O-9812_SGD_YeastPathways_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002234_CHEBI_57287_RXN3O-9811_SGD_YeastPathways_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_26d8886f-5d5e-459f-aa88-fff8b89813be_RXN3O-9812_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_7401a812-baf9-425d-8c4e-b8f4e219b0f0_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1191,18 +1235,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9812> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/26d8886f-5d5e-459f-aa88-fff8b89813be_RXN3O-9812>
+          <http://model.geneontology.org/7401a812-baf9-425d-8c4e-b8f4e219b0f0_RXN3O-9812>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002234_CHEBI_57287_RXN3O-9811_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002234_CHEBI_57287_RXN3O-9811_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1219,34 +1263,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/9bff6858-e4db-4041-9dc1-2c5879b01883_RXN3O-9813>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a <i>trans</i>-2-enoyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75474> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002234_CHEBI_15489_RXN3O-9811_SGD_YeastPathways_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1259,7 +1275,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9814_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57783_RXN3O-9814> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9814> , <http://model.geneontology.org/8fa80271-c815-4be4-9495-f25106121ccd_RXN3O-9813> ;
+                <http://model.geneontology.org/CHEBI_57783_RXN3O-9814> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9814> , <http://model.geneontology.org/6b94ccc8-763c-4901-8202-082c904fc57a_RXN3O-9813> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_58349_RXN3O-9814> , <http://model.geneontology.org/CHEBI_33184_RXN3O-9814> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1267,7 +1283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1279,11 +1295,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9812_BFO_0000050_YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9812_BFO_0000050_YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1294,26 +1310,15 @@
           <http://model.geneontology.org/YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002233_CHEBI_15489_RXN3O-9811_SGD_YeastPathways_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9811_BFO_0000050_YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9811_BFO_0000050_YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1324,15 +1329,18 @@
           <http://model.geneontology.org/YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1>
 ] .
 
+<http://model.geneontology.org/5871b142-e49f-43f1-83da-a50512067ef1_RXN3O-9812>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_9bff6858-e4db-4041-9dc1-2c5879b01883_RXN3O-9813_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_0ef64807-fcaf-40f8-8e86-d96caaf2e19e_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1340,11 +1348,22 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9813> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9bff6858-e4db-4041-9dc1-2c5879b01883_RXN3O-9813>
+          <http://model.geneontology.org/0ef64807-fcaf-40f8-8e86-d96caaf2e19e_RXN3O-9813>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002333_MONOMER3O-85_RXN3O-9813_controller_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-9812>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1355,7 +1374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1372,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1389,7 +1408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1402,7 +1421,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_0ef64807-fcaf-40f8-8e86-d96caaf2e19e_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1412,12 +1442,15 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/6b94ccc8-763c-4901-8202-082c904fc57a_RXN3O-9813>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 <http://model.geneontology.org/reaction_RXN3O-9813_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1425,11 +1458,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_8fa80271-c815-4be4-9495-f25106121ccd_RXN3O-9813_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_6b94ccc8-763c-4901-8202-082c904fc57a_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1437,31 +1470,20 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8fa80271-c815-4be4-9495-f25106121ccd_RXN3O-9813>
+          <http://model.geneontology.org/6b94ccc8-763c-4901-8202-082c904fc57a_RXN3O-9813>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0042761>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002333_MONOMER3O-70_RXN3O-9811_controller_SGD_YeastPathways_PWY-5080-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002234_CHEBI_57287_RXN3O-9811_SGD_PWY_YeastPathways_PWY-5080-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9811_BFO_0000050_YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1_SGD_YeastPathways_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
+                "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1472,11 +1494,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_CHEBI_58349_RXN3O-9812_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_CHEBI_58349_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1487,15 +1509,26 @@
           <http://model.geneontology.org/CHEBI_58349_RXN3O-9812>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9812_BFO_0000050_YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002234_CHEBI_16526_RXN3O-9811_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002234_CHEBI_16526_RXN3O-9811_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1506,26 +1539,15 @@
           <http://model.geneontology.org/CHEBI_16526_RXN3O-9811>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002411_RXN3O-9814_SGD_YeastPathways_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_CHEBI_15378_RXN3O-9814_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_CHEBI_15378_RXN3O-9814_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1536,17 +1558,6 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-9814>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002333_MONOMER3O-85_RXN3O-9813_controller_SGD_YeastPathways_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/RXN3O-9813>
         a       <http://purl.obolibrary.org/obo/GO_0004300> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1556,9 +1567,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9813_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/f8c2d8c4-c2fd-4c5f-b663-1b3607c19614_RXN3O-9812> ;
+                <http://model.geneontology.org/5871b142-e49f-43f1-83da-a50512067ef1_RXN3O-9812> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/9bff6858-e4db-4041-9dc1-2c5879b01883_RXN3O-9813> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9813> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN3O-9813> , <http://model.geneontology.org/0ef64807-fcaf-40f8-8e86-d96caaf2e19e_RXN3O-9813> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-85_RXN3O-9813_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1566,7 +1577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1574,26 +1585,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002234_CHEBI_58349_RXN3O-9814_SGD_YeastPathways_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a long-chain acyl-CoA + malonyl-CoA &rarr; a 3-oxoacyl-CoA + CO<SUB>2</SUB> + coenzyme A' 'null' 'a 3-oxoacyl-CoA + NADPH + H<SUP>+</SUP> &rarr; a 3-hydroxyacyl-CoA + NADP<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002413_RXN3O-9812_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002413_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1607,26 +1607,15 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002333_MONOMER3O-101_RXN3O-9814_controller_SGD_YeastPathways_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_CHEBI_15377_RXN3O-9813_SGD_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_CHEBI_15377_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1637,16 +1626,27 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-9813>
 ] .
 
-<http://identifiers.org/sgd/S000000630>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_CHEBI_57783_RXN3O-9814_SGD_YeastPathways_PWY-5080-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9811_BFO_0000066_reaction_RXN3O-9811_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5080-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000630>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002333_MONOMER3O-79_RXN3O-9812_controller_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-5084.ttl
+++ b/models/YeastPathways_PWY-5084.ttl
@@ -1,25 +1,14 @@
 <http://identifiers.org/sgd/S000002555>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-7716_BFO_0000050_YeastPathways_PWY-5084/YeastPathways_PWY-5084_SGD_YeastPathways_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7716_BFO_0000066_reaction_RXN-7716_location_lociGO_0005829_SGD_YeastPathways_PWY-5084>
+<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_BFO_0000050_YeastPathways_PWY-5084/YeastPathways_PWY-5084_SGD_PWY_YeastPathways_PWY-5084>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
+                "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -27,11 +16,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_1788b670-acbc-4538-9be2-e055b84d68ec_2OXOGLUTDECARB-RXN_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_a3c6e8b3-4d6a-4725-ae32-4afca62b89ef_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,18 +28,21 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1147> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1788b670-acbc-4538-9be2-e055b84d68ec_2OXOGLUTDECARB-RXN>
+          <http://model.geneontology.org/a3c6e8b3-4d6a-4725-ae32-4afca62b89ef_2OXOGLUTDECARB-RXN>
 ] .
+
+<http://model.geneontology.org/d9a754f7-9ea3-4e59-80dd-08f2693afce0_RXN-7716>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_CHEBI_57540_RXN-7716_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_CHEBI_57540_RXN-7716_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,18 +53,15 @@
           <http://model.geneontology.org/CHEBI_57540_RXN-7716>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002411_RXN0-1147_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002411_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -83,19 +72,36 @@
           <http://model.geneontology.org/RXN0-1147>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN0-1147_BFO_0000050_YeastPathways_PWY-5084/YeastPathways_PWY-5084_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_CHEBI_15378_2OXOGLUTDECARB-RXN_SGD_YeastPathways_PWY-5084>
+<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002411_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
+                "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/a3c6e8b3-4d6a-4725-ae32-4afca62b89ef_2OXOGLUTDECARB-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/CHEBI_57945_RXN-7716>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
@@ -106,7 +112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -114,25 +120,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/66520c87-65cb-4415-b5d7-07ca0e6131d9_RXN-7716>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://purl.obolibrary.org/obo/CHEBI_57292>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/1788b670-acbc-4538-9be2-e055b84d68ec_2OXOGLUTDECARB-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_433de863-1248-4c80-aa9f-9fddb1a34857_RXN-7716_SGD_YeastPathways_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -141,11 +130,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_CHEBI_15378_2OXOGLUTDECARB-RXN_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_CHEBI_15378_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -156,6 +145,34 @@
           <http://model.geneontology.org/CHEBI_15378_2OXOGLUTDECARB-RXN>
 ] .
 
+<http://model.geneontology.org/8f713ada-e1c4-4bd1-a41b-2e111971063d_2OXOGLUTDECARB-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-succinyldihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule17047> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7716_BFO_0000066_reaction_RXN-7716_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/2OXOGLUTDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004591> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -165,9 +182,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2OXOGLUTDECARB-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/CHEBI_16810_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/66520c87-65cb-4415-b5d7-07ca0e6131d9_RXN-7716> ;
+                <http://model.geneontology.org/d9a754f7-9ea3-4e59-80dd-08f2693afce0_RXN-7716> , <http://model.geneontology.org/CHEBI_15378_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/CHEBI_16810_2OXOGLUTDECARB-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/db62a79c-edae-4507-83f9-4bee07924fa7_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/CHEBI_16526_2OXOGLUTDECARB-RXN> ;
+                <http://model.geneontology.org/8f713ada-e1c4-4bd1-a41b-2e111971063d_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/CHEBI_16526_2OXOGLUTDECARB-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-12_2OXOGLUTDECARB-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -175,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -183,22 +200,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/db62a79c-edae-4507-83f9-4bee07924fa7_2OXOGLUTDECARB-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-succinyldihydrolipoyl-L-lysine" ;
+<http://model.geneontology.org/ev_w_id_RXN-7716_BFO_0000050_YeastPathways_PWY-5084/YeastPathways_PWY-5084_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule17047> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_27a72130-d12c-4aaa-b7f2-7d49395770ac_RXN-7716_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -211,31 +233,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_CHEBI_57292_RXN0-1147_SGD_YeastPathways_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002413_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
+                "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_CHEBI_57540_RXN-7716_SGD_YeastPathways_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/65779864-6e2e-46b9-96f8-2d924568e8bb_RXN0-1147>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16950> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YFL018C-MONOMER_RXN-7716_controller>
         a       <http://identifiers.org/sgd/S000001876> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -244,32 +272,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084Protein17009> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_CHEBI_57287_RXN0-1147_SGD_YeastPathways_PWY-5084> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-1147> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_RXN0-1147>
-] .
 
 <http://model.geneontology.org/CHEBI_16526_2OXOGLUTDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -280,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,37 +297,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_5546cb09-bc37-4fe8-8d0e-1c4ba4c7b1df_RXN0-1147_SGD_YeastPathways_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_66520c87-65cb-4415-b5d7-07ca0e6131d9_RXN-7716_SGD_YeastPathways_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_CHEBI_57287_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-1147> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57287_RXN0-1147>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_BFO_0000066_reaction_RXN-7716_location_lociGO_0005829_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7716_BFO_0000066_reaction_RXN-7716_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,11 +339,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002333_CPLX3O-12_2OXOGLUTDECARB-RXN_controller_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002333_CPLX3O-12_2OXOGLUTDECARB-RXN_controller_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -347,17 +353,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CPLX3O-12_2OXOGLUTDECARB-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_CHEBI_57945_RXN-7716_SGD_YeastPathways_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -374,33 +369,38 @@
 <http://purl.obolibrary.org/obo/GO_0004149>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002411_RXN-7716_SGD_YeastPathways_PWY-5084>
+<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002333_CPLX3O-12_2OXOGLUTDECARB-RXN_controller_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002411_RXN-7716_SGD_PWY_YeastPathways_PWY-5084>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
+                "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/433de863-1248-4c80-aa9f-9fddb1a34857_RXN-7716>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
+<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_CHEBI_57540_RXN-7716_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16973> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -409,11 +409,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_BFO_0000066_reaction_2OXOGLUTDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_BFO_0000066_reaction_2OXOGLUTDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -433,9 +433,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-1147_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57287_RXN0-1147> , <http://model.geneontology.org/1788b670-acbc-4538-9be2-e055b84d68ec_2OXOGLUTDECARB-RXN> ;
+                <http://model.geneontology.org/CHEBI_57287_RXN0-1147> , <http://model.geneontology.org/a3c6e8b3-4d6a-4725-ae32-4afca62b89ef_2OXOGLUTDECARB-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/5546cb09-bc37-4fe8-8d0e-1c4ba4c7b1df_RXN0-1147> , <http://model.geneontology.org/CHEBI_57292_RXN0-1147> ;
+                <http://model.geneontology.org/CHEBI_57292_RXN0-1147> , <http://model.geneontology.org/65779864-6e2e-46b9-96f8-2d924568e8bb_RXN0-1147> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-16_RXN0-1147_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -451,29 +451,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_BFO_0000066_reaction_2OXOGLUTDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002333_CPLX3O-16_RXN0-1147_controller_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
+                "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_CHEBI_57287_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002411_RXN-7716_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002411_RXN-7716_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -487,15 +498,26 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_CHEBI_57292_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_433de863-1248-4c80-aa9f-9fddb1a34857_RXN-7716_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_27a72130-d12c-4aaa-b7f2-7d49395770ac_RXN-7716_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,8 +525,30 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7716> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/433de863-1248-4c80-aa9f-9fddb1a34857_RXN-7716>
+          <http://model.geneontology.org/27a72130-d12c-4aaa-b7f2-7d49395770ac_RXN-7716>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_a3c6e8b3-4d6a-4725-ae32-4afca62b89ef_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_d9a754f7-9ea3-4e59-80dd-08f2693afce0_RXN-7716_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-7716>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -515,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -523,40 +567,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002333_YFL018C-MONOMER_RXN-7716_controller_SGD_YeastPathways_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002333_CPLX3O-16_RXN0-1147_controller_SGD_YeastPathways_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_BFO_0000066_reaction_RXN0-1147_location_lociGO_0005829_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_BFO_0000066_reaction_RXN0-1147_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -571,11 +593,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_BFO_0000050_YeastPathways_PWY-5084/YeastPathways_PWY-5084_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7716_BFO_0000050_YeastPathways_PWY-5084/YeastPathways_PWY-5084_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -590,11 +612,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_db62a79c-edae-4507-83f9-4bee07924fa7_2OXOGLUTDECARB-RXN_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_8f713ada-e1c4-4bd1-a41b-2e111971063d_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -602,26 +624,26 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2OXOGLUTDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/db62a79c-edae-4507-83f9-4bee07924fa7_2OXOGLUTDECARB-RXN>
+          <http://model.geneontology.org/8f713ada-e1c4-4bd1-a41b-2e111971063d_2OXOGLUTDECARB-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_1788b670-acbc-4538-9be2-e055b84d68ec_2OXOGLUTDECARB-RXN_SGD_YeastPathways_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN-7716_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_CHEBI_16810_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -631,14 +653,25 @@
 <http://purl.obolibrary.org/obo/GO_0004148>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-16_RXN0-1147_controller_BFO_0000051_SGD_S000002555_CPLX3O-16_component_SGD_YeastPathways_PWY-5084>
+<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_CHEBI_57945_RXN-7716_SGD_PWY_YeastPathways_PWY-5084>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_8f713ada-e1c4-4bd1-a41b-2e111971063d_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -648,15 +681,26 @@
 <http://identifiers.org/sgd/S000001387>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_CHEBI_15378_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_BFO_0000050_YeastPathways_PWY-5084/YeastPathways_PWY-5084_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_BFO_0000050_YeastPathways_PWY-5084/YeastPathways_PWY-5084_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,14 +711,14 @@
           <http://model.geneontology.org/YeastPathways_PWY-5084/YeastPathways_PWY-5084>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_CHEBI_16526_2OXOGLUTDECARB-RXN_SGD_YeastPathways_PWY-5084>
+<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_65779864-6e2e-46b9-96f8-2d924568e8bb_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
+                "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -688,11 +732,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002333_CPLX3O-16_RXN0-1147_controller_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002333_CPLX3O-16_RXN0-1147_controller_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,11 +751,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_CHEBI_57945_RXN-7716_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_CHEBI_57945_RXN-7716_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,46 +766,37 @@
           <http://model.geneontology.org/CHEBI_57945_RXN-7716>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002413_2OXOGLUTDECARB-RXN_SGD_YeastPathways_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_CHEBI_15378_RXN-7716_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
+                "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/49d8e007-4e85-4dc8-9703-4cc8efae56eb_RXN0-1147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/5546cb09-bc37-4fe8-8d0e-1c4ba4c7b1df_RXN0-1147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-16_RXN0-1147_controller_BFO_0000051_SGD_S000002555_CPLX3O-16_component_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16950> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_BFO_0000050_YeastPathways_PWY-5084/YeastPathways_PWY-5084_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_BFO_0000050_YeastPathways_PWY-5084/YeastPathways_PWY-5084_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -781,7 +816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -793,11 +828,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-16_RXN0-1147_controller_BFO_0000051_SGD_S000002555_CPLX3O-16_component_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-16_RXN0-1147_controller_BFO_0000051_SGD_S000002555_CPLX3O-16_component_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,11 +850,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_CHEBI_16526_2OXOGLUTDECARB-RXN_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_CHEBI_16526_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -836,28 +871,6 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1147_BFO_0000066_reaction_RXN0-1147_location_lociGO_0005829_SGD_YeastPathways_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_CHEBI_16810_2OXOGLUTDECARB-RXN_SGD_YeastPathways_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/RXN-7716>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004148> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -867,9 +880,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-7716_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_RXN-7716> , <http://model.geneontology.org/49d8e007-4e85-4dc8-9703-4cc8efae56eb_RXN0-1147> ;
+                <http://model.geneontology.org/CHEBI_57540_RXN-7716> , <http://model.geneontology.org/a64f02ef-3308-41e9-bc0c-d47d61961f54_RXN0-1147> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/433de863-1248-4c80-aa9f-9fddb1a34857_RXN-7716> , <http://model.geneontology.org/CHEBI_57945_RXN-7716> , <http://model.geneontology.org/CHEBI_15378_RXN-7716> ;
+                <http://model.geneontology.org/CHEBI_57945_RXN-7716> , <http://model.geneontology.org/27a72130-d12c-4aaa-b7f2-7d49395770ac_RXN-7716> , <http://model.geneontology.org/CHEBI_15378_RXN-7716> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YFL018C-MONOMER_RXN-7716_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -877,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -885,30 +898,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_a64f02ef-3308-41e9-bc0c-d47d61961f54_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_49d8e007-4e85-4dc8-9703-4cc8efae56eb_RXN0-1147_SGD_YeastPathways_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002333_CPLX3O-12_2OXOGLUTDECARB-RXN_controller_SGD_YeastPathways_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0045333>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -922,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -940,11 +942,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_5546cb09-bc37-4fe8-8d0e-1c4ba4c7b1df_RXN0-1147_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_65779864-6e2e-46b9-96f8-2d924568e8bb_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -952,7 +954,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1147> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5546cb09-bc37-4fe8-8d0e-1c4ba4c7b1df_RXN0-1147>
+          <http://model.geneontology.org/65779864-6e2e-46b9-96f8-2d924568e8bb_RXN0-1147>
 ] .
 
 <http://model.geneontology.org/SGD_S000001387_CPLX3O-12_component>
@@ -960,22 +962,19 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_CHEBI_15378_RXN-7716_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_CHEBI_15378_RXN-7716_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -986,23 +985,15 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-7716>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002411_RXN0-1147_SGD_YeastPathways_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/SGD_S000002555_CPLX3O-16_component>
         a       <http://identifiers.org/sgd/S000002555> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1014,7 +1005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1027,13 +1018,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084Complex17095> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002333_YFL018C-MONOMER_RXN-7716_controller_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_2OXOGLUTDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1044,7 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1056,11 +1058,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" , "Provides Input For Rule. The relation 'a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine + NAD<sup>+</sup> &rarr; a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine + NADH + H<SUP>+</SUP>' 'null' '2-oxoglutarate + a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine + H<SUP>+</SUP> &rarr; a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-succinyldihydrolipoyl-L-lysine + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002413_2OXOGLUTDECARB-RXN_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002413_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1080,7 +1082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1097,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1109,11 +1111,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-12_2OXOGLUTDECARB-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-12_component_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-12_2OXOGLUTDECARB-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-12_component_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,6 +1126,9 @@
           <http://model.geneontology.org/SGD_S000001387_CPLX3O-12_component>
 ] .
 
+<http://model.geneontology.org/a64f02ef-3308-41e9-bc0c-d47d61961f54_RXN0-1147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 <http://model.geneontology.org/YeastPathways_PWY-5084/YeastPathways_PWY-5084>
         a       <http://purl.obolibrary.org/obo/GO_0045333> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1131,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1139,26 +1144,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_db62a79c-edae-4507-83f9-4bee07924fa7_2OXOGLUTDECARB-RXN_SGD_YeastPathways_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_66520c87-65cb-4415-b5d7-07ca0e6131d9_RXN-7716_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_d9a754f7-9ea3-4e59-80dd-08f2693afce0_RXN-7716_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1166,47 +1160,14 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2OXOGLUTDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/66520c87-65cb-4415-b5d7-07ca0e6131d9_RXN-7716>
+          <http://model.geneontology.org/d9a754f7-9ea3-4e59-80dd-08f2693afce0_RXN-7716>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_CHEBI_15378_RXN-7716_SGD_YeastPathways_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_BFO_0000050_YeastPathways_PWY-5084/YeastPathways_PWY-5084_SGD_YeastPathways_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-12_2OXOGLUTDECARB-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-12_component_SGD_YeastPathways_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY-5084>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -1217,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "2-oxoglutarate decarboxylation to succinyl-CoA - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1231,15 +1192,26 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_CHEBI_16526_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_CHEBI_57292_RXN0-1147_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_CHEBI_57292_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1250,15 +1222,37 @@
           <http://model.geneontology.org/CHEBI_57292_RXN0-1147>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_BFO_0000066_reaction_2OXOGLUTDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-12_2OXOGLUTDECARB-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-12_component_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_49d8e007-4e85-4dc8-9703-4cc8efae56eb_RXN0-1147_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_a64f02ef-3308-41e9-bc0c-d47d61961f54_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1266,7 +1260,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7716> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/49d8e007-4e85-4dc8-9703-4cc8efae56eb_RXN0-1147>
+          <http://model.geneontology.org/a64f02ef-3308-41e9-bc0c-d47d61961f54_RXN0-1147>
 ] .
 
 <http://model.geneontology.org/CHEBI_16810_2OXOGLUTDECARB-RXN>
@@ -1278,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1289,29 +1283,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000001876>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_CHEBI_57287_RXN0-1147_SGD_YeastPathways_PWY-5084>
+<http://model.geneontology.org/ev_w_id_RXN0-1147_BFO_0000066_reaction_RXN0-1147_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5084>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
+                "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001876>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002333_YFL018C-MONOMER_RXN-7716_controller_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002333_YFL018C-MONOMER_RXN-7716_controller_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1329,11 +1323,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_CHEBI_16810_2OXOGLUTDECARB-RXN_SGD_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_CHEBI_16810_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1344,13 +1338,19 @@
           <http://model.geneontology.org/CHEBI_16810_2OXOGLUTDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1147_BFO_0000050_YeastPathways_PWY-5084/YeastPathways_PWY-5084_SGD_YeastPathways_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/27a72130-d12c-4aaa-b7f2-7d49395770ac_RXN-7716>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16973> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .

--- a/models/YeastPathways_PWY-5123.ttl
+++ b/models/YeastPathways_PWY-5123.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -48,23 +48,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_YeastPathways_PWY-5123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_IPPISOM-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -75,7 +64,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -92,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -100,26 +89,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_YeastPathways_PWY-5123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'dimethylallyl diphosphate + isopentenyl diphosphate &rarr; geranyl diphosphate + diphosphate' 'null' 'geranyl diphosphate + isopentenyl diphosphate &rarr; (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,14 +108,14 @@
           <http://model.geneontology.org/FPPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_GPPSYN-RXN_SGD_YeastPathways_PWY-5123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY-5123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
+                "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -145,11 +123,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,28 +147,6 @@
 <http://identifiers.org/sgd/S000006038>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_YeastPathways_PWY-5123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5123>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_128769_GPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_128769> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -200,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -208,29 +164,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_YeastPathways_PWY-5123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY-5123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_GPPSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000050_YeastPathways_PWY-5123/YeastPathways_PWY-5123_SGD_PWY_YeastPathways_PWY-5123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY-5123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -238,11 +216,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -253,15 +231,26 @@
           <http://model.geneontology.org/YJL167W-MONOMER_GPPSYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-5123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -279,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -307,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -318,6 +307,17 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_IPPISOM-RXN_SGD_PWY_YeastPathways_PWY-5123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57623_IPPISOM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57623> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -342,11 +342,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" , "Provides Input For Rule. The relation 'isopentenyl diphosphate &harr; dimethylallyl diphosphate' 'null' 'dimethylallyl diphosphate + isopentenyl diphosphate &rarr; geranyl diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002413_GPPSYN-RXN_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002413_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,14 +357,25 @@
           <http://model.geneontology.org/GPPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002413_GPPSYN-RXN_SGD_YeastPathways_PWY-5123>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY-5123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
+                "SGD_PWY:PWY-5123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -372,11 +383,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002234_CHEBI_57623_IPPISOM-RXN_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002234_CHEBI_57623_IPPISOM-RXN_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -394,11 +405,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,6 +420,17 @@
           <http://model.geneontology.org/reaction_GPPSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002413_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY-5123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58057_GPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58057> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -418,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -435,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -450,11 +472,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -465,26 +487,15 @@
           <http://model.geneontology.org/CHEBI_58057_GPPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002333_YPL117C-MONOMER_IPPISOM-RXN_controller_SGD_YeastPathways_PWY-5123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -508,11 +519,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002333_YPL117C-MONOMER_IPPISOM-RXN_controller_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002333_YPL117C-MONOMER_IPPISOM-RXN_controller_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,30 +534,30 @@
           <http://model.geneontology.org/YPL117C-MONOMER_IPPISOM-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_YeastPathways_PWY-5123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002233_CHEBI_128769_IPPISOM-RXN_SGD_PWY_YeastPathways_PWY-5123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
+                "SGD_PWY:PWY-5123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY-5123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_128769>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_PWY-5123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -555,11 +566,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002233_CHEBI_128769_IPPISOM-RXN_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002233_CHEBI_128769_IPPISOM-RXN_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,11 +585,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_PWY-5123/YeastPathways_PWY-5123_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_PWY-5123/YeastPathways_PWY-5123_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -598,7 +609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -611,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -619,11 +630,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -638,11 +649,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -668,41 +679,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002234_CHEBI_57623_IPPISOM-RXN_SGD_YeastPathways_PWY-5123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000050_YeastPathways_PWY-5123/YeastPathways_PWY-5123_SGD_YeastPathways_PWY-5123>
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5123>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
+                "SGD_PWY:PWY-5123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY-5123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_YeastPathways_PWY-5123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY-5123>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "<i>trans, trans</i>-farnesyl diphosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -728,11 +728,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000066_reaction_IPPISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000066_reaction_IPPISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -747,11 +747,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,25 +768,14 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000066_reaction_IPPISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5123>
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000066_reaction_IPPISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5123>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_IPPISOM-RXN_SGD_YeastPathways_PWY-5123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
+                "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -794,11 +783,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_IPPISOM-RXN_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_IPPISOM-RXN_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,11 +802,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_PWY-5123/YeastPathways_PWY-5123_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_PWY-5123/YeastPathways_PWY-5123_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -828,25 +817,36 @@
           <http://model.geneontology.org/YeastPathways_PWY-5123/YeastPathways_PWY-5123>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_YeastPathways_PWY-5123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_175763>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_PWY-5123/YeastPathways_PWY-5123_SGD_PWY_YeastPathways_PWY-5123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
+                "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_175763>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0004161>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY-5123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_175763_FPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_175763> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -857,24 +857,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5123SmallMolecule57270> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002233_CHEBI_128769_IPPISOM-RXN_SGD_YeastPathways_PWY-5123>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -886,7 +875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -894,39 +883,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_PWY-5123/YeastPathways_PWY-5123_SGD_YeastPathways_PWY-5123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_PWY-5123>
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002234_CHEBI_57623_IPPISOM-RXN_SGD_PWY_YeastPathways_PWY-5123>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
+                "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -937,11 +904,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000050_YeastPathways_PWY-5123/YeastPathways_PWY-5123_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000050_YeastPathways_PWY-5123/YeastPathways_PWY-5123_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -952,15 +919,26 @@
           <http://model.geneontology.org/YeastPathways_PWY-5123/YeastPathways_PWY-5123>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002333_YPL117C-MONOMER_IPPISOM-RXN_controller_SGD_PWY_YeastPathways_PWY-5123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -971,15 +949,26 @@
           <http://model.geneontology.org/CHEBI_29888_FPPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY-5123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_GPPSYN-RXN_SGD_YeastPathways_PWY-5123> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY-5123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -992,6 +981,17 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-5123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004452>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1015,7 +1015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1023,19 +1023,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_PWY-5123/YeastPathways_PWY-5123_SGD_PWY_YeastPathways_PWY-5123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57623>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0045337>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_PWY-5123/YeastPathways_PWY-5123_SGD_YeastPathways_PWY-5123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-5177.ttl
+++ b/models/YeastPathways_PWY-5177.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,6 +20,17 @@
 
 <http://purl.obolibrary.org/obo/GO_0003985>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACETYL-COA-ACETYLTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -38,7 +49,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -55,7 +66,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -63,26 +74,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-11667_RO_0002234_CHEBI_57316_RXN-11667_SGD_YeastPathways_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11667_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11667_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -96,26 +96,15 @@
 <http://purl.obolibrary.org/obo/GO_0003857>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_YeastPathways_PWY-5177>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_BFO_0000066_reaction_GLUTARYL-COA-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_BFO_0000066_reaction_GLUTARYL-COA-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -126,15 +115,26 @@
           <http://model.geneontology.org/reaction_GLUTARYL-COA-DEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_BFO_0000066_reaction_GLUTACONYL-COA-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,16 +145,8 @@
           <http://model.geneontology.org/CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11667_BFO_0000066_reaction_RXN-11667_location_lociGO_0005829_SGD_YeastPathways_PWY-5177>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57316_RXN-11667>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57316> ;
@@ -165,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -177,11 +169,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002234_CHEBI_57945_RXN-11662_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002234_CHEBI_57945_RXN-11662_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -192,11 +184,19 @@
           <http://model.geneontology.org/CHEBI_57945_RXN-11662>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GLUTACONYL-COA-DECARBOXYLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
@@ -215,7 +215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -223,25 +223,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002233_CHEBI_57353_GLUTARYL-COA-DEHYDROG-RXN_SGD_YeastPathways_PWY-5177>
+<http://model.geneontology.org/ev_w_id_RXN-11667_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_PWY_YeastPathways_PWY-5177>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57286_RXN-11662_SGD_YeastPathways_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
+                "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -249,11 +238,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11662_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11662_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -273,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -281,15 +270,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002233_CHEBI_15378_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>S</i>)-3-hydroxybutanoyl-CoA &larr; crotonyl-CoA + H<sub>2</sub>O' 'null' '(<i>S</i>)-3-hydroxybutanoyl-CoA + NAD<sup>+</sup> &harr; acetoacetyl-CoA + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11667_RO_0002413_RXN-11662_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11667_RO_0002413_RXN-11662_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -305,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -315,63 +326,35 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002413_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_GLUTACONYL-COA-DECARBOXYLASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_BFO_0000066_reaction_GLUTACONYL-COA-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5177>
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY-5177>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
+                "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_16526_GLUTACONYL-COA-DECARBOXYLASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "CO<SUB>2</SUB>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5177SmallMolecule43711> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,15 +365,43 @@
           <http://model.geneontology.org/YeastPathways_PWY-5177/YeastPathways_PWY-5177>
 ] .
 
+<http://model.geneontology.org/CHEBI_16526_GLUTACONYL-COA-DECARBOXYLASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "CO<SUB>2</SUB>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5177SmallMolecule43711> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11667_RO_0002234_CHEBI_57316_RXN-11667_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -401,26 +412,15 @@
           <http://model.geneontology.org/CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002233_CHEBI_15378_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002234_CHEBI_57286_RXN-11662_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002234_CHEBI_57286_RXN-11662_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,28 +431,17 @@
           <http://model.geneontology.org/CHEBI_57286_RXN-11662>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002234_ETF-Reduced_GLUTARYL-COA-DEHYDROG-RXN_SGD_YeastPathways_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
+                "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -465,14 +454,25 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-11667_RO_0002233_CHEBI_57332_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-5177>
+<http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002233_CHEBI_57540_RXN-11662_SGD_PWY_YeastPathways_PWY-5177>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11667_RO_0002233_CHEBI_15377_RXN-11667_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -485,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -500,11 +500,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" , "Provides Input For Rule. The relation 'glutaryl-CoA + an oxidized electron-transfer flavoprotein + H<SUP>+</SUP> &harr; (<i>E</i>)-glutaconyl-CoA + a reduced electron-transfer flavoprotein' 'null' '(<i>E</i>)-glutaconyl-CoA + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + crotonyl-CoA' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002413_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002413_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,15 +515,37 @@
           <http://model.geneontology.org/GLUTACONYL-COA-DECARBOXYLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002233_CHEBI_57353_GLUTARYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11667_RO_0002234_CHEBI_57316_RXN-11667_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11667_RO_0002234_CHEBI_57316_RXN-11667_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -543,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -551,28 +573,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_15378_GLUTARYL-COA-DEHYDROG-RXN_SGD_YeastPathways_PWY-5177>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57286_RXN-11662>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57286> ;
@@ -583,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -591,15 +593,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002234_CHEBI_57353_GLUTARYL-COA-DEHYDROG-RXN_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002234_CHEBI_57353_GLUTARYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -619,7 +630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -627,26 +638,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002413_RXN-11667_SGD_YeastPathways_PWY-5177>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002233_CHEBI_15378_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002233_CHEBI_15378_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -657,17 +657,6 @@
           <http://model.geneontology.org/CHEBI_15378_GLUTACONYL-COA-DECARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_57378_GLUTARYL-COA-DEHYDROG-RXN_SGD_YeastPathways_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -675,11 +664,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" , "Provides Input For Rule. The relation '(<i>E</i>)-glutaconyl-CoA + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + crotonyl-CoA' 'null' '(<i>S</i>)-3-hydroxybutanoyl-CoA &larr; crotonyl-CoA + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002413_RXN-11667_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002413_RXN-11667_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -694,11 +683,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57286_RXN-11662_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57286_RXN-11662_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,11 +702,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002234_CHEBI_15378_RXN-11662_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002234_CHEBI_15378_RXN-11662_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -740,24 +729,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5177SmallMolecule43696> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002333_YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY-5177>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57332_GLUTACONYL-COA-DECARBOXYLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57332> ;
@@ -768,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -779,26 +757,15 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY-5177>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002234_ETF-Reduced_GLUTARYL-COA-DEHYDROG-RXN_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002234_ETF-Reduced_GLUTARYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -809,40 +776,32 @@
           <http://model.geneontology.org/ETF-Reduced_GLUTARYL-COA-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002234_CHEBI_57286_RXN-11662_SGD_YeastPathways_PWY-5177>
+<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002233_ETF-Reduced_GLUTARYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5177>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
+                "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0046395>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-5177>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57288>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11667_RO_0002233_CHEBI_57332_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11667_RO_0002233_CHEBI_57332_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -853,8 +812,27 @@
           <http://model.geneontology.org/CHEBI_57332_GLUTACONYL-COA-DECARBOXYLASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57288>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002234_CHEBI_57353_GLUTARYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11667_RO_0002233_CHEBI_57332_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -867,7 +845,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11662_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -875,11 +864,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002233_ETF-Reduced_GLUTARYL-COA-DEHYDROG-RXN_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002233_ETF-Reduced_GLUTARYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -890,15 +879,26 @@
           <http://model.geneontology.org/ETF-Reduced_GLUTARYL-COA-DEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002413_RXN-11667_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_BFO_0000066_reaction_GLUTACONYL-COA-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_BFO_0000066_reaction_GLUTACONYL-COA-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -918,7 +918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -935,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -943,15 +943,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002234_CHEBI_57286_RXN-11662_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002234_CHEBI_57332_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002234_CHEBI_57332_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -962,40 +973,37 @@
           <http://model.geneontology.org/CHEBI_57332_GLUTACONYL-COA-DECARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002234_CHEBI_57945_RXN-11662_SGD_YeastPathways_PWY-5177>
+<http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5177>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
+                "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002233_ETF-Reduced_GLUTARYL-COA-DEHYDROG-RXN_SGD_YeastPathways_PWY-5177>
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57286_RXN-11662_SGD_PWY_YeastPathways_PWY-5177>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
+                "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57945>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1006,15 +1014,18 @@
           <http://model.geneontology.org/reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_57945>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002233_CHEBI_57540_RXN-11662_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002233_CHEBI_57540_RXN-11662_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1025,53 +1036,42 @@
           <http://model.geneontology.org/CHEBI_57540_RXN-11662>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002413_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_GLUTARYL-COA-DEHYDROG-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_YeastPathways_PWY-5177>
+<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_15378_GLUTARYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5177>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002234_CHEBI_57332_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_YeastPathways_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ETF-Reduced_GLUTARYL-COA-DEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1082,7 +1082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1094,11 +1094,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11667_RO_0002233_CHEBI_15377_RXN-11667_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11667_RO_0002233_CHEBI_15377_RXN-11667_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1109,30 +1109,19 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-11667>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002234_CHEBI_15378_RXN-11662_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_BFO_0000066_reaction_GLUTARYL-COA-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002233_CHEBI_57540_RXN-11662_SGD_YeastPathways_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1141,11 +1130,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_57378_GLUTARYL-COA-DEHYDROG-RXN_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_57378_GLUTARYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1156,21 +1145,21 @@
           <http://model.geneontology.org/CHEBI_57378_GLUTARYL-COA-DEHYDROG-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57353>
+<http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
+<http://purl.obolibrary.org/obo/CHEBI_57353>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1184,27 +1173,19 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002333_YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
+                "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002233_CHEBI_57316_RXN-11667_SGD_YeastPathways_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_33695>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YeastPathways_PWY-5177>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -1215,7 +1196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutaryl-CoA degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1223,17 +1204,14 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-11667_RO_0002233_CHEBI_15377_RXN-11667_SGD_YeastPathways_PWY-5177>
+<http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002233_CHEBI_57316_RXN-11667_SGD_PWY_YeastPathways_PWY-5177>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
+                "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1244,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1256,11 +1234,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1280,7 +1258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1292,11 +1270,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1307,15 +1285,37 @@
           <http://model.geneontology.org/YeastPathways_PWY-5177/YeastPathways_PWY-5177>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-11667_BFO_0000066_reaction_RXN-11667_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002234_CHEBI_57945_RXN-11662_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002233_CHEBI_57316_RXN-11667_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002233_CHEBI_57316_RXN-11667_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1329,22 +1329,22 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_BFO_0000066_reaction_GLUTARYL-COA-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57332>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002234_CHEBI_57353_GLUTARYL-COA-DEHYDROG-RXN_SGD_YeastPathways_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-11662>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003857> ;
@@ -1363,7 +1363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1378,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1386,51 +1386,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-11662_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_YeastPathways_PWY-5177>
+<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_57378_GLUTARYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5177>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
+                "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-11667_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_YeastPathways_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002413_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
+                "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002234_CHEBI_57332_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11667_BFO_0000066_reaction_RXN-11667_location_lociGO_0005829_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11667_BFO_0000066_reaction_RXN-11667_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1446,17 +1435,6 @@
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-11667_RO_0002413_RXN-11662_SGD_YeastPathways_PWY-5177>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GLUTARYL-COA-DEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
@@ -1475,7 +1453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1487,11 +1465,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_15378_GLUTARYL-COA-DEHYDROG-RXN_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_15378_GLUTARYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1502,14 +1480,14 @@
           <http://model.geneontology.org/CHEBI_15378_GLUTARYL-COA-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002234_CHEBI_15378_RXN-11662_SGD_YeastPathways_PWY-5177>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002413_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
+                "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1517,11 +1495,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002333_YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002333_YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1532,15 +1510,37 @@
           <http://model.geneontology.org/YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002234_ETF-Reduced_GLUTARYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11667_RO_0002413_RXN-11662_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" , "Provides Input For Rule. The relation '(<i>S</i>)-3-hydroxybutanoyl-CoA + NAD<sup>+</sup> &harr; acetoacetyl-CoA + NADH + H<SUP>+</SUP>' 'null' '2 acetyl-CoA &harr; acetoacetyl-CoA + coenzyme A' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002413_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002413_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1554,21 +1554,21 @@
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://purl.obolibrary.org/obo/CHEBI_57378>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002233_CHEBI_57353_GLUTARYL-COA-DEHYDROG-RXN_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002233_CHEBI_57353_GLUTARYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1578,17 +1578,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57353_GLUTARYL-COA-DEHYDROG-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-11662_BFO_0000066_reaction_RXN-11662_location_lociGO_0005829_SGD_YeastPathways_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-11667>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1607,7 +1596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1615,15 +1604,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_RXN-11662_BFO_0000066_reaction_RXN-11662_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11662_BFO_0000066_reaction_RXN-11662_location_lociGO_0005829_SGD_YeastPathways_PWY-5177> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11662_BFO_0000066_reaction_RXN-11662_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY-5194-1.ttl
+++ b/models/YeastPathways_PWY-5194-1.ttl
@@ -1,28 +1,28 @@
 <http://purl.obolibrary.org/obo/GO_0004851>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_15378_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY-5194-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57856>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_15378_RXN-13403_SGD_YeastPathways_PWY-5194-1>
+<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002233_CHEBI_57308_RXN-13403_SGD_PWY_YeastPathways_PWY-5194-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
+                "SGD_PWY:PWY-5194-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_57945_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5194-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "siroheme biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -47,11 +47,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_57856_RXN-13403_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_57856_RXN-13403_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -66,11 +66,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_15378_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_15378_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -81,6 +81,17 @@
           <http://model.geneontology.org/CHEBI_15378_DIMETHUROPORDEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002233_CHEBI_59789_RXN-13403_SGD_PWY_YeastPathways_PWY-5194-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5194-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -89,17 +100,6 @@
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002333_MONOMER3O-47_RXN-13403_controller_SGD_YeastPathways_PWY-5194-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57308>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -128,7 +128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -136,15 +136,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002234_CHEBI_60052_SIROHEME-FERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY-5194-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5194-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002233_CHEBI_58351_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002233_CHEBI_58351_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -164,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -186,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -209,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,15 +228,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002233_CHEBI_58827_RXN-13403_SGD_PWY_YeastPathways_PWY-5194-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5194-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_15378_RXN-13403_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_15378_RXN-13403_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -240,11 +262,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002233_CHEBI_58827_RXN-13403_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002233_CHEBI_58827_RXN-13403_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -278,25 +300,14 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-13403_BFO_0000066_reaction_RXN-13403_location_lociGO_0005829_SGD_YeastPathways_PWY-5194-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002413_SIROHEME-FERROCHELAT-RXN_SGD_YeastPathways_PWY-5194-1>
+<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002413_SIROHEME-FERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY-5194-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
+                "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -307,11 +318,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002233_CHEBI_29033_SIROHEME-FERROCHELAT-RXN_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002233_CHEBI_29033_SIROHEME-FERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -322,36 +333,36 @@
           <http://model.geneontology.org/CHEBI_29033_SIROHEME-FERROCHELAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002333_MONOMER3O-106_SIROHEME-FERROCHELAT-RXN_controller_SGD_YeastPathways_PWY-5194-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-13403_BFO_0000050_YeastPathways_PWY-5194-1/YeastPathways_PWY-5194-1_SGD_YeastPathways_PWY-5194-1>
+<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002233_CHEBI_58351_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5194-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
+                "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-5194-1/YeastPathways_PWY-5194-1_SGD_YeastPathways_PWY-5194-1>
+<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002333_MONOMER3O-106_DIMETHUROPORDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY-5194-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
+                "SGD_PWY:PWY-5194-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-13403_BFO_0000050_YeastPathways_PWY-5194-1/YeastPathways_PWY-5194-1_SGD_PWY_YeastPathways_PWY-5194-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -362,11 +373,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_BFO_0000050_YeastPathways_PWY-5194-1/YeastPathways_PWY-5194-1_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_BFO_0000050_YeastPathways_PWY-5194-1/YeastPathways_PWY-5194-1_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,11 +395,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" , "Provides Input For Rule. The relation 'precorrin-2 + NAD<sup>+</sup> &rarr; sirohydrochlorin + NADH + 2 H<SUP>+</SUP>' 'null' 'sirohydrochlorin + Fe<SUP>2+</SUP> &rarr; siroheme + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002413_SIROHEME-FERROCHELAT-RXN_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002413_SIROHEME-FERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -408,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -423,11 +434,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002233_CHEBI_59789_RXN-13403_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002233_CHEBI_59789_RXN-13403_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -442,11 +453,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002233_CHEBI_57540_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002233_CHEBI_57540_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -457,54 +468,54 @@
           <http://model.geneontology.org/CHEBI_57540_DIMETHUROPORDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_BFO_0000066_reaction_SIROHEME-FERROCHELAT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5194-1>
+<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-5194-1/YeastPathways_PWY-5194-1_SGD_PWY_YeastPathways_PWY-5194-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
+                "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_BFO_0000050_YeastPathways_PWY-5194-1/YeastPathways_PWY-5194-1_SGD_YeastPathways_PWY-5194-1>
+<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_57856_RXN-13403_SGD_PWY_YeastPathways_PWY-5194-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5194-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002233_CHEBI_29033_SIROHEME-FERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY-5194-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
+                "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_BFO_0000066_reaction_DIMETHUROPORDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5194-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_BFO_0000066_reaction_SIROHEME-FERROCHELAT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_BFO_0000066_reaction_SIROHEME-FERROCHELAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,44 +526,16 @@
           <http://model.geneontology.org/reaction_SIROHEME-FERROCHELAT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002413_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY-5194-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002234_CHEBI_15378_SIROHEME-FERROCHELAT-RXN_SGD_YeastPathways_PWY-5194-1>
+<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002234_CHEBI_15378_SIROHEME-FERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY-5194-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
+                "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_29033_SIROHEME-FERROCHELAT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29033> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Fe<SUP>2+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5194-1SmallMolecule41759> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/SIROHEME-FERROCHELAT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0051266> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -571,13 +554,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5194-1BiochemicalReaction41736> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/CHEBI_29033_SIROHEME-FERROCHELAT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29033> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Fe<SUP>2+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5194-1SmallMolecule41759> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29033>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -592,11 +592,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 <i>S</i>-adenosyl-L-methionine + uroporphyrinogen-III &rarr; 2 <i>S</i>-adenosyl-L-homocysteine + precorrin-2 + H<SUP>+</SUP>' 'null' 'precorrin-2 + NAD<sup>+</sup> &rarr; sirohydrochlorin + NADH + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002413_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002413_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -611,11 +611,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002333_MONOMER3O-106_DIMETHUROPORDEHYDROG-RXN_controller_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002333_MONOMER3O-106_DIMETHUROPORDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -635,7 +635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -643,14 +643,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002233_CHEBI_59789_RXN-13403_SGD_YeastPathways_PWY-5194-1>
+<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_BFO_0000066_reaction_SIROHEME-FERROCHELAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5194-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
+                "SGD_PWY:PWY-5194-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002333_MONOMER3O-47_RXN-13403_controller_SGD_PWY_YeastPathways_PWY-5194-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5194-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_58827_RXN-13403_SGD_PWY_YeastPathways_PWY-5194-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -658,11 +680,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002233_CHEBI_57308_RXN-13403_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002233_CHEBI_57308_RXN-13403_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -673,18 +695,15 @@
           <http://model.geneontology.org/CHEBI_57308_RXN-13403>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57945>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_BFO_0000066_reaction_DIMETHUROPORDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_BFO_0000066_reaction_DIMETHUROPORDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -698,24 +717,18 @@
 <http://purl.obolibrary.org/obo/CHEBI_60052>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/reaction_DIMETHUROPORDEHYDROG-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57945>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002333_MONOMER3O-106_SIROHEME-FERROCHELAT-RXN_controller_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002333_MONOMER3O-106_SIROHEME-FERROCHELAT-RXN_controller_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -726,19 +739,50 @@
           <http://model.geneontology.org/MONOMER3O-106_SIROHEME-FERROCHELAT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002333_MONOMER3O-106_DIMETHUROPORDEHYDROG-RXN_controller_SGD_YeastPathways_PWY-5194-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/reaction_DIMETHUROPORDEHYDROG-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002413_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5194-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
+                "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_BFO_0000050_YeastPathways_PWY-5194-1/YeastPathways_PWY-5194-1_SGD_PWY_YeastPathways_PWY-5194-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5194-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_58351_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5194-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5194-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-47_RXN-13403_controller>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -747,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -767,7 +811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -775,14 +819,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_57945_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY-5194-1>
+<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_15378_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5194-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
+                "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -795,7 +839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -806,37 +850,15 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_58827_RXN-13403_SGD_YeastPathways_PWY-5194-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002233_CHEBI_29033_SIROHEME-FERROCHELAT-RXN_SGD_YeastPathways_PWY-5194-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002333_MONOMER3O-47_RXN-13403_controller_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002333_MONOMER3O-47_RXN-13403_controller_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,15 +869,29 @@
           <http://model.geneontology.org/MONOMER3O-47_RXN-13403_controller>
 ] .
 
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_15378_RXN-13403_SGD_PWY_YeastPathways_PWY-5194-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5194-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_58351_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_58351_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -866,20 +902,28 @@
           <http://model.geneontology.org/CHEBI_58351_DIMETHUROPORDEHYDROG-RXN>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002233_CHEBI_57540_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5194-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5194-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_58351_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY-5194-1>
+<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_BFO_0000066_reaction_DIMETHUROPORDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5194-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
+                "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -890,11 +934,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13403_BFO_0000066_reaction_RXN-13403_location_lociGO_0005829_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13403_BFO_0000066_reaction_RXN-13403_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -909,11 +953,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-5194-1/YeastPathways_PWY-5194-1_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-5194-1/YeastPathways_PWY-5194-1_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -924,15 +968,26 @@
           <http://model.geneontology.org/YeastPathways_PWY-5194-1/YeastPathways_PWY-5194-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-13403_BFO_0000066_reaction_RXN-13403_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5194-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5194-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002234_CHEBI_60052_SIROHEME-FERROCHELAT-RXN_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002234_CHEBI_60052_SIROHEME-FERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -951,18 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002233_CHEBI_57308_RXN-13403_SGD_YeastPathways_PWY-5194-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -975,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -992,7 +1036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1003,17 +1047,6 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002234_CHEBI_60052_SIROHEME-FERROCHELAT-RXN_SGD_YeastPathways_PWY-5194-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_DIMETHUROPORDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1023,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1041,11 +1074,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_58827_RXN-13403_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_58827_RXN-13403_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1056,26 +1089,15 @@
           <http://model.geneontology.org/CHEBI_58827_RXN-13403>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_57856_RXN-13403_SGD_YeastPathways_PWY-5194-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_57945_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_57945_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1105,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1123,11 +1145,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13403_BFO_0000050_YeastPathways_PWY-5194-1/YeastPathways_PWY-5194-1_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13403_BFO_0000050_YeastPathways_PWY-5194-1/YeastPathways_PWY-5194-1_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1147,16 +1169,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5194-1SmallMolecule41725> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58351>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58827_RXN-13403>
         a       <http://purl.obolibrary.org/obo/CHEBI_58827> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1167,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1182,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1190,26 +1209,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002233_CHEBI_58827_RXN-13403_SGD_YeastPathways_PWY-5194-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_58351>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002234_CHEBI_15378_SIROHEME-FERROCHELAT-RXN_SGD_YeastPathways_PWY-5194-1> ;
+          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002234_CHEBI_15378_SIROHEME-FERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY-5194-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1220,24 +1231,13 @@
           <http://model.geneontology.org/CHEBI_15378_SIROHEME-FERROCHELAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002233_CHEBI_58351_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY-5194-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002233_CHEBI_57540_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY-5194-1>
+<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002333_MONOMER3O-106_SIROHEME-FERROCHELAT-RXN_controller_SGD_PWY_YeastPathways_PWY-5194-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5194-1" ;
+                "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-5340.ttl
+++ b/models/YeastPathways_PWY-5340.ttl
@@ -1,3 +1,14 @@
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-5340>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5340" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_ADENYLYLSULFKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7,24 +18,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5340SmallMolecule20622> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-5340>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5340" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0050427>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -33,11 +33,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-5340> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-5340> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -48,17 +48,6 @@
           <http://model.geneontology.org/CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_30616_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-5340>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5340" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -68,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -80,11 +69,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_15378_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-5340> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_15378_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-5340> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -116,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -133,24 +122,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5340SmallMolecule20580> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-5340>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5340" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001484> ;
@@ -159,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -176,7 +154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -194,13 +172,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY-5340" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-5340>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5340" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -209,11 +198,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-5340> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-5340> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -224,37 +213,15 @@
           <http://model.geneontology.org/CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_YeastPathways_PWY-5340/YeastPathways_PWY-5340_SGD_YeastPathways_PWY-5340>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5340" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-5340>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5340" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-5340> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-5340> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "sulfate activation (for sulfonation) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -288,14 +255,14 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-5340>
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-5340>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5340" ;
+                "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -316,7 +283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -336,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,40 +311,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_15378_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-5340>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5340" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000066_reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5340>
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-5340>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5340" ;
+                "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_YeastPathways_PWY-5340/YeastPathways_PWY-5340_SGD_PWY_YeastPathways_PWY-5340>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5340" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_YeastPathways_PWY-5340/YeastPathways_PWY-5340_SGD_YeastPathways_PWY-5340> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_YeastPathways_PWY-5340/YeastPathways_PWY-5340_SGD_PWY_YeastPathways_PWY-5340> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -388,6 +355,17 @@
           <http://model.geneontology.org/YeastPathways_PWY-5340/YeastPathways_PWY-5340>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-5340>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5340" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -395,11 +373,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-5340> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-5340> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -417,11 +395,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_30616_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-5340> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_30616_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-5340> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -447,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -463,23 +441,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002333_YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-5340>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_YeastPathways_PWY-5340>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5340" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58339_ADENYLYLSULFKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58339> ;
@@ -490,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -505,11 +483,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002333_YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller_SGD_YeastPathways_PWY-5340> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002333_YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-5340> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -520,25 +498,36 @@
           <http://model.geneontology.org/YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5340>
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5340>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5340" ;
+                "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-5340>
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_30616_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-5340>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5340" ;
+                "SGD_PWY:PWY-5340" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_15378_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-5340>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -547,7 +536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -555,11 +544,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-5340> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-5340> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,11 +563,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000066_reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5340> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000066_reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5340> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -588,6 +577,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_456216_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-5340>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5340" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004781> ;
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -619,55 +619,11 @@
 <http://identifiers.org/sgd/S000003771>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_456216_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-5340>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5340" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004781>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-5340>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5340" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002333_YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller_SGD_YeastPathways_PWY-5340>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5340" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-5340>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5340" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -676,11 +632,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'sulfate + ATP + H<SUP>+</SUP> &harr; adenosine 5'-phosphosulfate + diphosphate' 'null' 'adenosine 5'-phosphosulfate + ATP &harr; 3'-phosphoadenylyl-sulfate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-5340> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-5340> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -695,11 +651,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-5340> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-5340> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -720,11 +676,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-5340> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-5340> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -735,26 +691,15 @@
           <http://model.geneontology.org/CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-5340>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5340" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_YeastPathways_PWY-5340/YeastPathways_PWY-5340_SGD_YeastPathways_PWY-5340> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_YeastPathways_PWY-5340/YeastPathways_PWY-5340_SGD_PWY_YeastPathways_PWY-5340> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -774,11 +719,33 @@
 <http://purl.obolibrary.org/obo/GO_0004020>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-5340>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5340" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000066_reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5340>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5340" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -790,7 +757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -798,15 +765,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-5340>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5340" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_YeastPathways_PWY-5340> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-5340> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -821,11 +799,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_456216_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-5340> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_456216_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-5340> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -836,17 +814,6 @@
           <http://model.geneontology.org/CHEBI_456216_ADENYLYLSULFKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_YeastPathways_PWY-5340/YeastPathways_PWY-5340_SGD_YeastPathways_PWY-5340>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5340" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -856,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -864,15 +831,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_YeastPathways_PWY-5340/YeastPathways_PWY-5340_SGD_PWY_YeastPathways_PWY-5340>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5340" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5340> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5340> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -886,5 +864,27 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-5340>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5340" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000001484>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-5340>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5340" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-5344.ttl
+++ b/models/YeastPathways_PWY-5344.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13,61 +13,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-5344>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5344" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY-5344>
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_15378_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-5344>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5344" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5344>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5344" ;
+                "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30089>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-5344>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY-5344/YeastPathways_PWY-5344_SGD_PWY_YeastPathways_PWY-5344>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5344" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57476_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-5344>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5344" ;
+                "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -75,11 +42,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY-5344> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5344> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -94,11 +61,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_15378_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-5344> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_15378_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-5344> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -112,28 +79,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-5344>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-5344>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5344" ;
+                "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-5344>
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000050_YeastPathways_PWY-5344/YeastPathways_PWY-5344_SGD_PWY_YeastPathways_PWY-5344>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5344" ;
+                "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -150,24 +117,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5344Protein31931> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000066_reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5344>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5344" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16136>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -176,11 +132,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-5344> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-5344> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -191,15 +147,26 @@
           <http://model.geneontology.org/CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57476_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-5344>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5344" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-5344> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-5344> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -216,17 +183,6 @@
 <http://identifiers.org/sgd/S000004294>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-5344>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5344" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -242,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -260,11 +216,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY-5344/YeastPathways_PWY-5344_SGD_YeastPathways_PWY-5344> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY-5344/YeastPathways_PWY-5344_SGD_PWY_YeastPathways_PWY-5344> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -275,12 +231,23 @@
           <http://model.geneontology.org/YeastPathways_PWY-5344/YeastPathways_PWY-5344>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-5344>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5344" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -293,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -304,29 +271,26 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000050_YeastPathways_PWY-5344/YeastPathways_PWY-5344_SGD_YeastPathways_PWY-5344>
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5344>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5344" ;
+                "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004414>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-5344> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-5344> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -356,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -364,26 +328,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_30089_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-5344>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5344" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004414>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-5344> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-5344> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -417,14 +373,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-5344>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-5344>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5344" ;
+                "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -437,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -451,26 +407,15 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_15378_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-5344>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5344" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002333_YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller_SGD_YeastPathways_PWY-5344> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002333_YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller_SGD_PWY_YeastPathways_PWY-5344> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -490,13 +435,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-homocysteine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-5344>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5344" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY-5344/YeastPathways_PWY-5344>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0071269> ;
@@ -505,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -517,11 +473,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57476_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-5344> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57476_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-5344> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -532,26 +488,15 @@
           <http://model.geneontology.org/CHEBI_57476_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002333_YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller_SGD_YeastPathways_PWY-5344>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5344" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000066_reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5344> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000066_reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5344> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -565,6 +510,28 @@
 <http://purl.obolibrary.org/obo/GO_0003961>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-5344>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5344" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-5344>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5344" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -577,7 +544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -591,15 +558,26 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002333_YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller_SGD_PWY_YeastPathways_PWY-5344>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5344" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-5344> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-5344> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -625,7 +603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -653,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -665,11 +643,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-5344> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-5344> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -680,15 +658,26 @@
           <http://model.geneontology.org/CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-5344>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5344" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000050_YeastPathways_PWY-5344/YeastPathways_PWY-5344_SGD_YeastPathways_PWY-5344> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000050_YeastPathways_PWY-5344/YeastPathways_PWY-5344_SGD_PWY_YeastPathways_PWY-5344> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,25 +688,14 @@
           <http://model.geneontology.org/YeastPathways_PWY-5344/YeastPathways_PWY-5344>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY-5344/YeastPathways_PWY-5344_SGD_YeastPathways_PWY-5344>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5344>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5344" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-5344>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5344" ;
+                "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -736,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -756,27 +734,38 @@
 <http://purl.obolibrary.org/obo/CHEBI_57716>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000066_reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5344>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5344" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" , "Provides Input For Rule. The relation 'L-homoserine + acetyl-CoA &rarr; <i>O</i>-acetyl-L-homoserine + coenzyme A' 'null' '<i>O</i>-acetyl-L-homoserine + hydrogen sulfide &rarr; L-homocysteine + acetate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-5344> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-5344> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,11 +780,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_30089_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-5344> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_30089_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-5344> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -827,11 +816,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5344> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5344> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -844,3 +833,14 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_30089_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-5344>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5344" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-5651.ttl
+++ b/models/YeastPathways_PWY-5651.ttl
@@ -5,11 +5,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,11 +24,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,28 +39,6 @@
           <http://model.geneontology.org/CHEBI_57959_ARYLFORMAMIDASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY-5651>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY-5651>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -70,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -87,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -104,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -112,32 +90,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY-5651>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -152,11 +119,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -167,6 +134,17 @@
           <http://model.geneontology.org/CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -176,7 +154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -193,6 +171,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YJR078W-MONOMER_RXN-8665_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003839> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -200,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -208,15 +197,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -227,15 +227,26 @@
           <http://model.geneontology.org/YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,6 +257,17 @@
           <http://model.geneontology.org/YeastPathways_PWY-5651/YeastPathways_PWY-5651>
 ] .
 
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58629_RXN-8665>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58629> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -255,24 +277,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5651SmallMolecule73990> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY-5651>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -281,11 +292,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -296,6 +307,17 @@
           <http://model.geneontology.org/reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000002836> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -303,46 +325,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5651Protein74172> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5651>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_YeastPathways_PWY-5651>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_YeastPathways_PWY-5651>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -364,24 +353,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5651BiochemicalReaction74001> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY-5651>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004502> ;
@@ -402,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -417,11 +395,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,7 +415,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -450,7 +439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -458,48 +447,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_YeastPathways_PWY-5651>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_SGD_YeastPathways_PWY-5651>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY-5651>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -517,11 +473,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -544,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -564,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-tryptophan degradation to 2-amino-3-carboxymuconate semialdehyde - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -575,39 +531,39 @@
 <http://purl.obolibrary.org/obo/CHEBI_36559>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_YeastPathways_PWY-5651>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY-5651>
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004061>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY-5651>
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_PWY_YeastPathways_PWY-5651>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -615,11 +571,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -640,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -652,11 +608,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,14 +623,25 @@
           <http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY-5651>
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_PWY_YeastPathways_PWY-5651>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -685,11 +652,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,15 +667,26 @@
           <http://model.geneontology.org/CHEBI_15378_1.13.11.6-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -719,30 +697,19 @@
           <http://model.geneontology.org/reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY-5651>
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_PWY_YeastPathways_PWY-5651>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_YeastPathways_PWY-5651>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58125>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -751,11 +718,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -765,6 +732,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0030429> ;
@@ -785,7 +763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -797,11 +775,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -821,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -834,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -847,13 +825,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5651SmallMolecule74027> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-8665>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0033754> ;
@@ -874,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -885,14 +874,14 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_YeastPathways_PWY-5651>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -900,11 +889,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" , "Provides Input For Rule. The relation 'L-tryptophan + oxygen &rarr; <i>N</i>-Formyl-L-kynurenine' 'null' '<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -915,6 +904,17 @@
           <http://model.geneontology.org/ARYLFORMAMIDASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57972> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -924,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -936,11 +936,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -951,53 +951,42 @@
           <http://model.geneontology.org/MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0000334>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_YeastPathways_PWY-5651>
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5651>
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_YeastPathways_PWY-5651>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0000334>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY-5651>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1005,11 +994,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1029,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1041,11 +1030,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1072,11 +1061,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>' 'null' '3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1091,11 +1080,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1106,25 +1095,25 @@
           <http://model.geneontology.org/reaction_RXN-8665_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5651>
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY-5651>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_RXN-8665_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1132,11 +1121,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1147,6 +1136,17 @@
           <http://model.geneontology.org/CHEBI_15377_ARYLFORMAMIDASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15740> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1156,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1167,31 +1167,42 @@
 <http://purl.obolibrary.org/obo/GO_0033754>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_58349>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY-5651>
+<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_PWY_YeastPathways_PWY-5651>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58349>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0030429>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_YeastPathways_PWY-5651>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1199,11 +1210,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1218,11 +1229,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" , "Provides Input For Rule. The relation '<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>' 'null' 'L-kynurenine + NADPH + oxygen + H<SUP>+</SUP> &rarr; 3-hydroxy-L-kynurenine + NADP<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1233,17 +1244,6 @@
           <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_YeastPathways_PWY-5651>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57912_RXN-8665>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57912> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1253,7 +1253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1261,15 +1261,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1280,15 +1302,26 @@
           <http://model.geneontology.org/CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1304,7 +1337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1317,13 +1350,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5651SmallMolecule74027> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36559> ;
@@ -1334,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1346,11 +1390,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1361,37 +1405,15 @@
           <http://model.geneontology.org/CHEBI_58629_RXN-8665>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_YeastPathways_PWY-5651>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY-5651>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1401,6 +1423,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1412,11 +1445,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1431,11 +1464,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1458,24 +1491,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5651SmallMolecule74141> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY-5651>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1499,7 +1521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1516,7 +1538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1528,11 +1550,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1550,11 +1572,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-kynurenine + NADPH + oxygen + H<SUP>+</SUP> &rarr; 3-hydroxy-L-kynurenine + NADP<sup>+</sup> + H<sub>2</sub>O' 'null' '3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1565,14 +1587,14 @@
           <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_RXN-8665_SGD_YeastPathways_PWY-5651>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1581,7 +1603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1589,11 +1611,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1611,7 +1633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1622,14 +1644,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_57972>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_YeastPathways_PWY-5651>
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5651>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1637,11 +1670,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1659,7 +1692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1671,11 +1704,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1689,14 +1722,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_57959>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_YeastPathways_PWY-5651>
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5651>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1704,11 +1748,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1719,15 +1763,18 @@
           <http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1738,8 +1785,16 @@
           <http://model.geneontology.org/CHEBI_57959_ARYLFORMAMIDASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_994> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1750,7 +1805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1761,6 +1816,17 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000000194>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1770,14 +1836,14 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY-5651>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1785,11 +1851,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1800,25 +1866,14 @@
           <http://model.geneontology.org/CHEBI_15379_RXN-8665>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_YeastPathways_PWY-5651>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_YeastPathways_PWY-5651>
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1826,11 +1881,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_RXN-8665_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_RXN-8665_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1853,7 +1908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1867,62 +1922,18 @@
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY-5651>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_YeastPathways_PWY-5651>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57912>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_SGD_YeastPathways_PWY-5651>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY-5651>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1937,11 +1948,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1952,6 +1963,17 @@
           <http://model.geneontology.org/YeastPathways_PWY-5651/YeastPathways_PWY-5651>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5651" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YJR025C-MONOMER_1.13.11.6-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003786> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1959,7 +1981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1967,25 +1989,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY-5651>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY-5651>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY-5651>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1996,7 +2007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2008,11 +2019,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2027,11 +2038,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY-5651> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2045,14 +2056,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_58629>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5651>
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5651>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
+                "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2065,7 +2076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2073,22 +2084,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_PWY-5651/YeastPathways_PWY-5651_SGD_YeastPathways_PWY-5651>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5651" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-5653.ttl
+++ b/models/YeastPathways_PWY-5653.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11,11 +11,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,15 +49,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,6 +82,17 @@
 <http://identifiers.org/sgd/S000003242>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16675>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -83,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -97,26 +119,15 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY-5653>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_RXN-5721_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_RXN-5721_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -131,11 +142,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -146,36 +157,25 @@
           <http://model.geneontology.org/reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY-5653>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY-5653>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5653>
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY-5653>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -188,7 +188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -202,17 +202,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_PWY-5653/YeastPathways_PWY-5653_SGD_YeastPathways_PWY-5653>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_QUINOPRIBOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -222,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,11 +223,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" , "Provides Input For Rule. The relation '&beta;-nicotinate D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; nicotinate adenine dinucleotide + diphosphate' 'null' 'ATP + nicotinate adenine dinucleotide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + AMP + NAD<sup>+</sup> + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -270,11 +259,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -288,6 +277,17 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -297,15 +297,26 @@
 <http://purl.obolibrary.org/obo/GO_0009435>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -333,51 +344,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16675_RXN-5721_SGD_YeastPathways_PWY-5653>
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_PWY-5653/YeastPathways_PWY-5653_SGD_PWY_YeastPathways_PWY-5653>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY-5653>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_YeastPathways_PWY-5653>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
+                "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_RXN-5721_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2-amino-3-carboxymuconate-6-semialdehyde &rarr; quinolinate + H<sub>2</sub>O' 'null' 'CO<SUB>2</SUB> + &beta;-nicotinate D-ribonucleotide + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + quinolinate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002413_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002413_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,11 +406,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -413,14 +424,25 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY-5653>
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5653>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -431,11 +453,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -446,29 +468,29 @@
           <http://model.geneontology.org/CHEBI_15378_QUINOPRIBOTRANS-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5653>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002413_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
+                "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -479,30 +501,19 @@
           <http://model.geneontology.org/CHEBI_58359_NAD-SYNTH-GLN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_PWY-5653>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY-5653>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -511,11 +522,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_YeastPathways_PWY-5653/YeastPathways_PWY-5653_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_YeastPathways_PWY-5653/YeastPathways_PWY-5653_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -535,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -547,11 +558,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -562,12 +573,23 @@
           <http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -584,11 +606,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -606,24 +628,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5653Protein70252> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY-5653>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003952>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -633,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -643,14 +654,36 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5653>
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_PWY-5653/YeastPathways_PWY-5653_SGD_PWY_YeastPathways_PWY-5653>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
+                "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -663,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -675,11 +708,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -690,15 +723,26 @@
           <http://model.geneontology.org/CHEBI_16526_QUINOPRIBOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_16675_RXN-5721_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -709,19 +753,19 @@
           <http://model.geneontology.org/CHEBI_29888_NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_PWY-5653>
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY-5653>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
+                "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/QUINOPRIBOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004514> ;
@@ -742,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -754,11 +798,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -773,11 +817,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -797,6 +841,17 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -809,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -827,11 +882,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_YeastPathways_PWY-5653/YeastPathways_PWY-5653_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_YeastPathways_PWY-5653/YeastPathways_PWY-5653_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -851,7 +906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -863,11 +918,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -881,14 +936,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY-5653>
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY-5653>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -899,7 +965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -910,37 +976,15 @@
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_16675_RXN-5721_SGD_YeastPathways_PWY-5653>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY-5653>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -951,15 +995,26 @@
           <http://model.geneontology.org/YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -970,25 +1025,14 @@
           <http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY-5653>
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY-5653>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002413_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY-5653>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
+                "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -996,11 +1040,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1020,7 +1064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1028,36 +1072,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY-5653>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY-5653>
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_YeastPathways_PWY-5653/YeastPathways_PWY-5653_SGD_PWY_YeastPathways_PWY-5653>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_PWY-5653/YeastPathways_PWY-5653_SGD_YeastPathways_PWY-5653>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
+                "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1065,11 +1087,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16675_RXN-5721_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16675_RXN-5721_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1087,7 +1109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1099,11 +1121,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1113,17 +1135,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58437_NICONUCADENYLYLTRAN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY-5653>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1137,24 +1148,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5653SmallMolecule70231> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_YeastPathways_PWY-5653>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456215> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1165,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1182,7 +1182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1194,11 +1194,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1218,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1230,11 +1230,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_PWY-5653/YeastPathways_PWY-5653_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_PWY-5653/YeastPathways_PWY-5653_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1262,7 +1262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1270,21 +1270,54 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_994>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1299,11 +1332,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_PWY-5653/YeastPathways_PWY-5653_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_PWY-5653/YeastPathways_PWY-5653_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1314,25 +1347,36 @@
           <http://model.geneontology.org/YeastPathways_PWY-5653/YeastPathways_PWY-5653>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY-5653>
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-5653>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
+                "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_YeastPathways_PWY-5653/YeastPathways_PWY-5653_SGD_YeastPathways_PWY-5653>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_YeastPathways_PWY-5653/YeastPathways_PWY-5653_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16675_RXN-5721_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1345,7 +1389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1360,7 +1404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1368,15 +1412,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1404,7 +1459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1416,11 +1471,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1430,28 +1485,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_29985_NAD-SYNTH-GLN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_YeastPathways_PWY-5653>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY-5653>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001116>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1475,7 +1508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1483,25 +1516,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY-5653>
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_PWY_YeastPathways_PWY-5653>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY-5653>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
+                "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1512,7 +1534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1524,11 +1546,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_16675_RXN-5721_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_16675_RXN-5721_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1543,11 +1565,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1561,30 +1583,19 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY-5653>
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5653>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
+                "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY-5653>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004515>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1598,7 +1609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1613,11 +1624,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1637,7 +1648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1649,11 +1660,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1669,40 +1680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY-5653>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY-5653>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_YeastPathways_PWY-5653/YeastPathways_PWY-5653_SGD_YeastPathways_PWY-5653>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1710,11 +1688,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'CO<SUB>2</SUB> + &beta;-nicotinate D-ribonucleotide + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + quinolinate + 2 H<SUP>+</SUP>' 'null' '&beta;-nicotinate D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; nicotinate adenine dinucleotide + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1729,11 +1707,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1744,14 +1722,14 @@
           <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_RXN-5721_SGD_YeastPathways_PWY-5653>
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY-5653>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
+                "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1759,11 +1737,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY-5653> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY-5653> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1774,17 +1752,6 @@
           <http://model.geneontology.org/CHEBI_58437_NICONUCADENYLYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_SGD_YeastPathways_PWY-5653>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5653" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57502_QUINOPRIBOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57502> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1794,7 +1761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1805,6 +1772,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_58437>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY-5653>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1814,7 +1792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "NAD biosynthesis from 2-amino-3-carboxymuconate semialdehyde - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1831,10 +1809,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5653SmallMolecule70156> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY-5653>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5653" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-5669.ttl
+++ b/models/YeastPathways_PWY-5669.ttl
@@ -1,22 +1,11 @@
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY-5669>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000066_reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5669>
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PWY-5669>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
+                "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -29,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -42,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -50,11 +39,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,11 +58,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -90,43 +79,32 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY-5669>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000050_YeastPathways_PWY-5669/YeastPathways_PWY-5669_SGD_YeastPathways_PWY-5669>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY-5669>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5669" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -141,11 +119,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -156,14 +134,25 @@
           <http://model.geneontology.org/CHEBI_15378_PHOSPHASERDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PWY-5669>
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY-5669>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
+                "SGD_PWY:PWY-5669" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY_YeastPathways_PWY-5669>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -185,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -196,40 +185,29 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PWY-5669>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PWY-5669>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PWY-5669>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5669" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000050_YeastPathways_PWY-5669/YeastPathways_PWY-5669_SGD_YeastPathways_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000050_YeastPathways_PWY-5669/YeastPathways_PWY-5669_SGD_PWY_YeastPathways_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,7 +227,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/46963c7f-8659-46dc-a9f6-2036b2fe548a_PHOSPHASERSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/ac277f6b-34f4-47a4-becf-771c82de5f65_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -259,7 +237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -274,11 +252,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -293,11 +271,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -317,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -331,6 +309,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_ac277f6b-34f4-47a4-becf-771c82de5f65_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY-5669>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5669" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000050_YeastPathways_PWY-5669/YeastPathways_PWY-5669_SGD_PWY_YeastPathways_PWY-5669>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5669" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -343,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -368,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -376,20 +376,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ac277f6b-34f4-47a4-becf-771c82de5f65_PHOSPHASERSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5669SmallMolecule21674> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY_YeastPathways_PWY-5669>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5669" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000050_YeastPathways_PWY-5669/YeastPathways_PWY-5669_SGD_YeastPathways_PWY-5669>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002333_YER026C-MONOMER_PHOSPHASERSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-5669>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
+                "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -397,11 +425,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_YeastPathways_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY_YeastPathways_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -412,14 +440,14 @@
           <http://model.geneontology.org/YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000066_reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5669>
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000050_YeastPathways_PWY-5669/YeastPathways_PWY-5669_SGD_PWY_YeastPathways_PWY-5669>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
+                "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -432,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -447,11 +475,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_46963c7f-8659-46dc-a9f6-2036b2fe548a_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_ac277f6b-34f4-47a4-becf-771c82de5f65_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -459,18 +487,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/46963c7f-8659-46dc-a9f6-2036b2fe548a_PHOSPHASERSYN-RXN>
+          <http://model.geneontology.org/ac277f6b-34f4-47a4-becf-771c82de5f65_PHOSPHASERSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000066_reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000066_reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -481,14 +509,14 @@
           <http://model.geneontology.org/reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_YeastPathways_PWY-5669>
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY-5669>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
+                "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -501,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidylethanolamine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -509,28 +537,33 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002413_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PWY-5669>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5669" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0006646>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/46963c7f-8659-46dc-a9f6-2036b2fe548a_PHOSPHASERSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY-5669>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5669SmallMolecule21674> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_11750>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -542,11 +575,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a CDP-diacylglycerol + L-serine &harr; CMP + a 3-<i>O</i>-<i>sn</i>-phosphatidyl-L-serine + H<SUP>+</SUP>' 'null' 'a 3-<i>O</i>-<i>sn</i>-phosphatidyl-L-serine + H<SUP>+</SUP> &rarr; an L-1-phosphatidylethanolamine + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002413_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002413_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,11 +600,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_YeastPathways_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY_YeastPathways_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -588,15 +621,39 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller>
+        a       <http://identifiers.org/sgd/S000005113> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphatidylserine decarboxylase, mitochondria" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5669Protein21652> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,39 +664,15 @@
           <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller>
-        a       <http://identifiers.org/sgd/S000005113> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphatidylserine decarboxylase, mitochondria" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5669Protein21652> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000050_YeastPathways_PWY-5669/YeastPathways_PWY-5669_SGD_YeastPathways_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000050_YeastPathways_PWY-5669/YeastPathways_PWY-5669_SGD_PWY_YeastPathways_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -657,7 +690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -665,80 +698,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002333_YER026C-MONOMER_PHOSPHASERSYN-RXN_controller_SGD_YeastPathways_PWY-5669>
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000066_reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5669>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
+                "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_YeastPathways_PWY-5669>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_46963c7f-8659-46dc-a9f6-2036b2fe548a_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY-5669>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY-5669>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY-5669>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY-5669>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -747,11 +725,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002333_YER026C-MONOMER_PHOSPHASERSYN-RXN_controller_SGD_YeastPathways_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002333_YER026C-MONOMER_PHOSPHASERSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -769,11 +747,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -784,8 +762,30 @@
           <http://model.geneontology.org/CHEBI_16526_PHOSPHASERDECARB-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000066_reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5669>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5669" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004609>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY-5669>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5669" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY-5669/YeastPathways_PWY-5669>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0006646> ;
@@ -794,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -809,24 +809,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5669Protein21710> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002413_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PWY-5669>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_PHOSPHASERDECARB-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -837,7 +826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -849,11 +838,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000066_reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000066_reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -870,6 +859,17 @@
 <http://identifiers.org/sgd/S000000828>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PWY-5669>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5669" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_11750> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-5670-1.ttl
+++ b/models/YeastPathways_PWY-5670-1.ttl
@@ -1,22 +1,11 @@
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15379_RXN3O-9816_SGD_YeastPathways_PWY-5670-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002333_YHR190W-MONOMER_RXN66-281_controller_SGD_YeastPathways_PWY-5670-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15441_RXN3O-9816_SGD_PWY_YeastPathways_PWY-5670-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
+                "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -29,13 +18,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5670-1SmallMolecule74486> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15440_RXN66-281_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5670-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57310>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -44,11 +44,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15441_RXN3O-9816_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15441_RXN3O-9816_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,15 +59,26 @@
           <http://model.geneontology.org/CHEBI_15441_RXN3O-9816>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000066_reaction_RXN-12263_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5670-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_57310_RXN-12263_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_57310_RXN-12263_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,28 +89,6 @@
           <http://model.geneontology.org/CHEBI_57310_RXN-12263>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_29888_RXN-12263_SGD_YeastPathways_PWY-5670-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15377_RXN3O-9816_SGD_YeastPathways_PWY-5670-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -109,14 +98,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_13392_RXN66-281_SGD_YeastPathways_PWY-5670-1>
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_57310_RXN-12263_SGD_PWY_YeastPathways_PWY-5670-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
+                "SGD_PWY:PWY-5670-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_13390_RXN66-281_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -124,11 +124,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_13390_RXN66-281_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_13390_RXN66-281_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,8 +139,16 @@
           <http://model.geneontology.org/CHEBI_13390_RXN66-281>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004310>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15377_RXN3O-9816_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5670-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN66-281>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -151,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -159,27 +167,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000066_reaction_RXN-12263_location_lociGO_0005829_SGD_YeastPathways_PWY-5670-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15339_RXN3O-9816_SGD_YeastPathways_PWY-5670-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004310>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15379_RXN3O-9816>
         a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -190,13 +179,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5670-1SmallMolecule74389> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_13392_RXN66-281_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5670-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -206,23 +206,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_29888_RXN66-281_SGD_YeastPathways_PWY-5670-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY-5670-1/YeastPathways_PWY-5670-1>
         a       <http://purl.obolibrary.org/obo/GO_0016104> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -231,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -243,11 +232,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15377_RXN3O-9816_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15377_RXN3O-9816_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,26 +247,15 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-9816>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15440_RXN66-281_SGD_YeastPathways_PWY-5670-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_29888_RXN-12263_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_29888_RXN-12263_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -288,14 +266,14 @@
           <http://model.geneontology.org/CHEBI_29888_RXN-12263>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_17499_RXN3O-9816_SGD_YeastPathways_PWY-5670-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15379_RXN3O-9816_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
+                "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -305,33 +283,33 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002413_RXN3O-9816_SGD_YeastPathways_PWY-5670-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002333_YGR175C-MONOMER_RXN3O-9816_controller_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
+                "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000050_YeastPathways_PWY-5670-1/YeastPathways_PWY-5670-1_SGD_YeastPathways_PWY-5670-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_24431>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002333_YHR190W-MONOMER_RXN66-281_controller_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
+                "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_29888_RXN-12263>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
@@ -342,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -353,26 +331,15 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002413_RXN66-281_SGD_YeastPathways_PWY-5670-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_57310_RXN-12263_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_57310_RXN-12263_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -392,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -404,11 +371,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_13392_RXN66-281_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_13392_RXN66-281_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -422,26 +389,15 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002233_CHEBI_175763_RXN-12263_SGD_YeastPathways_PWY-5670-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9816_BFO_0000066_reaction_RXN3O-9816_location_lociGO_0005829_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9816_BFO_0000066_reaction_RXN3O-9816_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -469,35 +425,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5670-1BiochemicalReaction74350> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_57310_RXN-12263_SGD_YeastPathways_PWY-5670-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_15440_RXN66-281_SGD_YeastPathways_PWY-5670-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_13390_RXN66-281>
         a       <http://purl.obolibrary.org/obo/CHEBI_13390> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -508,13 +442,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5670-1SmallMolecule74471> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_57310_RXN-12263_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5670-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -523,11 +468,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15339_RXN3O-9816_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15339_RXN3O-9816_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -537,17 +482,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15339_RXN3O-9816>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000050_YeastPathways_PWY-5670-1/YeastPathways_PWY-5670-1_SGD_YeastPathways_PWY-5670-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN66-281>
         a       <http://purl.obolibrary.org/obo/GO_0004310> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -568,7 +502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -580,11 +514,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002233_CHEBI_175763_RXN-12263_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002233_CHEBI_175763_RXN-12263_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -595,15 +529,26 @@
           <http://model.geneontology.org/CHEBI_175763_RXN-12263>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000066_reaction_RXN66-281_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5670-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'presqualene diphosphate + NAD(P)H + H<SUP>+</SUP> &rarr; squalene + NAD(P)<sup>+</sup> + diphosphate' 'null' 'squalene + a reduced electron acceptor + oxygen &rarr; (3<i>S</i>)-2,3-epoxy-2,3-dihydrosqualene + an oxidized electron acceptor + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002413_RXN3O-9816_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002413_RXN3O-9816_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -629,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -646,15 +591,26 @@
 <http://purl.obolibrary.org/obo/GO_0004506>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002413_RXN66-281_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5670-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_15378_RXN66-281_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_15378_RXN66-281_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,25 +621,14 @@
           <http://model.geneontology.org/CHEBI_15378_RXN66-281>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_BFO_0000066_reaction_RXN3O-9816_location_lociGO_0005829_SGD_YeastPathways_PWY-5670-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_BFO_0000066_reaction_RXN3O-9816_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5670-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000066_reaction_RXN66-281_location_lociGO_0005829_SGD_YeastPathways_PWY-5670-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
+                "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -694,11 +639,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000066_reaction_RXN66-281_location_lociGO_0005829_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000066_reaction_RXN66-281_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -714,7 +659,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002333_YHR190W-MONOMER_RXN-12263_controller_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -722,11 +678,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9816_BFO_0000050_YeastPathways_PWY-5670-1/YeastPathways_PWY-5670-1_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9816_BFO_0000050_YeastPathways_PWY-5670-1/YeastPathways_PWY-5670-1_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -746,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "epoxysqualene biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -761,7 +717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -773,11 +729,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_17499_RXN3O-9816_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_17499_RXN3O-9816_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -788,26 +744,15 @@
           <http://model.geneontology.org/CHEBI_17499_RXN3O-9816>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_BFO_0000050_YeastPathways_PWY-5670-1/YeastPathways_PWY-5670-1_SGD_YeastPathways_PWY-5670-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000066_reaction_RXN-12263_location_lociGO_0005829_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000066_reaction_RXN-12263_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -818,15 +763,26 @@
           <http://model.geneontology.org/reaction_RXN-12263_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_29888_RXN-12263_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5670-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002333_YHR190W-MONOMER_RXN66-281_controller_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002333_YHR190W-MONOMER_RXN66-281_controller_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -846,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -854,41 +810,52 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_57310_RXN-12263_SGD_YeastPathways_PWY-5670-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000050_YeastPathways_PWY-5670-1/YeastPathways_PWY-5670-1_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
+                "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15441_RXN3O-9816_SGD_YeastPathways_PWY-5670-1>
+<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002233_CHEBI_175763_RXN-12263_SGD_PWY_YeastPathways_PWY-5670-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
+                "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_15378_RXN66-281_SGD_YeastPathways_PWY-5670-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000050_YeastPathways_PWY-5670-1/YeastPathways_PWY-5670-1_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
+                "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15441>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_29888_RXN66-281_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5670-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -912,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -923,15 +890,26 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_15440_RXN66-281_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5670-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000050_YeastPathways_PWY-5670-1/YeastPathways_PWY-5670-1_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000050_YeastPathways_PWY-5670-1/YeastPathways_PWY-5670-1_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -949,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,11 +939,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" , "Provides Input For Rule. The relation '2 (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate &rarr; presqualene diphosphate + diphosphate' 'null' 'presqualene diphosphate + NAD(P)H + H<SUP>+</SUP> &rarr; squalene + NAD(P)<sup>+</sup> + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002413_RXN66-281_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002413_RXN66-281_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -988,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1003,11 +981,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15440_RXN66-281_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15440_RXN66-281_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1022,11 +1000,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000050_YeastPathways_PWY-5670-1/YeastPathways_PWY-5670-1_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000050_YeastPathways_PWY-5670-1/YeastPathways_PWY-5670-1_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1046,7 +1024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1061,11 +1039,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_29888_RXN66-281_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_29888_RXN66-281_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1076,33 +1054,33 @@
           <http://model.geneontology.org/CHEBI_29888_RXN66-281>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_15378_RXN66-281_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5670-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002333_YHR190W-MONOMER_RXN-12263_controller_SGD_YeastPathways_PWY-5670-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_17499_RXN3O-9816_SGD_PWY_YeastPathways_PWY-5670-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
+                "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_13390>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_13390_RXN66-281_SGD_YeastPathways_PWY-5670-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15440>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1121,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1132,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1150,11 +1128,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002333_YGR175C-MONOMER_RXN3O-9816_controller_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002333_YGR175C-MONOMER_RXN3O-9816_controller_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1165,15 +1143,26 @@
           <http://model.geneontology.org/YGR175C-MONOMER_RXN3O-9816_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15339_RXN3O-9816_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5670-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002333_YHR190W-MONOMER_RXN-12263_controller_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002333_YHR190W-MONOMER_RXN-12263_controller_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1193,7 +1182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1204,15 +1193,37 @@
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_BFO_0000050_YeastPathways_PWY-5670-1/YeastPathways_PWY-5670-1_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5670-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002413_RXN3O-9816_SGD_PWY_YeastPathways_PWY-5670-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5670-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15379_RXN3O-9816_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15379_RXN3O-9816_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1235,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1247,11 +1258,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_15440_RXN66-281_SGD_YeastPathways_PWY-5670-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_15440_RXN66-281_SGD_PWY_YeastPathways_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1262,17 +1273,6 @@
           <http://model.geneontology.org/CHEBI_15440_RXN66-281>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002333_YGR175C-MONOMER_RXN3O-9816_controller_SGD_YeastPathways_PWY-5670-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15441_RXN3O-9816>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15441> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1282,7 +1282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-5686-1.ttl
+++ b/models/YeastPathways_PWY-5686-1.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,11 +21,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -43,11 +43,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -68,11 +68,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -81,25 +81,6 @@
           <http://model.geneontology.org/RXN-9929> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YKL216W-MONOMER_RXN-9929_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5686-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_OROPRIBTRANS-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_CARBPSYN-RXN>
@@ -111,13 +92,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5686-1SmallMolecule71048> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5686-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_OROPRIBTRANS-RXN_location_lociGO_0005829>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57865>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -126,11 +126,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,8 +153,41 @@
 <http://purl.obolibrary.org/obo/CHEBI_30031>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002413_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_32814>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_OROTPDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -165,13 +198,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5686-1SmallMolecule70844> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0044205>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -180,11 +224,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -199,11 +243,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -213,6 +257,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YJL130C-MONOMER_CARBPSYN-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -226,7 +281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -238,11 +293,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -253,14 +308,14 @@
           <http://model.geneontology.org/reaction_ASPCARBTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -271,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -306,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -317,14 +372,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30839_RXN-9929_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_30839_RXN-9929_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -337,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -345,26 +400,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000066_reaction_RXN-9929_location_lociGO_0005829_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000066_reaction_RXN-9929_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -375,26 +419,15 @@
           <http://model.geneontology.org/reaction_RXN-9929_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15378_DIHYDROOROT-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15377_DIHYDROOROT-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15377_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -405,25 +438,14 @@
           <http://model.geneontology.org/CHEBI_15377_DIHYDROOROT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_YeastPathways_PWY-5686-1>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -432,7 +454,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -440,11 +473,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_29888_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -474,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -489,11 +522,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,24 +549,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5686-1SmallMolecule70912> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_ASPCARBTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -544,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -552,15 +574,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -571,14 +604,14 @@
           <http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -589,11 +622,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,17 +640,6 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1>
         a       <http://purl.obolibrary.org/obo/GO_0044205> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -625,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -637,11 +659,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -658,18 +680,18 @@
 <http://purl.obolibrary.org/obo/CHEBI_29991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://identifiers.org/sgd/S000004412>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30031_RXN-9929_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30031_RXN-9929_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -680,16 +702,8 @@
           <http://model.geneontology.org/CHEBI_30031_RXN-9929>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002413_RXN-9929_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_29985_CARBPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -700,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -712,11 +726,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" , "Provides Input For Rule. The relation '(<i>S</i>)-dihydroorotate + H<sub>2</sub>O &harr; <i>N</i>-carbamoyl-L-aspartate + H<SUP>+</SUP>' 'null' '(<i>S</i>)-dihydroorotate + fumarate &rarr; orotate + succinate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002413_RXN-9929_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002413_RXN-9929_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -727,21 +741,29 @@
           <http://model.geneontology.org/RXN-9929>
 ] .
 
-<http://identifiers.org/sgd/S000004412>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/CHEBI_30839>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -752,42 +774,31 @@
           <http://model.geneontology.org/CHEBI_15377_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_YeastPathways_PWY-5686-1>
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_YeastPathways_PWY-5686-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -795,11 +806,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -814,11 +825,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -829,16 +840,8 @@
           <http://model.geneontology.org/CHEBI_58228_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -852,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -860,14 +863,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -880,16 +894,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5686-1SmallMolecule70858> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/YMR271C-MONOMER_OROPRIBTRANS-RXN_controller>
         a       <http://identifiers.org/sgd/S000004884> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -898,13 +909,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5686-1Protein70940> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000066_reaction_RXN-9929_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9929>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_1990663> ;
@@ -925,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -933,26 +955,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_30864_DIHYDROOROT-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,15 +977,26 @@
 <http://purl.obolibrary.org/obo/GO_0004590>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15378_DIHYDROOROT-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15378_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -985,26 +1007,15 @@
           <http://model.geneontology.org/CHEBI_15378_DIHYDROOROT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002413_OROTPDECARB-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1022,24 +1033,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5686-1Protein70829> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000066_reaction_RXN-9929_location_lociGO_0005829_SGD_YeastPathways_PWY-5686-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/OROTPDECARB-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004590> ;
@@ -1058,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1075,7 +1075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1083,18 +1083,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002413_RXN-9929_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" , "Provides Input For Rule. The relation '(<i>S</i>)-dihydroorotate + fumarate &rarr; orotate + succinate' 'null' 'orotidine 5'-phosphate + diphosphate &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + orotate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002413_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002413_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1114,7 +1147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1126,11 +1159,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_30839_RXN-9929_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_30839_RXN-9929_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1141,26 +1174,15 @@
           <http://model.geneontology.org/CHEBI_30839_RXN-9929>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1174,17 +1196,6 @@
 <http://purl.obolibrary.org/obo/GO_0004151>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1194,14 +1205,36 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_YeastPathways_PWY-5686-1>
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1212,11 +1245,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1231,11 +1264,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 ATP + L-glutamine + hydrogencarbonate + H<sub>2</sub>O &rarr; L-glutamate + carbamoyl phosphate + 2 ADP + phosphate + 2 H<SUP>+</SUP>' 'null' 'L-aspartate + carbamoyl phosphate &harr; <i>N</i>-carbamoyl-L-aspartate + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,15 +1279,26 @@
           <http://model.geneontology.org/ASPCARBTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1274,6 +1318,17 @@
 <http://identifiers.org/sgd/S000001699>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1286,7 +1341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1297,15 +1352,26 @@
 <http://purl.obolibrary.org/obo/GO_0004088>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1320,11 +1386,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_30864_DIHYDROOROT-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1342,11 +1408,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1357,70 +1423,26 @@
           <http://model.geneontology.org/YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003870> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1433,7 +1455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1445,11 +1467,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_57538_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1464,11 +1486,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1498,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1515,13 +1537,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5686-1SmallMolecule71077> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15377_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29991_ASPCARBTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1532,24 +1587,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5686-1SmallMolecule70994> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_YeastPathways_PWY-5686-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YEL021W-MONOMER_OROTPDECARB-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000747> ;
@@ -1558,24 +1602,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5686-1Protein70895> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002413_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_CARBPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -1586,7 +1619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1598,11 +1631,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1620,11 +1653,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1635,15 +1668,18 @@
           <http://model.geneontology.org/YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1>
 ] .
 
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1654,9 +1690,6 @@
           <http://model.geneontology.org/CHEBI_32814_ASPCARBTRANS-RXN>
 ] .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://model.geneontology.org/CHEBI_58228_CARBPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58228> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1666,7 +1699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1674,17 +1707,61 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1>
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30839_RXN-9929_SGD_PWY_YeastPathways_PWY-5686-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1695,11 +1772,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30839_RXN-9929_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30839_RXN-9929_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1714,11 +1791,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1733,11 +1810,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1748,28 +1825,6 @@
           <http://model.geneontology.org/CHEBI_17544_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YJL130C-MONOMER_CARBPSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000003666> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1777,7 +1832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1794,7 +1849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1811,7 +1866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1822,6 +1877,17 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002413_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29806_RXN-9929>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29806> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1831,24 +1897,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5686-1SmallMolecule70791> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57538>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1857,11 +1912,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'orotidine 5'-phosphate + diphosphate &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + orotate' 'null' 'orotidine 5'-phosphate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + UMP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002413_OROTPDECARB-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002413_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1872,14 +1927,14 @@
           <http://model.geneontology.org/OROTPDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_32814_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY-5686-1>
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_PWY_YeastPathways_PWY-5686-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1887,11 +1942,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1906,11 +1961,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1920,28 +1975,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5686-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/DIHYDROOROT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004151> ;
@@ -1962,7 +1995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1980,11 +2013,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1995,14 +2028,14 @@
           <http://model.geneontology.org/YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002413_DIHYDROOROT-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2010,11 +2043,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_32814_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2034,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "UMP biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2046,11 +2079,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" , "Provides Input For Rule. The relation 'L-aspartate + carbamoyl phosphate &harr; <i>N</i>-carbamoyl-L-aspartate + phosphate + H<SUP>+</SUP>' 'null' '(<i>S</i>)-dihydroorotate + H<sub>2</sub>O &harr; <i>N</i>-carbamoyl-L-aspartate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002413_DIHYDROOROT-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002413_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2061,17 +2094,6 @@
           <http://model.geneontology.org/DIHYDROOROT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_43474_ASPCARBTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2081,7 +2103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2089,14 +2111,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_30839_RXN-9929_SGD_YeastPathways_PWY-5686-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2108,7 +2130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2117,23 +2139,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003870>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30864>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2142,11 +2164,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_58017_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_58017_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2161,11 +2183,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2176,58 +2198,47 @@
           <http://model.geneontology.org/CHEBI_15378_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15377_DIHYDROOROT-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_YeastPathways_PWY-5686-1>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_456216_CARBPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2238,7 +2249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2246,14 +2257,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2262,40 +2273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_29888_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2303,11 +2281,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2325,11 +2303,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2347,7 +2325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2355,37 +2333,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2395,6 +2351,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58228_CARBPSYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15378_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_58017_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ASPCARBTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004070> ;
@@ -2415,13 +2393,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5686-1BiochemicalReaction70980> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30864> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2432,7 +2432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2445,7 +2445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2453,11 +2453,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2472,11 +2472,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2487,29 +2487,29 @@
           <http://model.geneontology.org/YLR420W-MONOMER_DIHYDROOROT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_YeastPathways_PWY-5686-1/YeastPathways_PWY-5686-1_SGD_YeastPathways_PWY-5686-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_29806>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_29806>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2520,17 +2520,50 @@
           <http://model.geneontology.org/reaction_CARBPSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000004574>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_YeastPathways_PWY-5686-1>
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_PWY_YeastPathways_PWY-5686-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30031_RXN-9929_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2543,7 +2576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2560,7 +2593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2568,14 +2601,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_YeastPathways_PWY-5686-1>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5686-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2583,11 +2616,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2598,26 +2631,15 @@
           <http://model.geneontology.org/YML106W-MONOMER_OROPRIBTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30031_RXN-9929_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2628,56 +2650,34 @@
           <http://model.geneontology.org/CHEBI_456216_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_YeastPathways_PWY-5686-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_OROTPDECARB-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_58017_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY-5686-1>
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002413_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_57538_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5686-1" ;
+                "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2686,6 +2686,6 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-5694.ttl
+++ b/models/YeastPathways_PWY-5694.ttl
@@ -1,22 +1,11 @@
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_15378_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5694>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000050_YeastPathways_PWY-5694/YeastPathways_PWY-5694_SGD_YeastPathways_PWY-5694>
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_17536_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5694>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
+                "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -25,18 +14,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000050_YeastPathways_PWY-5694/YeastPathways_PWY-5694_SGD_YeastPathways_PWY-5694>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_16199_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
+                "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -49,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -57,15 +46,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000050_YeastPathways_PWY-5694/YeastPathways_PWY-5694_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5694" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002333_YIR027C-MONOMER_ALLANTOINASE-RXN_controller_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002333_YIR027C-MONOMER_ALLANTOINASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -76,14 +76,14 @@
           <http://model.geneontology.org/YIR027C-MONOMER_ALLANTOINASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002234_CHEBI_16199_UREIDOGLYCOLATE-LYASE-RXN_SGD_YeastPathways_PWY-5694>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002333_YIR029W-MONOMER_ALLANTOICASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
+                "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -91,11 +91,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_16199_ALLANTOICASE-RXN_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_16199_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -121,29 +121,29 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004037>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002234_CHEBI_36655_UREIDOGLYCOLATE-LYASE-RXN_SGD_YeastPathways_PWY-5694>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_57296_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
+                "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004037>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002333_YIR032C-MONOMER_UREIDOGLYCOLATE-LYASE-RXN_controller_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002333_YIR032C-MONOMER_UREIDOGLYCOLATE-LYASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -154,16 +154,19 @@
           <http://model.geneontology.org/YIR032C-MONOMER_UREIDOGLYCOLATE-LYASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_17536_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5694>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002413_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
+                "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_15377_ALLANTOICASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -174,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -182,11 +185,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://identifiers.org/sgd/S000001468>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000066_reaction_ALLANTOINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5694" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_BFO_0000066_reaction_UREIDOGLYCOLATE-LYASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5694" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_17536_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5694" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_ALLANTOINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -197,13 +230,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5694SmallMolecule63111> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YeastPathways_PWY-5694>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -214,16 +250,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "allantoin degradation to glyoxylate I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YeastPathways_PWY-5694/YeastPathways_PWY-5694>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000256> ;
@@ -232,35 +265,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY-5694" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002233_CHEBI_57296_ALLANTOICASE-RXN_SGD_YeastPathways_PWY-5694>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000066_reaction_ALLANTOINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5694>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16199_ALLANTOICASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16199> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -271,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -279,15 +290,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002333_YIR027C-MONOMER_ALLANTOINASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5694" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_17536_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_17536_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -298,26 +320,15 @@
           <http://model.geneontology.org/CHEBI_17536_ALLANTOINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002413_ALLANTOICASE-RXN_SGD_YeastPathways_PWY-5694>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_17536_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_17536_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,47 +339,14 @@
           <http://model.geneontology.org/CHEBI_17536_ALLANTOINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000066_reaction_ALLANTOICASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5694>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002333_YIR032C-MONOMER_UREIDOGLYCOLATE-LYASE-RXN_controller_SGD_YeastPathways_PWY-5694>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_15377_ALLANTOICASE-RXN_SGD_YeastPathways_PWY-5694>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YIR032C-MONOMER_UREIDOGLYCOLATE-LYASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001471> ;
@@ -377,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -392,11 +370,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002234_CHEBI_36655_UREIDOGLYCOLATE-LYASE-RXN_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002234_CHEBI_36655_UREIDOGLYCOLATE-LYASE-RXN_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -411,11 +389,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002233_CHEBI_57296_ALLANTOICASE-RXN_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002233_CHEBI_57296_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -426,17 +404,6 @@
           <http://model.geneontology.org/CHEBI_57296_ALLANTOICASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002333_YIR027C-MONOMER_ALLANTOINASE-RXN_controller_SGD_YeastPathways_PWY-5694>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -444,11 +411,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000050_YeastPathways_PWY-5694/YeastPathways_PWY-5694_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000050_YeastPathways_PWY-5694/YeastPathways_PWY-5694_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -459,6 +426,17 @@
           <http://model.geneontology.org/YeastPathways_PWY-5694/YeastPathways_PWY-5694>
 ] .
 
+<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002234_CHEBI_16199_UREIDOGLYCOLATE-LYASE-RXN_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5694" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YIR029W-MONOMER_ALLANTOICASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001468> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -466,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -481,11 +459,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_15378_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_15378_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,11 +481,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_15377_ALLANTOICASE-RXN_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_15377_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -527,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -544,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -560,7 +538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -570,15 +548,26 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15377_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5694" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002234_CHEBI_16199_UREIDOGLYCOLATE-LYASE-RXN_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002234_CHEBI_16199_UREIDOGLYCOLATE-LYASE-RXN_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -598,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -616,11 +605,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_BFO_0000066_reaction_UREIDOGLYCOLATE-LYASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_BFO_0000066_reaction_UREIDOGLYCOLATE-LYASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,26 +620,15 @@
           <http://model.geneontology.org/reaction_UREIDOGLYCOLATE-LYASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_17536_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5694>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" , "Provides Input For Rule. The relation 'allantoate + H<sub>2</sub>O &rarr; (<i>S</i>)-ureidoglycolate + urea' 'null' '(<i>S</i>)-ureidoglycolate &rarr; urea + glyoxylate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002413_UREIDOGLYCOLATE-LYASE-RXN_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002413_UREIDOGLYCOLATE-LYASE-RXN_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,15 +639,26 @@
           <http://model.geneontology.org/UREIDOGLYCOLATE-LYASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15678_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5694" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15678_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15678_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -689,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -701,11 +690,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000066_reaction_ALLANTOICASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000066_reaction_ALLANTOICASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -715,6 +704,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_ALLANTOICASE-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_BFO_0000050_YeastPathways_PWY-5694/YeastPathways_PWY-5694_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5694" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ALLANTOINASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004038> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -735,7 +735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -760,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -775,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -783,8 +783,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000050_YeastPathways_PWY-5694/YeastPathways_PWY-5694_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5694" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_15378_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5694" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002413_UREIDOGLYCOLATE-LYASE-RXN_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5694" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0050385>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -796,11 +829,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_BFO_0000050_YeastPathways_PWY-5694/YeastPathways_PWY-5694_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_BFO_0000050_YeastPathways_PWY-5694/YeastPathways_PWY-5694_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -811,18 +844,15 @@
           <http://model.geneontology.org/YeastPathways_PWY-5694/YeastPathways_PWY-5694>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002333_YIR029W-MONOMER_ALLANTOICASE-RXN_controller_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002333_YIR029W-MONOMER_ALLANTOICASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,27 +863,8 @@
           <http://model.geneontology.org/YIR029W-MONOMER_ALLANTOICASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_BFO_0000066_reaction_UREIDOGLYCOLATE-LYASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5694>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_16199_ALLANTOICASE-RXN_SGD_YeastPathways_PWY-5694>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -862,11 +873,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15377_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15377_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -884,11 +895,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000050_YeastPathways_PWY-5694/YeastPathways_PWY-5694_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000050_YeastPathways_PWY-5694/YeastPathways_PWY-5694_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,14 +910,14 @@
           <http://model.geneontology.org/YeastPathways_PWY-5694/YeastPathways_PWY-5694>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002413_UREIDOGLYCOLATE-LYASE-RXN_SGD_YeastPathways_PWY-5694>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000066_reaction_ALLANTOICASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
+                "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -922,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -930,14 +941,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002333_YIR029W-MONOMER_ALLANTOICASE-RXN_controller_SGD_YeastPathways_PWY-5694>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002234_CHEBI_36655_UREIDOGLYCOLATE-LYASE-RXN_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
+                "SGD_PWY:PWY-5694" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002233_CHEBI_57296_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -947,6 +969,17 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_15377_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5694" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -954,11 +987,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" , "Provides Input For Rule. The relation '(<i>S</i>)-(+)-allantoin + H<sub>2</sub>O &rarr; allantoate + H<SUP>+</SUP>' 'null' 'allantoate + H<sub>2</sub>O &rarr; (<i>S</i>)-ureidoglycolate + urea' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002413_ALLANTOICASE-RXN_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002413_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,26 +1002,15 @@
           <http://model.geneontology.org/ALLANTOICASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15377_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5694>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_57296_ALLANTOICASE-RXN_SGD_YeastPathways_PWY-5694> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_57296_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_PWY-5694> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1002,11 +1024,30 @@
 <http://identifiers.org/sgd/S000001471>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004038>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000066_reaction_ALLANTOINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5694> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ALLANTOINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_ALLANTOINASE-RXN_location_lociGO_0005829>
+] .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/GO_0004038>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ALLANTOICASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004037> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1027,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1035,63 +1076,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000066_reaction_ALLANTOINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5694> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ALLANTOINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_ALLANTOINASE-RXN_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15678_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5694>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_BFO_0000050_YeastPathways_PWY-5694/YeastPathways_PWY-5694_SGD_YeastPathways_PWY-5694>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_57296_ALLANTOICASE-RXN_SGD_YeastPathways_PWY-5694>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5694" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_17536>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_16199>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_UREIDOGLYCOLATE-LYASE-RXN_RO_0002333_YIR032C-MONOMER_UREIDOGLYCOLATE-LYASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5694" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15678>
         a       <http://www.w3.org/2002/07/owl#Class> .

--- a/models/YeastPathways_PWY-5697.ttl
+++ b/models/YeastPathways_PWY-5697.ttl
@@ -1,34 +1,12 @@
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_17536_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000050_YeastPathways_PWY-5697/YeastPathways_PWY-5697_SGD_YeastPathways_PWY-5697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>S</i>)-(+)-allantoin + H<sub>2</sub>O &rarr; allantoate + H<SUP>+</SUP>' 'null' 'allantoate + H<sub>2</sub>O &rarr; (<i>S</i>)-ureidoglycolate + urea' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002413_ALLANTOICASE-RXN_SGD_YeastPathways_PWY-5697> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002413_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_PWY-5697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,15 +17,37 @@
           <http://model.geneontology.org/ALLANTOICASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15678_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000050_YeastPathways_PWY-5697/YeastPathways_PWY-5697_SGD_PWY_YeastPathways_PWY-5697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_16199_ALLANTOICASE-RXN_SGD_YeastPathways_PWY-5697> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_16199_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_PWY-5697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -79,6 +79,17 @@
 <http://purl.obolibrary.org/obo/GO_0004037>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_15378_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_ALLANTOICASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -88,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -111,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,17 +133,6 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_16199_ALLANTOICASE-RXN_SGD_YeastPathways_PWY-5697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16199_ALLANTOICASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16199> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -142,7 +142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -154,11 +154,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002333_YIR027C-MONOMER_ALLANTOINASE-RXN_controller_SGD_YeastPathways_PWY-5697> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002333_YIR027C-MONOMER_ALLANTOINASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -173,11 +173,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_17536_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5697> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_17536_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,36 +188,25 @@
           <http://model.geneontology.org/CHEBI_17536_ALLANTOINASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15377>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000050_YeastPathways_PWY-5697/YeastPathways_PWY-5697_SGD_YeastPathways_PWY-5697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000066_reaction_ALLANTOICASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5697" ;
+                "SGD_PWY:PWY-5697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002333_YIR029W-MONOMER_ALLANTOICASE-RXN_controller_SGD_YeastPathways_PWY-5697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -229,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -237,29 +226,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15377_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5697>
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_15377_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_PWY-5697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5697" ;
+                "SGD_PWY:PWY-5697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000066_reaction_ALLANTOINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5697> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000066_reaction_ALLANTOINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -277,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,26 +277,15 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15678_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_17536_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5697> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_17536_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,26 +299,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_57296>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_57296_ALLANTOICASE-RXN_SGD_YeastPathways_PWY-5697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_15377_ALLANTOICASE-RXN_SGD_YeastPathways_PWY-5697> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_15377_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_PWY-5697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -360,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -377,7 +344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -393,23 +360,45 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_15378_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5697>
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000050_YeastPathways_PWY-5697/YeastPathways_PWY-5697_SGD_PWY_YeastPathways_PWY-5697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5697" ;
+                "SGD_PWY:PWY-5697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_17536_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_16199_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_PWY-5697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001466>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -417,15 +406,26 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002333_YIR029W-MONOMER_ALLANTOICASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000050_YeastPathways_PWY-5697/YeastPathways_PWY-5697_SGD_YeastPathways_PWY-5697> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000050_YeastPathways_PWY-5697/YeastPathways_PWY-5697_SGD_PWY_YeastPathways_PWY-5697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -436,15 +436,26 @@
           <http://model.geneontology.org/YeastPathways_PWY-5697/YeastPathways_PWY-5697>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_57296_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_PWY-5697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_15378_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5697> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002234_CHEBI_15378_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -464,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -476,11 +487,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000066_reaction_ALLANTOICASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5697> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000066_reaction_ALLANTOICASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -510,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -518,14 +529,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_17536_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002413_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_PWY-5697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5697" ;
+                "SGD_PWY:PWY-5697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000066_reaction_ALLANTOINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -536,13 +558,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5697Protein20418> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_17536_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY-5697>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -553,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "allantoin degradation to ureidoglycolate I (urea producing) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -564,28 +597,17 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000066_reaction_ALLANTOINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002413_ALLANTOICASE-RXN_SGD_YeastPathways_PWY-5697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002333_YIR027C-MONOMER_ALLANTOINASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5697" ;
+                "SGD_PWY:PWY-5697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -593,11 +615,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002333_YIR029W-MONOMER_ALLANTOICASE-RXN_controller_SGD_YeastPathways_PWY-5697> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002333_YIR029W-MONOMER_ALLANTOICASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -611,40 +633,18 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000066_reaction_ALLANTOICASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002233_CHEBI_15377_ALLANTOICASE-RXN_SGD_YeastPathways_PWY-5697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15678_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5697> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15678_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -659,11 +659,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000050_YeastPathways_PWY-5697/YeastPathways_PWY-5697_SGD_YeastPathways_PWY-5697> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_BFO_0000050_YeastPathways_PWY-5697/YeastPathways_PWY-5697_SGD_PWY_YeastPathways_PWY-5697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -696,17 +696,6 @@
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002333_YIR027C-MONOMER_ALLANTOINASE-RXN_controller_SGD_YeastPathways_PWY-5697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -718,11 +707,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_57296_ALLANTOICASE-RXN_SGD_YeastPathways_PWY-5697> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOICASE-RXN_RO_0002234_CHEBI_57296_ALLANTOICASE-RXN_SGD_PWY_YeastPathways_PWY-5697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -733,15 +722,18 @@
           <http://model.geneontology.org/CHEBI_57296_ALLANTOICASE-RXN>
 ] .
 
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15377_ALLANTOINASE-RXN_SGD_YeastPathways_PWY-5697> ;
+          <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15377_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -752,8 +744,16 @@
           <http://model.geneontology.org/CHEBI_15377_ALLANTOINASE-RXN>
 ] .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15377_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004038>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -775,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-5703.ttl
+++ b/models/YeastPathways_PWY-5703.ttl
@@ -1,11 +1,22 @@
-<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002234_CHEBI_28938_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_PWY-5703>
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
+                "SGD_PWY:PWY-5703" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002333_YBR208C-MONOMER_UREA-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5703>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -18,32 +29,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5703SmallMolecule20278> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_PWY-5703> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UREA-CARBOXYLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_UREA-CARBOXYLASE-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_28938_ALLOPHANATE-HYDROLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_28938> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -54,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,12 +54,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_ALLOPHANATE-HYDROLASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_16199_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -75,11 +69,50 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15832_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_PWY-5703> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UREA-CARBOXYLASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_UREA-CARBOXYLASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_15832_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5703" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_ALLOPHANATE-HYDROLASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15832_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -95,6 +128,17 @@
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_BFO_0000066_reaction_ALLOPHANATE-HYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5703>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5703" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ALLOPHANATE-HYDROLASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004039> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -113,24 +157,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5703BiochemicalReaction20289> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_BFO_0000066_reaction_ALLOPHANATE-HYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5703>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_UREA-CARBOXYLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -141,24 +174,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5703SmallMolecule20268> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15378_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_PWY-5703>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16199_UREA-CARBOXYLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16199> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -169,7 +191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -180,28 +202,17 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_16526_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_PWY-5703>
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15377_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-5703>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_15377_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_PWY-5703>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
+                "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -209,11 +220,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_PWY-5703> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -224,26 +235,15 @@
           <http://model.geneontology.org/CHEBI_30616_UREA-CARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_PWY-5703>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15378_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_PWY-5703> ;
+          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15378_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -276,6 +276,17 @@
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002413_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-5703>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5703" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -292,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -300,14 +311,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15377_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_PWY-5703>
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_15377_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
+                "SGD_PWY:PWY-5703" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -315,11 +337,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002333_YBR208C-MONOMER_UREA-CARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY-5703> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002333_YBR208C-MONOMER_UREA-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -337,11 +359,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY-5703/YeastPathways_PWY-5703_SGD_YeastPathways_PWY-5703> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY-5703/YeastPathways_PWY-5703_SGD_PWY_YeastPathways_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -364,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "urea degradation I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -372,14 +394,14 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_BFO_0000066_reaction_UREA-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5703>
+<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY-5703/YeastPathways_PWY-5703_SGD_PWY_YeastPathways_PWY-5703>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
+                "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -390,11 +412,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_16526_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_PWY-5703> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_16526_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -405,26 +427,15 @@
           <http://model.geneontology.org/CHEBI_16526_UREA-CARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY-5703/YeastPathways_PWY-5703_SGD_YeastPathways_PWY-5703>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15377_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_PWY-5703> ;
+          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15377_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -438,6 +449,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_16526_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5703" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -448,11 +470,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'CO<SUB>2</SUB> + urea + ATP + H<sub>2</sub>O &rarr; ADP + urea-1-carboxylate + phosphate + 2 H<SUP>+</SUP>' 'null' 'urea-1-carboxylate + 3 H<SUP>+</SUP> + H<sub>2</sub>O &rarr; 2 ammonium + 2 CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002413_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_PWY-5703> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002413_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -463,23 +485,6 @@
           <http://model.geneontology.org/ALLOPHANATE-HYDROLASE-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_15377_UREA-CARBOXYLASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5703SmallMolecule20195> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_15377_ALLOPHANATE-HYDROLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -489,7 +494,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5703SmallMolecule20195> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_15377_UREA-CARBOXYLASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -500,17 +522,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002333_YBR208C-MONOMER_UREA-CARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY-5703>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YBR208C-MONOMER_ALLOPHANATE-HYDROLASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000000412> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -518,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -536,11 +547,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_PWY-5703> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -555,11 +566,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002333_YBR208C-MONOMER_ALLOPHANATE-HYDROLASE-RXN_controller_SGD_YeastPathways_PWY-5703> ;
+          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002333_YBR208C-MONOMER_ALLOPHANATE-HYDROLASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -579,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -587,14 +598,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002413_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_PWY-5703>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002234_CHEBI_28938_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-5703>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
+                "SGD_PWY:PWY-5703" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15378_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-5703>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -602,11 +624,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_16199_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_PWY-5703> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_16199_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -621,11 +643,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_BFO_0000066_reaction_ALLOPHANATE-HYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5703> ;
+          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_BFO_0000066_reaction_ALLOPHANATE-HYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,12 +661,34 @@
 <http://identifiers.org/sgd/S000000412>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5703" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_BFO_0000066_reaction_UREA-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5703>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5703" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_UREA-CARBOXYLASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -655,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -663,50 +707,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_PWY-5703>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002333_YBR208C-MONOMER_ALLOPHANATE-HYDROLASE-RXN_controller_SGD_YeastPathways_PWY-5703>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_PWY-5703>
+<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002333_YBR208C-MONOMER_ALLOPHANATE-HYDROLASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5703>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_16199_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_PWY-5703>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
+                "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -717,11 +728,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_PWY-5703> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -739,11 +750,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002234_CHEBI_28938_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_PWY-5703> ;
+          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002234_CHEBI_28938_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,6 +764,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_28938_ALLOPHANATE-HYDROLASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5703" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -764,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -775,17 +797,6 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002234_CHEBI_16526_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_PWY-5703>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_UREA-CARBOXYLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -795,7 +806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -807,11 +818,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_15377_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_PWY-5703> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_15377_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -832,11 +843,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY-5703/YeastPathways_PWY-5703_SGD_YeastPathways_PWY-5703> ;
+          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY-5703/YeastPathways_PWY-5703_SGD_PWY_YeastPathways_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -856,7 +867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -869,6 +880,17 @@
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002234_CHEBI_16526_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-5703>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5703" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -892,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -903,40 +925,18 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15832_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_PWY-5703>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_PWY-5703>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_15832_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_PWY-5703> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_15832_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -956,7 +956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -968,11 +968,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002234_CHEBI_16526_ALLOPHANATE-HYDROLASE-RXN_SGD_YeastPathways_PWY-5703> ;
+          <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002234_CHEBI_16526_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -983,14 +983,25 @@
           <http://model.geneontology.org/CHEBI_16526_ALLOPHANATE-HYDROLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_15832_UREA-CARBOXYLASE-RXN_SGD_YeastPathways_PWY-5703>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15832_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
+                "SGD_PWY:PWY-5703" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY-5703/YeastPathways_PWY-5703_SGD_PWY_YeastPathways_PWY-5703>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -998,11 +1009,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_BFO_0000066_reaction_UREA-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5703> ;
+          <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_BFO_0000066_reaction_UREA-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1021,14 +1032,3 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_16199>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY-5703/YeastPathways_PWY-5703_SGD_YeastPathways_PWY-5703>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5703" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-5760-1.ttl
+++ b/models/YeastPathways_PWY-5760-1.ttl
@@ -1,33 +1,33 @@
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_58374_RXN-9015_SGD_YeastPathways_PWY-5760-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5760-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_15377_RXN-9015_SGD_YeastPathways_PWY-5760-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5760-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_58374_RXN-9015_SGD_YeastPathways_PWY-5760-1>
+<http://model.geneontology.org/ev_w_id_RXN-9015_BFO_0000066_reaction_RXN-9015_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5760-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5760-1" ;
+                "SGD_PWY:PWY-5760-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9015_BFO_0000050_YeastPathways_PWY-5760-1/YeastPathways_PWY-5760-1_SGD_PWY_YeastPathways_PWY-5760-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5760-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-5760-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -38,11 +38,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_58374_RXN-9015_SGD_YeastPathways_PWY-5760-1> ;
+          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_58374_RXN-9015_SGD_PWY_YeastPathways_PWY-5760-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -57,11 +57,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_45725_RXN-9015_SGD_YeastPathways_PWY-5760-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_45725_RXN-9015_SGD_PWY_YeastPathways_PWY-5760-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,56 +72,56 @@
           <http://model.geneontology.org/CHEBI_45725_RXN-9015>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-5760-1>
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_16240_RXN-9015_SGD_PWY_YeastPathways_PWY-5760-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5760-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004779>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY-5760-1/YeastPathways_PWY-5760-1_SGD_PWY_YeastPathways_PWY-5760-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5760-1" ;
+                "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://identifiers.org/sgd/S000004779>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_58374_RXN-9015_SGD_PWY_YeastPathways_PWY-5760-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5760-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_3-PROPANAL-DEHYDROGENASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9015_BFO_0000050_YeastPathways_PWY-5760-1/YeastPathways_PWY-5760-1_SGD_YeastPathways_PWY-5760-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5760-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15377_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-5760-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5760-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57540_3-PROPANAL-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
@@ -132,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,17 +143,6 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002333_YMR170C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PWY-5760-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5760-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YMR169C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004779> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -161,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -179,11 +168,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-5760-1> ;
+          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-5760-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,11 +187,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_15379_RXN-9015_SGD_YeastPathways_PWY-5760-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_15379_RXN-9015_SGD_PWY_YeastPathways_PWY-5760-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -230,23 +219,34 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002333_YMR020W-MONOMER_RXN-9015_controller_SGD_YeastPathways_PWY-5760-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002413_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-5760-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5760-1" ;
+                "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002333_YMR170C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5760-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5760-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57834_RXN-9015>
         a       <http://purl.obolibrary.org/obo/CHEBI_57834> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -286,11 +286,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002333_YMR170C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PWY-5760-1> ;
+          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002333_YMR170C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5760-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,26 +304,15 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY-5760-1/YeastPathways_PWY-5760-1_SGD_YeastPathways_PWY-5760-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5760-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002333_YMR020W-MONOMER_RXN-9015_controller_SGD_YeastPathways_PWY-5760-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002333_YMR020W-MONOMER_RXN-9015_controller_SGD_PWY_YeastPathways_PWY-5760-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -334,6 +323,17 @@
           <http://model.geneontology.org/YMR020W-MONOMER_RXN-9015_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_57834_RXN-9015_SGD_PWY_YeastPathways_PWY-5760-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5760-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -341,11 +341,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15377_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-5760-1> ;
+          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15377_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-5760-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -360,11 +360,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_15377_RXN-9015_SGD_YeastPathways_PWY-5760-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_15377_RXN-9015_SGD_PWY_YeastPathways_PWY-5760-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -385,13 +385,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY-5760-1" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_BFO_0000066_reaction_3-PROPANAL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5760-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5760-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YMR170C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000004780> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -400,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -417,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -428,17 +439,6 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_45725_RXN-9015_SGD_YeastPathways_PWY-5760-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5760-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY-5760-1>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -448,13 +448,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "&beta;-alanine biosynthesis IV - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002333_YMR169C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5760-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5760-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-5760-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5760-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57966>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -465,15 +487,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_58374>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_15377_RXN-9015_SGD_PWY_YeastPathways_PWY-5760-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5760-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002333_YMR169C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PWY-5760-1> ;
+          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002333_YMR169C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY-5760-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,11 +521,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_58374_RXN-9015_SGD_YeastPathways_PWY-5760-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_58374_RXN-9015_SGD_PWY_YeastPathways_PWY-5760-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,25 +536,25 @@
           <http://model.geneontology.org/CHEBI_58374_RXN-9015>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_BFO_0000066_reaction_3-PROPANAL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5760-1>
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_58374_RXN-9015_SGD_PWY_YeastPathways_PWY-5760-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5760-1" ;
+                "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_57834_RXN-9015_SGD_YeastPathways_PWY-5760-1>
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15377_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-5760-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5760-1" ;
+                "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -532,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -549,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -557,15 +590,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_45725_RXN-9015_SGD_PWY_YeastPathways_PWY-5760-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5760-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_BFO_0000066_reaction_3-PROPANAL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5760-1> ;
+          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_BFO_0000066_reaction_3-PROPANAL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5760-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -580,11 +624,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_BFO_0000066_reaction_RXN-9015_location_lociGO_0005829_SGD_YeastPathways_PWY-5760-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_BFO_0000066_reaction_RXN-9015_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5760-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,14 +648,14 @@
 <http://identifiers.org/sgd/S000004622>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002413_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-5760-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57966_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-5760-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5760-1" ;
+                "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -624,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -641,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -655,26 +699,15 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_16240_RXN-9015_SGD_YeastPathways_PWY-5760-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5760-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57966_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-5760-1> ;
+          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57966_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-5760-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -688,18 +721,15 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_45725>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_57834_RXN-9015_SGD_YeastPathways_PWY-5760-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_57834_RXN-9015_SGD_PWY_YeastPathways_PWY-5760-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -710,16 +740,8 @@
           <http://model.geneontology.org/CHEBI_57834_RXN-9015>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_15379_RXN-9015_SGD_YeastPathways_PWY-5760-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5760-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_45725>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -728,11 +750,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY-5760-1/YeastPathways_PWY-5760-1_SGD_YeastPathways_PWY-5760-1> ;
+          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY-5760-1/YeastPathways_PWY-5760-1_SGD_PWY_YeastPathways_PWY-5760-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -747,11 +769,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_BFO_0000050_YeastPathways_PWY-5760-1/YeastPathways_PWY-5760-1_SGD_YeastPathways_PWY-5760-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_BFO_0000050_YeastPathways_PWY-5760-1/YeastPathways_PWY-5760-1_SGD_PWY_YeastPathways_PWY-5760-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -762,33 +784,22 @@
           <http://model.geneontology.org/YeastPathways_PWY-5760-1/YeastPathways_PWY-5760-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-5760-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5760-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16240>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-9015_BFO_0000066_reaction_RXN-9015_location_lociGO_0005829_SGD_YeastPathways_PWY-5760-1>
+<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002233_CHEBI_15379_RXN-9015_SGD_PWY_YeastPathways_PWY-5760-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5760-1" ;
+                "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -802,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -810,8 +821,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002333_YMR020W-MONOMER_RXN-9015_controller_SGD_PWY_YeastPathways_PWY-5760-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5760-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/CHEBI_16240_RXN-9015>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16240> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "hydrogen peroxide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5760-1SmallMolecule74336> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN-9015>
         a       <http://purl.obolibrary.org/obo/GO_0052904> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -832,41 +871,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5760-1BiochemicalReaction74278> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/CHEBI_16240_RXN-9015>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16240> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "hydrogen peroxide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5760-1SmallMolecule74336> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57966_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-5760-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5760-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -875,11 +886,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-5760-1> ;
+          <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-5760-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -894,11 +905,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_16240_RXN-9015_SGD_YeastPathways_PWY-5760-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002234_CHEBI_16240_RXN-9015_SGD_PWY_YeastPathways_PWY-5760-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -937,26 +948,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002333_YMR169C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PWY-5760-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5760-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'spermine + oxygen + H<sub>2</sub>O &rarr; spermidine + 3-aminopropanal + hydrogen peroxide' 'null' '3-aminopropanal + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; &beta;-alanine + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002413_3-PROPANAL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-5760-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9015_RO_0002413_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-5760-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -982,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-5971-1.ttl
+++ b/models/YeastPathways_PWY-5971-1.ttl
@@ -1,12 +1,23 @@
+<http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.59-RXN_controller_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9528_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9528_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,14 +28,14 @@
           <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002233_CHEBI_57783_RXN-9528_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002233_CHEBI_15378_RXN-9521_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -47,35 +58,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1BiochemicalReaction33143> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9530_BFO_0000066_reaction_RXN-9530_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002233_Myristoyl-ACPs_RXN-9538_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN-9655>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -86,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -94,15 +83,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002234_CHEBI_58349_RXN-9534_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002234_CHEBI_58349_RXN-9528_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002234_3-Oxo-octanoyl-ACPs_RXN-9523_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002234_3-Oxo-octanoyl-ACPs_RXN-9523_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -117,11 +128,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002234_CHEBI_15377_RXN-9655_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002234_CHEBI_15377_RXN-9655_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -132,26 +143,15 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-9655>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9533_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9518_BFO_0000066_reaction_RXN-9518_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9518_BFO_0000066_reaction_RXN-9518_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -162,26 +162,15 @@
           <http://model.geneontology.org/reaction_RXN-9518_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002234_ACP_RXN-9523_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002233_3-oxo-myristoyl-ACPs_RXN-9535_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002233_3-oxo-myristoyl-ACPs_RXN-9535_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -204,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -212,14 +201,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9518_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002233_CHEBI_57783_RXN-9530_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -227,11 +216,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9533_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9533_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,11 +235,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002233_Trans-D2-decenoyl-ACPs_RXN-9655_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002233_Trans-D2-decenoyl-ACPs_RXN-9655_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -261,25 +250,58 @@
           <http://model.geneontology.org/Trans-D2-decenoyl-ACPs_RXN-9655>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002233_ACP_RXN-9516_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002233_Dodecanoyl-ACPs_RXN-9534_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002233_CHEBI_57783_RXN-9524_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002233_CHEBI_57783_RXN-9518_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002413_RXN-9655_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002333_YKL182W-MONOMER_RXN-9534_controller_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002413_RXN-9528_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -287,11 +309,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9526_BFO_0000066_reaction_RXN-9526_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9526_BFO_0000066_reaction_RXN-9526_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,11 +331,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -324,6 +346,28 @@
           <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002234_CHEBI_58349_RXN-9530_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002234_CHEBI_58349_RXN-9524_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57783_RXN-9530>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -333,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,15 +385,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002413_RXN-9521_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9537_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002333_YKL182W-MONOMER_RXN-9520_controller_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002333_YKL182W-MONOMER_RXN-9520_controller_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -381,11 +447,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9538_BFO_0000066_reaction_RXN-9538_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9538_BFO_0000066_reaction_RXN-9538_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -396,14 +462,14 @@
           <http://model.geneontology.org/reaction_RXN-9538_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002234_ACP_RXN-9526_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002233_Dodec-2-enoyl-ACPs_RXN-9533_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -416,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -424,15 +490,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002234_CHEBI_57287_RXN-9626_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002234_CHEBI_58349_RXN-9534_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002234_CHEBI_58349_RXN-9534_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -447,11 +524,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002234_3-oxo-dodecanoyl-ACPs_RXN-9531_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002234_3-oxo-dodecanoyl-ACPs_RXN-9531_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,11 +543,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_BFO_0000066_reaction_4.2.1.59-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_BFO_0000066_reaction_4.2.1.59-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,11 +565,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9516_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9516_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -512,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -520,15 +597,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002233_CHEBI_15377_RXN-9626_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002234_Hexanoyl-ACPs_RXN-9521_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002233_CHEBI_15378_RXN-9527_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002233_CHEBI_15378_RXN-9527_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,15 +638,26 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-9527>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9535_BFO_0000066_reaction_RXN-9535_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002233_CHEBI_15378_RXN-9538_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002233_CHEBI_15378_RXN-9538_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -558,17 +668,6 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-9538>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002333_YKL182W-MONOMER_RXN-9520_controller_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_RXN-9531>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -578,7 +677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -593,7 +692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -601,25 +700,47 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002413_RXN-9518_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002233_Tetradec-2-enoyl-ACPs_RXN-9537_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002234_CHEBI_16526_RXN-9527_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002234_CHEBI_58349_RXN-9521_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002233_ACP_RXN-9526_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002333_YKL182W-MONOMER_RXN3O-8214_controller_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -627,11 +748,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9523_BFO_0000066_reaction_RXN-9523_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9523_BFO_0000066_reaction_RXN-9523_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -646,11 +767,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002234_Dodecanoyl-ACPs_RXN-9534_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002234_Dodecanoyl-ACPs_RXN-9534_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -678,23 +799,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9532_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN-9527_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -717,13 +827,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1BiochemicalReaction33008> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9523_BFO_0000066_reaction_RXN-9523_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9626>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -740,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -752,11 +873,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002234_CHEBI_58349_RXN-9528_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002234_CHEBI_58349_RXN-9528_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -771,11 +892,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002234_CHEBI_30807_RXN-9626_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002234_CHEBI_30807_RXN-9626_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -786,25 +907,25 @@
           <http://model.geneontology.org/CHEBI_30807_RXN-9626>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9534_BFO_0000066_reaction_RXN-9534_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002333_YPL231W-MONOMER_RXN-9516_controller_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002413_RXN3O-8214_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002333_YPL231W-MONOMER_RXN-9523_controller_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -813,29 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9526_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002233_ACP_RXN-9526_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -843,11 +942,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002233_CHEBI_57783_RXN-9524_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002233_CHEBI_57783_RXN-9524_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -862,11 +961,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Provides Input For Rule. The relation 'a dodecanoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxotetradecanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein' 'null' 'a (3<i>R</i>)-3-hydroxytetradecanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxotetradecanoyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002413_RXN-9536_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002413_RXN-9536_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -876,6 +975,39 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN-9536>
 ] .
+
+<http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002233_ACP_RXN-9524_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002234_Trans-D2-decenoyl-ACPs_RXN-9655_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002234_CHEBI_16526_RXN-9523_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -887,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -904,7 +1036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -916,11 +1048,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxyhexanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxohexanoyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (3<i>R</i>)-3-hydroxyhexanoyl-[acp] &rarr; a (2<i>E</i>)-hex-2-enoyl-[acp] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002413_RXN-9520_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002413_RXN-9520_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -935,11 +1067,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002233_CHEBI_57783_RXN-9532_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002233_CHEBI_57783_RXN-9532_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -950,28 +1082,6 @@
           <http://model.geneontology.org/CHEBI_57783_RXN-9532>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9518_BFO_0000066_reaction_RXN-9518_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002234_ACP_RXN-9535_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ACP_RXN3O-8214>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -981,7 +1091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -998,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1011,7 +1121,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002333_YPL231W-MONOMER_RXN-9535_controller_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1019,11 +1140,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002233_Myristoyl-ACPs_RXN-9538_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002233_Myristoyl-ACPs_RXN-9538_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1034,14 +1155,14 @@
           <http://model.geneontology.org/Myristoyl-ACPs_RXN-9538>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002233_CHEBI_15378_RXN-9538_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002234_CHEBI_15377_RXN-9537_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1049,11 +1170,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002234_CHEBI_15377_RXN-9537_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002234_CHEBI_15377_RXN-9537_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1064,41 +1185,27 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-9537>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002413_RXN-9534_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002234_3-Oxo-octanoyl-ACPs_RXN-9523_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002233_CHEBI_15378_RXN-9521_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002234_ACP_RXN-9527_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002234_CHEBI_15377_4.2.1.59-RXN_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0006633>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57783_RXN-9536>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1109,13 +1216,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1SmallMolecule32943> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0006633>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/RXN3O-8214>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -1136,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1144,26 +1254,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002234_CHEBI_15377_RXN-9537_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9534_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9534_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1178,11 +1277,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002233_ACP_RXN-9531_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002233_ACP_RXN-9531_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1193,6 +1292,28 @@
           <http://model.geneontology.org/ACP_RXN-9531>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002234_3-oxo-dodecanoyl-ACPs_RXN-9531_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002233_3-oxo-decanoyl-ACPs_RXN-9527_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1202,7 +1323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "myristate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1210,15 +1331,37 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002234_CHEBI_15377_4.2.1.59-RXN_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9532_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a (2<i>E</i>)-oct-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; an octanoyl-[acp] + NADP<sup>+</sup>' 'null' 'an octanoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxodecanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002413_RXN-9527_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002413_RXN-9527_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1228,17 +1371,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN-9527>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-9531_BFO_0000066_reaction_RXN-9531_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9524>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1257,7 +1389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1269,11 +1401,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002234_CHEBI_16526_RXN-9516_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002234_CHEBI_16526_RXN-9516_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1291,7 +1423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1299,37 +1431,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002413_RXN-9531_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9531_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002234_CHEBI_58349_RXN-9521_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002234_CHEBI_58349_RXN-9521_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1349,7 +1459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1361,11 +1471,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Provides Input For Rule. The relation 'a (2<i>E</i>)-tetradec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a myristoyl-[acp] + NADP<sup>+</sup>' 'null' 'a myristoyl-[acp] + coenzyme A &rarr; acyl-carrier protein + myristoyl-CoA' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002413_RXN3O-8214_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002413_RXN3O-8214_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1376,59 +1486,15 @@
           <http://model.geneontology.org/RXN3O-8214>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002413_RXN-9520_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002233_CHEBI_15378_RXN-9535_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002234_3-oxo-decanoyl-ACPs_RXN-9527_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9626_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002233_CHEBI_15378_RXN-9535_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002233_CHEBI_15378_RXN-9535_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1439,25 +1505,36 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-9535>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002233_Hexanoyl-ACPs_RXN-9521_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002233_CHEBI_15378_RXN-9535_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9516_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002413_RXN-9520_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002233_Myristoyl-ACPs_RXN-9538_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1470,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1487,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1495,37 +1572,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002333_YKL182W-MONOMER_RXN3O-8214_controller_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002413_RXN-9523_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9528_BFO_0000066_reaction_RXN-9528_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9528_BFO_0000066_reaction_RXN-9528_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1553,7 +1608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1565,11 +1620,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002333_YPL231W-MONOMER_RXN-9523_controller_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002333_YPL231W-MONOMER_RXN-9523_controller_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1587,11 +1642,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002234_Trans-D2-decenoyl-ACPs_RXN-9655_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002234_Trans-D2-decenoyl-ACPs_RXN-9655_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1602,19 +1657,41 @@
           <http://model.geneontology.org/Trans-D2-decenoyl-ACPs_RXN-9655>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002234_CHEBI_15378_RXN-9626_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9528_BFO_0000066_reaction_RXN-9528_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000006152>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9534_BFO_0000066_reaction_RXN-9534_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002234_ACP_RXN-9531_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN-9626>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1625,7 +1702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1637,11 +1714,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002233_CHEBI_15378_RXN-9518_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002233_CHEBI_15378_RXN-9518_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1652,24 +1729,15 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-9518>
 ] .
 
-<http://model.geneontology.org/reaction_RXN-9528_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002234_ACP_RXN-9536_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002234_ACP_RXN-9536_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1680,28 +1748,48 @@
           <http://model.geneontology.org/ACP_RXN-9536>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15377>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/reaction_RXN-9528_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9538_BFO_0000066_reaction_RXN-9538_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002233_CHEBI_57783_RXN-9538_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002233_CHEBI_15378_RXN-9518_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002233_CHEBI_15378_RXN-9526_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002333_YKL182W-MONOMER_RXN-9521_controller_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1714,7 +1802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1722,15 +1810,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9655_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9533_BFO_0000066_reaction_RXN-9533_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9533_BFO_0000066_reaction_RXN-9533_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1745,11 +1844,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002234_CHEBI_58349_RXN-9530_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002234_CHEBI_58349_RXN-9530_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1766,14 +1865,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002234_3-oxo-dodecanoyl-ACPs_RXN-9531_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002234_ACP_RXN-9526_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1782,7 +1881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1791,7 +1890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1799,11 +1898,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002233_CHEBI_15378_RXN-9526_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002233_CHEBI_15378_RXN-9526_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1813,6 +1912,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_RXN-9526>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-9516_BFO_0000066_reaction_RXN-9516_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9518>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1831,7 +1941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1839,37 +1949,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002234_CHEBI_58349_RXN-9528_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002233_3-oxo-myristoyl-ACPs_RXN-9535_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxyhexanoyl-[acp] &rarr; a (2<i>E</i>)-hex-2-enoyl-[acp] + H<sub>2</sub>O' 'null' 'a (2<i>E</i>)-hex-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a hexanoyl-[acp] + NADP<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002413_RXN-9521_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002413_RXN-9521_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1880,6 +1968,17 @@
           <http://model.geneontology.org/RXN-9521>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002333_YKL182W-MONOMER_RXN-9533_controller_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16526_RXN-9516>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1889,13 +1988,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1SmallMolecule33160> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002234_3-oxo-hexanoyl-ACPs_RXN-9516_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACP_RXN-9526>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1906,7 +2016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1914,14 +2024,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9530_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002233_ACP_RXN-9532_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002413_RXN-9535_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002234_CHEBI_15377_RXN-9520_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1931,14 +2063,25 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002233_ACP_RXN-9518_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9535_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002233_CHEBI_57783_RXN-9534_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1946,11 +2089,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002333_YPL231W-MONOMER_RXN-9531_controller_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002333_YPL231W-MONOMER_RXN-9531_controller_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1961,26 +2104,15 @@
           <http://model.geneontology.org/YPL231W-MONOMER_RXN-9531_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002234_CHEBI_57385_RXN3O-8214_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002233_ACP_RXN-9524_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002233_ACP_RXN-9524_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1991,14 +2123,14 @@
           <http://model.geneontology.org/ACP_RXN-9524>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002234_CHEBI_16526_RXN-9535_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002233_CHEBI_15378_RXN-9516_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2006,11 +2138,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9516_BFO_0000066_reaction_RXN-9516_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9516_BFO_0000066_reaction_RXN-9516_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2025,11 +2157,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002234_ACP_RXN-9527_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002234_ACP_RXN-9527_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2040,37 +2172,15 @@
           <http://model.geneontology.org/ACP_RXN-9527>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002333_YKL182W-MONOMER_RXN-9521_controller_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002234_3-oxo-hexanoyl-ACPs_RXN-9516_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002233_CHEBI_57783_RXN-9538_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002233_CHEBI_57783_RXN-9538_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2090,7 +2200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2101,36 +2211,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9524_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002233_ACP_RXN-9527_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002233_Trans-D2-decenoyl-ACPs_RXN-9655_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9535_BFO_0000066_reaction_RXN-9535_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2138,11 +2226,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002233_ACP_RXN-9523_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002233_ACP_RXN-9523_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2157,11 +2245,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002333_YKL182W-MONOMER_RXN-9534_controller_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002333_YKL182W-MONOMER_RXN-9534_controller_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2172,36 +2260,14 @@
           <http://model.geneontology.org/YKL182W-MONOMER_RXN-9534_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002413_RXN-9521_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002234_2-Octenoyl-ACPs_4.2.1.59-RXN_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002233_Decanoyl-ACPs_RXN-9530_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002233_Butanoyl-ACPs_RXN-9516_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2224,7 +2290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2232,19 +2298,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002333_YPL231W-MONOMER_RXN-9516_controller_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-8214_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0003674>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58349_RXN-9526>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2255,7 +2321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2263,14 +2329,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002233_CHEBI_57783_RXN-9526_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002413_RXN-9526_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2281,11 +2347,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxydecanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxodecanoyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (3<i>R</i>)-3-hydroxydecanoyl-[acp] &rarr; a (2<i>E</i>)-dec-2-enoyl-[acp] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002413_RXN-9655_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002413_RXN-9655_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2300,11 +2366,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002234_CHEBI_57287_RXN-9626_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002234_CHEBI_57287_RXN-9626_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2315,62 +2381,29 @@
           <http://model.geneontology.org/CHEBI_57287_RXN-9626>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002333_YPL231W-MONOMER_RXN-9527_controller_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9523_BFO_0000066_reaction_RXN-9523_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002234_3-oxo-myristoyl-ACPs_RXN-9535_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9655_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9523_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002233_3-Oxo-octanoyl-ACPs_RXN-9523_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002233_3-Oxo-octanoyl-ACPs_RXN-9523_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2385,11 +2418,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9536_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9536_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2400,14 +2433,14 @@
           <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9626_BFO_0000066_reaction_RXN-9626_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002413_4.2.1.59-RXN_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2415,11 +2448,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9520_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9520_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2434,11 +2467,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002233_3-oxo-dodecanoyl-ACPs_RXN-9531_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002233_3-oxo-dodecanoyl-ACPs_RXN-9531_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2453,11 +2486,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9530_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9530_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2477,7 +2510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2485,15 +2518,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002233_CHEBI_57783_RXN-9521_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002413_RXN-9518_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002234_ACP_RXN-9524_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002234_ACP_RXN-9524_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2504,37 +2559,15 @@
           <http://model.geneontology.org/ACP_RXN-9524>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002233_CHEBI_15378_RXN-9527_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002234_CHEBI_30807_RXN-9626_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002234_ACP_RXN3O-8214_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002234_ACP_RXN3O-8214_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2545,14 +2578,14 @@
           <http://model.geneontology.org/ACP_RXN3O-8214>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002234_3-Oxo-octanoyl-ACPs_RXN-9523_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002233_ACP_RXN-9531_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2563,7 +2596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2575,11 +2608,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9520_BFO_0000066_reaction_RXN-9520_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9520_BFO_0000066_reaction_RXN-9520_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2594,11 +2627,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002234_Tetradec-2-enoyl-ACPs_RXN-9537_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002234_Tetradec-2-enoyl-ACPs_RXN-9537_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2612,6 +2645,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_57385>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002333_YKL182W-MONOMER_RXN-9530_controller_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_RXN-9526>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2621,7 +2665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2629,45 +2673,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002234_ACP_RXN-9531_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9534_BFO_0000066_reaction_RXN-9534_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9534> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9534_location_lociGO_0005829>
-] .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002233_CHEBI_15378_RXN-9531_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002233_CHEBI_15378_RXN-9531_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2678,25 +2692,77 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-9531>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9523_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9534_BFO_0000066_reaction_RXN-9534_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9534> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN-9534_location_lociGO_0005829>
+] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9520_BFO_0000066_reaction_RXN-9520_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9527_BFO_0000066_reaction_RXN-9527_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002413_RXN-9524_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9538_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9533_BFO_0000066_reaction_RXN-9533_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002413_RXN-9537_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2705,7 +2771,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-8214_BFO_0000066_reaction_RXN3O-8214_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2713,11 +2790,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9527_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9527_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2728,14 +2805,14 @@
           <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002233_CHEBI_57783_RXN-9538_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002234_Dodec-2-enoyl-ACPs_RXN-9533_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2744,7 +2821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2752,11 +2829,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002234_3-oxo-hexanoyl-ACPs_RXN-9516_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002234_3-oxo-hexanoyl-ACPs_RXN-9516_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2767,25 +2844,14 @@
           <http://model.geneontology.org/3-oxo-hexanoyl-ACPs_RXN-9516>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-8214_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9530_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002233_CHEBI_15378_RXN-9524_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2793,11 +2859,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002234_Hexanoyl-ACPs_RXN-9521_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002234_Hexanoyl-ACPs_RXN-9521_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2812,11 +2878,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9626_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9626_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2827,6 +2893,17 @@
           <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002233_3-oxo-dodecanoyl-ACPs_RXN-9531_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16526_RXN-9523>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2836,7 +2913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2853,7 +2930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2861,15 +2938,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002234_Beta-hydroxydecanoyl-ACPs_RXN-9528_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002233_Dodecanoyl-ACPs_RXN-9534_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002233_Dodecanoyl-ACPs_RXN-9534_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2880,6 +2968,17 @@
           <http://model.geneontology.org/Dodecanoyl-ACPs_RXN-9534>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9521_BFO_0000066_reaction_RXN-9521_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30807_RXN-9626>
         a       <http://purl.obolibrary.org/obo/CHEBI_30807> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2889,7 +2988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2897,14 +2996,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002413_RXN-9537_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002234_ACP_RXN3O-8214_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2915,7 +3014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2932,7 +3031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2940,26 +3039,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002234_CHEBI_58349_RXN-9534_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002233_CHEBI_15378_RXN-9528_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002233_CHEBI_15378_RXN-9528_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2989,7 +3077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2997,35 +3085,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002233_ACP_RXN-9527_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002234_ACP_RXN-9532_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_BFO_0000066_reaction_4.2.1.59-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Provides Input For Rule. The relation 'a hexanoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxooctanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein' 'null' 'a (3<i>R</i>)-3-hydroxyoctanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxooctanoyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002413_RXN-9524_SGD_YeastPathways_PWY-5971-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9523> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9524>
-] .
 
 <http://model.geneontology.org/CHEBI_16526_RXN-9535>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -3036,7 +3116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3044,15 +3124,56 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002413_RXN-9530_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Provides Input For Rule. The relation 'a hexanoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxooctanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein' 'null' 'a (3<i>R</i>)-3-hydroxyoctanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxooctanoyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002413_RXN-9524_SGD_PWY_YeastPathways_PWY-5971-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9523> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN-9524>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-9526_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002333_YKL182W-MONOMER_RXN-9655_controller_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002333_YKL182W-MONOMER_RXN-9655_controller_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3063,6 +3184,17 @@
           <http://model.geneontology.org/YKL182W-MONOMER_RXN-9655_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002413_RXN-9533_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/Beta-hydroxydecanoyl-ACPs_RXN-9528>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3072,7 +3204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3080,37 +3212,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002413_RXN-9655_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002234_CHEBI_16526_RXN-9527_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002233_CHEBI_57783_RXN-9518_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002233_CHEBI_57783_RXN-9518_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3121,26 +3231,15 @@
           <http://model.geneontology.org/CHEBI_57783_RXN-9518>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002233_CHEBI_57385_RXN3O-8214_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002234_CHEBI_58349_RXN-9536_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002234_CHEBI_58349_RXN-9536_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3151,25 +3250,14 @@
           <http://model.geneontology.org/CHEBI_58349_RXN-9536>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9527_BFO_0000066_reaction_RXN-9527_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002234_ACP_RXN-9535_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9538_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3180,11 +3268,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002233_ACP_RXN-9532_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002233_ACP_RXN-9532_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3199,11 +3287,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002234_Decanoyl-ACPs_RXN-9530_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002234_Decanoyl-ACPs_RXN-9530_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3218,11 +3306,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxydecanoyl-[acp] &rarr; a (2<i>E</i>)-dec-2-enoyl-[acp] + H<sub>2</sub>O' 'null' 'a (2<i>E</i>)-dec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a decanoyl-[acp] + NADP<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002413_RXN-9530_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002413_RXN-9530_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3233,36 +3321,14 @@
           <http://model.geneontology.org/RXN-9530>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002333_YKL182W-MONOMER_RXN-9526_controller_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002233_3-oxo-myristoyl-ACPs_RXN-9535_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002234_CHEBI_15377_RXN-9520_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002333_YKL182W-MONOMER_RXN-9537_controller_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3270,11 +3336,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002233_CHEBI_57783_RXN-9526_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002233_CHEBI_57783_RXN-9526_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3289,11 +3355,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxytetradecanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxotetradecanoyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (3<i>R</i>)-3-hydroxytetradecanoyl-[acp] &rarr; a (2<i>E</i>)-tetradec-2-enoyl-[acp] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002413_RXN-9537_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002413_RXN-9537_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3304,17 +3370,6 @@
           <http://model.geneontology.org/RXN-9537>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002233_CHEBI_15378_RXN-9536_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_RXN-9521>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3324,13 +3379,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1SmallMolecule32956> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9626_BFO_0000066_reaction_RXN-9626_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57783_RXN-9532>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
@@ -3341,7 +3407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3353,11 +3419,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9521_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9521_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3372,11 +3438,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002234_CHEBI_15377_RXN-9533_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002234_CHEBI_15377_RXN-9533_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3396,7 +3462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3404,25 +3470,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002233_CHEBI_57783_RXN-9532_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002233_CHEBI_57783_RXN-9518_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002233_CHEBI_15378_RXN-9536_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3433,24 +3488,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein32987> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002233_CHEBI_57287_RXN3O-8214_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57287_RXN3O-8214>
         a       <http://purl.obolibrary.org/obo/CHEBI_57287> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3461,7 +3505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3476,11 +3520,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002234_CHEBI_15377_4.2.1.59-RXN_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002234_CHEBI_15377_4.2.1.59-RXN_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3491,24 +3535,16 @@
           <http://model.geneontology.org/CHEBI_15377_4.2.1.59-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Provides Input For Rule. The relation 'a decanoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxododecanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein' 'null' 'a (<i>3R</i>)-3-hydroxydodecanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxododecanoyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002413_RXN-9532_SGD_YeastPathways_PWY-5971-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9531> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9532>
-] .
+<http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002233_ACP_RXN-9536_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9520>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3529,7 +3565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3539,13 +3575,43 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Provides Input For Rule. The relation 'a decanoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxododecanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein' 'null' 'a (<i>3R</i>)-3-hydroxydodecanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxododecanoyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002233_ACP_RXN-9516_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002413_RXN-9532_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9531> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN-9532>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002233_ACP_RXN-9518_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002233_ACP_RXN-9516_SGD_PWY_YeastPathways_PWY-5971-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3556,14 +3622,14 @@
           <http://model.geneontology.org/ACP_RXN-9516>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002233_Dodec-2-enoyl-ACPs_RXN-9533_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9538_BFO_0000066_reaction_RXN-9538_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3571,11 +3637,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002233_Tetradec-2-enoyl-ACPs_RXN-9537_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002233_Tetradec-2-enoyl-ACPs_RXN-9537_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3586,15 +3652,26 @@
           <http://model.geneontology.org/Tetradec-2-enoyl-ACPs_RXN-9537>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9533_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002234_CHEBI_16526_RXN-9527_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002234_CHEBI_16526_RXN-9527_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3610,29 +3687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002333_YKL182W-MONOMER_RXN-9533_controller_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9524_BFO_0000066_reaction_RXN-9524_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3640,11 +3695,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002233_CHEBI_15378_RXN-9523_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002233_CHEBI_15378_RXN-9523_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3659,11 +3714,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Provides Input For Rule. The relation 'a (2<i>E</i>)-dodec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a dodecanoyl-[acp] + NADP<sup>+</sup>' 'null' 'a dodecanoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxotetradecanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002413_RXN-9535_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002413_RXN-9535_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3679,19 +3734,52 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002233_CHEBI_15378_RXN-9527_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-9535_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002413_RXN-9626_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002233_CHEBI_15378_RXN-9532_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3712,7 +3800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3720,14 +3808,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002413_RXN-9527_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9526_BFO_0000066_reaction_RXN-9526_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9532_BFO_0000066_reaction_RXN-9532_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3735,11 +3834,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9655_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9655_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3759,7 +3858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3771,11 +3870,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9536_BFO_0000066_reaction_RXN-9536_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9536_BFO_0000066_reaction_RXN-9536_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3786,25 +3885,25 @@
           <http://model.geneontology.org/reaction_RXN-9536_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002234_ACP_RXN-9516_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002333_YKL182W-MONOMER_RXN-9526_controller_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9521_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3817,62 +3916,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1SmallMolecule32943> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9530_BFO_0000066_reaction_RXN-9530_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9530> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9530_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002234_ACP_RXN-9532_SGD_YeastPathways_PWY-5971-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9532> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_RXN-9532>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN-9521_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/3-oxo-decanoyl-ACPs_RXN-9527>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -3883,13 +3933,84 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33205> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002333_YKL182W-MONOMER_RXN-9655_controller_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002234_ACP_RXN-9532_SGD_PWY_YeastPathways_PWY-5971-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9532> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ACP_RXN-9532>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9530_BFO_0000066_reaction_RXN-9530_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9530> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN-9530_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002234_Tetradec-2-enoyl-ACPs_RXN-9537_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002233_CHEBI_15378_RXN-9523_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/3-oxo-dodecanoyl-ACPs_RXN-9531>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3900,7 +4021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3908,36 +4029,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002413_RXN-9524_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN-9520_BFO_0000066_reaction_RXN-9520_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002233_CHEBI_15378_RXN-9530_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9655_BFO_0000066_reaction_RXN-9655_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002233_CHEBI_15378_RXN-9516_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002234_CHEBI_58349_RXN-9536_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3945,11 +4066,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002234_CHEBI_58349_RXN-9524_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002234_CHEBI_58349_RXN-9524_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3964,11 +4085,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002234_CHEBI_57385_RXN3O-8214_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002234_CHEBI_57385_RXN3O-8214_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3988,7 +4109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4000,11 +4121,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002233_ACP_RXN-9518_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002233_ACP_RXN-9518_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4015,14 +4136,36 @@
           <http://model.geneontology.org/ACP_RXN-9518>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002333_YPL231W-MONOMER_RXN-9535_controller_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002233_CHEBI_57287_RXN3O-8214_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002333_YKL182W-MONOMER_RXN-9538_controller_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002234_Dodecanoyl-ACPs_RXN-9534_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4030,11 +4173,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002333_YKL182W-MONOMER_RXN-9537_controller_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002333_YKL182W-MONOMER_RXN-9537_controller_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4054,7 +4197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4062,14 +4205,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002234_CHEBI_58349_RXN-9526_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002233_ACP_RXN-9535_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4082,7 +4225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4094,11 +4237,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002233_CHEBI_15378_RXN-9534_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002233_CHEBI_15378_RXN-9534_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4113,11 +4256,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002233_Decanoyl-ACPs_RXN-9530_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002233_Decanoyl-ACPs_RXN-9530_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4128,15 +4271,26 @@
           <http://model.geneontology.org/Decanoyl-ACPs_RXN-9530>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002233_CHEBI_57783_RXN-9526_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9527_BFO_0000066_reaction_RXN-9527_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9527_BFO_0000066_reaction_RXN-9527_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4147,17 +4301,6 @@
           <http://model.geneontology.org/reaction_RXN-9527_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002413_RXN-9538_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YKL182W-MONOMER_RXN-9526_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001665> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4165,13 +4308,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein32987> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9536_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9526>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -4192,7 +4346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4200,15 +4354,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002413_RXN3O-8214_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002333_YPL231W-MONOMER_RXN-9516_controller_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002333_YPL231W-MONOMER_RXN-9516_controller_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4219,6 +4384,39 @@
           <http://model.geneontology.org/YPL231W-MONOMER_RXN-9516_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002234_CHEBI_58349_RXN-9532_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002413_RXN-9531_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002234_CHEBI_58349_RXN-9526_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_RXN-9520>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4228,7 +4426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4240,11 +4438,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002333_YKL182W-MONOMER_RXN-9521_controller_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002333_YKL182W-MONOMER_RXN-9521_controller_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4259,11 +4457,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9626_BFO_0000066_reaction_RXN-9626_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9626_BFO_0000066_reaction_RXN-9626_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4274,17 +4472,6 @@
           <http://model.geneontology.org/reaction_RXN-9626_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002234_ACP_RXN-9524_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YPL231W-MONOMER_RXN-9535_controller>
         a       <http://identifiers.org/sgd/S000006152> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4292,7 +4479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4306,26 +4493,15 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9528_BFO_0000066_reaction_RXN-9528_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002234_ACP_RXN-9535_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002234_ACP_RXN-9535_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4336,58 +4512,14 @@
           <http://model.geneontology.org/ACP_RXN-9535>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002233_3-oxo-hexanoyl-ACPs_RXN-9516_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002234_Decanoyl-ACPs_RXN-9530_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002233_2-Octenoyl-ACPs_4.2.1.59-RXN_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002413_RXN-9535_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002233_CHEBI_15378_RXN-9528_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002233_3-oxo-decanoyl-ACPs_RXN-9527_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4395,11 +4527,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002233_CHEBI_57783_RXN-9528_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002233_CHEBI_57783_RXN-9528_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4410,12 +4542,23 @@
           <http://model.geneontology.org/CHEBI_57783_RXN-9528>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002233_Beta-hydroxydecanoyl-ACPs_RXN-9528_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-9538_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4438,7 +4581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4446,36 +4589,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9532_BFO_0000066_reaction_RXN-9532_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002233_Butanoyl-ACPs_RXN-9516_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002233_CHEBI_57783_RXN-9524_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9520_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4483,11 +4604,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9524_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9524_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4498,36 +4619,36 @@
           <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002234_CHEBI_16526_RXN-9516_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002333_YPL231W-MONOMER_RXN-9523_controller_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002234_CHEBI_58349_RXN-9538_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9537_BFO_0000066_reaction_RXN-9537_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002234_ACP_RXN-9536_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9626_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4536,7 +4657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4549,7 +4670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4557,14 +4678,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9516_BFO_0000066_reaction_RXN-9516_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002333_YPL231W-MONOMER_RXN-9527_controller_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4572,11 +4693,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002233_3-oxo-hexanoyl-ACPs_RXN-9516_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002233_3-oxo-hexanoyl-ACPs_RXN-9516_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4596,7 +4717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4604,36 +4725,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002413_RXN-9532_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9524_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002333_YKL182W-MONOMER_RXN-9655_controller_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002234_CHEBI_57287_RXN-9626_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4649,7 +4748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4657,26 +4756,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002233_ACP_RXN-9523_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002333_YKL182W-MONOMER_RXN-9530_controller_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002333_YKL182W-MONOMER_RXN-9530_controller_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4691,11 +4779,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-8214_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-8214_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4706,26 +4794,15 @@
           <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002333_YKL182W-MONOMER_RXN-9538_controller_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002233_2-Octenoyl-ACPs_4.2.1.59-RXN_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002233_2-Octenoyl-ACPs_4.2.1.59-RXN_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4740,11 +4817,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9537_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9537_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4755,25 +4832,14 @@
           <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.59-RXN_controller_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002234_CHEBI_16526_RXN-9531_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002233_CHEBI_57783_RXN-9521_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4781,11 +4847,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9521_BFO_0000066_reaction_RXN-9521_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9521_BFO_0000066_reaction_RXN-9521_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4800,11 +4866,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002234_Dodec-2-enoyl-ACPs_RXN-9533_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002234_Dodec-2-enoyl-ACPs_RXN-9533_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4819,11 +4885,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002234_2-Octenoyl-ACPs_4.2.1.59-RXN_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002234_2-Octenoyl-ACPs_4.2.1.59-RXN_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4838,11 +4904,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9532_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9532_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4852,6 +4918,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002413_RXN-9527_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9521>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -4872,7 +4949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4884,11 +4961,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002233_Butanoyl-ACPs_RXN-9516_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002233_Butanoyl-ACPs_RXN-9516_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4899,17 +4976,6 @@
           <http://model.geneontology.org/Butanoyl-ACPs_RXN-9516>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002333_YKL182W-MONOMER_RXN-9534_controller_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/Myristoyl-ACPs_RXN-9538>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4919,7 +4985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4927,26 +4993,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002233_CHEBI_57783_RXN-9536_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002234_3-oxo-decanoyl-ACPs_RXN-9527_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002234_3-oxo-decanoyl-ACPs_RXN-9527_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4961,11 +5016,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002234_CHEBI_58349_RXN-9538_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002234_CHEBI_58349_RXN-9538_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4976,6 +5031,17 @@
           <http://model.geneontology.org/CHEBI_58349_RXN-9538>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002234_3-oxo-decanoyl-ACPs_RXN-9527_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_RXN-9534>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4985,7 +5051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4993,15 +5059,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002234_ACP_RXN-9516_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002233_Hexanoyl-ACPs_RXN-9521_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002233_Hexanoyl-ACPs_RXN-9521_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5016,11 +5093,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9535_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9535_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5031,14 +5108,14 @@
           <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002234_ACP_RXN-9536_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9531_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5051,7 +5128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5063,11 +5140,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002333_YPL231W-MONOMER_RXN-9527_controller_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002333_YPL231W-MONOMER_RXN-9527_controller_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5097,7 +5174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5105,37 +5182,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002234_Dodecanoyl-ACPs_RXN-9534_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN-9521_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002234_CHEBI_58349_RXN-9532_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5148,7 +5200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5156,26 +5208,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002234_CHEBI_58349_RXN-9518_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002234_ACP_RXN-9523_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002234_ACP_RXN-9523_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5195,7 +5239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5207,11 +5251,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9655_BFO_0000066_reaction_RXN-9655_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9655_BFO_0000066_reaction_RXN-9655_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5222,15 +5266,26 @@
           <http://model.geneontology.org/reaction_RXN-9655_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002413_RXN-9523_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Provides Input For Rule. The relation 'a butanoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxohexanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein' 'null' 'a (3<i>R</i>)-3-hydroxyhexanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxohexanoyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002413_RXN-9518_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002413_RXN-9518_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5241,15 +5296,26 @@
           <http://model.geneontology.org/RXN-9518>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002333_YKL182W-MONOMER_RXN-9520_controller_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002233_CHEBI_15378_RXN-9536_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002233_CHEBI_15378_RXN-9536_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5260,25 +5326,25 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-9536>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9536_BFO_0000066_reaction_RXN-9536_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9527_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9655_BFO_0000066_reaction_RXN-9655_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002333_YPL231W-MONOMER_RXN-9531_controller_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5291,7 +5357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5304,7 +5370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5312,11 +5378,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002234_CHEBI_58349_RXN-9532_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002234_CHEBI_58349_RXN-9532_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5331,11 +5397,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002233_CHEBI_15378_RXN-9530_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002233_CHEBI_15378_RXN-9530_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5349,6 +5415,17 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002233_3-Oxo-octanoyl-ACPs_RXN-9523_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -5356,11 +5433,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxyoctanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxooctanoyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (3<i>R</i>)-3-hydroxyoctanoyl-[acp] &rarr; a (2<i>E</i>)-oct-2-enoyl-[acp] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002413_4.2.1.59-RXN_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002413_4.2.1.59-RXN_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5390,7 +5467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5398,26 +5475,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002233_ACP_RXN-9535_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002333_YKL182W-MONOMER_RXN3O-8214_controller_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002333_YKL182W-MONOMER_RXN3O-8214_controller_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5431,36 +5497,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-8214_BFO_0000066_reaction_RXN3O-8214_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002233_Trans-D2-decenoyl-ACPs_RXN-9655_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002413_4.2.1.59-RXN_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002233_Tetradec-2-enoyl-ACPs_RXN-9537_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002233_CHEBI_15378_RXN-9534_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5468,11 +5523,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002234_CHEBI_15377_RXN-9520_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002234_CHEBI_15377_RXN-9520_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5483,26 +5538,15 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-9520>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002233_ACP_RXN-9536_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxytetradecanoyl-[acp] &rarr; a (2<i>E</i>)-tetradec-2-enoyl-[acp] + H<sub>2</sub>O' 'null' 'a (2<i>E</i>)-tetradec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a myristoyl-[acp] + NADP<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002413_RXN-9538_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002413_RXN-9538_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5522,24 +5566,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33125> , <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33145> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002233_ACP_RXN-9524_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-9528>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -5550,7 +5583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5558,15 +5591,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002233_CHEBI_15378_RXN-9528_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002233_CHEBI_57783_RXN-9534_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002233_CHEBI_57783_RXN-9534_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5581,11 +5625,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002234_ACP_RXN-9531_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002234_ACP_RXN-9531_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5596,26 +5640,15 @@
           <http://model.geneontology.org/ACP_RXN-9531>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002233_CHEBI_57783_RXN-9530_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002233_ACP_RXN-9526_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002233_ACP_RXN-9526_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5645,7 +5678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5653,59 +5686,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9533_BFO_0000066_reaction_RXN-9533_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_BFO_0000066_reaction_4.2.1.59-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9528_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9537_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a (2<i>E</i>)-hex-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a hexanoyl-[acp] + NADP<sup>+</sup>' 'null' 'a hexanoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxooctanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002413_RXN-9523_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002413_RXN-9523_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5725,7 +5714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5737,11 +5726,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002233_CHEBI_15377_RXN-9626_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002233_CHEBI_15377_RXN-9626_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5752,40 +5741,95 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-9626>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002233_3-oxo-dodecanoyl-ACPs_RXN-9531_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9534_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002234_Decanoyl-ACPs_RXN-9530_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9518_BFO_0000066_reaction_RXN-9518_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002234_2-Octenoyl-ACPs_4.2.1.59-RXN_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002233_CHEBI_15378_RXN-9524_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002234_CHEBI_57385_RXN3O-8214_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002233_CHEBI_15378_RXN-9518_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002233_3-oxo-hexanoyl-ACPs_RXN-9516_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002234_CHEBI_16526_RXN-9535_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002234_CHEBI_16526_RXN-9535_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5796,25 +5840,25 @@
           <http://model.geneontology.org/CHEBI_16526_RXN-9535>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002233_Hex-2-enoyl-ACPs_RXN-9520_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002233_CHEBI_57783_RXN-9536_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002233_CHEBI_15378_RXN-9531_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002233_CHEBI_15378_RXN-9530_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5825,7 +5869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5842,24 +5886,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33012> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002233_Decanoyl-ACPs_RXN-9530_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YPL231W-MONOMER_RXN-9531_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006152> ;
@@ -5868,7 +5901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5880,11 +5913,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002233_3-oxo-decanoyl-ACPs_RXN-9527_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002233_3-oxo-decanoyl-ACPs_RXN-9527_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5899,11 +5932,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002233_CHEBI_57385_RXN3O-8214_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002233_CHEBI_57385_RXN3O-8214_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5914,17 +5947,6 @@
           <http://model.geneontology.org/CHEBI_57385_RXN3O-8214>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9521_BFO_0000066_reaction_RXN-9521_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_RXN-9533>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5934,7 +5956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5942,26 +5964,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002234_Trans-D2-decenoyl-ACPs_RXN-9655_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9524_BFO_0000066_reaction_RXN-9524_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9524_BFO_0000066_reaction_RXN-9524_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5976,11 +5987,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002234_3-oxo-myristoyl-ACPs_RXN-9535_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002234_3-oxo-myristoyl-ACPs_RXN-9535_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5991,14 +6002,14 @@
           <http://model.geneontology.org/3-oxo-myristoyl-ACPs_RXN-9535>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002234_ACP_RXN-9518_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002233_ACP_RXN-9516_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6006,11 +6017,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002234_ACP_RXN-9518_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002234_ACP_RXN-9518_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6025,11 +6036,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9532_BFO_0000066_reaction_RXN-9532_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9532_BFO_0000066_reaction_RXN-9532_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6040,14 +6051,25 @@
           <http://model.geneontology.org/reaction_RXN-9532_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002413_RXN-9526_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002233_CHEBI_57783_RXN-9532_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002413_RXN-9538_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6055,11 +6077,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Provides Input For Rule. The relation 'a (2<i>E</i>)-dec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a decanoyl-[acp] + NADP<sup>+</sup>' 'null' 'a decanoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxododecanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002413_RXN-9531_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002413_RXN-9531_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6074,11 +6096,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-8214_BFO_0000066_reaction_RXN3O-8214_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-8214_BFO_0000066_reaction_RXN3O-8214_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6093,11 +6115,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002234_ACP_RXN-9526_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002234_ACP_RXN-9526_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6112,11 +6134,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9537_BFO_0000066_reaction_RXN-9537_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9537_BFO_0000066_reaction_RXN-9537_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6132,7 +6154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6145,13 +6167,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1SmallMolecule32956> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002233_2-Octenoyl-ACPs_4.2.1.59-RXN_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57783_RXN-9534>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
@@ -6162,7 +6195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6174,30 +6207,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002333_YKL182W-MONOMER_RXN-9533_controller_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002233_CHEBI_15378_RXN-9521_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9533> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_RXN-9533_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002233_CHEBI_15378_RXN-9521_SGD_YeastPathways_PWY-5971-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6208,58 +6222,33 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-9521>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002333_YPL231W-MONOMER_RXN-9531_controller_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002333_YKL182W-MONOMER_RXN-9533_controller_SGD_PWY_YeastPathways_PWY-5971-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9533> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YKL182W-MONOMER_RXN-9533_controller>
+] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002234_Hex-2-enoyl-ACPs_RXN-9520_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002234_CHEBI_58349_RXN-9524_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9518_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9527_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9536_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6272,7 +6261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6284,11 +6273,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.59-RXN_controller_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.59-RXN_controller_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6303,11 +6292,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002233_CHEBI_15378_RXN-9516_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002233_CHEBI_15378_RXN-9516_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6318,29 +6307,29 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-9516>
 ] .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002234_CHEBI_16526_RXN-9531_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002234_CHEBI_58349_RXN-9518_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002234_Myristoyl-ACPs_RXN-9538_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002234_Myristoyl-ACPs_RXN-9538_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6360,13 +6349,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein32995> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002234_CHEBI_16526_RXN-9535_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-9535>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6377,7 +6377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6385,25 +6385,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002234_Myristoyl-ACPs_RXN-9538_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002413_RXN-9534_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002233_Beta-hydroxydecanoyl-ACPs_RXN-9528_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6411,11 +6400,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9535_BFO_0000066_reaction_RXN-9535_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9535_BFO_0000066_reaction_RXN-9535_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6426,52 +6415,11 @@
           <http://model.geneontology.org/reaction_RXN-9535_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9537_BFO_0000066_reaction_RXN-9537_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_30807>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002234_ACP_RXN-9527_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Provides Input For Rule. The relation 'an octanoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxodecanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein' 'null' 'a (3<i>R</i>)-3-hydroxydecanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxodecanoyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002413_RXN-9528_SGD_YeastPathways_PWY-5971-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9527> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-9528>
-] .
 
 <http://model.geneontology.org/Hexanoyl-ACPs_RXN-9521>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -6482,7 +6430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6490,14 +6438,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002413_RXN-9530_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Provides Input For Rule. The relation 'an octanoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxodecanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein' 'null' 'a (3<i>R</i>)-3-hydroxydecanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxodecanoyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002413_RXN-9528_SGD_PWY_YeastPathways_PWY-5971-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9527> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN-9528>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002233_ACP_RXN-9523_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6520,7 +6487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6528,48 +6495,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002234_CHEBI_58349_RXN-9521_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002233_CHEBI_15378_RXN-9526_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002234_Tetradec-2-enoyl-ACPs_RXN-9537_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002234_CHEBI_16526_RXN-9523_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002234_CHEBI_16526_RXN-9523_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6584,11 +6518,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002233_Beta-hydroxydecanoyl-ACPs_RXN-9528_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002233_Beta-hydroxydecanoyl-ACPs_RXN-9528_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6606,7 +6540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6617,15 +6551,26 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9531_BFO_0000066_reaction_RXN-9531_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9518_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9518_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6636,26 +6581,15 @@
           <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002234_ACP_RXN-9532_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002233_CHEBI_57783_RXN-9536_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002233_CHEBI_57783_RXN-9536_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6666,17 +6600,6 @@
           <http://model.geneontology.org/CHEBI_57783_RXN-9536>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002234_CHEBI_58349_RXN-9536_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57783_RXN-9528>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6686,7 +6609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6703,7 +6626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6715,11 +6638,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxydodecanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxododecanoyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (<i>3R</i>)-3-hydroxydodecanoyl-[acp] &rarr; a (2<i>E</i>)-dodec-2-enoyl-[acp] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002413_RXN-9533_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002413_RXN-9533_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6734,11 +6657,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002233_CHEBI_57783_RXN-9530_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002233_CHEBI_57783_RXN-9530_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6756,11 +6679,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9526_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9526_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6776,7 +6699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6784,11 +6707,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a myristoyl-[acp] + coenzyme A &rarr; acyl-carrier protein + myristoyl-CoA' 'null' 'myristoyl-CoA + H<sub>2</sub>O &rarr; myristate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002413_RXN-9626_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002413_RXN-9626_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6818,7 +6741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6826,37 +6749,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9535_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002233_CHEBI_15378_RXN-9523_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002234_Hex-2-enoyl-ACPs_RXN-9520_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002234_Hex-2-enoyl-ACPs_RXN-9520_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6876,7 +6777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6888,11 +6789,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9538_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9538_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6903,25 +6804,14 @@
           <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002413_RXN-9528_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002234_ACP_RXN3O-8214_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002234_CHEBI_16526_RXN-9516_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6930,7 +6820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6939,7 +6829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6952,7 +6842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6964,11 +6854,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002233_Dodec-2-enoyl-ACPs_RXN-9533_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002233_Dodec-2-enoyl-ACPs_RXN-9533_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6979,15 +6869,37 @@
           <http://model.geneontology.org/Dodec-2-enoyl-ACPs_RXN-9533>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002234_ACP_RXN-9524_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002234_CHEBI_15377_RXN-9655_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002234_CHEBI_16526_RXN-9531_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002234_CHEBI_16526_RXN-9531_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6998,14 +6910,14 @@
           <http://model.geneontology.org/CHEBI_16526_RXN-9531>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002233_ACP_RXN-9531_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002233_Dodecanoyl-ACPs_RXN-9534_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7013,11 +6925,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002233_ACP_RXN-9527_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002233_ACP_RXN-9527_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7045,24 +6957,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1BiochemicalReaction33201> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002413_RXN-9626_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YKL182W-MONOMER_RXN-9530_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001665> ;
@@ -7071,7 +6972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7088,7 +6989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7096,37 +6997,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002233_CHEBI_57783_RXN-9534_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002233_ACP_RXN-9532_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9523_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9523_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7144,41 +7023,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein32987> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002333_YKL182W-MONOMER_RXN-9530_controller_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15378_RXN-9626>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1SmallMolecule32956> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ACP_RXN-9536>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -7189,7 +7040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7197,14 +7048,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002234_Dodec-2-enoyl-ACPs_RXN-9533_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_15378_RXN-9626>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1SmallMolecule32956> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002233_CHEBI_15378_RXN-9538_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7217,13 +7085,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33065> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002234_Myristoyl-ACPs_RXN-9538_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9655>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7244,13 +7123,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1BiochemicalReaction33191> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002233_CHEBI_57385_RXN3O-8214_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002413_RXN-9536_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002233_Hex-2-enoyl-ACPs_RXN-9520_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -7264,7 +7176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7276,11 +7188,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002234_Beta-hydroxydecanoyl-ACPs_RXN-9528_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002234_Beta-hydroxydecanoyl-ACPs_RXN-9528_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7295,11 +7207,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002234_CHEBI_15378_RXN-9626_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002234_CHEBI_15378_RXN-9626_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7319,7 +7231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7327,14 +7239,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002234_CHEBI_58349_RXN-9530_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002234_CHEBI_15377_RXN-9533_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002234_3-oxo-myristoyl-ACPs_RXN-9535_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7342,11 +7265,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002233_CHEBI_15378_RXN-9524_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002233_CHEBI_15378_RXN-9524_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7361,11 +7284,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002333_YPL231W-MONOMER_RXN-9535_controller_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002333_YPL231W-MONOMER_RXN-9535_controller_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7376,15 +7299,37 @@
           <http://model.geneontology.org/YPL231W-MONOMER_RXN-9535_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002234_CHEBI_15378_RXN-9626_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002233_CHEBI_15378_RXN-9534_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002234_CHEBI_58349_RXN-9518_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002234_CHEBI_58349_RXN-9518_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7399,11 +7344,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002233_CHEBI_15378_RXN-9532_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002233_CHEBI_15378_RXN-9532_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7423,7 +7368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7438,7 +7383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7446,36 +7391,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9534_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9528_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002233_3-Oxo-octanoyl-ACPs_RXN-9523_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9536_BFO_0000066_reaction_RXN-9536_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002234_CHEBI_16526_RXN-9523_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7488,7 +7422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7496,15 +7430,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002333_YKL182W-MONOMER_RXN-9537_controller_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9531_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9531_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7519,11 +7464,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002233_CHEBI_57287_RXN3O-8214_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002233_CHEBI_57287_RXN3O-8214_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7534,14 +7479,14 @@
           <http://model.geneontology.org/CHEBI_57287_RXN3O-8214>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002234_CHEBI_15377_RXN-9533_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002234_CHEBI_30807_RXN-9626_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7554,7 +7499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7562,14 +7507,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002413_RXN-9536_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002234_ACP_RXN-9523_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002413_RXN-9532_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7577,11 +7533,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002234_CHEBI_58349_RXN-9526_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002234_CHEBI_58349_RXN-9526_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7596,11 +7552,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002233_ACP_RXN-9536_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9537_RO_0002233_ACP_RXN-9536_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7620,7 +7576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7628,26 +7584,56 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002233_CHEBI_15378_RXN-9532_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9520_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002233_CHEBI_57783_RXN-9521_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9531_BFO_0000066_reaction_RXN-9531_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9531> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN-9531_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002233_CHEBI_57783_RXN-9521_SGD_PWY_YeastPathways_PWY-5971-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7662,11 +7648,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxydodecanoyl-[acp] &rarr; a (2<i>E</i>)-dodec-2-enoyl-[acp] + H<sub>2</sub>O' 'null' 'a (2<i>E</i>)-dodec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a dodecanoyl-[acp] + NADP<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002413_RXN-9534_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9533_RO_0002413_RXN-9534_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7677,33 +7663,36 @@
           <http://model.geneontology.org/RXN-9534>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9531_BFO_0000066_reaction_RXN-9531_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9531> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9531_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002233_CHEBI_15377_RXN-9626_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9520_RO_0002234_Hex-2-enoyl-ACPs_RXN-9520_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9524_BFO_0000066_reaction_RXN-9524_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002233_CHEBI_15378_RXN-9531_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7716,7 +7705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7724,17 +7713,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002234_Hexanoyl-ACPs_RXN-9521_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9530_BFO_0000066_reaction_RXN-9530_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002234_ACP_RXN-9518_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002234_CHEBI_58349_RXN-9538_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7742,11 +7753,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002333_YKL182W-MONOMER_RXN-9526_controller_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002333_YKL182W-MONOMER_RXN-9526_controller_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7757,26 +7768,15 @@
           <http://model.geneontology.org/YKL182W-MONOMER_RXN-9526_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002234_CHEBI_15377_RXN-9655_SGD_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxyoctanoyl-[acp] &rarr; a (2<i>E</i>)-oct-2-enoyl-[acp] + H<sub>2</sub>O' 'null' 'a (2<i>E</i>)-oct-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; an octanoyl-[acp] + NADP<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002413_RXN-9526_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002413_RXN-9526_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7806,7 +7806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7818,11 +7818,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002234_ACP_RXN-9516_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002234_ACP_RXN-9516_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7833,17 +7833,6 @@
           <http://model.geneontology.org/ACP_RXN-9516>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002413_RXN-9533_SGD_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58349_RXN-9518>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7853,7 +7842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7866,7 +7855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7874,11 +7863,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002233_Hex-2-enoyl-ACPs_RXN-9520_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002233_Hex-2-enoyl-ACPs_RXN-9520_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7898,7 +7887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7910,11 +7899,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002333_YKL182W-MONOMER_RXN-9538_controller_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002333_YKL182W-MONOMER_RXN-9538_controller_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7932,13 +7921,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein32987> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9516_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-9536>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -7949,7 +7949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7962,18 +7962,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9526_BFO_0000066_reaction_RXN-9526_location_lociGO_0005829_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002233_Hexanoyl-ACPs_RXN-9521_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7982,7 +7982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7990,11 +7990,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002233_ACP_RXN-9535_SGD_YeastPathways_PWY-5971-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002233_ACP_RXN-9535_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8005,14 +8005,14 @@
           <http://model.geneontology.org/ACP_RXN-9535>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002234_Beta-hydroxydecanoyl-ACPs_RXN-9528_SGD_YeastPathways_PWY-5971-1>
+<http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002233_CHEBI_57783_RXN-9528_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8023,7 +8023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-6074-1.ttl
+++ b/models/YeastPathways_PWY-6074-1.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002333_YGR060W-MONOMER_RXN3O-9826_controller_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002333_YGR060W-MONOMER_RXN3O-9826_controller_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,11 +24,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002333_YGR060W-MONOMER_RXN3O-9823_controller_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002333_YGR060W-MONOMER_RXN3O-9823_controller_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,33 +44,19 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/2d8b72e1-4801-43c5-971c-16ac050159dd_RXN3O-9824>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" , "Provides Input For Rule. The relation 'lanosterol + 3 NADPH + 3 oxygen + 3 H<SUP>+</SUP> &rarr; 4,4-dimethyl-cholesta-8,14,24-trienol + formate + 3 NADP<sup>+</sup> + 4 H<sub>2</sub>O' 'null' '4,4-dimethylzymosterol + NADP<sup>+</sup> &larr; 4,4-dimethyl-cholesta-8,14,24-trienol + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002413_RXN66-306_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002413_RXN66-306_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,17 +66,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN66-306>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_15378_RXN3O-9820_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -104,24 +79,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74972> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_13392_RXN3O-9824_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0103067>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -130,11 +94,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_52386_RXN66-318_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_52386_RXN66-318_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -149,11 +113,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000066_reaction_RXN66-313_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000066_reaction_RXN66-313_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -173,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,37 +145,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002333_YGR060W-MONOMER_RXN3O-9825_controller_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -222,8 +164,33 @@
           <http://model.geneontology.org/YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002413_RXN3O-9823_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000066_reaction_RXN66-318_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/95c8d239-3c4a-47b6-9bb8-f0166a1acc90_RXN3O-9826>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/CHEBI_15378_RXN66-319>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -234,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -246,11 +213,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_BFO_0000066_reaction_RXN3O-9822_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_BFO_0000066_reaction_RXN3O-9822_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -270,13 +237,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule75091> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002413_RXN66-319_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16521_RXN3O-9820>
         a       <http://purl.obolibrary.org/obo/CHEBI_16521> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -287,7 +265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -295,26 +273,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002413_RXN3O-9822_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_57783_RXN66-314_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_57783_RXN66-314_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,11 +296,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -347,26 +314,15 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_13392_RXN66-318_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_13392_RXN3O-9826_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_13392_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -377,29 +333,73 @@
           <http://model.geneontology.org/CHEBI_13392_RXN3O-9826>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_3dd14b7a-e7a6-4cd2-9d25-4dad6b3b9989_RXN3O-9824_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000066_reaction_RXN3O-9826_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002333_YNL280C-MONOMER_RXN66-306_controller_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002411_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_487c243b-eb8f-486d-9466-1514c77eca2f_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002333_YGR060W-MONOMER_RXN3O-9826_controller_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_13392_RXN3O-9823_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_13392_RXN3O-9823_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,47 +410,25 @@
           <http://model.geneontology.org/CHEBI_13392_RXN3O-9823>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000066_reaction_RXN66-306_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_13390_RXN3O-9826_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_13392_RXN66-313_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000066_reaction_RXN3O-9823_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_18252_RXN66-319_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -458,11 +436,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_57783_RXN66-306_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_57783_RXN66-306_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -478,7 +456,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_13390_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -486,11 +475,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_1949_RXN66-314_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_1949_RXN66-314_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -501,6 +490,39 @@
           <http://model.geneontology.org/CHEBI_1949_RXN66-314>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_13390_RXN3O-9823_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_13390_RXN3O-9821_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_58349_RXN66-306_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_13392_RXN66-318>
         a       <http://purl.obolibrary.org/obo/CHEBI_13392> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -510,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -518,23 +540,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-9823_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -542,11 +553,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_13390_RXN3O-9821_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_13390_RXN3O-9821_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -561,11 +572,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000066_reaction_RXN66-318_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000066_reaction_RXN66-318_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -576,36 +587,17 @@
           <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_13392_RXN66-313_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/9a566228-0e2c-4a87-ba9e-89552d4ae739_RXN3O-9824>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_18364_RXN66-306_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002333_YLR100W-MONOMER_RXN66-319_controller_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_52386_RXN66-318_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -614,18 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002333_YGR060W-MONOMER_RXN3O-9826_controller_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -638,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -655,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -670,7 +651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -678,14 +659,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_13392_RXN3O-9821_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_87289_RXN3O-9821_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_57783_RXN66-306_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -698,7 +690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -725,7 +717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -733,14 +725,47 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_1949_RXN66-314_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_13392_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_be0101e4-71ae-43ee-af4e-753a76110aa2_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_13392_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -748,11 +773,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_57783_RXN66-319_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_57783_RXN66-319_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,11 +792,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" , "Provides Input For Rule. The relation '4&alpha;-carboxy-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> &rarr; 3-dehydro-4-methylzymosterol + CO<SUB>2</SUB> + NAD(P)H' 'null' '4&alpha;-methyl-zymosterol + NADP<sup>+</sup> &larr; 3-dehydro-4-methylzymosterol + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002413_RXN66-314_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002413_RXN66-314_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -781,6 +806,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN66-314>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_13392_RXN3O-9822_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001049>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -794,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -806,11 +842,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_8eca0e8a-737c-4724-9362-cc78978b2188_RXN3O-9825_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_487c243b-eb8f-486d-9466-1514c77eca2f_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -818,18 +854,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8eca0e8a-737c-4724-9362-cc78978b2188_RXN3O-9825>
+          <http://model.geneontology.org/487c243b-eb8f-486d-9466-1514c77eca2f_RXN3O-9825>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_15377_RXN3O-9820_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_15377_RXN3O-9820_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -840,15 +876,26 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-9820>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002413_RXN66-306_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002333_YGR060W-MONOMER_RXN3O-9822_controller_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002333_YGR060W-MONOMER_RXN3O-9822_controller_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -868,7 +915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -885,7 +932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -893,36 +940,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_15379_RXN3O-9820_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_64925_RXN3O-9823_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002411_RXN3O-9825_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_18364_RXN66-306_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -930,11 +955,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)H + oxygen &rarr; 4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + H<sub>2</sub>O' 'null' '4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> &rarr; zymosterone + CO<SUB>2</SUB> + NAD(P)H' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002413_RXN66-318_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002413_RXN66-318_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -948,26 +973,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_64925>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_13390_RXN3O-9823_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" , "Provides Input For Rule. The relation '4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)H + oxygen &rarr; 4&alpha;-carboxy-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + H<sub>2</sub>O' 'null' '4&alpha;-carboxy-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> &rarr; 3-dehydro-4-methylzymosterol + CO<SUB>2</SUB> + NAD(P)H' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002413_RXN66-313_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002413_RXN66-313_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -987,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1004,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1012,18 +1026,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_15379_RXN3O-9822_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0000254>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_15379_RXN3O-9820_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1034,51 +1070,51 @@
           <http://model.geneontology.org/YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_15378_RXN66-319_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_BFO_0000066_reaction_RXN3O-9822_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_58349_RXN66-306_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002333_YGR060W-MONOMER_RXN3O-9825_controller_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_15379_RXN3O-9826_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002333_YGR060W-MONOMER_RXN3O-9823_controller_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002333_YGL001C-MONOMER_RXN66-318_controller_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002333_YGL001C-MONOMER_RXN66-318_controller_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1093,11 +1129,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_13390_RXN3O-9823_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_13390_RXN3O-9823_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1119,7 +1155,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002333_YGR060W-MONOMER_RXN3O-9821_controller_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1127,11 +1174,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_BFO_0000066_reaction_RXN3O-9825_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_BFO_0000066_reaction_RXN3O-9825_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1147,36 +1194,41 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_15378_RXN3O-9820>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule75051> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_13392_RXN66-318_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_13392_RXN3O-9822_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_13392_RXN3O-9822_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1187,57 +1239,52 @@
           <http://model.geneontology.org/CHEBI_13392_RXN3O-9822>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_15377_RXN3O-9822_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_15378_RXN3O-9820>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_16521_RXN3O-9820_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_1949_RXN66-314_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule75051> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15740>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_e0c88a61-bc67-40a5-a265-f5c63aba4ae7_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_1949_RXN66-314_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_1949_RXN66-314_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1253,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1261,11 +1308,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_BFO_0000066_reaction_RXN3O-9820_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_BFO_0000066_reaction_RXN3O-9820_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1280,11 +1327,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_15379_RXN3O-9826_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_15379_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1295,29 +1342,29 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-9826>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57783>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002333_YGL001C-MONOMER_RXN66-313_controller_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57783>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_15379_RXN3O-9823_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_15379_RXN3O-9823_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1328,36 +1375,55 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-9823>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000066_reaction_RXN3O-9824_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0102176>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_15378_RXN66-306_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000066_reaction_RXN66-314_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_136486_RXN66-313_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004090>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002333_YGR060W-MONOMER_RXN3O-9822_controller_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_57783_RXN3O-9820_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/3a470607-9951-447a-93ad-69f58ad5e3a3_RXN3O-9826>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1366,11 +1432,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_18364_RXN66-306_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_18364_RXN66-306_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1381,14 +1447,47 @@
           <http://model.geneontology.org/CHEBI_18364_RXN66-306>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002413_RXN3O-9823_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_15377_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002333_YGL001C-MONOMER_RXN66-313_controller_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_15377_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_15377_RXN3O-9822_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1396,11 +1495,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_13390_RXN3O-9824_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_13390_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1411,15 +1510,26 @@
           <http://model.geneontology.org/CHEBI_13390_RXN3O-9824>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_15377_RXN3O-9820_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_15377_RXN3O-9821_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_15377_RXN3O-9821_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1434,11 +1544,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_13390_RXN3O-9826_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_13390_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1453,11 +1563,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_58349_RXN66-306_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_58349_RXN66-306_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1468,29 +1578,29 @@
           <http://model.geneontology.org/CHEBI_58349_RXN66-306>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0036197>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_BFO_0000066_reaction_RXN3O-9820_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0036197>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_15377_RXN3O-9824_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_15377_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1508,7 +1618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1516,14 +1626,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002413_RXN66-306_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002413_RXN66-314_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1531,11 +1641,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_87289_RXN3O-9821_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_87289_RXN3O-9821_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1546,17 +1656,6 @@
           <http://model.geneontology.org/CHEBI_87289_RXN3O-9821>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_13392_RXN3O-9823_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YHR007C-MONOMER_RXN3O-9820_controller>
         a       <http://identifiers.org/sgd/S000001049> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1564,35 +1663,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1Protein75099> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_15379_RXN3O-9823_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002413_RXN3O-9821_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9825>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -1603,7 +1680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1622,7 +1699,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_1949_RXN66-314> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9824> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_13390_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9824> , <http://model.geneontology.org/3dd14b7a-e7a6-4cd2-9d25-4dad6b3b9989_RXN3O-9824> ;
+                <http://model.geneontology.org/c6258ac8-7298-41b1-a1e4-369cfa90abb1_RXN3O-9824> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9824> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9824_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1630,7 +1707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1642,11 +1719,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_18252_RXN66-319_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_18252_RXN66-319_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1661,11 +1738,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1679,6 +1756,17 @@
 <http://identifiers.org/sgd/S000005224>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002333_YGR060W-MONOMER_RXN3O-9824_controller_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_13390_RXN3O-9823>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_13390> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1688,7 +1776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1696,15 +1784,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002333_YGR060W-MONOMER_RXN3O-9822_controller_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002333_YGR060W-MONOMER_RXN3O-9825_controller_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002333_YGR060W-MONOMER_RXN3O-9825_controller_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1715,26 +1814,32 @@
           <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9825_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_17813_RXN3O-9820_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/be0101e4-71ae-43ee-af4e-753a76110aa2_RXN3O-9826>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74891> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_15740_RXN3O-9820_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_15740_RXN3O-9820_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1745,23 +1850,12 @@
           <http://model.geneontology.org/CHEBI_15740_RXN3O-9820>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_87289_RXN3O-9821_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-9825_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1769,11 +1863,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002411_RXN3O-9822_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002411_RXN3O-9822_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1784,17 +1878,6 @@
           <http://model.geneontology.org/RXN3O-9822>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002413_RXN66-319_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_13392_RXN3O-9825>
         a       <http://purl.obolibrary.org/obo/CHEBI_13392> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1804,24 +1887,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74870> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_87289_RXN3O-9821_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_87289_RXN3O-9821>
         a       <http://purl.obolibrary.org/obo/CHEBI_87289> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1832,7 +1904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1849,7 +1921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1864,7 +1936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1872,14 +1944,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002333_YGR060W-MONOMER_RXN3O-9823_controller_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1887,11 +1959,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1902,48 +1974,15 @@
           <http://model.geneontology.org/YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_13390_RXN3O-9825_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_15377_RXN3O-9825_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002413_RXN3O-9824_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1954,25 +1993,25 @@
           <http://model.geneontology.org/YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_57783_RXN3O-9820_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_58349_RXN66-319_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_87287_RXN3O-9822_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_15378_RXN66-319_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1983,7 +2022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1995,11 +2034,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_BFO_0000066_reaction_RXN3O-9821_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_BFO_0000066_reaction_RXN3O-9821_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2010,28 +2049,17 @@
           <http://model.geneontology.org/reaction_RXN3O-9821_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002333_YGL001C-MONOMER_RXN66-318_controller_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_17813_RXN3O-9820_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_BFO_0000066_reaction_RXN3O-9820_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2039,11 +2067,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" , "Provides Input For Rule. The relation '4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> &rarr; zymosterone + CO<SUB>2</SUB> + NAD(P)H' 'null' 'zymosterol + NADP<sup>+</sup> &larr; zymosterone + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002413_RXN66-319_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002413_RXN66-319_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2058,11 +2086,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_64925_RXN3O-9823_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_64925_RXN3O-9823_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2073,16 +2101,8 @@
           <http://model.geneontology.org/CHEBI_64925_RXN3O-9823>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_57783_RXN66-319_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/e0c88a61-bc67-40a5-a265-f5c63aba4ae7_RXN3O-9825>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/CHEBI_1949_RXN66-314>
         a       <http://purl.obolibrary.org/obo/CHEBI_1949> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2093,7 +2113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2101,15 +2121,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002413_RXN3O-9822_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_13392_RXN3O-9825_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_13392_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2120,28 +2151,6 @@
           <http://model.geneontology.org/CHEBI_13392_RXN3O-9825>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002413_RXN66-313_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002411_RXN3O-9826_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9820>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2151,7 +2160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2159,25 +2168,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_1949_RXN66-314_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2188,11 +2186,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_15379_RXN3O-9822_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_15379_RXN3O-9822_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2207,11 +2205,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2222,8 +2220,52 @@
           <http://model.geneontology.org/YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_17813_RXN3O-9820_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002333_YGL001C-MONOMER_RXN66-318_controller_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002413_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGL001C-MONOMER_RXN66-318_controller>
         a       <http://identifiers.org/sgd/S000002969> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2232,7 +2274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2244,11 +2286,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_58349_RXN66-314_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_58349_RXN66-314_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2259,32 +2301,15 @@
           <http://model.geneontology.org/CHEBI_58349_RXN66-314>
 ] .
 
-<http://model.geneontology.org/2f9baacf-b282-4705-b848-ac27f4985c51_RXN3O-9826>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74891> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_15378_RXN3O-9820_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_15378_RXN3O-9820_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2295,23 +2320,12 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-9820>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_13390_RXN3O-9826_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2322,11 +2336,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_ef0f1296-ac98-43f6-97bc-1167359f0d0a_RXN3O-9825_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_e0c88a61-bc67-40a5-a265-f5c63aba4ae7_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2334,39 +2348,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ef0f1296-ac98-43f6-97bc-1167359f0d0a_RXN3O-9825>
+          <http://model.geneontology.org/e0c88a61-bc67-40a5-a265-f5c63aba4ae7_RXN3O-9825>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_58349_RXN66-314_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002411_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000066_reaction_RXN3O-9824_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002413_RXN66-318_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2374,11 +2366,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_87287_RXN3O-9822_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_87287_RXN3O-9822_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2389,8 +2381,16 @@
           <http://model.geneontology.org/CHEBI_87287_RXN3O-9822>
 ] .
 
-<http://model.geneontology.org/ef0f1296-ac98-43f6-97bc-1167359f0d0a_RXN3O-9825>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_64925_RXN3O-9823_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -2398,25 +2398,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_18364>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_13392_RXN3O-9826_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_58349_RXN66-314_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002411_RXN3O-9822_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2425,32 +2414,43 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000066_reaction_RXN66-306_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002969>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_57783_RXN66-306_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_15378_RXN66-314_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_13390_RXN3O-9822_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_16526_RXN66-318_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2458,30 +2458,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_3a470607-9951-447a-93ad-69f58ad5e3a3_RXN3O-9826_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002333_YNL280C-MONOMER_RXN66-306_controller_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-318> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3a470607-9951-447a-93ad-69f58ad5e3a3_RXN3O-9826>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002333_YNL280C-MONOMER_RXN66-306_controller_SGD_YeastPathways_PWY-6074-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2492,25 +2473,66 @@
           <http://model.geneontology.org/YNL280C-MONOMER_RXN66-306_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_13390_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_95c8d239-3c4a-47b6-9bb8-f0166a1acc90_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN66-318> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/95c8d239-3c4a-47b6-9bb8-f0166a1acc90_RXN3O-9826>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002411_RXN3O-9822_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_13390_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_13390_RXN3O-9822_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2521,7 +2543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2529,26 +2551,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_87287_RXN3O-9822_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_3dd14b7a-e7a6-4cd2-9d25-4dad6b3b9989_RXN3O-9824_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_c6258ac8-7298-41b1-a1e4-369cfa90abb1_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2556,30 +2567,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9824> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3dd14b7a-e7a6-4cd2-9d25-4dad6b3b9989_RXN3O-9824>
+          <http://model.geneontology.org/c6258ac8-7298-41b1-a1e4-369cfa90abb1_RXN3O-9824>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_87287_RXN3O-9822_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_15379_RXN3O-9825_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58349_RXN66-306>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2590,7 +2579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2602,11 +2591,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002333_YGR060W-MONOMER_RXN3O-9821_controller_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002333_YGR060W-MONOMER_RXN3O-9821_controller_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2626,7 +2615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2643,9 +2632,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9825_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13392_RXN3O-9825> , <http://model.geneontology.org/2d8b72e1-4801-43c5-971c-16ac050159dd_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_13392_RXN3O-9825> , <http://model.geneontology.org/9a566228-0e2c-4a87-ba9e-89552d4ae739_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_RXN3O-9825> , <http://model.geneontology.org/8eca0e8a-737c-4724-9362-cc78978b2188_RXN3O-9825> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN3O-9825> , <http://model.geneontology.org/487c243b-eb8f-486d-9466-1514c77eca2f_RXN3O-9825> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9825_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2653,7 +2642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2661,14 +2650,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_15378_RXN66-314_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_15378_RXN3O-9820_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2676,11 +2676,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_58349_RXN66-319_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_58349_RXN66-319_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2695,11 +2695,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000066_reaction_RXN66-314_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000066_reaction_RXN66-314_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2719,7 +2719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2727,14 +2727,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_15377_RXN3O-9821_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002333_YLR100W-MONOMER_RXN66-314_controller_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2742,11 +2742,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002411_RXN3O-9826_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002411_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2761,11 +2761,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_17813_RXN3O-9820_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_17813_RXN3O-9820_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2780,11 +2780,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)H + oxygen &rarr; 4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + 2 H<sub>2</sub>O' 'null' '4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)H + oxygen &rarr; 4&alpha;-carboxy-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002413_RXN3O-9823_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002413_RXN3O-9823_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2804,13 +2804,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74870> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9825_controller>
         a       <http://identifiers.org/sgd/S000003292> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2819,7 +2830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2842,7 +2853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2850,12 +2861,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_17813_RXN3O-9820_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN66-319_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_136486_RXN66-313_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2863,11 +2896,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000066_reaction_RXN66-306_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000066_reaction_RXN66-306_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2897,7 +2930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2905,32 +2938,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/8eca0e8a-737c-4724-9362-cc78978b2188_RXN3O-9825>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74861> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000066_reaction_RXN3O-9824_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000066_reaction_RXN3O-9824_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2941,26 +2957,15 @@
           <http://model.geneontology.org/reaction_RXN3O-9824_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_13392_RXN3O-9821_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_13392_RXN3O-9821_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2971,18 +2976,62 @@
           <http://model.geneontology.org/CHEBI_13392_RXN3O-9821>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_15379_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_15379_RXN3O-9823_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_15379_RXN3O-9821_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_16526_RXN66-313_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_13392_RXN66-313_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_13392_RXN66-313_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3002,7 +3051,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> , <http://model.geneontology.org/3a470607-9951-447a-93ad-69f58ad5e3a3_RXN3O-9826> ;
+                <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> , <http://model.geneontology.org/95c8d239-3c4a-47b6-9bb8-f0166a1acc90_RXN3O-9826> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16526_RXN66-318> , <http://model.geneontology.org/CHEBI_13392_RXN66-318> , <http://model.geneontology.org/CHEBI_52386_RXN66-318> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -3012,7 +3061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3020,25 +3069,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000066_reaction_RXN66-313_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_16526_RXN66-318_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_18364_RXN66-306_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3046,11 +3095,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_15379_RXN3O-9825_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_15379_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3070,7 +3119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3097,7 +3146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3105,37 +3154,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000066_reaction_RXN66-314_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000066_reaction_RXN66-313_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_87289_RXN3O-9821_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_87289_RXN3O-9821_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3150,11 +3177,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000066_reaction_RXN66-319_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000066_reaction_RXN66-319_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3165,25 +3192,25 @@
           <http://model.geneontology.org/reaction_RXN66-319_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_13392_RXN3O-9822_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_58349_RXN66-319_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_15379_RXN3O-9822_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_95c8d239-3c4a-47b6-9bb8-f0166a1acc90_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3191,11 +3218,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002333_YLR100W-MONOMER_RXN66-314_controller_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002333_YLR100W-MONOMER_RXN66-314_controller_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3206,15 +3233,26 @@
           <http://model.geneontology.org/YLR100W-MONOMER_RXN66-314_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000066_reaction_RXN3O-9823_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_15379_RXN3O-9820_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_15379_RXN3O-9820_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3234,7 +3272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3242,14 +3280,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002333_YHR007C-MONOMER_RXN3O-9820_controller_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3257,11 +3295,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_13390_RXN3O-9826_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_13390_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3281,7 +3319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3292,15 +3330,32 @@
 <http://purl.obolibrary.org/obo/CHEBI_13390>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/487c243b-eb8f-486d-9466-1514c77eca2f_RXN3O-9825>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74861> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_13390_RXN3O-9823_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_13390_RXN3O-9823_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3311,14 +3366,14 @@
           <http://model.geneontology.org/CHEBI_13390_RXN3O-9823>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_57783_RXN66-319_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3326,11 +3381,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_15377_RXN3O-9826_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_15377_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3341,17 +3396,6 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-9826>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_16526_RXN66-313_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -3359,11 +3403,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_15377_RXN3O-9823_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_15377_RXN3O-9823_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3381,7 +3425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3389,25 +3433,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_BFO_0000066_reaction_RXN3O-9821_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_87287_RXN3O-9822_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_64925_RXN3O-9823_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3415,11 +3448,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_58349_RXN3O-9820_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_58349_RXN3O-9820_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3430,48 +3463,56 @@
           <http://model.geneontology.org/CHEBI_58349_RXN3O-9820>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_ef0f1296-ac98-43f6-97bc-1167359f0d0a_RXN3O-9825_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_13390_RXN3O-9824_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_15377_RXN3O-9824_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002333_YLR100W-MONOMER_RXN66-319_controller_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_87289_RXN3O-9821_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" , "Provides Input For Rule. The relation '4,4-dimethylzymosterol + NADP<sup>+</sup> &larr; 4,4-dimethyl-cholesta-8,14,24-trienol + NADPH + H<SUP>+</SUP>' 'null' '4,4-dimethylzymosterol + NAD(P)H + oxygen &rarr; 4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_13392_RXN66-318_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002413_RXN3O-9821_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN66-306> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-9821>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_13392_RXN66-318_SGD_PWY_YeastPathways_PWY-6074-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3482,24 +3523,16 @@
           <http://model.geneontology.org/CHEBI_13392_RXN66-318>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" , "Provides Input For Rule. The relation '4,4-dimethylzymosterol + NADP<sup>+</sup> &larr; 4,4-dimethyl-cholesta-8,14,24-trienol + NADPH + H<SUP>+</SUP>' 'null' '4,4-dimethylzymosterol + NAD(P)H + oxygen &rarr; 4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002413_RXN3O-9821_SGD_YeastPathways_PWY-6074-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-306> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-9821>
-] .
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_BFO_0000066_reaction_RXN3O-9825_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3523,7 +3556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3538,11 +3571,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002333_YGR060W-MONOMER_RXN3O-9824_controller_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002333_YGR060W-MONOMER_RXN3O-9824_controller_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3553,29 +3586,29 @@
           <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9824_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_136486_RXN66-313_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002333_YHR007C-MONOMER_RXN3O-9820_controller_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '4,4-dimethylzymosterol + NAD(P)H + oxygen &rarr; 4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + H<sub>2</sub>O' 'null' '4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)H + oxygen &rarr; 4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002413_RXN3O-9822_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002413_RXN3O-9822_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3586,14 +3619,14 @@
           <http://model.geneontology.org/RXN3O-9822>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_136486_RXN66-313_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002413_RXN66-313_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3606,7 +3639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3623,9 +3656,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9826_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13392_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9826> , <http://model.geneontology.org/ef0f1296-ac98-43f6-97bc-1167359f0d0a_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_13392_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9826> , <http://model.geneontology.org/e0c88a61-bc67-40a5-a265-f5c63aba4ae7_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/2f9baacf-b282-4705-b848-ac27f4985c51_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> , <http://model.geneontology.org/be0101e4-71ae-43ee-af4e-753a76110aa2_RXN3O-9826> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9826_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3633,7 +3666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3644,15 +3677,26 @@
 <http://purl.obolibrary.org/obo/GO_0050613>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_c6258ac8-7298-41b1-a1e4-369cfa90abb1_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002333_YLR100W-MONOMER_RXN66-319_controller_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002333_YLR100W-MONOMER_RXN66-319_controller_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3667,11 +3711,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_136486_RXN66-313_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_136486_RXN66-313_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3694,7 +3738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3702,25 +3746,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_57783_RXN66-314_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002333_YGR060W-MONOMER_RXN3O-9824_controller_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3728,11 +3761,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3752,24 +3785,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule75076> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9824_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003292> ;
@@ -3778,7 +3800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3790,11 +3812,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3805,6 +3827,17 @@
           <http://model.geneontology.org/YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_9a566228-0e2c-4a87-ba9e-89552d4ae739_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15379_RXN3O-9825>
         a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3814,7 +3847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3822,15 +3855,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_57783_RXN66-314_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_15378_RXN66-306_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_15378_RXN66-306_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3841,14 +3885,36 @@
           <http://model.geneontology.org/CHEBI_15378_RXN66-306>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_15740_RXN3O-9820_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000066_reaction_RXN66-319_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_52386_RXN66-318_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_1949_RXN66-314_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3856,11 +3922,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_13392_RXN3O-9824_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_13392_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3871,26 +3937,15 @@
           <http://model.geneontology.org/CHEBI_13392_RXN3O-9824>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_13392_RXN3O-9825_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_15379_RXN3O-9821_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_15379_RXN3O-9821_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3905,11 +3960,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '4&alpha;-methyl-zymosterol + NADP<sup>+</sup> &larr; 3-dehydro-4-methylzymosterol + NADPH + H<SUP>+</SUP>' 'null' '4&alpha;-methyl-zymosterol + NAD(P)H + oxygen &rarr; 4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002413_RXN3O-9824_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002413_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3924,11 +3979,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_136486_RXN66-313_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_136486_RXN66-313_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3959,7 +4014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3967,25 +4022,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_13390_RXN3O-9821_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_13392_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_8eca0e8a-737c-4724-9362-cc78978b2188_RXN3O-9825_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_13392_RXN3O-9823_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3993,11 +4048,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_2d8b72e1-4801-43c5-971c-16ac050159dd_RXN3O-9824_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_9a566228-0e2c-4a87-ba9e-89552d4ae739_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4005,8 +4060,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2d8b72e1-4801-43c5-971c-16ac050159dd_RXN3O-9824>
+          <http://model.geneontology.org/9a566228-0e2c-4a87-ba9e-89552d4ae739_RXN3O-9824>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_13392_RXN3O-9821_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9822>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4017,7 +4083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4044,7 +4110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4052,26 +4118,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002333_YNL280C-MONOMER_RXN66-306_controller_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_13390_RXN3O-9822_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_13390_RXN3O-9822_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4086,11 +4141,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_15378_RXN66-319_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_15378_RXN66-319_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4108,35 +4163,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1Protein75123> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_18364_RXN66-306_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_15379_RXN3O-9824_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YNL280C-MONOMER_RXN66-306_controller>
         a       <http://identifiers.org/sgd/S000005224> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4145,7 +4178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4153,14 +4186,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_BFO_0000066_reaction_RXN3O-9825_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_52386_RXN66-318_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4168,11 +4212,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_16521_RXN3O-9820_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_16521_RXN3O-9820_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4192,13 +4236,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule75076> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_BFO_0000066_reaction_RXN3O-9821_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_87289>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4215,7 +4270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4230,24 +4285,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1Protein75174> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_15377_RXN3O-9820_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15379_RXN3O-9820>
         a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4258,7 +4302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4278,7 +4322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4290,11 +4334,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_2f9baacf-b282-4705-b848-ac27f4985c51_RXN3O-9826_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_be0101e4-71ae-43ee-af4e-753a76110aa2_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4302,29 +4346,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2f9baacf-b282-4705-b848-ac27f4985c51_RXN3O-9826>
+          <http://model.geneontology.org/be0101e4-71ae-43ee-af4e-753a76110aa2_RXN3O-9826>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002413_RXN66-314_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_64925_RXN3O-9823_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_64925_RXN3O-9823_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4335,17 +4368,6 @@
           <http://model.geneontology.org/CHEBI_64925_RXN3O-9823>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_52386_RXN66-318_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_RXN66-306>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4355,7 +4377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4366,24 +4388,27 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002333_YHR007C-MONOMER_RXN3O-9820_controller_SGD_YeastPathways_PWY-6074-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9820> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YHR007C-MONOMER_RXN3O-9820_controller>
-] .
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002413_RXN3O-9821_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002413_RXN66-318_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17813_RXN3O-9820>
         a       <http://purl.obolibrary.org/obo/CHEBI_17813> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4394,7 +4419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4402,67 +4427,45 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_15377_RXN3O-9826_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000066_reaction_RXN66-318_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_58349_RXN3O-9820_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002333_YHR007C-MONOMER_RXN3O-9820_controller_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-313> ;
+          <http://model.geneontology.org/RXN3O-9820> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1>
+          <http://model.geneontology.org/YHR007C-MONOMER_RXN3O-9820_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_13390_RXN3O-9823_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_16526_RXN66-318_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_16526_RXN66-318_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4473,16 +4476,24 @@
           <http://model.geneontology.org/CHEBI_16526_RXN66-318>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000066_reaction_RXN66-319_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN66-313> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_18252>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4506,7 +4517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4519,7 +4530,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_13390_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4530,11 +4552,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002411_RXN3O-9825_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002411_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4552,11 +4574,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4567,15 +4589,26 @@
           <http://model.geneontology.org/YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_15740_RXN3O-9820_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_15378_RXN66-314_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_15378_RXN66-314_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4595,7 +4628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4603,15 +4636,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000066_reaction_RXN3O-9826_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000066_reaction_RXN3O-9826_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4622,29 +4666,18 @@
           <http://model.geneontology.org/reaction_RXN3O-9826_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000066_reaction_RXN3O-9826_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_13390_RXN3O-9823_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_15378_RXN66-306_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/3dd14b7a-e7a6-4cd2-9d25-4dad6b3b9989_RXN3O-9824>
+<http://model.geneontology.org/c6258ac8-7298-41b1-a1e4-369cfa90abb1_RXN3O-9824>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -4653,7 +4686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4661,37 +4694,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_15379_RXN3O-9821_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_2f9baacf-b282-4705-b848-ac27f4985c51_RXN3O-9826_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000066_reaction_RXN3O-9823_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000066_reaction_RXN3O-9823_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4711,7 +4722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4728,24 +4739,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule75076> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_2d8b72e1-4801-43c5-971c-16ac050159dd_RXN3O-9824_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15379_RXN3O-9826>
         a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4756,7 +4756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4764,18 +4764,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_15377_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_15377_RXN3O-9823_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_15377_RXN3O-9821_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_17813_RXN3O-9820_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_17813_RXN3O-9820_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4790,11 +4823,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_15379_RXN3O-9824_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_15379_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4805,26 +4838,15 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-9824>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_18252_RXN66-319_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_18364_RXN66-306_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_18364_RXN66-306_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4839,11 +4861,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4854,25 +4876,14 @@
           <http://model.geneontology.org/YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_3a470607-9951-447a-93ad-69f58ad5e3a3_RXN3O-9826_SGD_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_16521_RXN3O-9820_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002333_YGR060W-MONOMER_RXN3O-9821_controller_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4880,11 +4891,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_16526_RXN66-313_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_16526_RXN66-313_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4895,14 +4906,14 @@
           <http://model.geneontology.org/CHEBI_16526_RXN66-313>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_15377_RXN3O-9823_SGD_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_15379_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4915,13 +4926,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule75166> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_15379_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008398>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4930,11 +4952,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_13390_RXN3O-9825_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_13390_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4945,17 +4967,6 @@
           <http://model.geneontology.org/CHEBI_13390_RXN3O-9825>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_64925_RXN3O-9823_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9823>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4965,7 +4976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4994,7 +5005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5006,11 +5017,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_15377_RXN3O-9822_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_15377_RXN3O-9822_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5030,7 +5041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5042,11 +5053,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_52386_RXN66-318_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_52386_RXN66-318_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5061,11 +5072,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002333_YGL001C-MONOMER_RXN66-313_controller_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002333_YGL001C-MONOMER_RXN66-313_controller_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5076,6 +5087,17 @@
           <http://model.geneontology.org/YGL001C-MONOMER_RXN66-313_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002234_CHEBI_58349_RXN3O-9820_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_13390_RXN3O-9821>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_13390> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5085,7 +5107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5100,11 +5122,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_15377_RXN3O-9825_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_15377_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5124,7 +5146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5139,11 +5161,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_57783_RXN3O-9820_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_57783_RXN3O-9820_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5163,7 +5185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "zymosterol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -5175,11 +5197,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_87287_RXN3O-9822_SGD_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_87287_RXN3O-9822_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5199,7 +5221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5216,7 +5238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5239,32 +5261,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74884> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002333_YLR100W-MONOMER_RXN66-314_controller_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_BFO_0000066_reaction_RXN3O-9822_location_lociGO_0005829_SGD_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-6075-1.ttl
+++ b/models/YeastPathways_PWY-6075-1.ttl
@@ -1,15 +1,26 @@
 <http://purl.obolibrary.org/obo/GO_0003838>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,15 +31,26 @@
           <http://model.geneontology.org/YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_57783_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_57856_RXN3O-178_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_57856_RXN3O-178_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,24 +80,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6075-1BiochemicalReaction75390> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_18249_RXN3O-9828_SGD_YeastPathways_PWY-6075-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-188_RXN3O-178_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004467> ;
@@ -84,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -111,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -128,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -151,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -163,11 +174,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_58349_RXN3O-9828_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_58349_RXN3O-9828_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -182,11 +193,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002333_YMR202W-MONOMER_RXN3O-203_controller_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002333_YMR202W-MONOMER_RXN3O-203_controller_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -197,25 +208,14 @@
           <http://model.geneontology.org/YMR202W-MONOMER_RXN3O-203_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_YeastPathways_PWY-6075-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_58349_1.3.1.71-RXN_SGD_YeastPathways_PWY-6075-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_59789_RXN3O-178_SGD_PWY_YeastPathways_PWY-6075-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
+                "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -229,11 +229,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_16933_1.3.1.71-RXN_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_16933_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -248,11 +248,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_15377_RXN3O-9827_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_15377_RXN3O-9827_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -262,17 +262,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_RXN3O-9827>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_57856_RXN3O-178_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16933>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -284,11 +273,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000066_reaction_RXN3O-178_location_lociGO_0005829_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000066_reaction_RXN3O-178_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,18 +293,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002333_YGL012W-MONOMER_1.3.1.71-RXN_controller_SGD_YeastPathways_PWY-6075-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_50586_RXN3O-203_SGD_PWY_YeastPathways_PWY-6075-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
+                "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -331,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -339,26 +328,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_16933_1.3.1.71-RXN_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_15379_RXN3O-9828_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_15379_RXN3O-9828_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -381,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "ergosterol biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -396,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -404,34 +382,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002333_MONOMER3O-232_RXN3O-9828_controller_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_52972_RXN3O-9827_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-9828_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -444,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -456,11 +412,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,7 +436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -498,11 +454,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_BFO_0000066_reaction_RXN3O-9827_location_lociGO_0005829_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_BFO_0000066_reaction_RXN3O-9827_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,6 +472,72 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_15378_RXN3O-178_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_15379_RXN3O-9828_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_57783_RXN3O-9828_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_57856_RXN3O-178_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002333_YMR202W-MONOMER_RXN3O-203_controller_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002333_YLR056W-MONOMER_RXN3O-9827_controller_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000004467>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -526,11 +548,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002333_YLR056W-MONOMER_RXN3O-9827_controller_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002333_YLR056W-MONOMER_RXN3O-9827_controller_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -548,11 +570,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_15378_RXN3O-178_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_15378_RXN3O-178_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,35 +594,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6075-1SmallMolecule75282> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_15379_RXN3O-9827_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000066_reaction_RXN3O-178_location_lociGO_0005829_SGD_YeastPathways_PWY-6075-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -609,11 +609,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_15377_RXN3O-9828_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_15377_RXN3O-9828_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -628,11 +628,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002233_CHEBI_17038_RXN3O-178_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002233_CHEBI_17038_RXN3O-178_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -643,39 +643,28 @@
           <http://model.geneontology.org/CHEBI_17038_RXN3O-178>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_YeastPathways_PWY-6075-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_58349_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_15378_1.3.1.71-RXN_SGD_YeastPathways_PWY-6075-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
+                "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_58349_RXN3O-9827_SGD_YeastPathways_PWY-6075-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_BFO_0000066_reaction_RXN3O-9827_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6075-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
+                "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -683,11 +672,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_18249_RXN3O-9828_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_18249_RXN3O-9828_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -698,14 +687,14 @@
           <http://model.geneontology.org/CHEBI_18249_RXN3O-9828>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002413_RXN3O-9828_SGD_YeastPathways_PWY-6075-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_15377_RXN3O-9828_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
+                "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -713,11 +702,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_50586_RXN3O-203_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_50586_RXN3O-203_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,17 +723,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002413_RXN3O-203_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58349_1.3.1.71-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -754,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -771,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -783,11 +761,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_BFO_0000066_reaction_RXN3O-9828_location_lociGO_0005829_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_BFO_0000066_reaction_RXN3O-9828_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -798,26 +776,15 @@
           <http://model.geneontology.org/reaction_RXN3O-9828_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_15379_RXN3O-9828_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002333_MONOMER3O-188_RXN3O-178_controller_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002333_MONOMER3O-188_RXN3O-178_controller_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -827,39 +794,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/MONOMER3O-188_RXN3O-178_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_YeastPathways_PWY-6075-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_57783_RXN3O-9827_SGD_YeastPathways_PWY-6075-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_52972_RXN3O-9827_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_50586>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -873,7 +807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -888,7 +822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -903,11 +837,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002333_MONOMER3O-232_RXN3O-9828_controller_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002333_MONOMER3O-232_RXN3O-9828_controller_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -923,7 +857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -931,11 +865,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'fecosterol &rarr; episterol' 'null' 'episterol + NADPH + oxygen + H<SUP>+</SUP> &rarr; ergosta-5,7,24(28)-trien-3&beta;-ol + NADP<sup>+</sup> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002413_RXN3O-9827_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002413_RXN3O-9827_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -949,25 +883,47 @@
 <http://purl.obolibrary.org/obo/GO_0006696>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_58349_RXN3O-9828_SGD_YeastPathways_PWY-6075-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_PWY_YeastPathways_PWY-6075-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
+                "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_15379_RXN3O-9827_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_57783_RXN3O-9827_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17038>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -982,11 +938,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_58349_1.3.1.71-RXN_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_58349_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1004,11 +960,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_52972_RXN3O-9827_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_52972_RXN3O-9827_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1023,11 +979,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_18252_RXN3O-178_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_18252_RXN3O-178_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1050,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1061,14 +1017,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_57783_RXN3O-9828_SGD_YeastPathways_PWY-6075-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_15378_RXN3O-9828_SGD_PWY_YeastPathways_PWY-6075-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_58349_RXN3O-9828_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1079,11 +1046,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_52972_RXN3O-9827_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_52972_RXN3O-9827_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1098,11 +1065,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1113,17 +1080,6 @@
           <http://model.geneontology.org/YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_15378_RXN3O-9827_SGD_YeastPathways_PWY-6075-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_59789_RXN3O-178>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59789> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1133,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1160,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1177,7 +1133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1185,15 +1141,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002413_RXN3O-9828_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000066_reaction_1.3.1.71-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000066_reaction_1.3.1.71-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1208,11 +1175,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_15378_RXN3O-9827_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_15378_RXN3O-9827_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1223,47 +1190,47 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-9827>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000066_reaction_1.3.1.71-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6075-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002413_RXN3O-203_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_15377_RXN3O-9827_SGD_PWY_YeastPathways_PWY-6075-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
+                "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002234_CHEBI_50586_RXN3O-203_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002413_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
+                "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_YeastPathways_PWY-6075-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002333_MONOMER3O-188_RXN3O-178_controller_SGD_PWY_YeastPathways_PWY-6075-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_BFO_0000066_reaction_RXN3O-9828_location_lociGO_0005829_SGD_YeastPathways_PWY-6075-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
+                "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1274,7 +1241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1286,11 +1253,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" , "Provides Input For Rule. The relation 'episterol + NADPH + oxygen + H<SUP>+</SUP> &rarr; ergosta-5,7,24(28)-trien-3&beta;-ol + NADP<sup>+</sup> + 2 H<sub>2</sub>O' 'null' 'ergosta-5,7,24(28)-trien-3&beta;-ol + NADPH + oxygen + H<SUP>+</SUP> &rarr; ergosta-5,7,22,24(28)-tetraen-3-&beta;-ol + NADP<sup>+</sup> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002413_RXN3O-9828_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002413_RXN3O-9828_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1308,11 +1275,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_17038_RXN3O-178_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_17038_RXN3O-178_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1323,41 +1290,8 @@
           <http://model.geneontology.org/CHEBI_17038_RXN3O-178>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_17038_RXN3O-178_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002333_YLR056W-MONOMER_RXN3O-9827_controller_SGD_YeastPathways_PWY-6075-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_YeastPathways_PWY-6075-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YLR056W-MONOMER_RXN3O-9827_controller>
         a       <http://identifiers.org/sgd/S000004046> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1366,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1383,24 +1317,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6075-1SmallMolecule75379> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_59789_RXN3O-178_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-9827>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0050046> ;
@@ -1421,7 +1344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1432,48 +1355,15 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_15377_RXN3O-9827_SGD_YeastPathways_PWY-6075-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_50586_RXN3O-203_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_15378_RXN3O-9828_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_18249_RXN3O-9828_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_18249_RXN3O-9828_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1488,11 +1378,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002234_CHEBI_50586_RXN3O-203_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002234_CHEBI_50586_RXN3O-203_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1503,14 +1393,25 @@
           <http://model.geneontology.org/CHEBI_50586_RXN3O-203>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002413_RXN3O-9827_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_18249_RXN3O-9828_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000066_reaction_RXN3O-203_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1521,7 +1422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1532,15 +1433,26 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_17038_RXN3O-178_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_57783_1.3.1.71-RXN_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_57783_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1555,11 +1467,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_57783_RXN3O-9827_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_57783_RXN3O-9827_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1574,11 +1486,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1598,35 +1510,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6075-1SmallMolecule75449> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_57783_1.3.1.71-RXN_SGD_YeastPathways_PWY-6075-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_18249_RXN3O-9828_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57783_RXN3O-9828>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
@@ -1637,7 +1527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1649,11 +1539,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_15378_RXN3O-9828_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_15378_RXN3O-9828_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1664,15 +1554,59 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-9828>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_52972_RXN3O-9827_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_58349_RXN3O-9827_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_15378_RXN3O-9827_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" , "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + zymosterol &rarr; <i>S</i>-adenosyl-L-homocysteine + fecosterol + H<SUP>+</SUP>' 'null' 'fecosterol &rarr; episterol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002413_RXN3O-203_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002413_RXN3O-203_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1683,25 +1617,47 @@
           <http://model.geneontology.org/RXN3O-203>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_15377_RXN3O-9828_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000066_reaction_RXN3O-203_location_lociGO_0005829_SGD_YeastPathways_PWY-6075-1>
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_15378_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY-6075-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002234_CHEBI_50586_RXN3O-203_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002333_YGL012W-MONOMER_1.3.1.71-RXN_controller_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_18252_RXN3O-178_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1714,7 +1670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1731,7 +1687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1739,15 +1695,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002234_CHEBI_18249_RXN3O-9828_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ergosta-5,7,24(28)-trien-3&beta;-ol + NADPH + oxygen + H<SUP>+</SUP> &rarr; ergosta-5,7,22,24(28)-tetraen-3-&beta;-ol + NADP<sup>+</sup> + 2 H<sub>2</sub>O' 'null' 'ergosterol + NADP<sup>+</sup> &larr; ergosta-5,7,22,24(28)-tetraen-3-&beta;-ol + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002413_1.3.1.71-RXN_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002413_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1762,11 +1729,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1792,7 +1759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1800,29 +1767,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15379>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_15379>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_RXN3O-178_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_18252_RXN3O-178_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1830,11 +1786,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002333_YGL012W-MONOMER_1.3.1.71-RXN_controller_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002333_YGL012W-MONOMER_1.3.1.71-RXN_controller_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1845,26 +1801,15 @@
           <http://model.geneontology.org/YGL012W-MONOMER_1.3.1.71-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002233_CHEBI_17038_RXN3O-178_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_58349_RXN3O-9827_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_58349_RXN3O-9827_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1875,15 +1820,37 @@
           <http://model.geneontology.org/CHEBI_58349_RXN3O-9827>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002413_RXN3O-9827_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000066_reaction_1.3.1.71-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_59789_RXN3O-178_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_59789_RXN3O-178_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1893,6 +1860,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_59789_RXN3O-178>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002333_MONOMER3O-232_RXN3O-9828_controller_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1906,7 +1884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1914,25 +1892,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002413_1.3.1.71-RXN_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002333_MONOMER3O-188_RXN3O-178_controller_SGD_YeastPathways_PWY-6075-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
+                "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1940,11 +1907,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_57783_RXN3O-9828_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9828_RO_0002233_CHEBI_57783_RXN3O-9828_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1955,15 +1922,26 @@
           <http://model.geneontology.org/CHEBI_57783_RXN3O-9828>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_16933_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000066_reaction_RXN3O-203_location_lociGO_0005829_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000066_reaction_RXN3O-203_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1979,18 +1957,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002333_YMR202W-MONOMER_RXN3O-203_controller_SGD_YeastPathways_PWY-6075-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000050_YeastPathways_PWY-6075-1/YeastPathways_PWY-6075-1_SGD_PWY_YeastPathways_PWY-6075-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
+                "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2011,7 +1989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2019,15 +1997,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_BFO_0000066_reaction_RXN3O-9828_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_15378_1.3.1.71-RXN_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_15378_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2038,6 +2027,17 @@
           <http://model.geneontology.org/CHEBI_15378_1.3.1.71-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002233_CHEBI_17038_RXN3O-178_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0000246>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2045,11 +2045,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_15379_RXN3O-9827_SGD_YeastPathways_PWY-6075-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002233_CHEBI_15379_RXN3O-9827_SGD_PWY_YeastPathways_PWY-6075-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2060,19 +2060,27 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-9827>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_15378_RXN3O-178_SGD_YeastPathways_PWY-6075-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000066_reaction_RXN3O-178_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6075-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6075-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_52972_RXN3O-9827_SGD_PWY_YeastPathways_PWY-6075-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
+                "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000002980>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-178>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2083,13 +2091,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6075-1SmallMolecule75295> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000002980>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_1.3.1.71-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2100,24 +2111,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6075-1SmallMolecule75295> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_BFO_0000066_reaction_RXN3O-9827_location_lociGO_0005829_SGD_YeastPathways_PWY-6075-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6075-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57783_1.3.1.71-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
@@ -2128,7 +2128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-6122-1.ttl
+++ b/models/YeastPathways_PWY-6122-1.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,26 +17,15 @@
           <http://model.geneontology.org/CHEBI_29888_PRPPAMIDOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,15 +39,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,6 +69,28 @@
           <http://model.geneontology.org/CHEBI_43474_AIRS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58359_PRPPAMIDOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58359> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -78,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -103,14 +125,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
+                "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -124,11 +146,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -143,11 +165,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -164,17 +186,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_77eb9040-0550-4266-a2a5-33224e5f479a_GART-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -187,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -195,14 +206,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_YeastPathways_PWY-6122-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
+                "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -215,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -227,11 +238,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,11 +257,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' 'null' 'ATP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine &rarr; ADP + 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -276,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,11 +299,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,25 +314,14 @@
           <http://model.geneontology.org/reaction_AIRS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6122-1>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
+                "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -338,11 +338,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,15 +353,26 @@
           <http://model.geneontology.org/YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -372,43 +383,18 @@
           <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000003203>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,6 +405,17 @@
           <http://model.geneontology.org/CHEBI_43474_GLYRIBONUCSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29888_PRPPAMIDOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -428,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -436,15 +433,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -455,41 +455,8 @@
           <http://model.geneontology.org/CHEBI_18413_FGAMSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_FGAMSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -500,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -508,27 +475,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1>
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
+                "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/8ff23b50-6dc1-4bc8-ae45-8b538033bff3_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71740> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0004637>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -537,11 +510,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -552,15 +525,26 @@
           <http://model.geneontology.org/CHEBI_58017_PRPPAMIDOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,26 +558,15 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_YeastPathways_PWY-6122-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -619,7 +592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -637,7 +610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -649,11 +622,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,11 +641,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -682,6 +655,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_FGAMSYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -694,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -702,11 +686,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -717,15 +701,26 @@
           <http://model.geneontology.org/YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -736,8 +731,41 @@
           <http://model.geneontology.org/CHEBI_456216_FGAMSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_8ff23b50-6dc1-4bc8-ae45-8b538033bff3_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_PRPPAMIDOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -748,7 +776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -760,11 +788,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -779,11 +807,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,14 +822,14 @@
           <http://model.geneontology.org/CHEBI_58426_GART-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
+                "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -809,11 +837,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,6 +852,17 @@
           <http://model.geneontology.org/CHEBI_456216_AIRS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_43474_GLYRIBONUCSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -833,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -859,17 +898,6 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YGR061C-MONOMER_FGAMSYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003293> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -877,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -889,11 +917,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -911,11 +939,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,61 +954,11 @@
           <http://model.geneontology.org/CHEBI_58426_GART-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/77eb9040-0550-4266-a2a5-33224e5f479a_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71718> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -994,24 +972,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71790> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1020,11 +987,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1039,11 +1006,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1054,15 +1021,37 @@
           <http://model.geneontology.org/YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1076,48 +1065,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_YeastPathways_PWY-6122-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '5-phospho-&beta;-D-ribosylamine + L-glutamate + diphosphate &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + L-glutamine + H<sub>2</sub>O' 'null' 'ATP + 5-phospho-&beta;-D-ribosylamine + glycine &rarr; ADP + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1137,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "5-aminoimidazole ribonucleotide biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1145,15 +1101,26 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' 'null' 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1168,11 +1135,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1183,6 +1150,17 @@
           <http://model.geneontology.org/YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_FGAMSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1192,7 +1170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1209,7 +1187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1220,45 +1198,6 @@
 <http://identifiers.org/sgd/S000004915>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/52fa9290-ef8c-402e-a846-9eff4bb90bd0_GART-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71740> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1267,7 +1206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1275,11 +1214,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1290,6 +1229,17 @@
           <http://model.geneontology.org/CHEBI_456216_GLYRIBONUCSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58457>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1297,11 +1247,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1312,41 +1262,30 @@
           <http://model.geneontology.org/CHEBI_29985_FGAMSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
+                "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002816>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0009260>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1355,11 +1294,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1370,15 +1309,37 @@
           <http://model.geneontology.org/CHEBI_58359_PRPPAMIDOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_77eb9040-0550-4266-a2a5-33224e5f479a_GART-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_a115d8b2-1459-4210-a404-ec01c3acd0db_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1386,18 +1347,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/77eb9040-0550-4266-a2a5-33224e5f479a_GART-RXN>
+          <http://model.geneontology.org/a115d8b2-1459-4210-a404-ec01c3acd0db_GART-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1414,58 +1375,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_52fa9290-ef8c-402e-a846-9eff4bb90bd0_GART-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1>
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-6122-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
+                "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY-6122-1>
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
+                "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1476,7 +1404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1488,11 +1416,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1503,6 +1431,17 @@
           <http://model.geneontology.org/CHEBI_30616_GLYRIBONUCSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_GLYRIBONUCSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1512,7 +1451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1524,11 +1463,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1542,6 +1481,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_18413>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1552,7 +1513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1564,11 +1525,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ATP + 5-phospho-&beta;-D-ribosylamine + glycine &rarr; ADP + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + phosphate + H<SUP>+</SUP>' 'null' 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1583,11 +1544,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1598,37 +1559,15 @@
           <http://model.geneontology.org/YGR061C-MONOMER_FGAMSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1656,13 +1595,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1BiochemicalReaction71776> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_a115d8b2-1459-4210-a404-ec01c3acd0db_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_GLYRIBONUCSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -1673,7 +1634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1684,6 +1645,28 @@
 <http://purl.obolibrary.org/obo/GO_0004641>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57305_GLYRIBONUCSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57305> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1693,7 +1676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1713,7 +1696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1725,11 +1708,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1747,11 +1730,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_52fa9290-ef8c-402e-a846-9eff4bb90bd0_GART-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_8ff23b50-6dc1-4bc8-ae45-8b538033bff3_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1759,8 +1742,30 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/52fa9290-ef8c-402e-a846-9eff4bb90bd0_GART-RXN>
+          <http://model.geneontology.org/8ff23b50-6dc1-4bc8-ae45-8b538033bff3_GART-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58426>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1769,11 +1774,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1783,17 +1788,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YGL234W-MONOMER_AIRS-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GLYRIBONUCSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004637> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1814,7 +1808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1822,34 +1816,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_YeastPathways_PWY-6122-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6122-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1862,7 +1834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1870,25 +1842,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
+                "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1896,11 +1857,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1911,26 +1872,15 @@
           <http://model.geneontology.org/CHEBI_15378_GLYRIBONUCSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1953,9 +1903,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> , <http://model.geneontology.org/77eb9040-0550-4266-a2a5-33224e5f479a_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> , <http://model.geneontology.org/a115d8b2-1459-4210-a404-ec01c3acd0db_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/52fa9290-ef8c-402e-a846-9eff4bb90bd0_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/8ff23b50-6dc1-4bc8-ae45-8b538033bff3_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1963,7 +1913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1971,23 +1921,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_AIRS-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1996,26 +1935,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
+                "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004915> ;
@@ -2024,7 +1974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2032,14 +1982,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6122-1>
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_PWY_YeastPathways_PWY-6122-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
+                "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2047,11 +1997,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2066,11 +2016,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2081,14 +2031,14 @@
           <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
+                "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2096,11 +2046,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2111,6 +2061,17 @@
           <http://model.geneontology.org/CHEBI_30616_AIRS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2120,7 +2081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2131,28 +2092,6 @@
 <http://purl.obolibrary.org/obo/GO_0004644>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_AIRS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2162,13 +2101,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71765> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_137981_AIRS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_137981> ;
@@ -2179,7 +2129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2191,11 +2141,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2225,7 +2175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2237,11 +2187,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2252,17 +2202,6 @@
           <http://model.geneontology.org/reaction_FGAMSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_GLYRIBONUCSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2272,7 +2211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2280,15 +2219,70 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2308,7 +2302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2325,13 +2319,43 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71801> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
+] .
 
 <http://model.geneontology.org/FGAMSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004642> ;
@@ -2352,7 +2376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2360,33 +2384,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY-6122-1>
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_PWY_YeastPathways_PWY-6122-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
+                "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2399,7 +2404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2416,7 +2421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2424,27 +2429,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_YeastPathways_PWY-6122-1>
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
+                "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/a115d8b2-1459-4210-a404-ec01c3acd0db_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71718> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_GART-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2455,21 +2466,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71765> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-6123-1.ttl
+++ b/models/YeastPathways_PWY-6123-1.ttl
@@ -1,34 +1,12 @@
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_YeastPathways_PWY-6123-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,6 +17,17 @@
           <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller>
         a       <http://identifiers.org/sgd/S000004727> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -46,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -54,15 +43,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" , "Provides Input For Rule. The relation '5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole &harr; fumarate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide' 'null' 'a 10-formyltetrahydrofolate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide &harr; a tetrahydrofolate + 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,14 +73,14 @@
           <http://model.geneontology.org/AICARTRANSFORM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
+                "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -99,9 +99,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/49aa05a6-b9f4-4da3-a5ac-15b863d13098_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
+                <http://model.geneontology.org/3544103b-e9fa-43d3-9dd2-5ea6747d87ef_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/2e08f681-39a9-4cb1-90a7-bf00400e7cdf_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/766fa3aa-cbbf-4e61-8147-4fdc0933a634_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -109,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,15 +117,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -136,26 +147,15 @@
           <http://model.geneontology.org/CHEBI_30616_SAICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -165,28 +165,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_YeastPathways_PWY-6123-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_2e08f681-39a9-4cb1-90a7-bf00400e7cdf_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004727>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -200,14 +178,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_YeastPathways_PWY-6123-1>
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -215,11 +204,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -237,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -252,11 +241,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,22 +256,22 @@
           <http://model.geneontology.org/reaction_AICARSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000004351>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YLR359W-MONOMER_AICARSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000004351> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -291,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -303,11 +292,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -333,15 +322,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -359,11 +359,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -374,19 +374,36 @@
           <http://model.geneontology.org/YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
+                "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/3544103b-e9fa-43d3-9dd2-5ea6747d87ef_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1SmallMolecule72807> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/AICARSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004018> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -407,13 +424,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1BiochemicalReaction72837> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58475> ;
@@ -424,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -432,14 +471,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_YeastPathways_PWY-6123-1>
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -447,11 +497,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -472,11 +522,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -490,17 +540,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_58564>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_137981>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -512,19 +551,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_29991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -535,18 +577,15 @@
           <http://model.geneontology.org/reaction_SAICARSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_29991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -557,6 +596,28 @@
           <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29806_AICARSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29806> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -566,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -574,62 +635,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6123-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_PWY-6123-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
+                "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRCARBOXY-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -644,11 +672,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -659,46 +687,29 @@
           <http://model.geneontology.org/CHEBI_16526_AIRCARBOXY-RXN>
 ] .
 
-<http://model.geneontology.org/2e08f681-39a9-4cb1-90a7-bf00400e7cdf_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1SmallMolecule72829> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_49aa05a6-b9f4-4da3-a5ac-15b863d13098_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_AIRCARBOXY-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -709,11 +720,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -728,11 +739,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,22 +754,16 @@
           <http://model.geneontology.org/YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1>
 ] .
 
-<http://model.geneontology.org/49aa05a6-b9f4-4da3-a5ac-15b863d13098_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1SmallMolecule72807> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58564_AIRCARBOXY-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58564> ;
@@ -769,46 +774,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1SmallMolecule72692> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -822,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -837,11 +809,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -852,15 +824,26 @@
           <http://model.geneontology.org/CHEBI_58564_AIRCARBOXY-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -871,6 +854,17 @@
           <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -880,6 +874,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -887,11 +892,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -911,13 +916,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1SmallMolecule72904> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58467> ;
@@ -928,7 +955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -936,37 +963,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -992,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1009,24 +1014,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1SmallMolecule72707> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004643>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1040,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1052,11 +1046,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1071,11 +1065,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1086,17 +1080,6 @@
           <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_PWY-6123-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY-6123-1>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1106,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "inosine-5'-phosphate biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1117,51 +1100,29 @@
 <http://purl.obolibrary.org/obo/GO_0009152>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
+                "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1181,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1193,11 +1154,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1208,25 +1169,14 @@
           <http://model.geneontology.org/reaction_AIRCARBOXY-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
+                "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1234,11 +1184,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1252,18 +1202,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0003937>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1281,7 +1228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1306,7 +1253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1314,23 +1261,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0003937>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1344,7 +1283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1356,11 +1295,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1371,14 +1310,14 @@
           <http://model.geneontology.org/CHEBI_29991_SAICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
+                "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1386,11 +1325,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_2e08f681-39a9-4cb1-90a7-bf00400e7cdf_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_766fa3aa-cbbf-4e61-8147-4fdc0933a634_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1398,20 +1337,31 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2e08f681-39a9-4cb1-90a7-bf00400e7cdf_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/766fa3aa-cbbf-4e61-8147-4fdc0933a634_AICARTRANSFORM-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000000070>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1424,7 +1374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1435,15 +1385,26 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ATP + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + L-aspartate &rarr; ADP + 5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole + phosphate + H<SUP>+</SUP>' 'null' '5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole &harr; fumarate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1454,15 +1415,32 @@
           <http://model.geneontology.org/AICARSYN-RXN>
 ] .
 
+<http://model.geneontology.org/766fa3aa-cbbf-4e61-8147-4fdc0933a634_AICARTRANSFORM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1SmallMolecule72829> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1477,11 +1455,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1492,17 +1470,6 @@
           <http://model.geneontology.org/YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004018> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1510,7 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1518,14 +1485,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_YeastPathways_PWY-6123-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_766fa3aa-cbbf-4e61-8147-4fdc0933a634_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
+                "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1533,11 +1500,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1552,11 +1519,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1576,7 +1543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1588,11 +1555,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1603,15 +1570,26 @@
           <http://model.geneontology.org/CHEBI_15378_SAICARSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" , "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide &harr; a tetrahydrofolate + 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' 'null' 'IMP + H<sub>2</sub>O &harr; 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1627,21 +1605,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_YeastPathways_PWY-6123-1>
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_PWY-6123-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
+                "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1650,12 +1628,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58053_IMPCYCLOHYDROLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58053> ;
@@ -1666,7 +1655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1677,25 +1666,36 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6123-1>
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6123-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
+                "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_YeastPathways_PWY-6123-1>
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_PWY_YeastPathways_PWY-6123-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_3544103b-e9fa-43d3-9dd2-5ea6747d87ef_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1703,11 +1703,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" , "Provides Input For Rule. The relation '5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + 2 H<SUP>+</SUP> &harr; 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + CO<SUB>2</SUB>' 'null' 'ATP + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + L-aspartate &rarr; ADP + 5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1718,14 +1718,14 @@
           <http://model.geneontology.org/SAICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_PWY-6123-1>
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
+                "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1736,11 +1736,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1750,6 +1750,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_29806_AICARSYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/AIRCARBOXY-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0043727> ;
@@ -1770,7 +1781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1785,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1802,7 +1813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1814,11 +1825,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1836,11 +1847,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_49aa05a6-b9f4-4da3-a5ac-15b863d13098_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_3544103b-e9fa-43d3-9dd2-5ea6747d87ef_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1848,7 +1859,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/49aa05a6-b9f4-4da3-a5ac-15b863d13098_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/3544103b-e9fa-43d3-9dd2-5ea6747d87ef_AICARTRANSFORM-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0043727>
@@ -1863,7 +1874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1871,26 +1882,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1905,11 +1905,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRCARBOXY-RXN_SGD_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1920,30 +1920,30 @@
           <http://model.geneontology.org/CHEBI_137981_AIRCARBOXY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
+                "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58053>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SAICARSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004639> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1964,7 +1964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1975,27 +1975,27 @@
 <http://identifiers.org/sgd/S000005654>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
+                "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004639>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
+                "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-6125.ttl
+++ b/models/YeastPathways_PWY-6125.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'GDP + ATP &rarr; GTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,15 +17,26 @@
           <http://model.geneontology.org/GDPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -43,11 +54,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -63,86 +74,64 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_YeastPathways_PWY-6125>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6125>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-6125>
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_61429>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_61429>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -166,11 +155,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,11 +174,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -200,17 +189,6 @@
           <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58595> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -220,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -228,29 +206,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15740>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/CHEBI_58595>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15740>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
         a       <http://identifiers.org/sgd/S000003563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -263,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -280,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -297,15 +275,26 @@
 <http://identifiers.org/sgd/S000003563>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -316,17 +305,6 @@
           <http://model.geneontology.org/CHEBI_15378_RXN0-746>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58359_GMP-SYN-GLUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58359> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -336,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -348,11 +326,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,15 +341,26 @@
           <http://model.geneontology.org/CHEBI_30616_GUANYL-KIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -392,11 +381,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -416,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -433,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -441,49 +430,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_PWY-6125>
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PWY_YeastPathways_PWY-6125>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6125SmallMolecule29297> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,37 +477,32 @@
           <http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6125SmallMolecule29297> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -544,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -555,47 +533,36 @@
 <http://purl.obolibrary.org/obo/CHEBI_37565>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_YeastPathways_PWY-6125>
+<http://purl.obolibrary.org/obo/GO_0004550>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY-6125>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004550>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000001259>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YML056C-MONOMER_IMP-DEHYDROG-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004520> ;
@@ -604,7 +571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -612,14 +579,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6125>
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6125>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -627,11 +594,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -642,26 +609,15 @@
           <http://model.geneontology.org/YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -675,15 +631,26 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -697,27 +664,71 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004830>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -728,14 +739,14 @@
           <http://model.geneontology.org/CHEBI_15377_RXN0-746>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -743,11 +754,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -765,7 +776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -782,7 +793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -794,11 +805,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -809,29 +820,29 @@
           <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -859,7 +870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -872,18 +883,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -896,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -904,14 +915,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -919,11 +941,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -941,11 +963,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -956,15 +978,26 @@
           <http://model.geneontology.org/CHEBI_58359_GMP-SYN-GLUT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -974,17 +1007,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY-6125/YeastPathways_PWY-6125>
 ] .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -996,11 +1018,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,11 +1037,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1034,11 +1056,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1049,6 +1071,17 @@
           <http://model.geneontology.org/YeastPathways_PWY-6125/YeastPathways_PWY-6125>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29888_GMP-SYN-GLUT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1058,24 +1091,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6125SmallMolecule29469> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1089,7 +1111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1109,7 +1131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1129,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1137,26 +1159,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'dGDP + an oxidized thioredoxin + H<sub>2</sub>O &larr; GDP + a reduced thioredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1171,11 +1182,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1191,7 +1202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1199,11 +1210,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_DGDPKIN-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1223,7 +1234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1231,20 +1242,53 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000001328>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_YeastPathways_PWY-6125>
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6125>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1252,11 +1296,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1271,11 +1315,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1298,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1310,11 +1354,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1333,12 +1377,45 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1353,7 +1430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1361,54 +1438,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1419,6 +1471,9 @@
           <http://model.geneontology.org/CHEBI_15740_RXN0-746>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1426,11 +1481,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1450,7 +1505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1462,11 +1517,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1477,6 +1532,17 @@
           <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57464> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1486,7 +1552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1498,11 +1564,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1522,7 +1588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1533,6 +1599,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YKL067W-MONOMER_DGDPKIN-RXN_controller>
         a       <http://identifiers.org/sgd/S000001550> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1540,7 +1617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1563,7 +1640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1574,15 +1651,29 @@
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1593,18 +1684,7 @@
           <http://model.geneontology.org/CHEBI_15377_IMP-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0032991>
+<http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_58115>
@@ -1614,11 +1694,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1629,18 +1709,15 @@
           <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1651,6 +1728,17 @@
           <http://model.geneontology.org/CHEBI_61429_DGDPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_GUANYL-KIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1660,7 +1748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1668,23 +1756,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN0-746_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1697,7 +1774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1722,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1730,8 +1807,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GUANYL-KIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004385> ;
@@ -1752,7 +1851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1764,11 +1863,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1779,14 +1878,14 @@
           <http://model.geneontology.org/YML056C-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1794,11 +1893,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1809,14 +1908,14 @@
           <http://model.geneontology.org/YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_YeastPathways_PWY-6125>
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-6125>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1824,11 +1923,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1839,17 +1938,6 @@
           <http://model.geneontology.org/YKL067W-MONOMER_GDPKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15740_RXN0-746>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15740> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1859,7 +1947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1879,13 +1967,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6125SmallMolecule29510> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004424> ;
@@ -1894,7 +1993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1911,7 +2010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1922,26 +2021,15 @@
 <http://identifiers.org/sgd/S000000872>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1956,11 +2044,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1975,11 +2063,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1990,14 +2078,25 @@
           <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2005,11 +2104,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2020,44 +2119,11 @@
           <http://model.geneontology.org/reaction_DGDPKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://identifiers.org/sgd/S000003412>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_GMP-SYN-GLUT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2068,7 +2134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2080,11 +2146,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2095,15 +2161,26 @@
           <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2123,7 +2200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2131,26 +2208,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2161,17 +2227,6 @@
           <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001259> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2179,7 +2234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2187,20 +2242,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_58189>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2208,11 +2274,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2227,11 +2293,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2242,14 +2308,14 @@
           <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-6125>
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-6125>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2257,11 +2323,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2272,15 +2338,26 @@
           <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2300,24 +2377,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6125SmallMolecule29197> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58115_GMP-SYN-GLUT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58115> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2328,24 +2394,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6125SmallMolecule29399> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58189> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2356,7 +2411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2364,61 +2419,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_YeastPathways_PWY-6125>
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-6125>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_YeastPathways_PWY-6125>
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY-6125>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2426,11 +2459,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2441,37 +2474,15 @@
           <http://model.geneontology.org/YeastPathways_PWY-6125/YeastPathways_PWY-6125>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2487,7 +2498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2500,7 +2511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2508,15 +2519,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2527,28 +2549,6 @@
           <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_GMP-SYN-GLUT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2558,7 +2558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2566,15 +2566,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2604,7 +2637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2612,26 +2645,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2642,14 +2664,25 @@
           <http://model.geneontology.org/CHEBI_456215_GMP-SYN-GLUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2657,11 +2690,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2681,29 +2714,51 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_YeastPathways_PWY-6125>
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-6125>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2714,15 +2769,37 @@
           <http://model.geneontology.org/CHEBI_37565_GDPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2745,7 +2822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of guanosine nucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2757,11 +2834,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2772,26 +2849,15 @@
           <http://model.geneontology.org/CHEBI_15377_GDPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2821,7 +2887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2829,25 +2895,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125>
+<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6125>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2860,7 +2915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2872,11 +2927,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2891,11 +2946,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2910,11 +2965,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2925,14 +2980,14 @@
           <http://model.geneontology.org/YKL067W-MONOMER_DGDPKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_DGDPKIN-RXN_SGD_YeastPathways_PWY-6125>
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY_YeastPathways_PWY-6125>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2955,7 +3010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2963,37 +3018,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0003922>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3002,40 +3035,40 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_PWY-6125/YeastPathways_PWY-6125_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_YeastPathways_PWY-6125>
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-6125>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3043,11 +3076,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3058,37 +3091,15 @@
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3106,7 +3117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3114,15 +3125,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" , "Provides Input For Rule. The relation 'GDP + ATP &rarr; GTP + ADP' 'null' 'formate + GTP + H<SUP>+</SUP> &rarr; dGTP + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3132,28 +3154,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN0-746>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58053>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3165,7 +3165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3173,29 +3173,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-6125>
+<http://purl.obolibrary.org/obo/GO_0106387>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-6125>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
+                "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0106387>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_YeastPathways_PWY-6125> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3215,7 +3215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-6126-1.ttl
+++ b/models/YeastPathways_PWY-6126-1.ttl
@@ -1,23 +1,12 @@
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_YeastPathways_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -32,11 +21,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -51,11 +40,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -66,22 +55,33 @@
           <http://model.geneontology.org/YER170W-MONOMER_ADENYL-KIN-RXN_controller>
 ] .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_YeastPathways_PWY-6126-1>
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY-6126-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_456216_DADPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -109,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -130,11 +130,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" , "Provides Input For Rule. The relation 'adenylo-succinate &harr; fumarate + AMP' 'null' 'AMP + ATP &harr; 2 ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -149,11 +149,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -178,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -194,14 +194,14 @@
 <http://identifiers.org/sgd/S000003563>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-6126-1>
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -209,11 +209,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -224,26 +224,15 @@
           <http://model.geneontology.org/CHEBI_57667_ADPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,45 +243,26 @@
           <http://model.geneontology.org/CHEBI_456216_ADENYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6126-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ADENYL-KIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_ADENYL-KIN-RXN_location_lociGO_0005829>
-] .
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -303,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -311,25 +281,44 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6126-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ADENYL-KIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_ADENYL-KIN-RXN_location_lociGO_0005829>
+] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_PWY-6126-1>
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -345,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -362,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -396,15 +385,26 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,11 +419,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -449,7 +449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,32 +457,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_PWY-6126-1>
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_PWY_YeastPathways_PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0046086>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -493,29 +512,21 @@
           <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0046086>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -538,13 +549,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6126-1SmallMolecule29972> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_ADENYL-KIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -555,24 +577,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6126-1SmallMolecule30078> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_RXN0-745>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -583,46 +594,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6126-1SmallMolecule30017> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57667_ADPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57667> ;
@@ -633,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -645,11 +623,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,37 +638,15 @@
           <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -701,43 +657,21 @@
           <http://model.geneontology.org/CHEBI_57667_ADPREDUCT-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004019>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004019>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -766,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -774,26 +708,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -811,11 +734,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,7 +758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -850,11 +773,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -865,17 +788,6 @@
           <http://model.geneontology.org/CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -885,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -900,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -911,15 +823,26 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -930,26 +853,15 @@
           <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -977,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -985,82 +897,44 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_PWY-6126-1>
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_YeastPathways_PWY-6126-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-745> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN0-745>
-] .
-
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY-6126-1>
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'dADP + an oxidized thioredoxin + H<sub>2</sub>O &larr; ADP + a reduced thioredoxin' 'null' 'dADP + ATP &rarr; dATP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_YeastPathways_PWY-6126-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ADPREDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DADPKIN-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN0-745>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1071,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1079,38 +953,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY_YeastPathways_PWY-6126-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-745> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_RXN0-745>
+] .
+
 <http://model.geneontology.org/reaction_AMPSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_61404> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "dATP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6126-1SmallMolecule30031> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000872> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1133,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1143,13 +1010,91 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'AMP + ATP &harr; 2 ADP' 'null' 'dADP + an oxidized thioredoxin + H<sub>2</sub>O &larr; ADP + a reduced thioredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+          "Provides Input For Rule. The relation 'dADP + an oxidized thioredoxin + H<sub>2</sub>O &larr; ADP + a reduced thioredoxin' 'null' 'dADP + ATP &rarr; dATP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ADPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/DADPKIN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_61404> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "dATP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6126-1SmallMolecule30031> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000872> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'AMP + ATP &harr; 2 ADP' 'null' 'dADP + an oxidized thioredoxin + H<sub>2</sub>O &larr; ADP + a reduced thioredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1159,6 +1104,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/ADPREDUCT-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ADPREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004748> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1179,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1200,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1208,30 +1164,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-6126-1>
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1>
         a       <http://purl.obolibrary.org/obo/GO_0046086> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1240,7 +1196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1248,15 +1204,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1267,15 +1234,18 @@
           <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0004748>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1286,17 +1256,25 @@
           <http://model.geneontology.org/CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004748>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_YeastPathways_PWY-6126-1>
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1307,7 +1285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1324,18 +1302,40 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1350,11 +1350,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1365,17 +1365,6 @@
           <http://model.geneontology.org/Red-Thioredoxin_ADPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58053_ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58053> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1385,7 +1374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1396,14 +1385,14 @@
 <http://purl.obolibrary.org/obo/GO_0004017>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1411,11 +1400,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1429,17 +1418,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1447,11 +1425,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1469,11 +1447,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1494,11 +1472,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1509,62 +1487,62 @@
           <http://model.geneontology.org/reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1584,7 +1562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1596,11 +1574,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1611,25 +1589,25 @@
           <http://model.geneontology.org/YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6126-1>
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_PWY-6126-1>
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6126-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1645,7 +1623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1662,13 +1640,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of adenosine nucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1679,7 +1668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1691,11 +1680,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1706,15 +1695,26 @@
           <http://model.geneontology.org/YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1732,11 +1732,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1747,14 +1747,14 @@
           <http://model.geneontology.org/YDR226W-MONOMER_ADENYL-KIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-6126-1>
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1767,15 +1767,26 @@
 <http://identifiers.org/sgd/S000003412>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1790,11 +1801,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1810,7 +1821,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1822,18 +1844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1843,26 +1854,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_58189>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1877,11 +1877,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1892,15 +1892,26 @@
           <http://model.geneontology.org/reaction_ADPREDUCT-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1920,7 +1931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1937,7 +1948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1951,26 +1962,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_57567>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1985,11 +1985,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2000,14 +2000,14 @@
           <http://model.geneontology.org/YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_YeastPathways_PWY-6126-1>
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_PWY_YeastPathways_PWY-6126-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2018,7 +2018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2033,11 +2033,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2048,14 +2048,25 @@
           <http://model.geneontology.org/YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_PWY-6126-1>
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2078,7 +2089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2090,11 +2101,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2109,11 +2120,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2127,33 +2138,11 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000001550>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_YeastPathways_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -2167,7 +2156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2175,14 +2164,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_YeastPathways_PWY-6126-1>
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2205,7 +2205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2222,7 +2222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2234,11 +2234,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2249,14 +2249,14 @@
           <http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2264,11 +2264,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2288,13 +2288,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6126-1SmallMolecule30188> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004018>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2303,11 +2314,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2318,25 +2329,47 @@
           <http://model.geneontology.org/CHEBI_456215_AMPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_YeastPathways_PWY-6126-1>
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_PWY_YeastPathways_PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2344,11 +2377,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2363,11 +2396,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2385,11 +2418,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2400,14 +2433,14 @@
           <http://model.geneontology.org/CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2420,7 +2453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2428,34 +2461,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN0-745_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2463,11 +2496,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_PWY-6126-1/YeastPathways_PWY-6126-1_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2482,11 +2515,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-aspartate + IMP + GTP &rarr; adenylo-succinate + GDP + phosphate + 2 H<SUP>+</SUP>' 'null' 'adenylo-succinate &harr; fumarate + AMP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_YeastPathways_PWY-6126-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2500,46 +2533,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_58053>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6126-1>
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PWY_YeastPathways_PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-6132.ttl
+++ b/models/YeastPathways_PWY-6132.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -17,11 +17,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002333_YHR072W-MONOMER_LANOSTEROL-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY-6132> ;
+          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002333_YHR072W-MONOMER_LANOSTEROL-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY-6132> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,23 +35,12 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002234_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_YeastPathways_PWY-6132>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6132" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_LANOSTEROL-SYNTHASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -64,7 +53,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -78,6 +67,17 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002233_CHEBI_15441_LANOSTEROL-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6132>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6132" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000001114>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -85,11 +85,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002234_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_YeastPathways_PWY-6132> ;
+          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002234_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6132> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -103,17 +103,6 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000066_reaction_LANOSTEROL-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6132>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6132" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -126,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "lanosterol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -143,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -153,6 +142,17 @@
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-6132/YeastPathways_PWY-6132_SGD_PWY_YeastPathways_PWY-6132>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6132" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16521>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -189,11 +189,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002233_CHEBI_15441_LANOSTEROL-SYNTHASE-RXN_SGD_YeastPathways_PWY-6132> ;
+          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002233_CHEBI_15441_LANOSTEROL-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6132> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -203,6 +203,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15441_LANOSTEROL-SYNTHASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000066_reaction_LANOSTEROL-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6132>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6132" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -217,11 +228,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000066_reaction_LANOSTEROL-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6132> ;
+          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000066_reaction_LANOSTEROL-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6132> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -238,14 +249,14 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002333_YHR072W-MONOMER_LANOSTEROL-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY-6132>
+<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002234_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-6132>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6132" ;
+                "SGD_PWY:PWY-6132" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -262,11 +273,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-6132/YeastPathways_PWY-6132_SGD_YeastPathways_PWY-6132> ;
+          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-6132/YeastPathways_PWY-6132_SGD_PWY_YeastPathways_PWY-6132> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -293,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -301,33 +312,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002233_CHEBI_15441_LANOSTEROL-SYNTHASE-RXN_SGD_YeastPathways_PWY-6132>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6132" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-6132/YeastPathways_PWY-6132_SGD_YeastPathways_PWY-6132>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002333_YHR072W-MONOMER_LANOSTEROL-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY-6132>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6132" ;
+                "SGD_PWY:PWY-6132" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .

--- a/models/YeastPathways_PWY-6147.ttl
+++ b/models/YeastPathways_PWY-6147.ttl
@@ -1,34 +1,12 @@
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -43,11 +21,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '7,8-dihydroneopterin 3'-phosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin + phosphate' 'null' '7,8-dihydroneopterin &rarr; glycolaldehyde + 6-(hydroxymethyl)-7,8-dihydropterin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -67,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -84,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -101,15 +79,37 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -124,11 +124,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -138,6 +138,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58462_GTP-CYCLOHYDRO-I-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004150>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -170,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -178,14 +189,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY-6147>
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY-6147>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
+                "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -193,11 +226,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -217,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,11 +262,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -247,14 +280,25 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_YeastPathways_PWY-6147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -264,14 +308,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY-6147>
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY-6147>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
+                "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -279,11 +334,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -297,46 +352,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_37565>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
+                "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58762> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "7,8-dihydroneopterin 3'-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6147SmallMolecule67063> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -347,6 +385,23 @@
           <http://model.geneontology.org/CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58762> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "7,8-dihydroneopterin 3'-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6147SmallMolecule67063> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -354,11 +409,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,30 +424,8 @@
           <http://model.geneontology.org/YeastPathways_PWY-6147/YeastPathways_PWY-6147>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_YeastPathways_PWY-6147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_YeastPathways_PWY-6147>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -403,46 +436,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6147SmallMolecule67001> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -453,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "6-hydroxymethyl-dihydropterin diphosphate biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -478,26 +478,15 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,11 +504,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -564,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -581,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -589,14 +578,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_YeastPathways_PWY-6147>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
+                "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -609,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -617,29 +606,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
+                "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -654,11 +654,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -669,6 +669,17 @@
           <http://model.geneontology.org/CHEBI_15378_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58462_GTP-CYCLOHYDRO-I-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58462> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -678,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -703,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -711,30 +722,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_YeastPathways_PWY-6147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005200>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -743,11 +732,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -757,6 +746,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_17071_H2NEOPTERINALDOL-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -768,11 +779,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -787,11 +798,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -802,17 +813,6 @@
           <http://model.geneontology.org/YeastPathways_PWY-6147/YeastPathways_PWY-6147>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -822,24 +822,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6147SmallMolecule67078> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -848,11 +837,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -867,11 +856,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -907,12 +896,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -932,11 +943,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '7,8-dihydroneopterin &rarr; glycolaldehyde + 6-(hydroxymethyl)-7,8-dihydropterin' 'null' '6-(hydroxymethyl)-7,8-dihydropterin + ATP &rarr; (7,8-dihydropterin-6-yl)methyl diphosphate + AMP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,17 +958,6 @@
           <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58462>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -965,11 +965,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -980,22 +980,22 @@
           <http://model.geneontology.org/CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0003934>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_YeastPathways_PWY-6147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1006,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1019,7 +1019,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1030,11 +1041,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '7,8-dihydroneopterin 3'-triphosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin 3'-phosphate + diphosphate + H<SUP>+</SUP>' 'null' '7,8-dihydroneopterin 3'-phosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1049,11 +1060,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1067,14 +1078,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_58762>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6147>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
+                "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1097,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1110,7 +1121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1118,11 +1129,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1133,15 +1144,26 @@
           <http://model.geneontology.org/YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1152,25 +1174,14 @@
           <http://model.geneontology.org/reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_PWY-6147>
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_PWY_YeastPathways_PWY-6147>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
+                "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1179,18 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1201,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1209,15 +1209,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1232,11 +1243,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1253,6 +1264,28 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17001> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1262,24 +1295,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6147SmallMolecule67095> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003499> ;
@@ -1288,7 +1310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1300,11 +1322,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1324,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1336,11 +1358,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1351,8 +1373,30 @@
           <http://model.geneontology.org/CHEBI_15740_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_44841_H2NEOPTERINALDOL-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_44841> ;
@@ -1363,7 +1407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1371,15 +1415,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1399,7 +1454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1414,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1422,26 +1477,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_YeastPathways_PWY-6147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1452,25 +1496,14 @@
           <http://model.geneontology.org/YeastPathways_PWY-6147/YeastPathways_PWY-6147>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_YeastPathways_PWY-6147>
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_PWY-6147>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
+                "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1483,24 +1516,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6147SmallMolecule67128> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0019177>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1512,11 +1534,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1527,15 +1549,26 @@
           <http://model.geneontology.org/CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1553,7 +1586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1561,36 +1594,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
+                "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1601,11 +1612,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1623,11 +1634,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'GTP + H<sub>2</sub>O &rarr; formate + 7,8-dihydroneopterin 3'-triphosphate + H<SUP>+</SUP>' 'null' '7,8-dihydroneopterin 3'-triphosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin 3'-phosphate + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1637,17 +1648,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1662,11 +1662,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1677,14 +1677,14 @@
           <http://model.geneontology.org/YeastPathways_PWY-6147/YeastPathways_PWY-6147>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
+                "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1692,11 +1692,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1707,60 +1707,27 @@
           <http://model.geneontology.org/CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6147>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0046656>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1771,15 +1738,26 @@
           <http://model.geneontology.org/YeastPathways_PWY-6147/YeastPathways_PWY-6147>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1790,14 +1768,25 @@
           <http://model.geneontology.org/CHEBI_37565_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_PWY-6147>
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-6147>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1805,11 +1794,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY-6147> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY-6147> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1819,6 +1808,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6147" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_73083>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1832,7 +1832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1840,13 +1840,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY-6147>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_YeastPathways_PWY-6147/YeastPathways_PWY-6147_SGD_PWY_YeastPathways_PWY-6147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6147" ;
+                "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-6482-1.ttl
+++ b/models/YeastPathways_PWY-6482-1.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002411_RXN-11373_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002411_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,11 +21,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_17509_RXN-11371_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_17509_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,25 +36,14 @@
           <http://model.geneontology.org/CHEBI_17509_RXN-11371>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX-8046_RXN-11371_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX-8046_component_SGD_YeastPathways_PWY-6482-1>
+<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002333_MONOMER-15582_RXN-11374_controller_SGD_PWY_YeastPathways_PWY-6482-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57856_RXN-11370_SGD_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -62,11 +51,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_a28aa722-530c-4dfc-8910-a14328805a62_RXN-11373_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_d0d26045-b12e-4719-b032-09296fe455ef_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,8 +63,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a28aa722-530c-4dfc-8910-a14328805a62_RXN-11373>
+          <http://model.geneontology.org/d0d26045-b12e-4719-b032-09296fe455ef_RXN-11373>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57856_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456215> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -100,15 +100,37 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002333_CPLX-8046_RXN-11371_controller_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_59789_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_15378_RXN-11373_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_15378_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -119,17 +141,6 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-11373>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57856_RXN-11373>
         a       <http://purl.obolibrary.org/obo/CHEBI_57856> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -139,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -151,11 +162,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_BFO_0000066_reaction_RXN-11370_location_lociGO_0005829_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_BFO_0000066_reaction_RXN-11370_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -166,25 +177,14 @@
           <http://model.geneontology.org/reaction_RXN-11370_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11374_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_YeastPathways_PWY-6482-1>
+<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_c4c79402-bf70-42c4-8528-385c29bc20e5_RXN-11371_SGD_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -193,28 +193,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_15378_RXN-11371_SGD_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_57856_RXN-11373_SGD_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-11371>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -225,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -233,15 +211,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-11371_BFO_0000066_reaction_RXN-11371_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_59789_RXN-11374_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_59789_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -256,11 +245,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -283,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -295,11 +284,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-14_component_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-14_component_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,14 +299,14 @@
           <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-14_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_YeastPathways_PWY-6482-1>
+<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_CHEBI_59789_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -330,7 +319,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-11371_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/c4c79402-bf70-42c4-8528-385c29bc20e5_RXN-11371> , <http://model.geneontology.org/CHEBI_59789_RXN-11371> ;
+                <http://model.geneontology.org/CHEBI_59789_RXN-11371> , <http://model.geneontology.org/357f347a-b8f2-41c1-bb3f-b4bea5fbb2ab_RXN-11371> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_17509_RXN-11371> , <http://model.geneontology.org/CHEBI_15378_RXN-11371> , <http://model.geneontology.org/CHEBI_58031_RXN-11371> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -340,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -348,14 +337,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-11371_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_58031_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -365,23 +354,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_869a46f4-bccc-418e-94a6-30d6e364b1da_RXN-11374_SGD_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-14_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002411_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -392,7 +381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -404,11 +393,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + an L-histidine-[translation elongation factor 2] &rarr; a 2-[(3S)-3-amino-3-carboxypropyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a 2-[(3S)-3-amino-3-carboxypropyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002413_RXN-11370_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002413_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,14 +408,14 @@
           <http://model.geneontology.org/RXN-11370>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_15378_RXN-11374_SGD_YeastPathways_PWY-6482-1>
+<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_6a6572f4-e19a-4799-96cf-c14d84354089_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -439,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -447,57 +436,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/44052a4d-b3b6-4445-8515-1b899ce559aa_RXN-11373>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a diphthine-[translation elongation factor 2]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43322> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002233_CHEBI_58031_RXN-11371_SGD_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_CHEBI_59789_RXN-11373_SGD_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002333_MONOMER-15582_RXN-11373_controller_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002333_MONOMER-15582_RXN-11373_controller_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -508,6 +458,28 @@
           <http://model.geneontology.org/MONOMER-15582_RXN-11373_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002333_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_357f347a-b8f2-41c1-bb3f-b4bea5fbb2ab_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -515,11 +487,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_15378_RXN-11370_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_15378_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -533,25 +505,36 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000066_reaction_RXN-11373_location_lociGO_0005829_SGD_YeastPathways_PWY-6482-1>
+<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_57856_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002333_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_SGD_YeastPathways_PWY-6482-1>
+<http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_fa4d8b0d-1328-4e5e-a070-b76154e72c56_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -564,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -572,26 +555,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-14_component_SGD_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_6af2b475-3939-4749-b5da-1c6e212b693b_RXN-11374_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_fa4d8b0d-1328-4e5e-a070-b76154e72c56_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,18 +571,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11374> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6af2b475-3939-4749-b5da-1c6e212b693b_RXN-11374>
+          <http://model.geneontology.org/fa4d8b0d-1328-4e5e-a070-b76154e72c56_RXN-11374>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_c4c79402-bf70-42c4-8528-385c29bc20e5_RXN-11371_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_357f347a-b8f2-41c1-bb3f-b4bea5fbb2ab_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,7 +590,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11371> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c4c79402-bf70-42c4-8528-385c29bc20e5_RXN-11371>
+          <http://model.geneontology.org/357f347a-b8f2-41c1-bb3f-b4bea5fbb2ab_RXN-11371>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
@@ -633,7 +605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -645,11 +617,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -659,9 +631,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN>
 ] .
-
-<http://model.geneontology.org/869a46f4-bccc-418e-94a6-30d6e364b1da_RXN-11374>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/RXN-11374>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -674,7 +643,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57784_RXN-11370> , <http://model.geneontology.org/CHEBI_59789_RXN-11374> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/6af2b475-3939-4749-b5da-1c6e212b693b_RXN-11374> , <http://model.geneontology.org/CHEBI_15378_RXN-11374> , <http://model.geneontology.org/CHEBI_57856_RXN-11374> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN-11374> , <http://model.geneontology.org/fa4d8b0d-1328-4e5e-a070-b76154e72c56_RXN-11374> , <http://model.geneontology.org/CHEBI_57856_RXN-11374> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER-15582_RXN-11374_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -682,7 +651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -690,49 +659,54 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57784>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/c4c79402-bf70-42c4-8528-385c29bc20e5_RXN-11371>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an L-histidine-[translation elongation factor 2]" ;
+<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_57856_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43400> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://purl.obolibrary.org/obo/CHEBI_57784>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57784_RXN-11370_SGD_YeastPathways_PWY-6482-1>
+<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002411_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX-8046_RXN-11371_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX-8046_component_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_CHEBI_59789_RXN-11373_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_CHEBI_59789_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -750,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -762,11 +736,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002333_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002333_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,66 +751,16 @@
           <http://model.geneontology.org/CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_57856_RXN-11374_SGD_YeastPathways_PWY-6482-1>
+<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002333_MONOMER-15582_RXN-11370_controller_SGD_PWY_YeastPathways_PWY-6482-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002333_MONOMER-15582_RXN-11374_controller_SGD_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_a28aa722-530c-4dfc-8910-a14328805a62_RXN-11373_SGD_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/6af2b475-3939-4749-b5da-1c6e212b693b_RXN-11374>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43314> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_17509_RXN-11371>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17509> ;
@@ -847,35 +771,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43416> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002333_MONOMER-15582_RXN-11373_controller_SGD_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -884,11 +786,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_BFO_0000066_reaction_RXN-11374_location_lociGO_0005829_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_BFO_0000066_reaction_RXN-11374_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,26 +801,15 @@
           <http://model.geneontology.org/reaction_RXN-11374_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_6af2b475-3939-4749-b5da-1c6e212b693b_RXN-11374_SGD_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002333_MONOMER-15582_RXN-11370_controller_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002333_MONOMER-15582_RXN-11370_controller_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -929,14 +820,31 @@
           <http://model.geneontology.org/MONOMER-15582_RXN-11370_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002333_MONOMER-15582_RXN-11370_controller_SGD_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/357f347a-b8f2-41c1-bb3f-b4bea5fbb2ab_RXN-11371>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an L-histidine-[translation elongation factor 2]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43400> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_17509_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -947,11 +855,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_58031_RXN-11371_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_58031_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -962,15 +870,49 @@
           <http://model.geneontology.org/CHEBI_58031_RXN-11371>
 ] .
 
+<http://model.geneontology.org/6a6572f4-e19a-4799-96cf-c14d84354089_RXN-11373>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a diphthine-[translation elongation factor 2]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43322> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/fa4d8b0d-1328-4e5e-a070-b76154e72c56_RXN-11374>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43314> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -981,29 +923,29 @@
           <http://model.geneontology.org/CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_17509_RXN-11371_SGD_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_57856_RXN-11373_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_57856_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1023,7 +965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1035,11 +977,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002233_CHEBI_58031_RXN-11371_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002233_CHEBI_58031_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1050,27 +992,11 @@
           <http://model.geneontology.org/CHEBI_58031_RXN-11371>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002413_RXN-11374_SGD_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/04063f58-0da1-4aba-9f55-3f0f0d81b16c_RXN-11374>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000066_reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1078,11 +1004,41 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-11371_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002333_MONOMER-15582_RXN-11373_controller_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -1093,7 +1049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1108,11 +1064,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_15378_RXN-11374_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_15378_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1130,11 +1086,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_BFO_0000066_reaction_RXN-11371_location_lociGO_0005829_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_BFO_0000066_reaction_RXN-11371_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1152,11 +1108,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1170,6 +1126,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000066_reaction_RXN-11373_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16692>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1182,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1190,14 +1157,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-11371_BFO_0000066_reaction_RXN-11371_location_lociGO_0005829_SGD_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_04063f58-0da1-4aba-9f55-3f0f0d81b16c_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1205,11 +1172,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1230,11 +1197,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1245,39 +1212,17 @@
           <http://model.geneontology.org/CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002333_CPLX-8046_RXN-11371_controller_SGD_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_17509>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_58031_RXN-11371_SGD_YeastPathways_PWY-6482-1>
+<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_15378_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002233_CHEBI_59789_RXN-11370_SGD_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1285,11 +1230,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002411_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002411_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1304,11 +1249,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57784_RXN-11370_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57784_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1322,15 +1267,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_58031>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-11370_BFO_0000066_reaction_RXN-11370_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002333_MONOMER-15582_RXN-11374_controller_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002333_MONOMER-15582_RXN-11374_controller_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1345,11 +1301,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_15378_RXN-11371_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_15378_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1365,7 +1321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1376,11 +1332,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1400,7 +1356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1411,6 +1367,17 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002233_CHEBI_58031_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57784_RXN-11370>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57784> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1420,7 +1387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1431,26 +1398,15 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-11370_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_869a46f4-bccc-418e-94a6-30d6e364b1da_RXN-11374_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_04063f58-0da1-4aba-9f55-3f0f0d81b16c_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1458,7 +1414,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11373> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/869a46f4-bccc-418e-94a6-30d6e364b1da_RXN-11374>
+          <http://model.geneontology.org/04063f58-0da1-4aba-9f55-3f0f0d81b16c_RXN-11374>
 ] .
 
 <http://model.geneontology.org/CPLX-8046_RXN-11371_controller>
@@ -1470,13 +1426,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1Complex43422> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
+
+<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16692> ;
@@ -1487,7 +1454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1495,26 +1462,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002413_RXN-11370_SGD_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1525,12 +1481,26 @@
           <http://model.geneontology.org/YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1>
 ] .
 
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_57784_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-11371_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1539,12 +1509,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-11370>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1555,7 +1533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1567,11 +1545,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_57784_RXN-11370_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_57784_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1586,11 +1564,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" , "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + a 2-[(3S)-3-amino-3-carboxypropyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002413_RXN-11374_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002413_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1601,17 +1579,6 @@
           <http://model.geneontology.org/RXN-11374>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_44052a4d-b3b6-4445-8515-1b899ce559aa_RXN-11373_SGD_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_59789_RXN-11370>
         a       <http://purl.obolibrary.org/obo/CHEBI_59789> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1621,7 +1588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1633,11 +1600,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX-8046_RXN-11371_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX-8046_component_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-8046_RXN-11371_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX-8046_component_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1647,6 +1614,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX-8046_component>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_15378_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-11370>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -1667,7 +1645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1677,6 +1655,17 @@
 
 <http://purl.obolibrary.org/obo/GO_0017183>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1690,7 +1679,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/a28aa722-530c-4dfc-8910-a14328805a62_RXN-11373> , <http://model.geneontology.org/CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN> ;
+                <http://model.geneontology.org/d0d26045-b12e-4719-b032-09296fe455ef_RXN-11373> , <http://model.geneontology.org/CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1698,7 +1687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1710,11 +1699,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002333_CPLX-8046_RXN-11371_controller_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002333_CPLX-8046_RXN-11371_controller_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1725,26 +1714,15 @@
           <http://model.geneontology.org/CPLX-8046_RXN-11371_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_CHEBI_59789_RXN-11371_SGD_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1755,14 +1733,25 @@
           <http://model.geneontology.org/CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_YeastPathways_PWY-6482-1>
+<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_CHEBI_59789_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_15378_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1770,11 +1759,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_44052a4d-b3b6-4445-8515-1b899ce559aa_RXN-11373_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_6a6572f4-e19a-4799-96cf-c14d84354089_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1782,18 +1771,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11373> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/44052a4d-b3b6-4445-8515-1b899ce559aa_RXN-11373>
+          <http://model.geneontology.org/6a6572f4-e19a-4799-96cf-c14d84354089_RXN-11373>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002233_CHEBI_59789_RXN-11370_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002233_CHEBI_59789_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1804,6 +1793,17 @@
           <http://model.geneontology.org/CHEBI_59789_RXN-11370>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-11370_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58031_RXN-11371>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58031> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1813,7 +1813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1824,14 +1824,17 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-11374_BFO_0000066_reaction_RXN-11374_location_lociGO_0005829_SGD_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/d0d26045-b12e-4719-b032-09296fe455ef_RXN-11373>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-14_component_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1843,7 +1846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1853,14 +1856,14 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_59789_RXN-11374_SGD_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-11374_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1873,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1881,26 +1884,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_57856_RXN-11374_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_57856_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1916,18 +1908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002411_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1935,11 +1916,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_CHEBI_59789_RXN-11371_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_CHEBI_59789_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1950,24 +1931,16 @@
           <http://model.geneontology.org/CHEBI_59789_RXN-11371>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000066_reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829>
-] .
+<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002233_CHEBI_59789_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_59789_RXN-11373>
         a       <http://purl.obolibrary.org/obo/CHEBI_59789> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1978,7 +1951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1986,19 +1959,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_15378_RXN-11370_SGD_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000066_reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/RXN-11373>
-        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "<i>S</i>-adenosyl-L-methionine + a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2] &rarr; a diphthine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -2006,9 +1987,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-11373_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/869a46f4-bccc-418e-94a6-30d6e364b1da_RXN-11374> , <http://model.geneontology.org/CHEBI_59789_RXN-11373> ;
+                <http://model.geneontology.org/CHEBI_59789_RXN-11373> , <http://model.geneontology.org/04063f58-0da1-4aba-9f55-3f0f0d81b16c_RXN-11374> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/44052a4d-b3b6-4445-8515-1b899ce559aa_RXN-11373> , <http://model.geneontology.org/CHEBI_15378_RXN-11373> , <http://model.geneontology.org/CHEBI_57856_RXN-11373> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN-11373> , <http://model.geneontology.org/CHEBI_57856_RXN-11373> , <http://model.geneontology.org/6a6572f4-e19a-4799-96cf-c14d84354089_RXN-11373> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER-15582_RXN-11373_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2016,7 +1997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2033,7 +2014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "diphthamide biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2041,25 +2022,14 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_RXN-11370_BFO_0000066_reaction_RXN-11370_location_lociGO_0005829_SGD_YeastPathways_PWY-6482-1>
+<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000066_reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_57784_RXN-11370_SGD_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2068,7 +2038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2076,11 +2046,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000066_reaction_RXN-11373_location_lociGO_0005829_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000066_reaction_RXN-11373_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2091,17 +2061,6 @@
           <http://model.geneontology.org/reaction_RXN-11373_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57856_RXN-11370>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57856> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2111,7 +2070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2123,11 +2082,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2138,14 +2097,36 @@
           <http://model.geneontology.org/CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_15378_RXN-11373_SGD_YeastPathways_PWY-6482-1>
+<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_15378_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_d0d26045-b12e-4719-b032-09296fe455ef_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2153,11 +2134,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2168,9 +2149,6 @@
           <http://model.geneontology.org/YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1>
 ] .
 
-<http://model.geneontology.org/a28aa722-530c-4dfc-8910-a14328805a62_RXN-11373>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_28938> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2180,7 +2158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2192,11 +2170,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57856_RXN-11370_SGD_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57856_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2207,25 +2185,47 @@
           <http://model.geneontology.org/CHEBI_57856_RXN-11370>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002413_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002411_RXN-11373_SGD_YeastPathways_PWY-6482-1>
+<http://model.geneontology.org/ev_w_id_RXN-11374_BFO_0000066_reaction_RXN-11374_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57784_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002413_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2236,7 +2236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2251,7 +2251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-6543.ttl
+++ b/models/YeastPathways_PWY-6543.ttl
@@ -1,3 +1,36 @@
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_PWY_YeastPathways_PWY-6543>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6543" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_PWY_YeastPathways_PWY-6543>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6543" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_PWY-6543/YeastPathways_PWY-6543_SGD_PWY_YeastPathways_PWY-6543>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6543" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0046656>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -5,11 +38,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-glutamine + chorismate &harr; 4-amino-4-deoxychorismate + L-glutamate' 'null' '4-amino-4-deoxychorismate &rarr; 4-aminobenzoate + pyruvate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_YeastPathways_PWY-6543> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_PWY_YeastPathways_PWY-6543> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,14 +53,14 @@
           <http://model.geneontology.org/ADCLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_YeastPathways_PWY-6543>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_PWY-6543>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6543" ;
+                "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -35,11 +68,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_YeastPathways_PWY-6543> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_PWY_YeastPathways_PWY-6543> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -73,25 +106,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_PWY-6543/YeastPathways_PWY-6543_SGD_YeastPathways_PWY-6543>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_PWY_YeastPathways_PWY-6543>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6543" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_YeastPathways_PWY-6543>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6543" ;
+                "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -104,25 +126,14 @@
 <http://purl.obolibrary.org/obo/GO_0008696>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_YeastPathways_PWY-6543>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6543>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6543" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_YeastPathways_PWY-6543>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6543" ;
+                "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -145,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -153,26 +164,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_YeastPathways_PWY-6543>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6543" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_YeastPathways_PWY-6543> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_PWY_YeastPathways_PWY-6543> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -187,11 +187,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_YeastPathways_PWY-6543> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_PWY_YeastPathways_PWY-6543> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -222,28 +222,6 @@
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_PWY-6543>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6543" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_YeastPathways_PWY-6543>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6543" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -260,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -271,26 +249,15 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_PWY-6543/YeastPathways_PWY-6543_SGD_YeastPathways_PWY-6543>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6543" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6543> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6543> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,11 +281,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_PWY-6543> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_PWY-6543> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,11 +300,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_PWY-6543> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_PWY-6543> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -374,6 +341,17 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_PWY_YeastPathways_PWY-6543>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6543" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58406_PABASYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58406> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -383,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -391,30 +369,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_PWY-6543>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6543" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6543>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6543" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY-6543>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -425,7 +381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "4-aminobenzoate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -437,11 +393,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_PWY-6543/YeastPathways_PWY-6543_SGD_YeastPathways_PWY-6543> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_PWY-6543/YeastPathways_PWY-6543_SGD_PWY_YeastPathways_PWY-6543> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -460,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -473,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -501,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -513,11 +469,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_YeastPathways_PWY-6543> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_PWY_YeastPathways_PWY-6543> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -528,15 +484,26 @@
           <http://model.geneontology.org/CHEBI_29985_PABASYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_PWY_YeastPathways_PWY-6543>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6543" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6543> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6543> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -547,14 +514,14 @@
           <http://model.geneontology.org/reaction_ADCLY-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_YeastPathways_PWY-6543>
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_PWY_YeastPathways_PWY-6543>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6543" ;
+                "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -567,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -585,11 +552,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_YeastPathways_PWY-6543> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_PWY_YeastPathways_PWY-6543> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -606,12 +573,34 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6543>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6543" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_PABASYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_PWY_YeastPathways_PWY-6543>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -619,11 +608,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_YeastPathways_PWY-6543> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_PWY_YeastPathways_PWY-6543> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -641,11 +630,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_PWY-6543/YeastPathways_PWY-6543_SGD_YeastPathways_PWY-6543> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_PWY-6543/YeastPathways_PWY-6543_SGD_PWY_YeastPathways_PWY-6543> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -655,17 +644,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY-6543/YeastPathways_PWY-6543>
 ] .
-
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_YeastPathways_PWY-6543>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6543" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -677,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -695,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -709,17 +687,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_17836>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6543>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6543" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15361_ADCLY-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -729,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -740,15 +707,26 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_PWY-6543/YeastPathways_PWY-6543_SGD_PWY_YeastPathways_PWY-6543>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6543" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_YeastPathways_PWY-6543> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_PWY_YeastPathways_PWY-6543> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,6 +737,28 @@
           <http://model.geneontology.org/CHEBI_17836_ADCLY-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_PWY_YeastPathways_PWY-6543>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6543" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_PWY_YeastPathways_PWY-6543>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6543" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_29748>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -766,11 +766,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_YeastPathways_PWY-6543> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_PWY_YeastPathways_PWY-6543> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -784,13 +784,13 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_YeastPathways_PWY-6543>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_PWY-6543>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6543" ;
+                "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-6614.ttl
+++ b/models/YeastPathways_PWY-6614.ttl
@@ -1,47 +1,14 @@
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY-6614>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6614>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY-6614>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17839_H2PTEROATESYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17839> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -52,7 +19,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -60,17 +27,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57451>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY-6614>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
+                "SGD_PWY:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57451>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -78,11 +56,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -93,15 +71,26 @@
           <http://model.geneontology.org/CHEBI_43474_DIHYDROFOLATESYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_d00c5241-7067-4c2c-b6d7-dbc5a183e79f_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_470080ae-4929-4f32-9fbd-524361d51b88_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -109,8 +98,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d00c5241-7067-4c2c-b6d7-dbc5a183e79f_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/470080ae-4929-4f32-9fbd-524361d51b88_DIHYDROFOLATEREDUCT-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -124,7 +124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -138,17 +138,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY-6614>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY-6614/YeastPathways_PWY-6614>
         a       <http://purl.obolibrary.org/obo/GO_0046654> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -156,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -164,26 +153,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_YeastPathways_PWY-6614>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -194,48 +172,31 @@
           <http://model.geneontology.org/CHEBI_17836_H2PTEROATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY-6614>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
+                "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/d00c5241-7067-4c2c-b6d7-dbc5a183e79f_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_PWY-6614/YeastPathways_PWY-6614_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614SmallMolecule64284> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6614>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
+                "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -248,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -268,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -276,15 +237,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -299,11 +271,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,11 +293,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' 'null' 'L-glutamate + 7,8-dihydropteroate + ATP &rarr; ADP + 7,8-dihydrofolate monoglutamate + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -335,17 +307,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY-6614>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -359,18 +320,15 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_17839>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -388,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -396,16 +354,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY-6614>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_17839>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
@@ -416,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -443,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -456,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -467,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -478,15 +428,26 @@
 <http://purl.obolibrary.org/obo/GO_0004156>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" , "Provides Input For Rule. The relation 'L-glutamate + 7,8-dihydropteroate + ATP &rarr; ADP + 7,8-dihydrofolate monoglutamate + phosphate + H<SUP>+</SUP>' 'null' 'a tetrahydrofolate + NADP<sup>+</sup> &larr; a 7,8-dihydrofolate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,11 +465,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_PWY-6614/YeastPathways_PWY-6614_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_PWY-6614/YeastPathways_PWY-6614_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -519,30 +480,8 @@
           <http://model.geneontology.org/YeastPathways_PWY-6614/YeastPathways_PWY-6614>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_YeastPathways_PWY-6614>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0046654>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY-6614>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -551,11 +490,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -570,11 +509,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -585,32 +524,15 @@
           <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/4791d7a9-4818-4e68-a9a1-01c65f0e86f6_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614SmallMolecule64261> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -620,17 +542,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_YeastPathways_PWY-6614/YeastPathways_PWY-6614_SGD_YeastPathways_PWY-6614>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -642,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -650,19 +561,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY-6614>
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
+                "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_470080ae-4929-4f32-9fbd-524361d51b88_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004146> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -673,21 +595,32 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/d00c5241-7067-4c2c-b6d7-dbc5a183e79f_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/470080ae-4929-4f32-9fbd-524361d51b88_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/4791d7a9-4818-4e68-a9a1-01c65f0e86f6_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/93d41722-267d-4c7a-9f1e-8ab352ad23a4_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614BiochemicalReaction64252> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_93d41722-267d-4c7a-9f1e-8ab352ad23a4_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -698,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -710,11 +643,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_YeastPathways_PWY-6614/YeastPathways_PWY-6614_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_YeastPathways_PWY-6614/YeastPathways_PWY-6614_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -724,6 +657,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY-6614/YeastPathways_PWY-6614>
 ] .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -735,11 +679,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,7 +703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -771,11 +715,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -786,39 +730,56 @@
           <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_YeastPathways_PWY-6614>
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY-6614>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
+                "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY-6614>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
+                "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/93d41722-267d-4c7a-9f1e-8ab352ad23a4_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614SmallMolecule64261> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY-6614>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_PWY-6614/YeastPathways_PWY-6614_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
+                "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -826,11 +787,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -845,11 +806,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -860,26 +821,15 @@
           <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY-6614>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -909,13 +859,57 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614BiochemicalReaction64323> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -929,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -946,7 +940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -957,17 +951,6 @@
 <http://identifiers.org/sgd/S000005762>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY-6614>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY-6614>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -977,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "tetrahydrofolate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -985,14 +968,14 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_4791d7a9-4818-4e68-a9a1-01c65f0e86f6_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY-6614>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
+                "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1005,7 +988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1020,11 +1003,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1035,14 +1018,14 @@
           <http://model.geneontology.org/CHEBI_57451_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_PWY-6614/YeastPathways_PWY-6614_SGD_YeastPathways_PWY-6614>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
+                "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1050,11 +1033,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_4791d7a9-4818-4e68-a9a1-01c65f0e86f6_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_93d41722-267d-4c7a-9f1e-8ab352ad23a4_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1062,7 +1045,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4791d7a9-4818-4e68-a9a1-01c65f0e86f6_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/93d41722-267d-4c7a-9f1e-8ab352ad23a4_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -1071,25 +1054,14 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6614>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_d00c5241-7067-4c2c-b6d7-dbc5a183e79f_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY-6614>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
+                "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1097,11 +1069,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1117,18 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY-6614>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1136,11 +1097,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_PWY-6614/YeastPathways_PWY-6614_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_PWY-6614/YeastPathways_PWY-6614_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1151,26 +1112,15 @@
           <http://model.geneontology.org/YeastPathways_PWY-6614/YeastPathways_PWY-6614>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY-6614>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1202,6 +1152,17 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1211,13 +1172,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614SmallMolecule64338> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17836>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1234,7 +1206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1246,11 +1218,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1265,11 +1237,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1289,7 +1261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1297,29 +1269,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_PWY-6614/YeastPathways_PWY-6614_SGD_YeastPathways_PWY-6614>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_YeastPathways_PWY-6614/YeastPathways_PWY-6614_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
+                "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005200>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1333,15 +1316,43 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/470080ae-4929-4f32-9fbd-524361d51b88_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614SmallMolecule64284> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1354,14 +1365,3 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY-6614>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-7176.ttl
+++ b/models/YeastPathways_PWY-7176.ttl
@@ -1,11 +1,22 @@
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_YeastPathways_PWY-7176>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_YeastPathways_PWY-7176/YeastPathways_PWY-7176_SGD_PWY_YeastPathways_PWY-7176>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
+                "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -24,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -32,14 +43,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_YeastPathways_PWY-7176>
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7176>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
+                "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -52,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -60,29 +71,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_YeastPathways_PWY-7176/YeastPathways_PWY-7176_SGD_YeastPathways_PWY-7176>
+<http://purl.obolibrary.org/obo/CHEBI_46398>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_PWY_YeastPathways_PWY-7176>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
+                "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_46398>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -91,25 +102,6 @@
           <http://model.geneontology.org/RXN-12002> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN-12002_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_UDPKIN-RXN_SGD_YeastPathways_PWY-7176> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_46398_UDPKIN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29985_CTPSYN-RXN>
@@ -121,13 +113,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7176SmallMolecule70646> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7176> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CTPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_46398_UDPKIN-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_58359_CTPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58359> ;
@@ -138,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -150,11 +161,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'UDP + ATP &rarr; UTP + ADP' 'null' 'L-glutamine + UTP + ATP + H<sub>2</sub>O &rarr; ADP + CTP + L-glutamate + phosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -171,15 +182,26 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_YeastPathways_PWY-7176/YeastPathways_PWY-7176_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_YeastPathways_PWY-7176/YeastPathways_PWY-7176_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -190,6 +212,17 @@
           <http://model.geneontology.org/YeastPathways_PWY-7176/YeastPathways_PWY-7176>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_CTPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -199,13 +232,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7176SmallMolecule70486> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_UDPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -216,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,14 +274,14 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_YeastPathways_PWY-7176>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
+                "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -246,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -254,11 +298,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_YeastPathways_PWY-7176/YeastPathways_PWY-7176_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_YeastPathways_PWY-7176/YeastPathways_PWY-7176_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -273,11 +317,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -288,15 +332,18 @@
           <http://model.geneontology.org/CHEBI_30616_CTPSYN-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -307,11 +354,30 @@
           <http://model.geneontology.org/CHEBI_46398_UDPKIN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15377>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004550>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000135>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -325,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -345,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -356,17 +422,6 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_YeastPathways_PWY-7176>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_37563>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -375,7 +430,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_YeastPathways_PWY-7176/YeastPathways_PWY-7176_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -388,7 +454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -403,11 +469,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ATP + UMP &rarr; ADP + UDP' 'null' 'UDP + ATP &rarr; UTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -418,14 +484,36 @@
           <http://model.geneontology.org/UDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7176>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY-7176>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
+                "SGD_PWY:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -438,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -446,26 +534,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_UDPKIN-RXN_SGD_YeastPathways_PWY-7176>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -483,11 +560,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -505,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -516,6 +593,17 @@
 <http://purl.obolibrary.org/obo/GO_0003883>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YBL039C-MONOMER_CTPSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000000135> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -523,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -538,11 +626,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -553,37 +641,15 @@
           <http://model.geneontology.org/YJR103W-MONOMER_CTPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_YeastPathways_PWY-7176>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_SGD_YeastPathways_PWY-7176>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -598,11 +664,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,6 +679,17 @@
           <http://model.geneontology.org/CHEBI_456216_UDPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YJR103W-MONOMER_CTPSYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003864> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -620,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -634,28 +711,28 @@
 <http://purl.obolibrary.org/obo/GO_0006207>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_YeastPathways_PWY-7176>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_YeastPathways_PWY-7176>
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY-7176>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
+                "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -663,11 +740,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -708,11 +785,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -730,11 +807,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -745,21 +822,18 @@
           <http://model.geneontology.org/CHEBI_29985_CTPSYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58359>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_YeastPathways_PWY-7176>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY-7176>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
+                "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_29985>
+<http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58223_RXN-12002>
@@ -771,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -779,37 +853,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_RXN-12002_SGD_YeastPathways_PWY-7176>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_YeastPathways_PWY-7176/YeastPathways_PWY-7176_SGD_YeastPathways_PWY-7176>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_29985>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,11 +879,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -843,11 +898,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_RXN-12002_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_RXN-12002_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -858,14 +913,14 @@
           <http://model.geneontology.org/CHEBI_58223_RXN-12002>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_SGD_YeastPathways_PWY-7176>
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7176>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
+                "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -874,7 +929,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_RXN-12002_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -887,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -914,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -931,24 +997,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7176SmallMolecule70600> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_YeastPathways_PWY-7176/YeastPathways_PWY-7176_SGD_YeastPathways_PWY-7176>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -962,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "UTP and CTP <i>de novo</i> biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -990,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1002,11 +1057,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_RXN-12002_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_RXN-12002_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1017,37 +1072,15 @@
           <http://model.geneontology.org/CHEBI_57865_RXN-12002>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_YeastPathways_PWY-7176>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7176>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1064,17 +1097,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57865>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_YeastPathways_PWY-7176>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1087,7 +1109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1095,15 +1117,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1114,26 +1147,15 @@
           <http://model.geneontology.org/CHEBI_456216_CTPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_SGD_YeastPathways_PWY-7176>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_YeastPathways_PWY-7176/YeastPathways_PWY-7176_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_YeastPathways_PWY-7176/YeastPathways_PWY-7176_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1144,15 +1166,26 @@
           <http://model.geneontology.org/YeastPathways_PWY-7176/YeastPathways_PWY-7176>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1169,28 +1202,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_YeastPathways_PWY-7176>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_RXN-12002_SGD_YeastPathways_PWY-7176>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1201,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1209,54 +1220,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_YeastPathways_PWY-7176/YeastPathways_PWY-7176_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_YeastPathways_PWY-7176>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_YeastPathways_PWY-7176>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_YeastPathways_PWY-7176>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1267,37 +1256,15 @@
           <http://model.geneontology.org/CHEBI_30616_RXN-12002>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_YeastPathways_PWY-7176>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_YeastPathways_PWY-7176>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1308,14 +1275,17 @@
           <http://model.geneontology.org/CHEBI_58359_CTPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_YeastPathways_PWY-7176>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7176" ;
+                "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1323,11 +1293,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1337,9 +1307,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_43474_CTPSYN-RXN>
 ] .
-
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CTPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003883> ;
@@ -1358,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1366,15 +1333,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_RXN-12002_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7176> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7176> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1387,3 +1365,25 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-7219.ttl
+++ b/models/YeastPathways_PWY-7219.ttl
@@ -1,16 +1,27 @@
-<http://purl.obolibrary.org/obo/GO_0004017>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-7219>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7219" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_YeastPathways_PWY-7219>
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY-7219>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
+                "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004017>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005164> ;
@@ -19,7 +30,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -36,7 +47,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,11 +62,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,11 +84,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -97,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -108,14 +119,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-7219/YeastPathways_PWY-7219_SGD_YeastPathways_PWY-7219>
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_PWY-7219/YeastPathways_PWY-7219_SGD_PWY_YeastPathways_PWY-7219>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
+                "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -127,29 +138,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7219>
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-7219>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-7219>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
+                "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -162,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -184,18 +184,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_PWY-7219>
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-7219/YeastPathways_PWY-7219_SGD_PWY_YeastPathways_PWY-7219>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
+                "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -206,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -218,11 +218,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,6 +236,17 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY-7219>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7219" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -248,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -263,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -271,14 +282,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_PWY-7219/YeastPathways_PWY-7219_SGD_YeastPathways_PWY-7219>
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-7219>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
+                "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -291,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -299,32 +310,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57567> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "adenylo-succinate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7219SmallMolecule72348> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -335,25 +329,42 @@
           <http://model.geneontology.org/CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-7219>
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY-7219>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
+                "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-7219>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57567> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "adenylo-succinate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7219SmallMolecule72348> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-7219>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
+                "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -361,11 +372,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -376,25 +387,47 @@
           <http://model.geneontology.org/CHEBI_456215_AMPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_PWY-7219>
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY-7219>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
+                "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58189>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY-7219>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7219" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-7219>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7219" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -403,11 +436,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -418,26 +451,15 @@
           <http://model.geneontology.org/CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_YeastPathways_PWY-7219>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_PWY-7219/YeastPathways_PWY-7219_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_PWY-7219/YeastPathways_PWY-7219_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -455,11 +477,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,11 +499,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -496,11 +518,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -511,30 +533,30 @@
           <http://model.geneontology.org/CHEBI_30616_ADENYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_YeastPathways_PWY-7219>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-7219>
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY-7219>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
+                "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7219>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7219" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_37565> ;
@@ -545,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -560,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -571,26 +593,15 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7219>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,17 +615,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57567>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_PWY-7219>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -625,11 +625,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-aspartate + IMP + GTP &rarr; adenylo-succinate + GDP + phosphate + 2 H<SUP>+</SUP>' 'null' 'adenylo-succinate &harr; fumarate + AMP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -640,17 +640,6 @@
           <http://model.geneontology.org/AMPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_PWY-7219>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000005164>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -658,11 +647,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-7219/YeastPathways_PWY-7219_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-7219/YeastPathways_PWY-7219_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -680,11 +669,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,11 +688,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -718,11 +707,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" , "Provides Input For Rule. The relation 'adenylo-succinate &harr; fumarate + AMP' 'null' 'AMP + ATP &harr; 2 ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -733,14 +722,36 @@
           <http://model.geneontology.org/ADENYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-7219>
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-7219>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
+                "SGD_PWY:PWY-7219" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_PWY-7219/YeastPathways_PWY-7219_SGD_PWY_YeastPathways_PWY-7219>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7219" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-7219>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -753,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -777,11 +788,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -795,26 +806,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_58053>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_YeastPathways_PWY-7219>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -831,6 +831,17 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-7219>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7219" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_ADENYL-KIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -840,7 +851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,26 +859,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7219>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -878,26 +878,15 @@
           <http://model.geneontology.org/CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-7219>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_PWY-7219/YeastPathways_PWY-7219_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_PWY-7219/YeastPathways_PWY-7219_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -912,11 +901,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -932,6 +921,17 @@
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-7219>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7219" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -953,24 +953,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7219BiochemicalReaction72269> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_PWY-7219/YeastPathways_PWY-7219_SGD_YeastPathways_PWY-7219>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29991>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -984,7 +973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "adenosine ribonucleotides <i>de novo</i> biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1007,13 +996,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7219SmallMolecule72389> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-7219>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7219" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY-7219>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7219" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58053_ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58053> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1024,13 +1035,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7219SmallMolecule72404> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-7219>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7219" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1042,11 +1064,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1061,11 +1083,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1076,14 +1098,14 @@
           <http://model.geneontology.org/YDR226W-MONOMER_ADENYL-KIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-7219>
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7219>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
+                "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1106,7 +1128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1114,25 +1136,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-7219>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-7219>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
+                "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_YeastPathways_PWY-7219>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7219>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
+                "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1143,11 +1165,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1161,29 +1183,15 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_PWY-7219>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_43474>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_PWY-7219> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1194,16 +1202,8 @@
           <http://model.geneontology.org/CHEBI_456215_AMPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY-7219>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7219" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_43474>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1215,7 +1215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1242,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-7220-1.ttl
+++ b/models/YeastPathways_PWY-7220-1.ttl
@@ -1,6 +1,17 @@
 <http://identifiers.org/sgd/S000001550>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_DADPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -10,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -57,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -65,51 +76,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_YeastPathways_PWY-7220-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_PWY-7220-1/YeastPathways_PWY-7220-1_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
+                "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_PWY-7220-1>
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7220-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
+                "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0046085>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_YeastPathways_PWY-7220-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,32 +139,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7220-1BiochemicalReaction73384> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_YeastPathways_PWY-7220-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ADPREDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_ADPREDUCT-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_30616_DADPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -175,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -183,18 +164,45 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7220-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ADPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_ADPREDUCT-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -205,70 +213,29 @@
           <http://model.geneontology.org/CHEBI_16526_RXN0-745>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_PWY-7220-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_YeastPathways_PWY-7220-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN0-745_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_YeastPathways_PWY-7220-1>
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7220-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_PWY-7220-1/YeastPathways_PWY-7220-1_SGD_YeastPathways_PWY-7220-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_PWY-7220-1/YeastPathways_PWY-7220-1_SGD_YeastPathways_PWY-7220-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
+                "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -279,11 +246,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_PWY-7220-1/YeastPathways_PWY-7220-1_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_PWY-7220-1/YeastPathways_PWY-7220-1_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -294,6 +261,17 @@
           <http://model.geneontology.org/YeastPathways_PWY-7220-1/YeastPathways_PWY-7220-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
         a       <http://identifiers.org/sgd/S000001550> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -301,7 +279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -309,26 +287,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000872> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_PWY-7220-1/YeastPathways_PWY-7220-1_SGD_YeastPathways_PWY-7220-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
+                "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -341,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -361,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "adenosine deoxyribonucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -369,25 +347,36 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_YeastPathways_PWY-7220-1>
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7220-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
+                "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_YeastPathways_PWY-7220-1>
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_PWY-7220-1/YeastPathways_PWY-7220-1_SGD_PWY_YeastPathways_PWY-7220-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
+                "SGD_PWY:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -395,11 +384,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_PWY-7220-1/YeastPathways_PWY-7220-1_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_PWY-7220-1/YeastPathways_PWY-7220-1_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -413,26 +402,15 @@
 <http://purl.obolibrary.org/obo/GO_0004748>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADPREDUCT-RXN_SGD_YeastPathways_PWY-7220-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,11 +428,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -497,6 +475,39 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -504,11 +515,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002411_RXN0-745_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002411_RXN0-745_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,7 +545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -551,13 +562,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7220-1SmallMolecule73307> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -566,11 +588,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -588,11 +610,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" , "Provides Input For Rule. The relation 'dADP + an oxidized thioredoxin + H<sub>2</sub>O &larr; ADP + a reduced thioredoxin' 'null' 'dADP + ATP &rarr; dATP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -603,23 +625,12 @@
           <http://model.geneontology.org/DADPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002411_RXN0-745_SGD_YeastPathways_PWY-7220-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -628,18 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_YeastPathways_PWY-7220-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -650,11 +650,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,26 +665,15 @@
           <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_YeastPathways_PWY-7220-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADPREDUCT-RXN_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,11 +688,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -714,33 +703,22 @@
           <http://model.geneontology.org/CHEBI_30616_RXN0-745>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_YeastPathways_PWY-7220-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57667>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_PWY-7220-1>
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-7220-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
+                "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57667>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -751,7 +729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -762,14 +740,14 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_YeastPathways_PWY-7220-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
+                "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -778,7 +756,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -786,11 +775,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -801,14 +790,14 @@
           <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7220-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
+                "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -825,11 +814,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -849,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -861,11 +850,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -885,13 +874,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7220-1SmallMolecule73413> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_61404> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -902,7 +902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -910,26 +910,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_PWY-7220-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -940,17 +929,6 @@
           <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_YeastPathways_PWY-7220-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57667_ADPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57667> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -960,7 +938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -973,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -981,11 +959,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1000,11 +978,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,53 +993,20 @@
           <http://model.geneontology.org/CHEBI_15740_RXN0-745>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7220-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_YeastPathways_PWY-7220-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_PWY-7220-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_PWY-7220-1>
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PWY_YeastPathways_PWY-7220-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
+                "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1078,7 +1023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1090,11 +1035,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1105,18 +1050,15 @@
           <http://model.geneontology.org/CHEBI_57667_ADPREDUCT-RXN>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1127,16 +1069,8 @@
           <http://model.geneontology.org/Red-Thioredoxin_ADPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_PWY-7220-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1149,7 +1083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1165,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1177,11 +1111,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1196,11 +1130,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_PWY-7220-1/YeastPathways_PWY-7220-1_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_PWY-7220-1/YeastPathways_PWY-7220-1_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1211,26 +1145,15 @@
           <http://model.geneontology.org/YeastPathways_PWY-7220-1/YeastPathways_PWY-7220-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_YeastPathways_PWY-7220-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1241,19 +1164,19 @@
           <http://model.geneontology.org/CHEBI_15378_RXN0-745>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_YeastPathways_PWY-7220-1>
+<http://purl.obolibrary.org/obo/CHEBI_456216>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY-7220-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
+                "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_456216>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000003563>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1261,11 +1184,55 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002411_RXN0-745_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_PWY-7220-1/YeastPathways_PWY-7220-1_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1274,11 +1241,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1289,15 +1256,26 @@
           <http://model.geneontology.org/CHEBI_30616_DADPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1312,11 +1290,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1336,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1353,7 +1331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1361,29 +1339,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_PWY-7220-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7220-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1394,18 +1364,48 @@
           <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_YeastPathways_PWY-7220-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7220-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY-7221.ttl
+++ b/models/YeastPathways_PWY-7221.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16,6 +16,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -29,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "guanosine ribonucleotides <i>de novo</i> biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -41,11 +52,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,25 +70,14 @@
 <http://purl.obolibrary.org/obo/GO_0003938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_PWY-7221/YeastPathways_PWY-7221_SGD_PWY_YeastPathways_PWY-7221>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
+                "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -91,11 +91,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -110,11 +110,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -162,28 +162,28 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221>
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7221>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -204,37 +204,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_PWY-7221/YeastPathways_PWY-7221_SGD_YeastPathways_PWY-7221>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_YeastPathways_PWY-7221>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -245,30 +223,19 @@
           <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-7221/YeastPathways_PWY-7221_SGD_YeastPathways_PWY-7221>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000002862>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -277,11 +244,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -309,22 +276,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -335,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -347,11 +314,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -365,17 +332,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_37565>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004550>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-7221>
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-7221>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004550>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -389,7 +367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -397,29 +375,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://identifiers.org/sgd/S000001259>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
+                "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001259>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -433,15 +411,26 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -455,25 +444,14 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
+                "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -482,12 +460,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004830>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
         a       <http://identifiers.org/sgd/S000002862> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -496,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -504,15 +493,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,17 +523,6 @@
           <http://model.geneontology.org/CHEBI_456216_GUANYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -541,11 +530,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -565,13 +554,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7221SmallMolecule72113> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -580,11 +580,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,11 +599,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,28 +613,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_PWY-7221/YeastPathways_PWY-7221_SGD_YeastPathways_PWY-7221>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -646,11 +624,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" , "Provides Input For Rule. The relation 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,17 +639,6 @@
           <http://model.geneontology.org/GUANYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7221>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_GMP-SYN-GLUT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -681,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -698,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -719,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -731,11 +698,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'GDP + ATP &rarr; GTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -746,14 +713,14 @@
           <http://model.geneontology.org/GDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7221>
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-7221>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
+                "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -761,11 +728,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_PWY-7221/YeastPathways_PWY-7221_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_PWY-7221/YeastPathways_PWY-7221_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -785,7 +752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -793,39 +760,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_YeastPathways_PWY-7221>
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7221>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
+                "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_PWY-7221/YeastPathways_PWY-7221_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -833,11 +800,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -857,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -869,11 +836,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -889,12 +856,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004385>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -912,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -938,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -950,11 +928,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,11 +947,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -993,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1004,17 +982,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY-7221>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58115>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1022,11 +989,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1037,26 +1004,15 @@
           <http://model.geneontology.org/CHEBI_15377_IMP-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_YeastPathways_PWY-7221>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1076,24 +1032,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7221SmallMolecule72048> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1104,7 +1049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1112,8 +1057,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GUANYL-KIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004385> ;
@@ -1134,7 +1101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1142,15 +1109,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1161,26 +1139,15 @@
           <http://model.geneontology.org/YML056C-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_YeastPathways_PWY-7221>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1203,7 +1170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1218,7 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1226,14 +1193,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY-7221>
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1241,11 +1219,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1260,11 +1238,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1274,6 +1252,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_456216_GDPKIN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1287,7 +1276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1299,11 +1288,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1318,11 +1307,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1333,17 +1322,6 @@
           <http://model.geneontology.org/CHEBI_58359_GMP-SYN-GLUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001259> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1351,7 +1329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1365,15 +1343,37 @@
 <http://purl.obolibrary.org/obo/CHEBI_58189>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_PWY-7221/YeastPathways_PWY-7221_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_PWY-7221/YeastPathways_PWY-7221_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1384,15 +1384,26 @@
           <http://model.geneontology.org/YeastPathways_PWY-7221/YeastPathways_PWY-7221>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_PWY-7221/YeastPathways_PWY-7221_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_PWY-7221/YeastPathways_PWY-7221_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1403,17 +1414,6 @@
           <http://model.geneontology.org/YeastPathways_PWY-7221/YeastPathways_PWY-7221>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58115_GMP-SYN-GLUT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58115> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1423,7 +1423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1440,7 +1440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1448,15 +1448,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-7221/YeastPathways_PWY-7221_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-7221/YeastPathways_PWY-7221_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-7221/YeastPathways_PWY-7221_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1467,23 +1489,23 @@
           <http://model.geneontology.org/YeastPathways_PWY-7221/YeastPathways_PWY-7221>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1491,11 +1513,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1515,24 +1537,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7221SmallMolecule72113> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/IMP-DEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003938> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1553,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1565,11 +1576,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1580,15 +1591,26 @@
           <http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_PWY-7221/YeastPathways_PWY-7221_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1602,6 +1624,17 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000001550>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1611,15 +1644,26 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1633,14 +1677,14 @@
 <http://identifiers.org/sgd/S000004424>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
+                "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1648,11 +1692,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1682,35 +1726,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7221BiochemicalReaction72085> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY-7221>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_GDPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1721,7 +1743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1729,14 +1751,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
+                "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1744,11 +1766,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1759,26 +1781,15 @@
           <http://model.geneontology.org/CHEBI_57540_IMP-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7221>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1788,17 +1799,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7221>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004550> ;
@@ -1817,7 +1817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1828,45 +1828,12 @@
 <http://purl.obolibrary.org/obo/GO_0003922>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_PWY-7221/YeastPathways_PWY-7221_SGD_YeastPathways_PWY-7221>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY-7221>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1874,11 +1841,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" , "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1893,11 +1860,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_YeastPathways_PWY-7221> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_PWY_YeastPathways_PWY-7221> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1908,14 +1875,25 @@
           <http://model.geneontology.org/YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY-7221>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7221" ;
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1929,7 +1907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1939,3 +1917,25 @@
 
 <http://purl.obolibrary.org/obo/GO_0106387>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY-7221>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7221" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-7222-1.ttl
+++ b/models/YeastPathways_PWY-7222-1.ttl
@@ -1,41 +1,30 @@
 <http://identifiers.org/sgd/S000001550>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_PWY-7222-1/YeastPathways_PWY-7222-1_SGD_YeastPathways_PWY-7222-1>
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-7222-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
+                "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_PWY-7222-1/YeastPathways_PWY-7222-1_SGD_YeastPathways_PWY-7222-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
+                "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001328>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_YeastPathways_PWY-7222-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/DGDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004550> ;
@@ -56,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -64,14 +53,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_YeastPathways_PWY-7222-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
+                "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -84,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -92,37 +81,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_PWY-7222-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GDPREDUCT-RXN_SGD_YeastPathways_PWY-7222-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GDPREDUCT-RXN_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,26 +100,15 @@
           <http://model.geneontology.org/CHEBI_58189_GDPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_PWY-7222-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_PWY-7222-1/YeastPathways_PWY-7222-1_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_PWY-7222-1/YeastPathways_PWY-7222-1_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -163,14 +119,17 @@
           <http://model.geneontology.org/YeastPathways_PWY-7222-1/YeastPathways_PWY-7222-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_YeastPathways_PWY-7222-1>
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PWY_YeastPathways_PWY-7222-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
+                "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -178,11 +137,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,20 +152,28 @@
           <http://model.geneontology.org/CHEBI_16526_RXN0-746>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_RXN0-746_SGD_YeastPathways_PWY-7222-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002411_RXN0-746_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
+                "SGD_PWY:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -219,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "guanosine deoxyribonucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -234,11 +201,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_PWY-7222-1/YeastPathways_PWY-7222-1_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_PWY-7222-1/YeastPathways_PWY-7222-1_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -264,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -281,7 +248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -298,7 +265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -311,24 +278,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_YeastPathways_PWY-7222-1>
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7222-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
+                "SGD_PWY:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_RXN0-746_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -341,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -349,15 +338,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -384,11 +398,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,18 +413,29 @@
           <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15377>
+<http://purl.obolibrary.org/obo/GO_0004550>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,22 +446,30 @@
           <http://model.geneontology.org/CHEBI_15377_RXN0-746>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004550>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_58189>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002411_RXN0-746_SGD_YeastPathways_PWY-7222-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
+                "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58189>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000003412>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -450,17 +483,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_PWY-7222-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_61429_RXN0-746>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_61429> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -470,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -487,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -499,11 +521,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'dGDP + an oxidized thioredoxin + H<sub>2</sub>O &larr; GDP + a reduced thioredoxin' 'null' 'dGDP + ATP &rarr; dGTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -514,14 +536,25 @@
           <http://model.geneontology.org/DGDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_YeastPathways_PWY-7222-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
+                "SGD_PWY:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_PWY-7222-1/YeastPathways_PWY-7222-1_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -531,26 +564,15 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_YeastPathways_PWY-7222-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -566,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -579,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -591,11 +613,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -609,14 +631,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_58595>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_YeastPathways_PWY-7222-1>
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_PWY-7222-1/YeastPathways_PWY-7222-1_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7222-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
+                "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -627,11 +660,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_PWY-7222-1/YeastPathways_PWY-7222-1_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_PWY-7222-1/YeastPathways_PWY-7222-1_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -655,11 +688,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -677,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -689,11 +722,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_RXN0-746_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_RXN0-746_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -704,6 +737,17 @@
           <http://model.geneontology.org/CHEBI_37565_RXN0-746>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY-7222-1/YeastPathways_PWY-7222-1>
         a       <http://purl.obolibrary.org/obo/GO_0106387> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -711,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -722,19 +766,19 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_PWY-7222-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_PWY-7222-1/YeastPathways_PWY-7222-1_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
+                "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -745,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -758,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -769,11 +813,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -787,6 +831,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -797,11 +852,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -812,15 +867,26 @@
           <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -831,15 +897,26 @@
           <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002411_RXN0-746_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002411_RXN0-746_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -855,7 +932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -863,11 +940,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -878,17 +955,6 @@
           <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7222-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58595> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -898,7 +964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -910,11 +976,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -927,6 +993,17 @@
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GDPREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004748> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -947,7 +1024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -958,41 +1035,19 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_15740>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_PWY-7222-1/YeastPathways_PWY-7222-1_SGD_YeastPathways_PWY-7222-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_YeastPathways_PWY-7222-1>
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-7222-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
+                "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_PWY-7222-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15740>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1001,11 +1056,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1016,26 +1071,15 @@
           <http://model.geneontology.org/CHEBI_15377_GDPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_YeastPathways_PWY-7222-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1063,7 +1107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1079,7 +1123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1087,37 +1131,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_YeastPathways_PWY-7222-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_YeastPathways_PWY-7222-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1132,11 +1154,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1151,11 +1173,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1184,7 +1206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1195,30 +1217,19 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_PWY-7222-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_PWY-7222-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN0-746>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1229,7 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1244,11 +1255,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1263,11 +1274,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1282,11 +1293,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1296,6 +1307,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_61429_RXN0-746>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY_YeastPathways_PWY-7222-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7222-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1307,11 +1329,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1325,26 +1347,15 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_YeastPathways_PWY-7222-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_YeastPathways_PWY-7222-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7222-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1355,36 +1366,25 @@
           <http://model.geneontology.org/reaction_RXN0-746_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_YeastPathways_PWY-7222-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-7222-1>
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-7222-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
+                "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_PWY-7222-1>
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-7222-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-7222-1" ;
+                "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1397,7 +1397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1414,7 +1414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-781.ttl
+++ b/models/YeastPathways_PWY-781.ttl
@@ -1,3 +1,14 @@
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004781>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -5,11 +16,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,6 +31,17 @@
           <http://model.geneontology.org/CHEBI_16136_SULFITE-REDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_YeastPathways_PWY-781/YeastPathways_PWY-781_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY-781/YeastPathways_PWY-781>
         a       <http://purl.obolibrary.org/obo/GO_0000103> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -29,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -41,11 +63,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,17 +77,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58339_ADENYLYLSULFKIN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-781>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -93,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -105,11 +116,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_17359_1.8.4.8-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_17359_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -124,11 +135,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -138,28 +149,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_YeastPathways_PWY-781>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_Red-Thioredoxin_1.8.4.8-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -179,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -187,26 +176,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002333_YPR167C-MONOMER_1.8.4.8-RXN_controller_SGD_YeastPathways_PWY-781>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -224,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -236,11 +214,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000066_reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000066_reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,6 +232,17 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002413_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/Red-Thioredoxin_1.8.4.8-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -263,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -274,28 +263,17 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002413_1.8.4.8-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-781>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_15378_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
+                "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -303,11 +281,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000050_YeastPathways_PWY-781/YeastPathways_PWY-781_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000050_YeastPathways_PWY-781/YeastPathways_PWY-781_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -318,14 +296,14 @@
           <http://model.geneontology.org/YeastPathways_PWY-781/YeastPathways_PWY-781>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000001926_CPLX3O-23_component_SGD_YeastPathways_PWY-781>
+<http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000001926_CPLX3O-23_component_SGD_PWY_YeastPathways_PWY-781>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
+                "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -338,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -346,54 +324,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_456216_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000003771>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000066_reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-781>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002413_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002333_YPR167C-MONOMER_1.8.4.8-RXN_controller_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002333_YPR167C-MONOMER_1.8.4.8-RXN_controller_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,16 +346,8 @@
           <http://model.geneontology.org/YPR167C-MONOMER_1.8.4.8-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_15378_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YPR167C-MONOMER_1.8.4.8-RXN_controller>
         a       <http://identifiers.org/sgd/S000006371> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -422,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -434,11 +368,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -455,28 +389,39 @@
 <http://purl.obolibrary.org/obo/CHEBI_58243>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
+                "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58343>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_15378_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_58343_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -484,11 +429,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_57783_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_57783_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,11 +451,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_15378_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_15378_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -524,17 +469,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_16189>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_YeastPathways_PWY-781/YeastPathways_PWY-781_SGD_YeastPathways_PWY-781>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_SULFITE-REDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -544,7 +478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -552,18 +486,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_30616_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_Red-Thioredoxin_1.8.4.8-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,11 +534,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_YeastPathways_PWY-781/YeastPathways_PWY-781_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_YeastPathways_PWY-781/YeastPathways_PWY-781_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -592,6 +548,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY-781/YeastPathways_PWY-781>
 ] .
+
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_17359_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ADENYLYLSULFKIN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004020> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -612,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -632,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -640,14 +607,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_58343_1.8.4.8-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_15378_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
+                "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -655,11 +622,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'sulfate + ATP + H<SUP>+</SUP> &harr; adenosine 5'-phosphosulfate + diphosphate' 'null' 'adenosine 5'-phosphosulfate + ATP &harr; 3'-phosphoadenylyl-sulfate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -689,7 +656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -697,48 +664,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-781>
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_17359_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-781>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
+                "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_17359_1.8.4.8-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000003898_CPLX3O-23_component>
         a       <http://identifiers.org/sgd/S000003898> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -746,11 +691,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -761,15 +706,26 @@
           <http://model.geneontology.org/CHEBI_58349_SULFITE-REDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002333_YPR167C-MONOMER_1.8.4.8-RXN_controller_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002333_YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002333_YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -807,14 +763,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-781>
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_15377_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-781>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_15378_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -827,7 +805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -838,37 +816,15 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000003898_CPLX3O-23_component_SGD_YeastPathways_PWY-781>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_58343_1.8.4.8-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_58343_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -884,7 +840,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000050_YeastPathways_PWY-781/YeastPathways_PWY-781_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -892,11 +859,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -907,6 +874,17 @@
           <http://model.geneontology.org/CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -916,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -933,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -941,63 +919,52 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002333_YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller_SGD_YeastPathways_PWY-781>
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002333_YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-781>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
+                "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003898>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_17359_1.8.4.8-RXN_SGD_YeastPathways_PWY-781>
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-781>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
+                "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_15378_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_15378_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1008,6 +975,17 @@
           <http://model.geneontology.org/CHEBI_15378_SULFITE-REDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16136_SULFITE-REDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16136> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1017,7 +995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1029,11 +1007,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_30616_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_30616_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1056,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1076,7 +1054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "sulfate assimilation pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1088,11 +1066,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000001926_CPLX3O-23_component_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000001926_CPLX3O-23_component_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1107,11 +1085,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000066_reaction_1.8.4.8-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000066_reaction_1.8.4.8-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1121,17 +1099,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_1.8.4.8-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1147,18 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000050_YeastPathways_PWY-781/YeastPathways_PWY-781_SGD_YeastPathways_PWY-781>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1171,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1179,21 +1135,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000066_reaction_1.8.4.8-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0000103>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_456216_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'adenosine 3',5'-bisphosphate + sulfite + an oxidized thioredoxin + 2 H<SUP>+</SUP> &harr; 3'-phosphoadenylyl-sulfate + a reduced thioredoxin' 'null' 'hydrogen sulfide + 3 NADP<sup>+</sup> + 3 H<sub>2</sub>O &larr; sulfite + 3 NADPH + 5 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002413_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002413_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1208,11 +1186,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1223,14 +1201,14 @@
           <http://model.geneontology.org/CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-781>
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002333_CPLX3O-23_SULFITE-REDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY-781>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
+                "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1243,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1251,14 +1229,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_15378_1.8.4.8-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000003898_CPLX3O-23_component_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1271,7 +1260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1283,11 +1272,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_15377_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_15377_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1301,15 +1290,26 @@
 <http://purl.obolibrary.org/obo/GO_0004020>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_57783_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_456216_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_456216_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1320,52 +1320,19 @@
           <http://model.geneontology.org/CHEBI_456216_ADENYLYLSULFKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000050_YeastPathways_PWY-781/YeastPathways_PWY-781_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000050_YeastPathways_PWY-781/YeastPathways_PWY-781_SGD_YeastPathways_PWY-781>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_YeastPathways_PWY-781/YeastPathways_PWY-781_SGD_YeastPathways_PWY-781>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000066_reaction_1.8.4.8-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-781>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004604>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1374,11 +1341,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_15378_1.8.4.8-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_15378_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1389,15 +1356,26 @@
           <http://model.geneontology.org/CHEBI_15378_1.8.4.8-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1408,23 +1386,12 @@
           <http://model.geneontology.org/reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_30616_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1434,26 +1401,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_58339>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000050_YeastPathways_PWY-781/YeastPathways_PWY-781_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000050_YeastPathways_PWY-781/YeastPathways_PWY-781_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1468,11 +1424,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_YeastPathways_PWY-781/YeastPathways_PWY-781_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_YeastPathways_PWY-781/YeastPathways_PWY-781_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1483,6 +1439,20 @@
           <http://model.geneontology.org/YeastPathways_PWY-781/YeastPathways_PWY-781>
 ] .
 
+<http://identifiers.org/sgd/S000001484>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58339_ADENYLYLSULFKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58339> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1492,7 +1462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1500,8 +1470,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000001484>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000066_reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1514,7 +1492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1522,11 +1500,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002333_CPLX3O-23_SULFITE-REDUCT-RXN_controller_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002333_CPLX3O-23_SULFITE-REDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1537,6 +1515,17 @@
           <http://model.geneontology.org/CPLX3O-23_SULFITE-REDUCT-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000001926>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1544,11 +1533,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'adenosine 5'-phosphosulfate + ATP &harr; 3'-phosphoadenylyl-sulfate + ADP + H<SUP>+</SUP>' 'null' 'adenosine 3',5'-bisphosphate + sulfite + an oxidized thioredoxin + 2 H<SUP>+</SUP> &harr; 3'-phosphoadenylyl-sulfate + a reduced thioredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002413_1.8.4.8-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002413_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1559,25 +1548,14 @@
           <http://model.geneontology.org/1.8.4.8-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002333_CPLX3O-23_SULFITE-REDUCT-RXN_controller_SGD_YeastPathways_PWY-781>
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-781>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_57783_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
+                "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1585,11 +1563,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1600,17 +1578,6 @@
           <http://model.geneontology.org/Red-Thioredoxin_1.8.4.8-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_17359_1.8.4.8-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17359> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1620,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1632,11 +1599,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1656,6 +1623,28 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1665,7 +1654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1677,11 +1666,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_17359_1.8.4.8-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_17359_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1696,11 +1685,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1710,17 +1699,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_15377_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1732,7 +1710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1740,15 +1718,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002413_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1768,7 +1757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1780,11 +1769,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000003898_CPLX3O-23_component_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000003898_CPLX3O-23_component_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1800,7 +1789,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1813,7 +1813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1821,14 +1821,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-781>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_YeastPathways_PWY-781/YeastPathways_PWY-781_SGD_PWY_YeastPathways_PWY-781>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-781" ;
+                "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1841,7 +1841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1853,11 +1853,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_YeastPathways_PWY-781> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-781> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY-821-1.ttl
+++ b/models/YeastPathways_PWY-821-1.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -32,12 +32,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002413_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_15378_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -45,11 +67,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,12 +87,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29991>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_ADENYLYLSULFKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -81,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -93,11 +126,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000066_reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000066_reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -108,6 +141,28 @@
           <http://model.geneontology.org/reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002333_YJR130C-MONOMER_RXN-721_controller_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -117,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -129,11 +184,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -151,11 +206,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -173,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -185,11 +240,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -200,17 +255,6 @@
           <http://model.geneontology.org/YeastPathways_PWY-821-1/YeastPathways_PWY-821-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-LYASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_537519>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -218,11 +262,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_28938_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_28938_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,23 +283,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_16136>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/4be84133-04e6-4e68-9c2a-678543aea894_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule30990> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/YJR130C-MONOMER_RXN-721_controller>
         a       <http://identifiers.org/sgd/S000003891> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -263,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -271,14 +298,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -286,11 +324,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -305,11 +343,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'adenosine 3',5'-bisphosphate + sulfite + an oxidized thioredoxin + 2 H<SUP>+</SUP> &harr; 3'-phosphoadenylyl-sulfate + a reduced thioredoxin' 'null' 'sulfate + ATP + H<SUP>+</SUP> &harr; adenosine 5'-phosphosulfate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002413_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002413_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,43 +367,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1Protein31645> , <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1Protein31641> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ACETYLHOMOSER-CYS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY-821-1/YeastPathways_PWY-821-1>
-] .
 
 <http://model.geneontology.org/CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58243> ;
@@ -376,24 +384,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule31564> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -402,11 +399,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -417,14 +414,14 @@
           <http://model.geneontology.org/MONOMER3O-1014_S-ADENMETSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -432,11 +429,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_30089_RXN-721_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_30089_RXN-721_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -474,42 +471,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ACETYLHOMOSER-CYS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY-821-1/YeastPathways_PWY-821-1>
+] .
+
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTAGLY-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_15378_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -517,11 +508,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-homocysteine + L-serine &harr; L-cystathionine + H<sub>2</sub>O' 'null' 'L-cystathionine + H<sub>2</sub>O &rarr; L-homocysteine + pyruvate + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -536,11 +527,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'adenosine 3',5'-bisphosphate + sulfite + an oxidized thioredoxin + 2 H<SUP>+</SUP> &harr; 3'-phosphoadenylyl-sulfate + a reduced thioredoxin' 'null' 'hydrogen sulfide + 3 NADP<sup>+</sup> + 3 H<sub>2</sub>O &larr; sulfite + 3 NADPH + 5 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002413_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002413_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,58 +542,17 @@
           <http://model.geneontology.org/SULFITE-REDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_24431>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002413_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_15378_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -610,11 +560,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -634,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -646,11 +596,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,14 +611,14 @@
           <http://model.geneontology.org/YLR180W-MONOMER_S-ADENMETSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -681,9 +631,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/4be84133-04e6-4e68-9c2a-678543aea894_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/59488dab-f557-4b04-bf29-2cfd2318665d_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/729c2695-f808-4219-b22e-0341111b93bc_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
+                <http://model.geneontology.org/51d31dc1-87e7-4a90-bcb9-bfc72b411a7f_RXN3O-22> , <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -691,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -699,19 +649,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-23_SULFITE-REDUCT-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -722,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -730,36 +691,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000066_reaction_RXN-721_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_58343_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_30089_RXN-721_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -767,11 +728,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,7 +752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of sulfur amino acid biosynthesis (<i>Saccharomyces cerevisiae</i>) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -799,15 +760,37 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-cystathionine + H<sub>2</sub>O &harr; 2-oxobutanoate + L-cysteine + ammonia' 'null' 'L-cysteine + <i>O</i>-acetyl-L-homoserine &rarr; L-cystathionine + acetate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002413_RXN-721_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002413_RXN-721_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -822,11 +805,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_15378_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_15378_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -837,25 +820,14 @@
           <http://model.geneontology.org/CHEBI_15378_SULFITE-REDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_729c2695-f808-4219-b22e-0341111b93bc_RXN3O-22_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTAGLY-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_15378_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -869,7 +841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -877,26 +849,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002333_YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002333_YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -911,11 +872,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -925,17 +886,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58343>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -949,7 +899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -962,7 +912,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000003898_CPLX3O-23_component_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -975,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -983,25 +944,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_15377_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_RXN-721_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1009,11 +970,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_15378_1.8.4.8-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_15378_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1024,18 +985,51 @@
           <http://model.geneontology.org/CHEBI_15378_1.8.4.8-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_15378_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1046,26 +1040,15 @@
           <http://model.geneontology.org/CHEBI_30616_S-ADENMETSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Provides Input For Rule. The relation 'L-homoserine + acetyl-CoA &rarr; <i>O</i>-acetyl-L-homoserine + coenzyme A' 'null' '<i>O</i>-acetyl-L-homoserine + hydrogen sulfide &rarr; L-homocysteine + acetate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1085,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1096,6 +1079,17 @@
 <http://identifiers.org/sgd/S000000893>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57476_HOMOSERDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57476> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1105,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1113,21 +1107,10 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57535>
+<http://purl.obolibrary.org/obo/GO_0004783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004783>
+<http://purl.obolibrary.org/obo/CHEBI_57535>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_33384>
@@ -1137,11 +1120,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1152,21 +1135,43 @@
           <http://model.geneontology.org/CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_17359_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57716>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000004294>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1177,14 +1182,36 @@
           <http://model.geneontology.org/CHEBI_58199_ACETYLHOMOSER-CYS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000066_reaction_1.8.4.8-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1192,11 +1219,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1207,28 +1234,6 @@
           <http://model.geneontology.org/reaction_ASPARTATEKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002413_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YLR180W-MONOMER_S-ADENMETSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000004170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1236,7 +1241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1248,11 +1253,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1263,14 +1268,36 @@
           <http://model.geneontology.org/CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000003898_CPLX3O-23_component_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1283,7 +1310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1295,11 +1322,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1313,23 +1340,34 @@
 <http://identifiers.org/sgd/S000001484>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_ASPARTATEKIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_57783_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002413_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1337,11 +1375,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_RXN-721_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_RXN-721_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1352,69 +1390,25 @@
           <http://model.geneontology.org/CHEBI_58161_RXN-721>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_4be84133-04e6-4e68-9c2a-678543aea894_RXN3O-22_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTAGLY-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1422,11 +1416,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_30616_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_30616_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1437,15 +1431,37 @@
           <http://model.geneontology.org/CHEBI_30616_ADENYLYLSULFKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002333_CPLX3O-23_SULFITE-REDUCT-RXN_controller_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002333_CPLX3O-23_SULFITE-REDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1475,7 +1491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1483,14 +1499,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1502,32 +1529,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_729c2695-f808-4219-b22e-0341111b93bc_RXN3O-22_SGD_YeastPathways_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-22> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/729c2695-f808-4219-b22e-0341111b93bc_RXN3O-22>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1538,6 +1546,36 @@
           <http://model.geneontology.org/reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_51d31dc1-87e7-4a90-bcb9-bfc72b411a7f_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-22> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/51d31dc1-87e7-4a90-bcb9-bfc72b411a7f_RXN3O-22>
+] .
+
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58343_1.8.4.8-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58343> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1547,7 +1585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1558,37 +1596,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002413_RXN-721_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002333_YJR130C-MONOMER_RXN-721_controller_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1599,6 +1615,28 @@
           <http://model.geneontology.org/CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_17359_1.8.4.8-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17359> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1608,7 +1646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1620,11 +1658,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1635,6 +1673,9 @@
           <http://model.geneontology.org/CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0047804>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_30616_ADENYLYLSULFKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1644,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1652,8 +1693,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0047804>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1665,13 +1714,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1Protein31485> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_15377_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_15378_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005221> ;
@@ -1680,24 +1751,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1Protein31526> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000066_reaction_1.8.4.8-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1708,7 +1768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1729,7 +1789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1737,26 +1797,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002333_YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_58161_RXN-721_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_58161_RXN-721_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1776,7 +1825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1784,26 +1833,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_15377_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000066_reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000066_reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1814,34 +1852,12 @@
           <http://model.geneontology.org/reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002413_1.8.4.8-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1849,11 +1865,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1867,14 +1883,14 @@
 <http://purl.obolibrary.org/obo/GO_0000097>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002413_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1897,24 +1913,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1BiochemicalReaction31203> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1928,7 +1933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1936,14 +1941,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000001926_CPLX3O-23_component_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1951,11 +1956,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-aspartate + ATP &rarr; L-aspartyl-4-phosphate + ADP' 'null' 'L-aspartate 4-semialdehyde + NADP<sup>+</sup> + phosphate &larr; L-aspartyl-4-phosphate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1970,11 +1975,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1994,7 +1999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2011,7 +2016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2019,14 +2024,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_58161_RXN-721_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2037,7 +2042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2052,11 +2057,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2067,14 +2072,14 @@
           <http://model.geneontology.org/CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2088,11 +2093,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2107,11 +2112,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_17359_1.8.4.8-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_17359_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2122,6 +2127,39 @@
           <http://model.geneontology.org/CHEBI_17359_1.8.4.8-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57288>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2130,18 +2168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_15361_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2149,11 +2176,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Provides Input For Rule. The relation 'adenosine 5'-phosphosulfate + ATP &harr; 3'-phosphoadenylyl-sulfate + ADP + H<SUP>+</SUP>' 'null' 'adenosine 3',5'-bisphosphate + sulfite + an oxidized thioredoxin + 2 H<SUP>+</SUP> &harr; 3'-phosphoadenylyl-sulfate + a reduced thioredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002413_1.8.4.8-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002413_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2168,11 +2195,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2187,11 +2214,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2211,7 +2238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2219,14 +2246,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2234,11 +2261,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-LYASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-LYASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2249,15 +2276,48 @@
           <http://model.geneontology.org/reaction_CYSTATHIONINE-BETA-LYASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2268,15 +2328,26 @@
           <http://model.geneontology.org/YeastPathways_PWY-821-1/YeastPathways_PWY-821-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_17359_1.8.4.8-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_17359_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2287,6 +2358,17 @@
           <http://model.geneontology.org/CHEBI_17359_1.8.4.8-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_456216_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_S-ADENMETSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2296,7 +2378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2323,7 +2405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2331,14 +2413,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002333_YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2349,11 +2431,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2364,26 +2446,15 @@
           <http://model.geneontology.org/CHEBI_57844_HOMOCYSMET-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2403,7 +2474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2411,25 +2482,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002413_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2440,11 +2500,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2454,17 +2514,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_30089_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/HOMOCYSMET-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003871> ;
@@ -2485,7 +2534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2497,11 +2546,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002333_YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002333_YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2512,6 +2561,17 @@
           <http://model.geneontology.org/YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_15378_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2519,11 +2579,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2541,7 +2601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2553,11 +2613,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2571,14 +2631,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_57844>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_RXN-721_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002413_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2591,7 +2651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2606,7 +2666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2633,7 +2693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2645,11 +2705,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Provides Input For Rule. The relation 'L-homocysteine + 5-methyltetrahydropteroyl tri-L-glutamate &harr; L-methionine + tetrahydropteroyl tri-L-glutamate' 'null' 'ATP + L-methionine + H<sub>2</sub>O &rarr; <i>S</i>-adenosyl-L-methionine + phosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002413_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002413_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2660,14 +2720,14 @@
           <http://model.geneontology.org/S-ADENMETSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_57783_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2680,7 +2740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2688,14 +2748,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002333_CPLX3O-23_SULFITE-REDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2708,7 +2768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2720,11 +2780,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2744,7 +2804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2752,51 +2812,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000066_reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58199>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2811,11 +2838,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Provides Input For Rule. The relation 'hydrogen sulfide + 3 NADP<sup>+</sup> + 3 H<sub>2</sub>O &larr; sulfite + 3 NADPH + 5 H<SUP>+</SUP>' 'null' '<i>O</i>-acetyl-L-homoserine + hydrogen sulfide &rarr; L-homocysteine + acetate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2826,29 +2853,29 @@
           <http://model.geneontology.org/ACETYLHOMOSER-CYS-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2868,7 +2895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2880,11 +2907,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2903,7 +2930,40 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2926,7 +2986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2943,7 +3003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2955,30 +3015,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002333_YGL184C-MONOMER_CYSTATHIONINE-BETA-LYASE-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.8.4.8-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY-821-1/YeastPathways_PWY-821-1>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002333_YGL184C-MONOMER_CYSTATHIONINE-BETA-LYASE-RXN_controller_SGD_YeastPathways_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2989,29 +3030,59 @@
           <http://model.geneontology.org/YGL184C-MONOMER_CYSTATHIONINE-BETA-LYASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_YeastPathways_PWY-821-1>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.8.4.8-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY-821-1/YeastPathways_PWY-821-1>
+] .
+
+<http://identifiers.org/sgd/S000005767>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002413_RXN-721_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_51d31dc1-87e7-4a90-bcb9-bfc72b411a7f_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000005767>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3026,11 +3097,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3043,6 +3114,17 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_57476>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000066_reaction_RXN-721_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58140>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3059,7 +3141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3074,11 +3156,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002333_YJR130C-MONOMER_RXN-721_controller_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002333_YJR130C-MONOMER_RXN-721_controller_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3089,15 +3171,26 @@
           <http://model.geneontology.org/YJR130C-MONOMER_RXN-721_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_15361_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3106,36 +3199,6 @@
           <http://model.geneontology.org/ACETYLHOMOSER-CYS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16136_SULFITE-REDUCT-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOCYSMET-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_HOMOCYSMET-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_58207_HOMOCYSMET-RXN>
@@ -3147,7 +3210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3155,16 +3218,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000001926_CPLX3O-23_component_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HOMOCYSMET-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_HOMOCYSMET-RXN_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/CHEBI_30616_ASPARTATEKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -3175,7 +3246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3202,7 +3273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3213,25 +3284,25 @@
 <http://identifiers.org/sgd/S000002565>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_15378_1.8.4.8-RXN_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3244,7 +3315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3256,11 +3327,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000001926_CPLX3O-23_component_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000001926_CPLX3O-23_component_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3275,11 +3346,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3290,19 +3361,19 @@
           <http://model.geneontology.org/reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_58161_RXN-721_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://identifiers.org/sgd/S000001926>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000001926>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3310,26 +3381,37 @@
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004604>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_1.8.4.8-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002333_YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004604>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3342,7 +3424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3353,6 +3435,17 @@
 <http://purl.obolibrary.org/obo/GO_0004073>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_13392_HOMOSERDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_13392> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3362,7 +3455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3379,7 +3472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3387,14 +3480,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3402,11 +3495,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_57783_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_57783_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3417,6 +3510,17 @@
           <http://model.geneontology.org/CHEBI_57783_SULFITE-REDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_ACETYLHOMOSER-CYS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3426,7 +3530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3434,45 +3538,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-22> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_RXN3O-22>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3487,11 +3561,41 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_15377_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-22> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_RXN3O-22>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_15377_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3502,33 +3606,11 @@
           <http://model.geneontology.org/CHEBI_15377_CYSTATHIONINE-BETA-LYASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000006371>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_CYSTAGLY-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -3539,7 +3621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3547,26 +3629,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3581,11 +3652,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_58343_1.8.4.8-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_58343_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3605,7 +3676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3622,7 +3693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3633,14 +3704,25 @@
 <http://identifiers.org/sgd/S000002910>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3648,11 +3730,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3667,11 +3749,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000066_reaction_RXN-721_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_BFO_0000066_reaction_RXN-721_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3699,13 +3781,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1BiochemicalReaction31399> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002333_YGL184C-MONOMER_CYSTATHIONINE-BETA-LYASE-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003898>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3714,11 +3807,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3734,7 +3827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3742,11 +3835,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>O</i>-acetyl-L-homoserine + hydrogen sulfide &rarr; L-homocysteine + acetate + H<SUP>+</SUP>' 'null' 'L-homocysteine + L-serine &harr; L-cystathionine + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002413_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002413_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3776,7 +3869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3787,43 +3880,15 @@
 <http://identifiers.org/sgd/S000004170>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/CHEBI_57535_ASPARTATEKIN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57535> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "L-aspartyl-4-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule31104> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002413_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3834,16 +3899,33 @@
           <http://model.geneontology.org/CHEBI_30616_ASPARTATEKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_57535_ASPARTATEKIN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57535> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "L-aspartyl-4-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule31104> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CYSTATHIONINE-BETA-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004122> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3864,7 +3946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3875,29 +3957,29 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002413_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3918,11 +4000,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3933,40 +4015,29 @@
           <http://model.geneontology.org/YeastPathways_PWY-821-1/YeastPathways_PWY-821-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58339>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000066_reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16763_CYSTAGLY-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16763_CYSTAGLY-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3977,36 +4048,47 @@
           <http://model.geneontology.org/CHEBI_16763_CYSTAGLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002413_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4014,11 +4096,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_15378_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_15378_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4029,14 +4111,14 @@
           <http://model.geneontology.org/CHEBI_15378_ADENYLYLSULFKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-LYASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4045,29 +4127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4075,11 +4135,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4099,7 +4159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4107,25 +4167,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_28938_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4133,11 +4193,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Provides Input For Rule. The relation 'L-cystathionine + H<sub>2</sub>O &rarr; L-homocysteine + pyruvate + ammonium' 'null' 'L-homocysteine + L-serine &harr; L-cystathionine + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002413_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002413_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4152,11 +4212,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000066_reaction_1.8.4.8-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000066_reaction_1.8.4.8-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4167,17 +4227,6 @@
           <http://model.geneontology.org/reaction_1.8.4.8-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_43474_S-ADENMETSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4187,7 +4236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4199,11 +4248,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4218,11 +4267,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4239,6 +4288,28 @@
 <http://purl.obolibrary.org/obo/GO_0004412>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_HOMOSERDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4248,7 +4319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4260,11 +4331,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Provides Input For Rule. The relation 'L-cysteine + <i>O</i>-acetyl-L-homoserine &rarr; L-cystathionine + acetate' 'null' 'L-cystathionine + H<sub>2</sub>O &harr; 2-oxobutanoate + L-cysteine + ammonia' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTAGLY-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTAGLY-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4275,26 +4346,15 @@
           <http://model.geneontology.org/CYSTAGLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4305,14 +4365,14 @@
           <http://model.geneontology.org/CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_30089_RXN-721_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4320,11 +4380,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4347,7 +4407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4377,7 +4437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4385,45 +4445,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_58343_1.8.4.8-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000003898_CPLX3O-23_component_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000051> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CPLX3O-23_SULFITE-REDUCT-RXN_controller> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SGD_S000003898_CPLX3O-23_component>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4434,25 +4464,44 @@
           <http://model.geneontology.org/CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_YeastPathways_PWY-821-1>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000003898_CPLX3O-23_component_SGD_PWY_YeastPathways_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-23_SULFITE-REDUCT-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003898_CPLX3O-23_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16763_CYSTAGLY-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4460,11 +4509,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4475,6 +4524,17 @@
           <http://model.geneontology.org/CHEBI_58207_HOMOCYSMET-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_59488dab-f557-4b04-bf29-2cfd2318665d_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -4482,11 +4542,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4506,7 +4566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4514,26 +4574,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>O</i>-acetyl-L-homoserine + hydrogen sulfide &rarr; L-homocysteine + acetate + H<SUP>+</SUP>' 'null' 'L-homocysteine + 5-methyltetrahydropteroyl tri-L-glutamate &harr; L-methionine + tetrahydropteroyl tri-L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002413_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002413_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4544,14 +4593,14 @@
           <http://model.geneontology.org/HOMOCYSMET-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16763_CYSTAGLY-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4560,7 +4609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4568,11 +4617,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_15377_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_15377_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4583,17 +4632,28 @@
           <http://model.geneontology.org/CHEBI_15377_SULFITE-REDUCT-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000003900>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003900>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4601,11 +4661,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_4be84133-04e6-4e68-9c2a-678543aea894_RXN3O-22_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_59488dab-f557-4b04-bf29-2cfd2318665d_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4613,18 +4673,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4be84133-04e6-4e68-9c2a-678543aea894_RXN3O-22>
+          <http://model.geneontology.org/59488dab-f557-4b04-bf29-2cfd2318665d_RXN3O-22>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4638,26 +4698,26 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/reaction_S-ADENMETSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4665,11 +4725,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_58161_RXN-721_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_58161_RXN-721_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4692,7 +4752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4700,20 +4760,20 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0004478>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://identifiers.org/sgd/S000000854>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002333_YPR167C-MONOMER_1.8.4.8-RXN_controller_SGD_YeastPathways_PWY-821-1>
+<http://purl.obolibrary.org/obo/GO_0004478>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4721,11 +4781,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4740,11 +4800,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4755,8 +4815,16 @@
           <http://model.geneontology.org/Red-Thioredoxin_1.8.4.8-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000000010>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_35235_CYSTAGLY-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
@@ -4767,7 +4835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4775,14 +4843,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4790,11 +4858,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4809,11 +4877,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_35235_CYSTAGLY-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_35235_CYSTAGLY-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4824,16 +4892,8 @@
           <http://model.geneontology.org/CHEBI_35235_CYSTAGLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000000010>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_SULFITE-REDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4844,7 +4904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4855,15 +4915,26 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002333_YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4874,17 +4945,6 @@
           <http://model.geneontology.org/YGR155W-MONOMER_CYSTATHIONINE-BETA-SYNTHASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_S-ADENMETSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4894,7 +4954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4909,13 +4969,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1Protein31360> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004073> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4936,7 +5007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4944,26 +5015,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4974,14 +5034,25 @@
           <http://model.geneontology.org/CHEBI_456216_ASPARTATEKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002333_YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_35235_CYSTAGLY-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_30089_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4989,11 +5060,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Provides Input For Rule. The relation 'sulfate + ATP + H<SUP>+</SUP> &harr; adenosine 5'-phosphosulfate + diphosphate' 'null' 'adenosine 5'-phosphosulfate + ATP &harr; 3'-phosphoadenylyl-sulfate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5014,11 +5085,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5029,17 +5100,6 @@
           <http://model.geneontology.org/reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15361_CYSTATHIONINE-BETA-LYASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5049,7 +5109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5066,7 +5126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5077,15 +5137,26 @@
 <http://purl.obolibrary.org/obo/GO_0102028>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_35235_CYSTAGLY-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_35235_CYSTAGLY-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5100,11 +5171,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5118,14 +5189,14 @@
 <http://identifiers.org/sgd/S000003152>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_17359_1.8.4.8-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5138,7 +5209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5146,26 +5217,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002333_YGL184C-MONOMER_CYSTATHIONINE-BETA-LYASE-RXN_controller_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_456216_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_456216_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5180,11 +5240,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Provides Input For Rule. The relation 'L-cysteine + <i>O</i>-acetyl-L-homoserine &rarr; L-cystathionine + acetate' 'null' 'L-cystathionine + H<sub>2</sub>O &rarr; L-homocysteine + pyruvate + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5195,14 +5255,25 @@
           <http://model.geneontology.org/CYSTATHIONINE-BETA-LYASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002233_CHEBI_58161_RXN-721_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5215,7 +5286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5223,25 +5294,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002333_CPLX3O-23_SULFITE-REDUCT-RXN_controller_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTAGLY-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5249,11 +5309,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5264,23 +5324,34 @@
           <http://model.geneontology.org/CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000001926_CPLX3O-23_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001926> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5288,11 +5359,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5307,11 +5378,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5341,7 +5412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5354,37 +5425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_S-ADENMETSYN-RXN_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5392,11 +5433,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5407,41 +5448,27 @@
           <http://model.geneontology.org/YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_S-ADENMETSYN-RXN_location_lociGO_0005829>
+] .
 
 <http://identifiers.org/sgd/S000005221>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_57716_RXN-721_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_456216_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004781>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5451,18 +5478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5473,11 +5489,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_15378_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_15378_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5497,7 +5513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5505,47 +5521,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_35235_CYSTAGLY-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000003387>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/729c2695-f808-4219-b22e-0341111b93bc_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/51d31dc1-87e7-4a90-bcb9-bfc72b411a7f_RXN3O-22>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -5553,7 +5558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5561,14 +5566,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5577,7 +5604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5585,11 +5612,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5600,17 +5627,6 @@
           <http://model.geneontology.org/CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -5618,11 +5634,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5633,26 +5649,15 @@
           <http://model.geneontology.org/CHEBI_57844_HOMOCYSMET-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5663,14 +5668,36 @@
           <http://model.geneontology.org/reaction_CYSTAGLY-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_15377_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_30616_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5681,11 +5708,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5715,7 +5742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5723,15 +5750,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5742,17 +5780,6 @@
           <http://model.geneontology.org/CHEBI_16136_SULFITE-REDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_RXN3O-22>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5762,7 +5789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5770,37 +5797,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_28938_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002413_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5815,11 +5820,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Provides Input For Rule. The relation 'L-homoserine + NAD(P)<sup>+</sup> &larr; L-aspartate 4-semialdehyde + NAD(P)H + H<SUP>+</SUP>' 'null' 'L-homoserine + acetyl-CoA &rarr; <i>O</i>-acetyl-L-homoserine + coenzyme A' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5833,12 +5838,23 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_HOMOCYSMET-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5846,11 +5862,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_15361_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_15361_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5861,15 +5877,26 @@
           <http://model.geneontology.org/CHEBI_15361_CYSTATHIONINE-BETA-LYASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5884,11 +5911,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002333_YPR167C-MONOMER_1.8.4.8-RXN_controller_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002333_YPR167C-MONOMER_1.8.4.8-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5899,59 +5926,15 @@
           <http://model.geneontology.org/YPR167C-MONOMER_1.8.4.8-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_30616_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5962,15 +5945,26 @@
           <http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_57716_RXN-721_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_57716_RXN-721_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5981,6 +5975,20 @@
           <http://model.geneontology.org/CHEBI_57716_RXN-721>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002333_YPR167C-MONOMER_1.8.4.8-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0003871>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_16134_CYSTAGLY-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16134> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5990,7 +5998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5998,41 +6006,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0003871>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/CHEBI_17359>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Provides Input For Rule. The relation 'L-homocysteine + L-serine &harr; L-cystathionine + H<sub>2</sub>O' 'null' 'L-cystathionine + H<sub>2</sub>O &harr; 2-oxobutanoate + L-cysteine + ammonia' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTAGLY-RXN_SGD_YeastPathways_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CYSTATHIONINE-BETA-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CYSTAGLY-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_58140_HOMOCYSMET-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58140> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6043,13 +6040,43 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule31478> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Provides Input For Rule. The relation 'L-homocysteine + L-serine &harr; L-cystathionine + H<sub>2</sub>O' 'null' 'L-cystathionine + H<sub>2</sub>O &harr; 2-oxobutanoate + L-cysteine + ammonia' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTAGLY-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CYSTATHIONINE-BETA-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CYSTAGLY-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000066_reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30089>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6063,7 +6090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6078,7 +6105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6090,11 +6117,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6105,14 +6132,14 @@
           <http://model.geneontology.org/CHEBI_57535_ASPARTATEKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000066_reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6121,18 +6148,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_17359_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6145,7 +6183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6153,53 +6191,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16189>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/59488dab-f557-4b04-bf29-2cfd2318665d_RXN3O-22>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule30990> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_Red-Thioredoxin_1.8.4.8-RXN_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6212,7 +6245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6224,11 +6257,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6239,6 +6272,17 @@
           <http://model.geneontology.org/CHEBI_13392_HOMOSERDEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57716> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6248,7 +6292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6263,7 +6307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6278,7 +6322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6293,11 +6337,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6312,11 +6356,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6327,21 +6371,18 @@
           <http://model.geneontology.org/reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58161>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_35235_CYSTAGLY-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_16763>
+<http://purl.obolibrary.org/obo/CHEBI_58161>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN>
@@ -6353,7 +6394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6361,15 +6402,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002233_CHEBI_57716_RXN-721_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16763>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6380,26 +6435,15 @@
           <http://model.geneontology.org/CHEBI_58339_ADENYLYLSULFKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6410,26 +6454,15 @@
           <http://model.geneontology.org/YeastPathways_PWY-821-1/YeastPathways_PWY-821-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6440,14 +6473,25 @@
           <http://model.geneontology.org/CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_58161_RXN-721_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6455,11 +6499,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_BFO_0000066_reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6474,11 +6518,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_Red-Thioredoxin_1.8.4.8-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6489,14 +6533,14 @@
           <http://model.geneontology.org/Red-Thioredoxin_1.8.4.8-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_17359_1.8.4.8-RXN_SGD_YeastPathways_PWY-821-1>
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6507,7 +6551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6517,32 +6561,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOSERINE-O-ACETYLTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-aspartate 4-semialdehyde + NADP<sup>+</sup> + phosphate &larr; L-aspartyl-4-phosphate + NADPH + H<SUP>+</SUP>' 'null' 'L-homoserine + NAD(P)<sup>+</sup> &larr; L-aspartate 4-semialdehyde + NAD(P)H + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6557,11 +6582,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6572,16 +6597,24 @@
           <http://model.geneontology.org/CHEBI_15377_S-ADENMETSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HOMOSERINE-O-ACETYLTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller>
+] .
 
 <http://purl.obolibrary.org/obo/GO_0004414>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6595,7 +6628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6603,18 +6636,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002413_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6634,7 +6675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6642,37 +6683,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_30089_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_30089_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6690,7 +6712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -6698,15 +6720,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6717,43 +6750,21 @@
           <http://model.geneontology.org/YeastPathways_PWY-821-1/YeastPathways_PWY-821-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002413_HOMOCYSMET-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_59789>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_13392>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6763,14 +6774,3 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-901.ttl
+++ b/models/YeastPathways_PWY-901.ttl
@@ -1,11 +1,22 @@
-<http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002234_CHEBI_57474_GLYOXI-RXN_SGD_YeastPathways_PWY-901>
+<http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002234_CHEBI_57925_GLYOXII-RXN_SGD_PWY_YeastPathways_PWY-901>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-901" ;
+                "SGD_PWY:PWY-901" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002234_CHEBI_57474_GLYOXI-RXN_SGD_PWY_YeastPathways_PWY-901>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16,11 +27,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002333_YDR272W-MONOMER_GLYOXII-RXN_controller_SGD_YeastPathways_PWY-901> ;
+          <http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002333_YDR272W-MONOMER_GLYOXII-RXN_controller_SGD_PWY_YeastPathways_PWY-901> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,11 +49,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002234_CHEBI_57474_GLYOXI-RXN_SGD_YeastPathways_PWY-901> ;
+          <http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002234_CHEBI_57474_GLYOXI-RXN_SGD_PWY_YeastPathways_PWY-901> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -93,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -101,23 +112,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002234_CHEBI_57925_GLYOXII-RXN_SGD_YeastPathways_PWY-901>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-901" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_GLYOXI-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -144,15 +144,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002234_CHEBI_16004_GLYOXII-RXN_SGD_PWY_YeastPathways_PWY-901>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-901" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002234_CHEBI_57925_GLYOXII-RXN_SGD_YeastPathways_PWY-901> ;
+          <http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002234_CHEBI_57925_GLYOXII-RXN_SGD_PWY_YeastPathways_PWY-901> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -168,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -181,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -193,11 +204,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002233_CHEBI_57925_GLYOXI-RXN_SGD_YeastPathways_PWY-901> ;
+          <http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002233_CHEBI_57925_GLYOXI-RXN_SGD_PWY_YeastPathways_PWY-901> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -208,17 +219,6 @@
           <http://model.geneontology.org/CHEBI_57925_GLYOXI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002233_CHEBI_57925_GLYOXI-RXN_SGD_YeastPathways_PWY-901>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-901" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -228,41 +228,30 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLYOXI-RXN_BFO_0000066_reaction_GLYOXI-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-901>
+<http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002333_YML004C-MONOMER_GLYOXI-RXN_controller_SGD_PWY_YeastPathways_PWY-901>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-901" ;
+                "SGD_PWY:PWY-901" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002233_CHEBI_57925_GLYOXI-RXN_SGD_PWY_YeastPathways_PWY-901>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002234_CHEBI_15378_GLYOXII-RXN_SGD_YeastPathways_PWY-901>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-901" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002234_CHEBI_16004_GLYOXII-RXN_SGD_YeastPathways_PWY-901>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-901" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -271,11 +260,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOXII-RXN_BFO_0000066_reaction_GLYOXII-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-901> ;
+          <http://model.geneontology.org/ev_w_id_GLYOXII-RXN_BFO_0000066_reaction_GLYOXII-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-901> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -286,14 +275,14 @@
           <http://model.geneontology.org/reaction_GLYOXII-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002413_GLYOXII-RXN_SGD_YeastPathways_PWY-901>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002233_CHEBI_15377_GLYOXII-RXN_SGD_PWY_YeastPathways_PWY-901>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-901" ;
+                "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -304,11 +293,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002234_CHEBI_16004_GLYOXII-RXN_SGD_YeastPathways_PWY-901> ;
+          <http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002234_CHEBI_16004_GLYOXII-RXN_SGD_PWY_YeastPathways_PWY-901> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -319,15 +308,26 @@
           <http://model.geneontology.org/CHEBI_16004_GLYOXII-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002233_CHEBI_57474_GLYOXI-RXN_SGD_PWY_YeastPathways_PWY-901>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-901" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002233_CHEBI_17158_GLYOXI-RXN_SGD_YeastPathways_PWY-901> ;
+          <http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002233_CHEBI_17158_GLYOXI-RXN_SGD_PWY_YeastPathways_PWY-901> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,6 +338,9 @@
           <http://model.geneontology.org/CHEBI_17158_GLYOXI-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://model.geneontology.org/CHEBI_57925_GLYOXII-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57925> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -347,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -364,7 +367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -372,17 +375,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002233_CHEBI_17158_GLYOXI-RXN_SGD_YeastPathways_PWY-901>
+<http://model.geneontology.org/ev_w_id_GLYOXII-RXN_BFO_0000066_reaction_GLYOXII-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-901>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-901" ;
+                "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -426,7 +426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -437,21 +437,43 @@
 <http://purl.obolibrary.org/obo/GO_0004462>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLYOXI-RXN_BFO_0000066_reaction_GLYOXI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-901>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-901" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57925>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002333_YOR040W-MONOMER_GLYOXII-RXN_controller_SGD_PWY_YeastPathways_PWY-901>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-901" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOXII-RXN_BFO_0000050_YeastPathways_PWY-901/YeastPathways_PWY-901_SGD_YeastPathways_PWY-901> ;
+          <http://model.geneontology.org/ev_w_id_GLYOXII-RXN_BFO_0000050_YeastPathways_PWY-901/YeastPathways_PWY-901_SGD_PWY_YeastPathways_PWY-901> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,11 +488,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002234_CHEBI_15378_GLYOXII-RXN_SGD_YeastPathways_PWY-901> ;
+          <http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002234_CHEBI_15378_GLYOXII-RXN_SGD_PWY_YeastPathways_PWY-901> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -481,18 +503,15 @@
           <http://model.geneontology.org/CHEBI_15378_GLYOXII-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57474>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOXI-RXN_BFO_0000066_reaction_GLYOXI-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-901> ;
+          <http://model.geneontology.org/ev_w_id_GLYOXI-RXN_BFO_0000066_reaction_GLYOXI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-901> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,16 +522,8 @@
           <http://model.geneontology.org/reaction_GLYOXI-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002333_YDR272W-MONOMER_GLYOXII-RXN_controller_SGD_YeastPathways_PWY-901>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-901" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57474>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YOR040W-MONOMER_GLYOXII-RXN_controller>
         a       <http://identifiers.org/sgd/S000005566> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -521,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -538,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -546,10 +557,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002333_YDR272W-MONOMER_GLYOXII-RXN_controller_SGD_PWY_YeastPathways_PWY-901>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-901" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://identifiers.org/sgd/S000004463>
@@ -559,11 +584,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>R</i>)-<i>S</i>-lactoylglutathione &larr; methylglyoxal + glutathione' 'null' '(<i>R</i>)-<i>S</i>-lactoylglutathione + H<sub>2</sub>O &rarr; glutathione + (<i>R</i>)-lactate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002413_GLYOXII-RXN_SGD_YeastPathways_PWY-901> ;
+          <http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002413_GLYOXII-RXN_SGD_PWY_YeastPathways_PWY-901> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,8 +599,16 @@
           <http://model.geneontology.org/GLYOXII-RXN>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_GLYOXI-RXN_BFO_0000050_YeastPathways_PWY-901/YeastPathways_PWY-901_SGD_PWY_YeastPathways_PWY-901>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-901" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_GLYOXII-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -586,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -606,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -614,14 +647,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002333_YML004C-MONOMER_GLYOXI-RXN_controller_SGD_YeastPathways_PWY-901>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002413_GLYOXII-RXN_SGD_PWY_YeastPathways_PWY-901>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-901" ;
+                "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -629,11 +662,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002233_CHEBI_57474_GLYOXI-RXN_SGD_YeastPathways_PWY-901> ;
+          <http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002233_CHEBI_57474_GLYOXI-RXN_SGD_PWY_YeastPathways_PWY-901> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -648,11 +681,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOXI-RXN_BFO_0000050_YeastPathways_PWY-901/YeastPathways_PWY-901_SGD_YeastPathways_PWY-901> ;
+          <http://model.geneontology.org/ev_w_id_GLYOXI-RXN_BFO_0000050_YeastPathways_PWY-901/YeastPathways_PWY-901_SGD_PWY_YeastPathways_PWY-901> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,14 +696,14 @@
           <http://model.geneontology.org/YeastPathways_PWY-901/YeastPathways_PWY-901>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002233_CHEBI_57474_GLYOXI-RXN_SGD_YeastPathways_PWY-901>
+<http://model.geneontology.org/ev_w_id_GLYOXII-RXN_BFO_0000050_YeastPathways_PWY-901/YeastPathways_PWY-901_SGD_PWY_YeastPathways_PWY-901>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-901" ;
+                "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -680,53 +713,20 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLYOXII-RXN_BFO_0000066_reaction_GLYOXII-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-901>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-901" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002333_YOR040W-MONOMER_GLYOXII-RXN_controller_SGD_YeastPathways_PWY-901>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-901" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_17158>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLYOXII-RXN_BFO_0000050_YeastPathways_PWY-901/YeastPathways_PWY-901_SGD_YeastPathways_PWY-901>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-901" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOXI-RXN_BFO_0000050_YeastPathways_PWY-901/YeastPathways_PWY-901_SGD_YeastPathways_PWY-901>
+<http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002234_CHEBI_15378_GLYOXII-RXN_SGD_PWY_YeastPathways_PWY-901>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-901" ;
+                "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -742,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "methylglyoxal catabolism - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -754,11 +754,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002333_YOR040W-MONOMER_GLYOXII-RXN_controller_SGD_YeastPathways_PWY-901> ;
+          <http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002333_YOR040W-MONOMER_GLYOXII-RXN_controller_SGD_PWY_YeastPathways_PWY-901> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -776,11 +776,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002333_YML004C-MONOMER_GLYOXI-RXN_controller_SGD_YeastPathways_PWY-901> ;
+          <http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002333_YML004C-MONOMER_GLYOXI-RXN_controller_SGD_PWY_YeastPathways_PWY-901> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,14 +791,14 @@
           <http://model.geneontology.org/YML004C-MONOMER_GLYOXI-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002233_CHEBI_15377_GLYOXII-RXN_SGD_YeastPathways_PWY-901>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLYOXI-RXN_RO_0002233_CHEBI_17158_GLYOXI-RXN_SGD_PWY_YeastPathways_PWY-901>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-901" ;
+                "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -806,11 +806,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002233_CHEBI_15377_GLYOXII-RXN_SGD_YeastPathways_PWY-901> ;
+          <http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002233_CHEBI_15377_GLYOXII-RXN_SGD_PWY_YeastPathways_PWY-901> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -834,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-922.ttl
+++ b/models/YeastPathways_PWY-922.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -19,11 +19,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002333_YMR220W-MONOMER_PHOSPHOMEVALONATE-KINASE-RXN_controller_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002333_YMR220W-MONOMER_PHOSPHOMEVALONATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -34,26 +34,15 @@
           <http://model.geneontology.org/YMR220W-MONOMER_PHOSPHOMEVALONATE-KINASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002333_YPL117C-MONOMER_IPPISOM-RXN_controller_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'acetoacetyl-CoA + acetyl-CoA + H<sub>2</sub>O &harr; (<i>S</i>)-3-hydroxy-3-methylglutaryl-CoA + coenzyme A + H<SUP>+</SUP>' 'null' '(<i>R</i>)-mevalonate + coenzyme A + 2 NADP<sup>+</sup> &harr; (<i>S</i>)-3-hydroxy-3-methylglutaryl-CoA + 2 NADPH + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002413_1.1.1.34-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002413_1.1.1.34-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -68,11 +57,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" , "Provides Input For Rule. The relation '2 acetyl-CoA &harr; acetoacetyl-CoA + coenzyme A' 'null' 'acetoacetyl-CoA + acetyl-CoA + H<sub>2</sub>O &harr; (<i>S</i>)-3-hydroxy-3-methylglutaryl-CoA + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002413_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002413_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -93,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -108,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -128,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -136,14 +125,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YML075C-MONOMER_1.1.1.34-RXN_controller_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -153,26 +153,15 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_IPPISOM-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_57287_1.1.1.34-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_57287_1.1.1.34-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -183,15 +172,26 @@
           <http://model.geneontology.org/CHEBI_57287_1.1.1.34-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_MEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -202,17 +202,6 @@
           <http://model.geneontology.org/CHEBI_30616_MEVALONATE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57623_IPPISOM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57623> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -222,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,11 +223,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,14 +238,25 @@
           <http://model.geneontology.org/CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_58349_1.1.1.34-RXN_SGD_YeastPathways_PWY-922>
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002233_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-922>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -265,6 +265,17 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -275,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -286,14 +297,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_36464>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY-922>
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002333_YPL117C-MONOMER_IPPISOM-RXN_controller_SGD_PWY_YeastPathways_PWY-922>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -307,7 +318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -317,13 +328,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000066_reaction_PHOSPHOMEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000066_reaction_PHOSPHOMEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "mevalonate pathway I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -355,11 +366,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57288_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57288_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,6 +380,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57288_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -392,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -404,11 +426,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -436,24 +458,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-922BiochemicalReaction74529> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002413_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -465,24 +476,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-922Protein74568> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005949>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -491,11 +491,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000066_reaction_1.1.1.34-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000066_reaction_1.1.1.34-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,15 +506,26 @@
           <http://model.geneontology.org/reaction_1.1.1.34-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_15378_1.1.1.34-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002233_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002233_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -525,14 +536,14 @@
           <http://model.geneontology.org/CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922>
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY-922>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -555,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -563,26 +574,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YML075C-MONOMER_1.1.1.34-RXN_controller_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YML075C-MONOMER_1.1.1.34-RXN_controller_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -593,15 +593,26 @@
           <http://model.geneontology.org/YML075C-MONOMER_1.1.1.34-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002413_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_MEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -619,11 +630,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" , "Provides Input For Rule. The relation '(R)-mevalonate diphosphate + ATP &rarr; CO<SUB>2</SUB> + isopentenyl diphosphate + ADP + phosphate' 'null' 'isopentenyl diphosphate &harr; dimethylallyl diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_IPPISOM-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_IPPISOM-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -637,17 +648,6 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57288_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57288> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -657,24 +657,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-922SmallMolecule74828> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002333_YNR043W-MONOMER_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57286> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -685,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -693,15 +682,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002333_YNR043W-MONOMER_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_36464_1.1.1.34-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -721,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -733,11 +744,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_57287_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_57287_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -751,26 +762,15 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_15377_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -784,17 +784,6 @@
 <http://identifiers.org/sgd/S000005326>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57287_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57287> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -804,35 +793,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-922SmallMolecule74739> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000066_reaction_1.1.1.34-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000066_reaction_IPPISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY-922/YeastPathways_PWY-922>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0010142> ;
@@ -841,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -858,7 +825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -870,11 +837,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_57783_1.1.1.34-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_57783_1.1.1.34-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -892,11 +859,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -911,11 +878,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,6 +893,17 @@
           <http://model.geneontology.org/CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002413_1.1.1.34-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_MEVALONATE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -935,7 +913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -943,41 +921,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_15378_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002233_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002333_YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_15378_MEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58146>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -985,26 +941,15 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" , "Provides Input For Rule. The relation '(<i>R</i>)-mevalonate + ATP &harr; (<i>R</i>)-mevalonate 5-phosphate + ADP + H<SUP>+</SUP>' 'null' '(<i>R</i>)-mevalonate 5-phosphate + ATP &harr; (R)-mevalonate diphosphate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002413_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002413_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,15 +960,26 @@
           <http://model.geneontology.org/PHOSPHOMEVALONATE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_15377_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_15377_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1034,22 +990,44 @@
           <http://model.geneontology.org/CHEBI_15377_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_IPPISOM-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000066_reaction_IPPISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004833>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1058,11 +1036,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" , "Provides Input For Rule. The relation '(<i>R</i>)-mevalonate 5-phosphate + ATP &harr; (R)-mevalonate diphosphate + ADP' 'null' '(R)-mevalonate diphosphate + ATP &rarr; CO<SUB>2</SUB> + isopentenyl diphosphate + ADP + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002413_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002413_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1073,14 +1051,14 @@
           <http://model.geneontology.org/DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002413_MEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_57287_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1088,11 +1066,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1107,11 +1085,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1122,43 +1100,65 @@
           <http://model.geneontology.org/YeastPathways_PWY-922/YeastPathways_PWY-922>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_YeastPathways_PWY-922>
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_PWY_YeastPathways_PWY-922>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000066_reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000006038>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_YeastPathways_PWY-922>
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_PWY_YeastPathways_PWY-922>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002234_CHEBI_57623_IPPISOM-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_58349_1.1.1.34-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_58349_1.1.1.34-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1178,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1186,14 +1186,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002333_YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1201,11 +1212,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_36464_1.1.1.34-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_36464_1.1.1.34-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1220,11 +1231,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_456216_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_456216_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1235,14 +1246,25 @@
           <http://model.geneontology.org/CHEBI_456216_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000066_reaction_PHOSPHOMEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-922>
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_58349_1.1.1.34-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_15377_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-922>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1251,6 +1273,17 @@
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_57783_1.1.1.34-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1267,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1279,11 +1312,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1294,15 +1327,26 @@
           <http://model.geneontology.org/CHEBI_30616_PHOSPHOMEVALONATE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YLR450W-MONOMER_1.1.1.34-RXN_controller_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_15378_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_15378_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1313,26 +1357,15 @@
           <http://model.geneontology.org/CHEBI_15378_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1343,14 +1376,14 @@
           <http://model.geneontology.org/CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002333_YML126C-MONOMER_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1366,7 +1399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1393,13 +1426,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-922BiochemicalReaction74571> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1408,11 +1452,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_15378_1.1.1.34-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_15378_1.1.1.34-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1423,15 +1467,26 @@
           <http://model.geneontology.org/CHEBI_15378_1.1.1.34-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002234_CHEBI_57623_IPPISOM-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002234_CHEBI_57623_IPPISOM-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1446,11 +1501,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1461,12 +1516,23 @@
           <http://model.geneontology.org/CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_36464_1.1.1.34-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_PHOSPHOMEVALONATE-KINASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1476,6 +1542,17 @@
 <http://purl.obolibrary.org/obo/GO_0010142>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1483,11 +1560,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" , "Provides Input For Rule. The relation '(<i>R</i>)-mevalonate + coenzyme A + 2 NADP<sup>+</sup> &harr; (<i>S</i>)-3-hydroxy-3-methylglutaryl-CoA + 2 NADPH + 2 H<SUP>+</SUP>' 'null' '(<i>R</i>)-mevalonate + ATP &harr; (<i>R</i>)-mevalonate 5-phosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002413_MEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002413_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1503,7 +1580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1511,11 +1588,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1530,11 +1607,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1545,62 +1622,40 @@
           <http://model.geneontology.org/YeastPathways_PWY-922/YeastPathways_PWY-922>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY-922>
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_PWY_YeastPathways_PWY-922>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_36464_1.1.1.34-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000066_reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_128769>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_57287_1.1.1.34-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1615,11 +1670,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002333_YML126C-MONOMER_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002333_YML126C-MONOMER_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1649,7 +1704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1666,7 +1721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1678,11 +1733,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002333_YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002333_YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1699,17 +1754,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000066_reaction_MEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller>
         a       <http://identifiers.org/sgd/S000005949> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1717,7 +1761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1728,14 +1772,25 @@
 <http://purl.obolibrary.org/obo/GO_0004496>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002234_CHEBI_57623_IPPISOM-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002413_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1758,7 +1813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1766,15 +1821,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_15378_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_36464_1.1.1.34-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_36464_1.1.1.34-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1785,17 +1851,6 @@
           <http://model.geneontology.org/CHEBI_36464_1.1.1.34-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_456216_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57287_1.1.1.34-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57287> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1805,7 +1860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1817,11 +1872,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000066_reaction_MEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000066_reaction_MEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1832,15 +1887,26 @@
           <http://model.geneontology.org/reaction_MEVALONATE-KINASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1860,7 +1926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1868,30 +1934,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57288_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57288>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_15378_1.1.1.34-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57783_1.1.1.34-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
@@ -1902,7 +1946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1919,7 +1963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1939,38 +1983,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-922SmallMolecule74611> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_57783_1.1.1.34-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000004442>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1981,7 +2000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1996,7 +2015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2004,40 +2023,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/GO_0004420>
+<http://identifiers.org/sgd/S000004442>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002413_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002413_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004420>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2052,11 +2052,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2076,7 +2076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2084,15 +2084,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2103,47 +2114,25 @@
           <http://model.geneontology.org/YeastPathways_PWY-922/YeastPathways_PWY-922>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000066_reaction_1.1.1.34-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002413_1.1.1.34-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2151,11 +2140,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2173,7 +2162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2181,15 +2170,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_43474_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000066_reaction_IPPISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_BFO_0000066_reaction_IPPISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2204,11 +2204,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000066_reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000066_reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2219,6 +2219,39 @@
           <http://model.geneontology.org/reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002333_YMR220W-MONOMER_PHOSPHOMEVALONATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002413_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57288_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000004821>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2226,11 +2259,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YLR450W-MONOMER_1.1.1.34-RXN_controller_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YLR450W-MONOMER_1.1.1.34-RXN_controller_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2245,11 +2278,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_15378_MEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_15378_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2260,14 +2293,14 @@
           <http://model.geneontology.org/CHEBI_15378_MEVALONATE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922>
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_BFO_0000066_reaction_PHOSPHOMEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-922>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2275,11 +2308,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002333_YNR043W-MONOMER_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002333_YNR043W-MONOMER_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2302,7 +2335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2315,55 +2348,55 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002333_YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002234_CHEBI_57287_1.1.1.34-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YLR450W-MONOMER_1.1.1.34-RXN_controller_SGD_YeastPathways_PWY-922>
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_PWY_YeastPathways_PWY-922>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_MEVALONATE-KINASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_456216_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2371,11 +2404,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2386,26 +2419,15 @@
           <http://model.geneontology.org/CHEBI_58146_MEVALONATE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_15378_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2415,6 +2437,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004421> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2435,13 +2479,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-922BiochemicalReaction74782> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002333_YPL028W-MONOMER_ACETYL-COA-ACETYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_PHOSPHOMEVALONATE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -2452,7 +2507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2469,7 +2524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2481,11 +2536,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57286_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2504,7 +2559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2513,7 +2568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2524,11 +2579,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2543,11 +2598,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002333_YPL117C-MONOMER_IPPISOM-RXN_controller_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002333_YPL117C-MONOMER_IPPISOM-RXN_controller_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2565,11 +2620,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2587,7 +2642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2598,17 +2653,28 @@
 <http://identifiers.org/sgd/S000004595>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_57286>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YML075C-MONOMER_1.1.1.34-RXN_controller_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002333_YML126C-MONOMER_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57286>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002413_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2618,26 +2684,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_57557>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_456216_MEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002333_YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002333_YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2657,7 +2712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2669,11 +2724,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY-922> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-922> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2684,30 +2739,8 @@
           <http://model.geneontology.org/reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_MEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000004540>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_MEVALONATE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2718,7 +2751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2726,58 +2759,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY-922>
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY-922>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002333_YMR220W-MONOMER_PHOSPHOMEVALONATE-KINASE-RXN_controller_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000050_YeastPathways_PWY-922/YeastPathways_PWY-922_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002233_CHEBI_36464_1.1.1.34-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_57287_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2786,17 +2775,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_30616_PHOSPHOMEVALONATE-KINASE-RXN_SGD_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-922" ;
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000066_reaction_MEVALONATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY0-162.ttl
+++ b/models/YeastPathways_PWY0-162.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,25 +20,14 @@
 <http://identifiers.org/sgd/S000001507>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002413_RXN-9929_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -46,11 +35,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_32814_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -60,17 +49,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_32814_ASPCARBTRANS-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003666>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -84,35 +62,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY0-162SmallMolecule61499> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000066_reaction_RXN-9929_location_lociGO_0005829_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15378_DIHYDROOROT-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29991>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -121,11 +77,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -148,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -160,11 +116,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -184,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -192,14 +148,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -207,11 +174,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -235,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -247,11 +214,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -262,14 +229,25 @@
           <http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY0-162>
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -280,11 +258,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -298,14 +276,14 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -313,11 +291,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,14 +306,14 @@
           <http://model.geneontology.org/CHEBI_30616_RXN-12002>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30031_RXN-9929_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -348,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -361,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -369,11 +347,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -402,29 +380,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0009220>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_58017_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY0-162>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0009220>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -435,26 +413,15 @@
           <http://model.geneontology.org/YKL216W-MONOMER_RXN-9929_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -468,14 +435,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_30031>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_YeastPathways_PWY0-162>
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -483,11 +450,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -510,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -518,30 +485,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_YeastPathways_PWY0-162>
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15378_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58228>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57538> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -552,24 +508,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY0-162SmallMolecule61620> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -593,13 +538,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY0-162BiochemicalReaction61645> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30031_RXN-9929_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -613,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -621,14 +588,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -641,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -653,11 +620,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,26 +635,15 @@
           <http://model.geneontology.org/CHEBI_57865_OROTPDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -698,15 +654,26 @@
           <http://model.geneontology.org/CHEBI_43474_ASPCARBTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -717,40 +684,29 @@
           <http://model.geneontology.org/CHEBI_58359_CTPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_30839>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000066_reaction_RXN-9929_location_lociGO_0005829_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000066_reaction_RXN-9929_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -761,14 +717,14 @@
           <http://model.geneontology.org/reaction_RXN-9929_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_YeastPathways_PWY0-162>
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -781,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -789,15 +745,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15377_DIHYDROOROT-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15377_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -808,26 +775,15 @@
           <http://model.geneontology.org/CHEBI_15377_DIHYDROOROT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -838,28 +794,28 @@
           <http://model.geneontology.org/CHEBI_17544_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_YeastPathways_PWY0-162>
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -867,11 +823,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -885,8 +841,30 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58223>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_CTPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -897,7 +875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -909,11 +887,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" , "Provides Input For Rule. The relation 'orotidine 5'-phosphate + diphosphate &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + orotate' 'null' 'orotidine 5'-phosphate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + UMP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002413_OROTPDECARB-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002413_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -928,11 +906,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -955,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -966,14 +944,14 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15377_DIHYDROOROT-RXN_SGD_YeastPathways_PWY0-162>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -981,11 +959,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1008,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1016,26 +994,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_OROTPDECARB-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1046,15 +1013,26 @@
           <http://model.geneontology.org/CHEBI_57865_OROTPDECARB-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,25 +1043,14 @@
           <http://model.geneontology.org/YBL039C-MONOMER_CTPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY0-162>
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1092,37 +1059,19 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/YLR420W-MONOMER_DIHYDROOROT-RXN_controller>
-        a       <http://identifiers.org/sgd/S000004412> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "dihydrooratase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY0-162Protein61710> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" , "Provides Input For Rule. The relation '(<i>S</i>)-dihydroorotate + fumarate &rarr; orotate + succinate' 'null' 'orotidine 5'-phosphate + diphosphate &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + orotate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002413_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002413_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1133,6 +1082,35 @@
           <http://model.geneontology.org/OROPRIBTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/YLR420W-MONOMER_DIHYDROOROT-RXN_controller>
+        a       <http://identifiers.org/sgd/S000004412> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "dihydrooratase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY0-162Protein61710> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_CTPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1142,7 +1120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1153,15 +1131,26 @@
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_30839_RXN-9929_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_30839_RXN-9929_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1179,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1191,11 +1180,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1206,26 +1195,15 @@
           <http://model.geneontology.org/CHEBI_456216_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1241,40 +1219,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_57538_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162>
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15377_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_YeastPathways_PWY0-162>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1282,11 +1249,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_58017_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_58017_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1304,7 +1271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1319,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1334,11 +1301,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1358,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of pyrimidine ribonucleotides <i>de novo</i> biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1375,24 +1342,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY0-162SmallMolecule61580> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29888_OROPRIBTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
@@ -1403,7 +1359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1411,15 +1367,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1439,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1447,26 +1414,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1481,11 +1437,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1501,6 +1457,17 @@
 
 <http://purl.obolibrary.org/obo/GO_0004151>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/OROTPDECARB-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004590> ;
@@ -1521,24 +1488,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY0-162BiochemicalReaction61606> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_RXN-12002>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1549,7 +1505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1557,23 +1513,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN-9929_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1581,11 +1526,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1615,7 +1560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1642,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1650,23 +1595,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_OROPRIBTRANS-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1674,11 +1608,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_30864_DIHYDROOROT-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1698,13 +1632,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY0-162SmallMolecule61515> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29806>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1713,11 +1658,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1728,17 +1673,6 @@
           <http://model.geneontology.org/CHEBI_30616_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_CTPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1748,7 +1682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1756,14 +1690,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_OROTPDECARB-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002413_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1775,7 +1709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1783,11 +1717,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" , "Provides Input For Rule. The relation 'UDP + ATP &rarr; UTP + ADP' 'null' 'L-glutamine + UTP + ATP + H<sub>2</sub>O &rarr; ADP + CTP + L-glutamate + phosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1801,17 +1735,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_RXN-12002_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30031_RXN-9929>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30031> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1821,7 +1744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1833,11 +1756,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1848,26 +1771,15 @@
           <http://model.geneontology.org/YeastPathways_PWY0-162/YeastPathways_PWY0-162>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1878,51 +1790,18 @@
           <http://model.geneontology.org/YeastPathways_PWY0-162/YeastPathways_PWY0-162>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1932,6 +1811,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_29991_ASPCARBTRANS-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CTPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003883> ;
@@ -1950,7 +1840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1962,11 +1852,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1977,47 +1867,14 @@
           <http://model.geneontology.org/CHEBI_456216_RXN-12002>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY0-162>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2025,11 +1882,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2047,7 +1904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2067,35 +1924,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY0-162SmallMolecule61484> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YEL021W-MONOMER_OROTPDECARB-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000747> ;
@@ -2104,13 +1939,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY0-162Protein61642> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30839_RXN-9929_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004127>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2124,7 +1970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2144,7 +1990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2155,6 +2001,17 @@
 <http://purl.obolibrary.org/obo/GO_0004550>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_RXN-12002_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YKL216W-MONOMER_RXN-9929_controller>
         a       <http://identifiers.org/sgd/S000001699> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2162,7 +2019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2170,26 +2027,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_29806_RXN-9929_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2204,11 +2050,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_29888_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2219,6 +2065,17 @@
           <http://model.geneontology.org/CHEBI_29888_OROPRIBTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29806_RXN-9929>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29806> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2228,7 +2085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2236,15 +2093,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2254,17 +2122,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_1990663>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2277,7 +2134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2285,11 +2142,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" , "Provides Input For Rule. The relation 'orotidine 5'-phosphate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + UMP' 'null' 'ATP + UMP &rarr; ADP + UDP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2304,11 +2161,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" , "Provides Input For Rule. The relation 'L-aspartate + carbamoyl phosphate &harr; <i>N</i>-carbamoyl-L-aspartate + phosphate + H<SUP>+</SUP>' 'null' '(<i>S</i>)-dihydroorotate + H<sub>2</sub>O &harr; <i>N</i>-carbamoyl-L-aspartate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002413_DIHYDROOROT-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002413_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2323,11 +2180,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2338,14 +2195,14 @@
           <http://model.geneontology.org/CHEBI_29985_CTPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2371,7 +2228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2382,6 +2239,28 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_58017_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2391,7 +2270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2403,11 +2282,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2418,19 +2297,19 @@
           <http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY0-162>
+<http://identifiers.org/sgd/S000004574>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000004574>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58359_CTPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58359> ;
@@ -2441,7 +2320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2453,11 +2332,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2468,25 +2347,14 @@
           <http://model.geneontology.org/YLR420W-MONOMER_DIHYDROOROT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2497,11 +2365,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2512,12 +2380,23 @@
           <http://model.geneontology.org/CHEBI_58359_CARBPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000003870_CPLX3O-887_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003870> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2540,7 +2419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2557,7 +2436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2565,36 +2444,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_YeastPathways_PWY0-162>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2602,11 +2459,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2622,7 +2479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2630,11 +2487,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2645,14 +2502,14 @@
           <http://model.geneontology.org/reaction_CTPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_YeastPathways_PWY0-162>
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2665,7 +2522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2677,11 +2534,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2701,7 +2558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2728,7 +2585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2736,26 +2593,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2770,11 +2616,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2785,14 +2631,25 @@
           <http://model.geneontology.org/YeastPathways_PWY0-162/YeastPathways_PWY0-162>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY0-162>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2803,11 +2660,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2823,7 +2680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2836,7 +2693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2848,11 +2705,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2866,15 +2723,26 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2885,26 +2753,15 @@
           <http://model.geneontology.org/YeastPathways_PWY0-162/YeastPathways_PWY0-162>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2921,15 +2778,26 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_57538_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2940,19 +2808,19 @@
           <http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_456216_UDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -2963,7 +2831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2975,11 +2843,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2990,14 +2858,14 @@
           <http://model.geneontology.org/YJL130C-MONOMER_CARBPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3013,7 +2881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3028,11 +2896,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3043,26 +2911,15 @@
           <http://model.geneontology.org/YeastPathways_PWY0-162/YeastPathways_PWY0-162>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3073,39 +2930,6 @@
           <http://model.geneontology.org/CHEBI_37563_CTPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_30839_RXN-9929_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_ASPCARBTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3115,7 +2939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3123,17 +2947,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000003870>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002413_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003870>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3144,7 +2979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3156,11 +2991,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30031_RXN-9929_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30031_RXN-9929_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3171,26 +3006,15 @@
           <http://model.geneontology.org/CHEBI_30031_RXN-9929>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" , "Provides Input For Rule. The relation '(<i>S</i>)-dihydroorotate + H<sub>2</sub>O &harr; <i>N</i>-carbamoyl-L-aspartate + H<SUP>+</SUP>' 'null' '(<i>S</i>)-dihydroorotate + fumarate &rarr; orotate + succinate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002413_RXN-9929_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002413_RXN-9929_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3201,6 +3025,17 @@
           <http://model.geneontology.org/RXN-9929>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_RXN-12002>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3210,7 +3045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3222,11 +3057,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3237,6 +3072,17 @@
           <http://model.geneontology.org/CHEBI_15378_CARBPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YKL024C-MONOMER_RXN-12002_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001507> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3244,7 +3090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3261,7 +3107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3273,11 +3119,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3288,17 +3134,6 @@
           <http://model.geneontology.org/CHEBI_15378_OROTPDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_OROTPDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3308,7 +3143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3320,11 +3155,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3335,14 +3170,14 @@
           <http://model.geneontology.org/CHEBI_15377_CTPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_YeastPathways_PWY0-162>
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3350,11 +3185,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3368,54 +3203,76 @@
 <http://identifiers.org/sgd/S000003864>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002413_RXN-9929_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_30864_DIHYDROOROT-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_YeastPathways_PWY0-162>
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" , "Provides Input For Rule. The relation 'ATP + UMP &rarr; ADP + UDP' 'null' 'UDP + ATP &rarr; UTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3426,6 +3283,17 @@
           <http://model.geneontology.org/UDPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58228_CARBPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58228> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3435,7 +3303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3443,26 +3311,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002413_DIHYDROOROT-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15378_DIHYDROOROT-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15378_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3472,6 +3329,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_DIHYDROOROT-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/UDPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004550> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3490,24 +3358,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY0-162BiochemicalReaction61531> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30839_RXN-9929_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3516,11 +3373,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3540,7 +3397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3548,14 +3405,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_30839_RXN-9929_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002413_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3563,11 +3431,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_RXN-12002_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_RXN-12002_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3582,11 +3450,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3600,17 +3468,28 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_46398>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_YeastPathways_PWY0-162>
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3618,11 +3497,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 ATP + L-glutamine + hydrogencarbonate + H<sub>2</sub>O &rarr; L-glutamate + carbamoyl phosphate + 2 ADP + phosphate + 2 H<SUP>+</SUP>' 'null' 'L-aspartate + carbamoyl phosphate &harr; <i>N</i>-carbamoyl-L-aspartate + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3641,22 +3520,55 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3667,26 +3579,15 @@
           <http://model.geneontology.org/reaction_RXN-12002_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3697,21 +3598,57 @@
           <http://model.geneontology.org/CHEBI_43474_CTPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9929_BFO_0000066_reaction_RXN-9929_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0003883>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000001699>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30839_RXN-9929_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002234_CHEBI_30839_RXN-9929_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3722,8 +3659,16 @@
           <http://model.geneontology.org/CHEBI_30839_RXN-9929>
 ] .
 
-<http://identifiers.org/sgd/S000001699>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004588>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3738,11 +3683,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3753,15 +3698,70 @@
           <http://model.geneontology.org/YeastPathways_PWY0-162/YeastPathways_PWY0-162>
 ] .
 
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3772,28 +3772,39 @@
           <http://model.geneontology.org/CHEBI_29985_CARBPSYN-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000004884>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002413_OROTPDECARB-RXN_SGD_YeastPathways_PWY0-162>
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002413_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004884>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_YeastPathways_PWY0-162/YeastPathways_PWY0-162_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3801,11 +3812,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3816,14 +3827,14 @@
           <http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_32814_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
+                "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3831,11 +3842,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3855,7 +3866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3863,15 +3874,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3885,26 +3907,15 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_UDPKIN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3915,15 +3926,26 @@
           <http://model.geneontology.org/CHEBI_32814_ASPCARBTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-162>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-162" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_UDPKIN-RXN_SGD_YeastPathways_PWY0-162> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_UDPKIN-RXN_SGD_PWY_YeastPathways_PWY0-162> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3934,30 +3956,8 @@
           <http://model.geneontology.org/CHEBI_46398_UDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000000747>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_29888_OROPRIBTRANS-RXN_SGD_YeastPathways_PWY0-162>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-162" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57865_OROTPDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57865> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3968,7 +3968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY0-662.ttl
+++ b/models/YeastPathways_PWY0-662.ttl
@@ -1,40 +1,26 @@
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YBL068W-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PWY0-662>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YBL068W-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY0-662>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-662" ;
+                "SGD_PWY:PWY0-662" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000901>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YKL181W-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PWY0-662>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-662" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004749>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_15378_PRPPSYN-RXN_SGD_YeastPathways_PWY0-662> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_15378_PRPPSYN-RXN_SGD_PWY_YeastPathways_PWY0-662> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,25 +31,28 @@
           <http://model.geneontology.org/CHEBI_15378_PRPPSYN-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0004749>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_456215_PRPPSYN-RXN_SGD_PWY_YeastPathways_PWY0-662>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-662" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000000164>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_456215_PRPPSYN-RXN_SGD_YeastPathways_PWY0-662>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-662" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YKL181W-MONOMER_PRPPSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000001664> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -72,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -89,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -106,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,25 +109,14 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_58017_PRPPSYN-RXN_SGD_YeastPathways_PWY0-662>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-662" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000066_reaction_PRPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY0-662>
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YER099C-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY0-662>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-662" ;
+                "SGD_PWY:PWY0-662" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -149,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -161,11 +139,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_78346_PRPPSYN-RXN_SGD_YeastPathways_PWY0-662> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_78346_PRPPSYN-RXN_SGD_PWY_YeastPathways_PWY0-662> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -210,7 +188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -225,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -244,7 +222,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_30616_PRPPSYN-RXN_SGD_PWY_YeastPathways_PWY0-662>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-662" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -255,11 +244,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YER099C-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PWY0-662> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YER099C-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY0-662> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -273,48 +262,15 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000050_YeastPathways_PWY0-662/YeastPathways_PWY0-662_SGD_YeastPathways_PWY0-662>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-662" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_15378_PRPPSYN-RXN_SGD_YeastPathways_PWY0-662>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-662" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YER099C-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PWY0-662>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-662" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_30616_PRPPSYN-RXN_SGD_YeastPathways_PWY0-662> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_30616_PRPPSYN-RXN_SGD_PWY_YeastPathways_PWY0-662> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -340,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -357,7 +313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "PRPP biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -368,17 +324,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_30616_PRPPSYN-RXN_SGD_YeastPathways_PWY0-662>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-662" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -386,11 +331,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YBL068W-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PWY0-662> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YBL068W-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY0-662> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -408,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -416,26 +361,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YOL061W-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PWY0-662>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-662" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YOL061W-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PWY0-662> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YOL061W-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY0-662> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -453,11 +387,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000066_reaction_PRPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY0-662> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000066_reaction_PRPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-662> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -485,14 +419,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YHL011C-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PWY0-662>
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000050_YeastPathways_PWY0-662/YeastPathways_PWY0-662_SGD_PWY_YeastPathways_PWY0-662>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-662" ;
+                "SGD_PWY:PWY0-662" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YOL061W-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY0-662>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-662" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -503,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -521,11 +466,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_58017_PRPPSYN-RXN_SGD_YeastPathways_PWY0-662> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_58017_PRPPSYN-RXN_SGD_PWY_YeastPathways_PWY0-662> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,15 +487,26 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YKL181W-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY0-662>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-662" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YKL181W-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PWY0-662> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YKL181W-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY0-662> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -561,14 +517,14 @@
           <http://model.geneontology.org/YKL181W-MONOMER_PRPPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_78346_PRPPSYN-RXN_SGD_YeastPathways_PWY0-662>
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_58017_PRPPSYN-RXN_SGD_PWY_YeastPathways_PWY0-662>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-662" ;
+                "SGD_PWY:PWY0-662" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -576,11 +532,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000050_YeastPathways_PWY0-662/YeastPathways_PWY0-662_SGD_YeastPathways_PWY0-662> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000050_YeastPathways_PWY0-662/YeastPathways_PWY0-662_SGD_PWY_YeastPathways_PWY0-662> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -590,6 +546,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY0-662/YeastPathways_PWY0-662>
 ] .
+
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_78346_PRPPSYN-RXN_SGD_PWY_YeastPathways_PWY0-662>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-662" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_15378_PRPPSYN-RXN_SGD_PWY_YeastPathways_PWY0-662>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-662" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -602,6 +580,17 @@
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YHL011C-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY0-662>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-662" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -616,7 +605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -628,11 +617,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_456215_PRPPSYN-RXN_SGD_YeastPathways_PWY0-662> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_456215_PRPPSYN-RXN_SGD_PWY_YeastPathways_PWY0-662> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -650,11 +639,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YHL011C-MONOMER_PRPPSYN-RXN_controller_SGD_YeastPathways_PWY0-662> ;
+          <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002333_YHL011C-MONOMER_PRPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY0-662> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,3 +659,14 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_BFO_0000066_reaction_PRPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY0-662>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY0-662" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-0.ttl
+++ b/models/YeastPathways_PWY3O-0.ttl
@@ -1,3 +1,14 @@
+<http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002333_YGL253W-MONOMER_RXN3O-9790_controller_SGD_PWY_YeastPathways_PWY3O-0>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-0" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-0/YeastPathways_PWY3O-0>
         a       <http://purl.obolibrary.org/obo/GO_0006001> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7,24 +18,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY3O-0" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_RXN-14812_RO_0002234_CHEBI_57634_RXN-14812_SGD_YeastPathways_PWY3O-0>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-0" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_RXN3O-9790>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -47,11 +47,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9790_BFO_0000050_YeastPathways_PWY3O-0/YeastPathways_PWY3O-0_SGD_YeastPathways_PWY3O-0> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9790_BFO_0000050_YeastPathways_PWY3O-0/YeastPathways_PWY3O-0_SGD_PWY_YeastPathways_PWY3O-0> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,11 +62,66 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-0/YeastPathways_PWY3O-0>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002333_YFR053C-MONOMER_RXN3O-9790_controller_SGD_PWY_YeastPathways_PWY3O-0>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-0" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-14812_BFO_0000050_YeastPathways_PWY3O-0/YeastPathways_PWY3O-0_SGD_PWY_YeastPathways_PWY3O-0>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-0" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002233_CHEBI_15824_RXN3O-9790_SGD_PWY_YeastPathways_PWY3O-0>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-0" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9790_BFO_0000050_YeastPathways_PWY3O-0/YeastPathways_PWY3O-0_SGD_PWY_YeastPathways_PWY3O-0>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-0" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9790_BFO_0000066_reaction_RXN3O-9790_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-0>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-0" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57579_RXN3O-9790>
         a       <http://purl.obolibrary.org/obo/CHEBI_57579> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -77,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -100,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -112,11 +167,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" , "Provides Input For Rule. The relation 'D-fructose + ATP &rarr; <i>keto</i>-D-fructose 6-phosphate + ADP + H<SUP>+</SUP>' 'null' '<i>keto</i>-D-fructose 6-phosphate &harr; &beta;-D-fructofuranose 6-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002413_RXN-14812_SGD_YeastPathways_PWY3O-0> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002413_RXN-14812_SGD_PWY_YeastPathways_PWY3O-0> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -131,11 +186,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14812_RO_0002234_CHEBI_57634_RXN-14812_SGD_YeastPathways_PWY3O-0> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14812_RO_0002234_CHEBI_57634_RXN-14812_SGD_PWY_YeastPathways_PWY3O-0> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -146,14 +201,14 @@
           <http://model.geneontology.org/CHEBI_57634_RXN-14812>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002233_CHEBI_30616_RXN3O-9790_SGD_YeastPathways_PWY3O-0>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002413_RXN-14812_SGD_PWY_YeastPathways_PWY3O-0>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-0" ;
+                "SGD_PWY:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -175,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -186,17 +241,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57634>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9790_BFO_0000066_reaction_RXN3O-9790_location_lociGO_0005829_SGD_YeastPathways_PWY3O-0>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-0" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -204,11 +248,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002234_CHEBI_15378_RXN3O-9790_SGD_YeastPathways_PWY3O-0> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002234_CHEBI_15378_RXN3O-9790_SGD_PWY_YeastPathways_PWY3O-0> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -226,11 +270,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002333_YGL253W-MONOMER_RXN3O-9790_controller_SGD_YeastPathways_PWY3O-0> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002333_YGL253W-MONOMER_RXN3O-9790_controller_SGD_PWY_YeastPathways_PWY3O-0> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -245,11 +289,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14812_RO_0002233_CHEBI_57579_RXN3O-9790_SGD_YeastPathways_PWY3O-0> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14812_RO_0002233_CHEBI_57579_RXN3O-9790_SGD_PWY_YeastPathways_PWY3O-0> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,56 +307,23 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-14812_RO_0002233_CHEBI_57579_RXN3O-9790_SGD_YeastPathways_PWY3O-0>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-0" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002413_RXN-14812_SGD_YeastPathways_PWY3O-0>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-0" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-14812_BFO_0000050_YeastPathways_PWY3O-0/YeastPathways_PWY3O-0_SGD_YeastPathways_PWY3O-0>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-0" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002333_YFR053C-MONOMER_RXN3O-9790_controller_SGD_YeastPathways_PWY3O-0>
+<http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002234_CHEBI_57579_RXN3O-9790_SGD_PWY_YeastPathways_PWY3O-0>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-0" ;
+                "SGD_PWY:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -320,11 +331,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002233_CHEBI_30616_RXN3O-9790_SGD_YeastPathways_PWY3O-0> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002233_CHEBI_30616_RXN3O-9790_SGD_PWY_YeastPathways_PWY3O-0> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -344,13 +355,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-0SmallMolecule26763> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002234_CHEBI_456216_RXN3O-9790_SGD_PWY_YeastPathways_PWY3O-0>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-0" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0006001>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -359,11 +381,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002333_YFR053C-MONOMER_RXN3O-9790_controller_SGD_YeastPathways_PWY3O-0> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002333_YFR053C-MONOMER_RXN3O-9790_controller_SGD_PWY_YeastPathways_PWY3O-0> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -374,14 +396,14 @@
           <http://model.geneontology.org/YFR053C-MONOMER_RXN3O-9790_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002234_CHEBI_15378_RXN3O-9790_SGD_YeastPathways_PWY3O-0>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002233_CHEBI_30616_RXN3O-9790_SGD_PWY_YeastPathways_PWY3O-0>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-0" ;
+                "SGD_PWY:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -389,11 +411,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14812_BFO_0000066_reaction_RXN-14812_location_lociGO_0005829_SGD_YeastPathways_PWY3O-0> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14812_BFO_0000066_reaction_RXN-14812_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-0> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,23 +426,34 @@
           <http://model.geneontology.org/reaction_RXN-14812_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-14812_BFO_0000066_reaction_RXN-14812_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-0>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-0" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-14812_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002333_YGL253W-MONOMER_RXN3O-9790_controller_SGD_YeastPathways_PWY3O-0>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002234_CHEBI_15378_RXN3O-9790_SGD_PWY_YeastPathways_PWY3O-0>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-0" ;
+                "SGD_PWY:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -448,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -463,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -477,18 +510,15 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://identifiers.org/sgd/S000001949>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002233_CHEBI_15824_RXN3O-9790_SGD_YeastPathways_PWY3O-0> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002233_CHEBI_15824_RXN3O-9790_SGD_PWY_YeastPathways_PWY3O-0> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -499,39 +529,20 @@
           <http://model.geneontology.org/CHEBI_15824_RXN3O-9790>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002234_CHEBI_57579_RXN3O-9790_SGD_YeastPathways_PWY3O-0>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-0" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000001949>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_RXN3O-9790_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002233_CHEBI_15824_RXN3O-9790_SGD_YeastPathways_PWY3O-0>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-0" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGL253W-MONOMER_RXN3O-9790_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003222> ;
@@ -540,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -552,11 +563,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002234_CHEBI_57579_RXN3O-9790_SGD_YeastPathways_PWY3O-0> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002234_CHEBI_57579_RXN3O-9790_SGD_PWY_YeastPathways_PWY3O-0> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -571,11 +582,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14812_BFO_0000050_YeastPathways_PWY3O-0/YeastPathways_PWY3O-0_SGD_YeastPathways_PWY3O-0> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14812_BFO_0000050_YeastPathways_PWY3O-0/YeastPathways_PWY3O-0_SGD_PWY_YeastPathways_PWY3O-0> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,11 +600,33 @@
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-14812_RO_0002233_CHEBI_57579_RXN3O-9790_SGD_PWY_YeastPathways_PWY3O-0>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-0" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-14812_RO_0002234_CHEBI_57634_RXN-14812_SGD_PWY_YeastPathways_PWY3O-0>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-0" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -617,7 +650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -638,11 +671,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9790_BFO_0000066_reaction_RXN3O-9790_location_lociGO_0005829_SGD_YeastPathways_PWY3O-0> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9790_BFO_0000066_reaction_RXN3O-9790_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-0> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -653,17 +686,6 @@
           <http://model.geneontology.org/reaction_RXN3O-9790_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-14812_BFO_0000066_reaction_RXN-14812_location_lociGO_0005829_SGD_YeastPathways_PWY3O-0>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-0" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_RXN3O-9790>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -673,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -681,40 +703,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9790_BFO_0000050_YeastPathways_PWY3O-0/YeastPathways_PWY3O-0_SGD_YeastPathways_PWY3O-0>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-0" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002234_CHEBI_456216_RXN3O-9790_SGD_YeastPathways_PWY3O-0>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-0" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002234_CHEBI_456216_RXN3O-9790_SGD_YeastPathways_PWY3O-0> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9790_RO_0002234_CHEBI_456216_RXN3O-9790_SGD_PWY_YeastPathways_PWY3O-0> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -737,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fructose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-1.ttl
+++ b/models/YeastPathways_PWY3O-1.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,26 +17,15 @@
           <http://model.geneontology.org/CHEBI_58017_GUANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_43474_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'AMP + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + adenine' 'null' 'AMP + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; IMP + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -47,14 +36,25 @@
           <http://model.geneontology.org/AMP-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002333_YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller_SGD_YeastPathways_PWY3O-1>
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_16235_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_16708_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -62,11 +62,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,6 +77,17 @@
           <http://model.geneontology.org/CHEBI_28938_ADENINE-DEAMINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16335_ADENOSINE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16335> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -86,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -103,35 +114,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1SmallMolecule47452> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004498>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -142,26 +131,15 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15378_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -176,11 +154,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002333_YML035C-MONOMER_AMP-DEAMINASE-RXN_controller_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002333_YML035C-MONOMER_AMP-DEAMINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -191,15 +169,26 @@
           <http://model.geneontology.org/YML035C-MONOMER_AMP-DEAMINASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002333_YJR133W-MONOMER_XANPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_15378_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_15378_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -210,17 +199,6 @@
           <http://model.geneontology.org/CHEBI_15378_ADENOSINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002333_YJR133W-MONOMER_XANPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY3O-1>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -230,7 +208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of purines and their nucleosides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -238,44 +216,44 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_17368_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1>
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_28938_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_YeastPathways_PWY3O-1>
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_15377>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000005085> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -284,13 +262,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1Protein47459> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_ADENINE-DEAMINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -301,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -309,14 +298,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -324,11 +313,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_17368_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_17368_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -339,15 +328,26 @@
           <http://model.geneontology.org/CHEBI_17368_INOPHOSPHOR-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002333_YLR209C-MONOMER_INOPHOSPHOR-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002333_MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002333_MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -358,15 +358,26 @@
           <http://model.geneontology.org/MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002413_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,13 +397,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1SmallMolecule47371> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15377_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -401,11 +423,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000066_reaction_ADENINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000066_reaction_ADENINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -415,50 +437,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_ADENINE-DEAMINASE-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58115_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_30616_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -475,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -492,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -504,11 +482,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -519,15 +497,26 @@
           <http://model.geneontology.org/CHEBI_29888_XANPRIBOSYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_HYPOXANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -545,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -557,11 +546,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15377_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15377_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,37 +561,70 @@
           <http://model.geneontology.org/CHEBI_15377_AMP-DEAMINASE-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000002849>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_57720_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-1>
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_58053_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000002849>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_GUANINE-DEAMINASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1>
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000066_reaction_ADENOSINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002333_YML035C-MONOMER_AMP-DEAMINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -615,7 +637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -631,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -644,24 +666,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1SmallMolecule47602> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -670,11 +681,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -689,11 +700,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -728,11 +739,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002333_YJR105W-MONOMER_ADENOSINE-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002333_YJR105W-MONOMER_ADENOSINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -745,39 +756,6 @@
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_17368_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17368_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ADENINE-DEAMINASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0000034> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -798,7 +776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -806,14 +784,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_456215_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000066_reaction_GUANINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -826,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -834,15 +823,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'inosine + phosphate &rarr; &alpha;-D-ribose-1-phosphate + hypoxanthine' 'null' 'IMP + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + hypoxanthine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -853,17 +853,6 @@
           <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16708_ADENINE-DEAMINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16708> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -873,7 +862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -885,11 +874,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -907,11 +896,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -925,15 +914,26 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002333_MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_16708_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_16708_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,58 +961,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_28938_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_YeastPathways_PWY3O-1>
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_PWY_YeastPathways_PWY3O-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008892>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0000310>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_57464_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1>
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0000310>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_30616_ADENOSINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -1023,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1035,11 +1013,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_HYPOXANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_HYPOXANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1060,11 +1038,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_28938_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_28938_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1075,26 +1053,15 @@
           <http://model.geneontology.org/CHEBI_28938_AMP-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_16335_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_16335_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1114,13 +1081,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1SmallMolecule47386> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_16335_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_ADENOSINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -1131,7 +1131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1151,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1166,11 +1166,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_17596_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_17596_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1188,7 +1188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1196,15 +1196,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456216_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1220,7 +1231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1228,11 +1239,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000066_reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000066_reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1243,20 +1254,64 @@
           <http://model.geneontology.org/reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_43474_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0000034>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000004199>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15377_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1>
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000066_reaction_INOPHOSPHOR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1272,7 +1327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1280,14 +1335,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1295,11 +1350,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1315,7 +1370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1326,7 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1338,11 +1393,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1353,15 +1408,26 @@
           <http://model.geneontology.org/CHEBI_29888_GUANPRIBOSYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1381,13 +1447,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1SmallMolecule47477> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15378_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004001>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1396,11 +1473,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002333_YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002333_YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1411,25 +1488,47 @@
           <http://model.geneontology.org/YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1>
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_57464_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1>
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_57720_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000066_reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_456215_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1442,7 +1541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1450,28 +1549,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000066_reaction_ADENOSINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YML022W-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-1>
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_PWY_YeastPathways_PWY3O-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1479,11 +1567,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1498,11 +1586,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1513,26 +1601,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-1/YeastPathways_PWY3O-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_16235_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456215_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456215_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1542,6 +1619,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_456215_ADENOSINE-KINASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_17368_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004422> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1562,35 +1650,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1BiochemicalReaction47326> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16235_GUANPRIBOSYLTRAN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16235> ;
@@ -1601,7 +1667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1628,7 +1694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1648,32 +1714,32 @@
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0003876>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16708_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16708_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0003876>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0004422>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_57720_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_57720_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1683,6 +1749,9 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57720_INOPHOSPHOR-RXN>
 ] .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0000310> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1701,7 +1770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1726,7 +1795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1734,18 +1803,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/GO_0004422>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'guanine + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; ammonium + xanthine' 'null' 'XMP + diphosphate &larr; xanthine + 5-phospho-&alpha;-D-ribose 1-diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002413_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002413_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1756,15 +1822,26 @@
           <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002333_YJR105W-MONOMER_ADENOSINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1774,17 +1851,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_29888_ADENPRIBOSYLTRAN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002333_YLR209C-MONOMER_INOPHOSPHOR-RXN_controller_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1798,7 +1864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1810,11 +1876,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1828,14 +1894,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456216_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1848,7 +1914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1856,46 +1922,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_15378_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_57464_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_57464_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1906,6 +1941,15 @@
           <http://model.geneontology.org/CHEBI_57464_XANPRIBOSYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000002397> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1913,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1925,11 +1969,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002411_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002411_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1940,6 +1984,17 @@
           <http://model.geneontology.org/GUANINE-DEAMINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58115>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1947,11 +2002,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15378_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15378_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1966,11 +2021,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1981,6 +2036,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-1/YeastPathways_PWY3O-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_17596_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-1/YeastPathways_PWY3O-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0043101> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1990,7 +2056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1998,39 +2064,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16708>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002333_YML035C-MONOMER_AMP-DEAMINASE-RXN_controller_SGD_YeastPathways_PWY3O-1>
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_16335_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2041,11 +2096,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2060,11 +2115,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2075,26 +2130,15 @@
           <http://model.geneontology.org/CHEBI_15378_GUANINE-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'adenosine + ATP &rarr; AMP + ADP + H<SUP>+</SUP>' 'null' 'AMP + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; IMP + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2105,6 +2149,17 @@
           <http://model.geneontology.org/AMP-DEAMINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456215_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_ADENOSINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2114,7 +2169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2125,6 +2180,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_57464>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_28938_ADENINE-DEAMINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_28938> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2134,7 +2200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2146,11 +2212,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2161,6 +2227,28 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-1/YeastPathways_PWY3O-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58017_GUANPRIBOSYLTRAN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58017> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2170,7 +2258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2182,11 +2270,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16235_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16235_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2197,26 +2285,15 @@
           <http://model.geneontology.org/CHEBI_16235_GUANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_HYPOXANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YML022W-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YML022W-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2231,11 +2308,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_17368_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_17368_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2271,35 +2348,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1BiochemicalReaction47612> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_16708_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005085>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2316,7 +2371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2324,14 +2379,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_17368_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-1>
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2339,11 +2394,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17368_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17368_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2354,26 +2409,15 @@
           <http://model.geneontology.org/CHEBI_17368_ADENINE-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_58053_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_58053_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2384,26 +2428,15 @@
           <http://model.geneontology.org/CHEBI_58053_AMP-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002333_MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_30616_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_30616_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2414,25 +2447,14 @@
           <http://model.geneontology.org/CHEBI_30616_ADENOSINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_58053_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2445,7 +2467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2462,7 +2484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2479,7 +2501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2490,25 +2512,14 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000066_reaction_INOPHOSPHOR-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456215_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-1>
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_PWY_YeastPathways_PWY3O-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2524,7 +2535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2536,11 +2547,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_43474_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_43474_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2555,11 +2566,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2573,15 +2584,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_16235>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16708_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16708_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2595,37 +2617,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_17712>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000066_reaction_GUANINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2635,6 +2635,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-1/YeastPathways_PWY3O-1>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YML022W-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16335>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2648,7 +2659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2665,7 +2676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2677,11 +2688,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2696,11 +2707,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58115_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58115_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2720,7 +2731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2732,11 +2743,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000066_reaction_AMP-DEAMINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000066_reaction_AMP-DEAMINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2747,37 +2758,15 @@
           <http://model.geneontology.org/reaction_AMP-DEAMINASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" , "Provides Input For Rule. The relation 'adenine + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; ammonium + hypoxanthine' 'null' 'IMP + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + hypoxanthine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2788,25 +2777,47 @@
           <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002411_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1>
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000066_reaction_ADENINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17368_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000066_reaction_AMP-DEAMINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2814,11 +2825,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2829,26 +2840,15 @@
           <http://model.geneontology.org/CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000066_reaction_GUANINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000066_reaction_GUANINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2863,11 +2863,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456216_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456216_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2881,30 +2881,19 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000066_reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1>
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002849> ;
@@ -2913,7 +2902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2928,7 +2917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2948,7 +2937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2956,12 +2945,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_ADENINE-DEAMINASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2970,7 +2970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2978,11 +2978,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002333_YLR209C-MONOMER_INOPHOSPHOR-RXN_controller_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002333_YLR209C-MONOMER_INOPHOSPHOR-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2997,11 +2997,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3031,7 +3031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3043,11 +3043,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3058,12 +3058,23 @@
           <http://model.geneontology.org/CHEBI_456215_ADENPRIBOSYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002333_YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_INOPHOSPHOR-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3071,11 +3082,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3086,14 +3097,25 @@
           <http://model.geneontology.org/CHEBI_15378_ADENINE-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-1>
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16235_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_15378_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3106,7 +3128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3123,7 +3145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3138,7 +3160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3146,40 +3168,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0043101>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000066_reaction_ADENINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002333_YJR133W-MONOMER_XANPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002333_YJR133W-MONOMER_XANPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3197,11 +3208,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3212,26 +3223,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-1/YeastPathways_PWY3O-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_456215_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_456215_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3246,11 +3246,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000066_reaction_ADENOSINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000066_reaction_ADENOSINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3261,6 +3261,17 @@
           <http://model.geneontology.org/reaction_ADENOSINE-KINASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_30616_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002807> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3268,7 +3279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3276,30 +3287,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002333_YJR105W-MONOMER_ADENOSINE-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000003894>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000066_reaction_AMP-DEAMINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16708_ADENPRIBOSYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16708> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3310,7 +3299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3322,11 +3311,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000066_reaction_INOPHOSPHOR-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000066_reaction_INOPHOSPHOR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3336,6 +3325,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_INOPHOSPHOR-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/AMP-DEAMINASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003876> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3354,7 +3354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3366,11 +3366,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_16235_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_16235_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3381,14 +3381,14 @@
           <http://model.geneontology.org/CHEBI_16235_GUANINE-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002413_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002411_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3399,7 +3399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3414,11 +3414,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-1/YeastPathways_PWY3O-1_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3429,42 +3429,42 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-1/YeastPathways_PWY3O-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004731>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_58053>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16235_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-1>
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58115_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_17596_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_58053>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
+                "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3487,7 +3487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3500,7 +3500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3508,11 +3508,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-10.ttl
+++ b/models/YeastPathways_PWY3O-10.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002333_YKL182W-MONOMER_RXN-9515_controller_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002333_YKL182W-MONOMER_RXN-9515_controller_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,14 +17,14 @@
           <http://model.geneontology.org/YKL182W-MONOMER_RXN-9515_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002413_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -32,11 +32,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -47,26 +47,15 @@
           <http://model.geneontology.org/ACP_MALONYL-COA-ACP-TRANSACYL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_43474_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_43474_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,32 +69,43 @@
 <http://identifiers.org/sgd/S000005299>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -120,11 +120,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_15378_RXN-9514_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_15378_RXN-9514_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -135,37 +135,15 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-9514>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -182,25 +160,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002333_YKL182W-MONOMER_RXN-9515_controller_SGD_YeastPathways_PWY3O-10>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-10>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-10>
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000066_reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-10>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -208,11 +186,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.58-RXN_controller_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.58-RXN_controller_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -227,11 +205,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -242,26 +220,15 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-9515>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,28 +239,6 @@
           <http://model.geneontology.org/SGD_S000005299_CPLX3O-8_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_ACP_RXN-9514_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -301,11 +246,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-CARBOXYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-CARBOXYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -316,25 +261,14 @@
           <http://model.geneontology.org/reaction_ACETYL-COA-CARBOXYLTRANSFER-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_Crotonyl-ACPs_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -347,7 +281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -358,6 +292,17 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57783_RXN-9515>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -367,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -384,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -392,26 +337,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_15378_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -422,26 +356,15 @@
           <http://model.geneontology.org/ACP_ACP-S-ACETYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,14 +375,14 @@
           <http://model.geneontology.org/YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_43474_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10>
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_RXN-9514_SGD_PWY_YeastPathways_PWY3O-10>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -472,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -499,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -512,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -521,34 +444,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000863>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57384>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -557,11 +458,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -576,11 +477,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_58349_RXN-9514_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_58349_RXN-9514_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -591,17 +492,6 @@
           <http://model.geneontology.org/CHEBI_58349_RXN-9514>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -609,11 +499,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -627,25 +517,25 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_58349_RXN-9514_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -658,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -666,14 +556,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -684,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -696,11 +586,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_Butanoyl-ACPs_RXN-9515_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_Butanoyl-ACPs_RXN-9515_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -715,11 +605,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -733,25 +623,14 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10>
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-10>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -764,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -772,26 +651,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_15378_RXN-9514_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -802,14 +670,47 @@
           <http://model.geneontology.org/CHEBI_57288_ACETYL-COA-CARBOXYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-10>
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-10>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_57783_RXN-9514_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -817,11 +718,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -839,11 +740,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000066_reaction_RXN-9514_location_lociGO_0005829_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000066_reaction_RXN-9514_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -858,11 +759,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" , "Provides Input For Rule. The relation 'acetyl-CoA + ATP + hydrogencarbonate &rarr; ADP + malonyl-CoA + phosphate + H<SUP>+</SUP>' 'null' 'acyl-carrier protein + malonyl-CoA &rarr; a malonyl-[acp] + coenzyme A' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002413_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002413_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -873,14 +774,14 @@
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_456216_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -896,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -904,14 +805,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -924,7 +825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -935,26 +836,15 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -967,32 +857,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" , "Provides Input For Rule. The relation 'acyl-carrier protein + acetyl-CoA &rarr; an acetyl-[acp] + coenzyme A' 'null' 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-10> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ACP-S-ACETYLTRANSFER-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1006,16 +877,24 @@
 <http://identifiers.org/sgd/S000005747>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" , "Provides Input For Rule. The relation 'acyl-carrier protein + acetyl-CoA &rarr; an acetyl-[acp] + coenzyme A' 'null' 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ACP-S-ACETYLTRANSFER-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN>
+] .
 
 <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000006152> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1024,7 +903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1032,23 +911,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000005299_CPLX3O-8_component>
         a       <http://identifiers.org/sgd/S000005299> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1058,6 +937,17 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YKL182W-MONOMER_4.2.1.58-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001665> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1065,7 +955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1077,11 +967,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1092,17 +982,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-10/YeastPathways_PWY3O-10>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1112,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1120,15 +999,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1139,26 +1029,15 @@
           <http://model.geneontology.org/CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000066_reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_456216_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_456216_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1169,46 +1048,46 @@
           <http://model.geneontology.org/CHEBI_456216_ACETYL-COA-CARBOXYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-CARBOXYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004314>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_ACP_RXN-9514_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000004820>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1219,15 +1098,26 @@
           <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_15378_RXN-9514_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_57783_RXN-9514_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_57783_RXN-9514_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1248,7 +1138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1260,11 +1150,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1294,7 +1184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1314,7 +1204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1340,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1357,7 +1247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1365,15 +1255,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O' 'null' 'a (2<i>E</i>)-but-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a butanoyl-[acp] + NADP<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1387,26 +1288,15 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1417,15 +1307,26 @@
           <http://model.geneontology.org/CHEBI_57783_RXN-9515>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1445,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1457,11 +1358,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_17544_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_17544_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1475,50 +1376,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000066_reaction_RXN-9515_location_lociGO_0005829_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_15378_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_Butanoyl-ACPs_RXN-9515_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1526,11 +1405,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1541,14 +1420,14 @@
           <http://model.geneontology.org/ACP_MALONYL-COA-ACP-TRANSACYL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-10>
+<http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000066_reaction_RXN-9514_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-10>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1556,11 +1435,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" , "Provides Input For Rule. The relation 'acyl-carrier protein + malonyl-CoA &rarr; a malonyl-[acp] + coenzyme A' 'null' 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1581,11 +1460,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1595,6 +1474,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001665>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1608,24 +1498,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-10Protein16279> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_58349_RXN-9514_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1639,7 +1518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1651,11 +1530,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1675,7 +1554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1688,7 +1567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1696,11 +1575,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1711,16 +1590,46 @@
           <http://model.geneontology.org/YPL231W-MONOMER_RXN-9514_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000004820_CPLX3O-102_component_SGD_YeastPathways_PWY3O-10>
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-10>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ACP-S-ACETYLTRANSFER-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57287_ACP-S-ACETYLTRANSFER-RXN>
+] .
 
 <http://model.geneontology.org/RXN-9514>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1741,7 +1650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1749,44 +1658,47 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ACP-S-ACETYLTRANSFER-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_ACP-S-ACETYLTRANSFER-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_456216_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-10>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-10>
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_PWY_YeastPathways_PWY3O-10>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.58-RXN_controller_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1794,11 +1706,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_CHEBI_58349_RXN-9515_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_CHEBI_58349_RXN-9515_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1816,7 +1728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1824,26 +1736,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1854,12 +1755,23 @@
           <http://model.geneontology.org/CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-CARBOXYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1867,11 +1779,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_15378_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_15378_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1881,17 +1793,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_ACETYL-COA-CARBOXYLTRANSFER-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002333_YKL182W-MONOMER_ACP-S-ACETYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1904,18 +1805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_CHEBI_58349_RXN-9515_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1941,7 +1831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1949,15 +1839,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1968,15 +1869,26 @@
           <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000004820_CPLX3O-102_component_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1991,11 +1903,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2016,7 +1928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2024,29 +1936,62 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000066_reaction_RXN-9514_location_lociGO_0005829_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_CHEBI_58349_RXN-9515_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2066,7 +2011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2074,26 +2019,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000066_reaction_RXN-9515_location_lociGO_0005829_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000066_reaction_RXN-9515_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2104,37 +2038,15 @@
           <http://model.geneontology.org/reaction_RXN-9515_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_RXN-9514_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_57783_RXN-9514_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000004820_CPLX3O-102_component_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000004820_CPLX3O-102_component_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2154,7 +2066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2166,11 +2078,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2181,14 +2093,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-10/YeastPathways_PWY3O-10>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_YeastPathways_PWY3O-10>
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002333_YKL182W-MONOMER_ACP-S-ACETYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-10>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2201,7 +2113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2221,7 +2133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2229,15 +2141,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2251,15 +2174,26 @@
 <http://identifiers.org/sgd/S000006152>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2270,6 +2204,28 @@
           <http://model.geneontology.org/YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2279,7 +2235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2287,15 +2243,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2305,6 +2272,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_43474_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004315>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2318,7 +2296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2326,26 +2304,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' 'null' 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2356,26 +2323,15 @@
           <http://model.geneontology.org/RXN-9514>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_ACP_RXN-9514_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_ACP_RXN-9514_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2405,7 +2361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2413,15 +2369,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2432,8 +2391,16 @@
           <http://model.geneontology.org/CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-10>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -2444,7 +2411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fatty acid biosynthesis, initial steps - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2452,14 +2419,14 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2470,13 +2437,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-10Protein16532> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -2493,7 +2471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2510,24 +2488,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-10SmallMolecule16485> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YPL231W-MONOMER_RXN-9514_controller>
         a       <http://identifiers.org/sgd/S000006152> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2536,13 +2503,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-10Protein16461> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002413_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACP_RXN-9514>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2553,7 +2531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2565,11 +2543,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_Crotonyl-ACPs_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2587,11 +2565,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000066_reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000066_reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2602,37 +2580,15 @@
           <http://model.geneontology.org/reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_Butanoyl-ACPs_RXN-9515_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2648,23 +2604,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002413_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.58-RXN_controller_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACP-S-ACETYLTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2685,7 +2641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2693,15 +2649,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002333_YKL182W-MONOMER_RXN-9515_controller_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000066_reaction_RXN-9515_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2717,7 +2706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2725,11 +2714,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000050_YeastPathways_PWY3O-10/YeastPathways_PWY3O-10_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2744,11 +2733,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2759,36 +2748,47 @@
           <http://model.geneontology.org/CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_YeastPathways_PWY3O-10>
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_17544_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-10>
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002413_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2801,7 +2801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2809,25 +2809,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10>
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_17544_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
+                "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2835,11 +2824,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_RXN-9514_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_RXN-9514_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2859,7 +2848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2871,11 +2860,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" , "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002413_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002413_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2890,11 +2879,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002333_YKL182W-MONOMER_ACP-S-ACETYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-10> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002333_YKL182W-MONOMER_ACP-S-ACETYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-10> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2922,7 +2911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2930,23 +2919,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN-9515_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2959,10 +2937,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-10SmallMolecule16367> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-103.ttl
+++ b/models/YeastPathways_PWY3O-103.ttl
@@ -1,45 +1,12 @@
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_37563_CDPDIGLYSYN-RXN_SGD_YeastPathways_PWY3O-103>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-103" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_fc6f0c06-6458-414f-b835-e6b7e4ac8ab6_CDPDIGLYSYN-RXN_SGD_YeastPathways_PWY3O-103>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-103" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002333_YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller_SGD_YeastPathways_PWY3O-103>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-103" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_37563_CDPDIGLYSYN-RXN_SGD_YeastPathways_PWY3O-103> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_37563_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PWY3O-103> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,6 +26,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000066_reaction_CDPDIGLYSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-103>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-103" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_CHEBI_29888_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PWY3O-103>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-103" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -68,14 +57,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_29089>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_29089_CDPDIGLYSYN-RXN_SGD_YeastPathways_PWY3O-103>
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002333_YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-103>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-103" ;
+                "SGD_PWY:PWY3O-103" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_15378_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PWY3O-103>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -83,11 +83,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_29089_CDPDIGLYSYN-RXN_SGD_YeastPathways_PWY3O-103> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_29089_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PWY3O-103> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,17 +98,6 @@
           <http://model.geneontology.org/CHEBI_29089_CDPDIGLYSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000066_reaction_CDPDIGLYSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-103>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-103" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000000233> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -116,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -133,6 +122,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_37563>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/1f9d521b-d1a4-4309-bdb7-c5d7f9c5e88e_CDPDIGLYSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-103SmallMolecule70439> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -145,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -165,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -180,11 +186,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_15378_CDPDIGLYSYN-RXN_SGD_YeastPathways_PWY3O-103> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_15378_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PWY3O-103> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -194,17 +200,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_CDPDIGLYSYN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_15378_CDPDIGLYSYN-RXN_SGD_YeastPathways_PWY3O-103>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-103" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CDPDIGLYSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004605> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -217,13 +212,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_37563_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_29089_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/fc6f0c06-6458-414f-b835-e6b7e4ac8ab6_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/1f9d521b-d1a4-4309-bdb7-c5d7f9c5e88e_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,18 +229,40 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_1f9d521b-d1a4-4309-bdb7-c5d7f9c5e88e_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PWY3O-103>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-103" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000050_YeastPathways_PWY3O-103/YeastPathways_PWY3O-103_SGD_PWY_YeastPathways_PWY3O-103>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-103" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002333_YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller_SGD_YeastPathways_PWY3O-103> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002333_YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-103> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,11 +280,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000066_reaction_CDPDIGLYSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-103> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000066_reaction_CDPDIGLYSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-103> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -290,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -310,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -321,18 +338,26 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_29089_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PWY3O-103>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-103" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_fc6f0c06-6458-414f-b835-e6b7e4ac8ab6_CDPDIGLYSYN-RXN_SGD_YeastPathways_PWY3O-103> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_1f9d521b-d1a4-4309-bdb7-c5d7f9c5e88e_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PWY3O-103> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -340,25 +365,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CDPDIGLYSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fc6f0c06-6458-414f-b835-e6b7e4ac8ab6_CDPDIGLYSYN-RXN>
+          <http://model.geneontology.org/1f9d521b-d1a4-4309-bdb7-c5d7f9c5e88e_CDPDIGLYSYN-RXN>
 ] .
 
-<http://model.geneontology.org/fc6f0c06-6458-414f-b835-e6b7e4ac8ab6_CDPDIGLYSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-103SmallMolecule70439> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -367,11 +378,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000050_YeastPathways_PWY3O-103/YeastPathways_PWY3O-103_SGD_YeastPathways_PWY3O-103> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000050_YeastPathways_PWY3O-103/YeastPathways_PWY3O-103_SGD_PWY_YeastPathways_PWY3O-103> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -415,11 +426,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_CHEBI_29888_CDPDIGLYSYN-RXN_SGD_YeastPathways_PWY3O-103> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_CHEBI_29888_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PWY3O-103> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -430,28 +441,6 @@
           <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_CHEBI_29888_CDPDIGLYSYN-RXN_SGD_YeastPathways_PWY3O-103>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-103" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000050_YeastPathways_PWY3O-103/YeastPathways_PWY3O-103_SGD_YeastPathways_PWY3O-103>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-103" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY3O-103>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -461,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "CDP-diacylglycerol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -477,7 +466,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_37563_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PWY3O-103>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 

--- a/models/YeastPathways_PWY3O-1109.ttl
+++ b/models/YeastPathways_PWY3O-1109.ttl
@@ -1,12 +1,23 @@
+<http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002413_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_15499_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_15499_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,14 +28,14 @@
           <http://model.geneontology.org/CHEBI_15499_4-COUMARATE--COA-LIGASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002411_RXN3O-1121_SGD_YeastPathways_PWY3O-1109>
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_15378_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -32,11 +43,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -47,14 +58,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30616_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-1118_BFO_0000066_reaction_RXN3O-1118_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -62,11 +73,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,6 +88,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57945_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29748_CHORPYRLY-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29748> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -86,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -94,14 +116,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_15499_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-1109>
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_57287_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -116,29 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_36242_RXN3O-1116_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002413_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-1109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -146,11 +146,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57356_RXN3O-1120_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57356_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -161,26 +161,15 @@
           <http://model.geneontology.org/CHEBI_57356_RXN3O-1120>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_YeastPathways_PWY3O-1109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" , "Provides Input For Rule. The relation '(R)-3-(4-hydroxyphenyl)lactate + NAD<sup>+</sup> &larr; 3-(4-hydroxyphenyl)pyruvate + NADH + H<SUP>+</SUP>' 'null' '(R)-3-(4-hydroxyphenyl)lactate &rarr; 4-coumarate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002413_RXN3O-1118_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002413_RXN3O-1118_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -200,35 +189,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1109SmallMolecule61884> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_456215_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-1109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002233_CHEBI_58315_RXN3O-1116_SGD_YeastPathways_PWY3O-1109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456215_4-COUMARATE--COA-LIGASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456215> ;
@@ -239,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -247,24 +214,46 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002234_CHEBI_30763_RXN3O-1121_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15377>
+<http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_10980>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002234_CHEBI_15361_CHORPYRLY-RXN_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -279,11 +268,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1118_BFO_0000066_reaction_RXN3O-1118_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1118_BFO_0000066_reaction_RXN3O-1118_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -293,6 +282,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN3O-1118_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57288_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/4-COUMARATE--COA-LIGASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0016207> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -326,11 +326,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_BFO_0000066_reaction_CHORPYRLY-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_BFO_0000066_reaction_CHORPYRLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -341,6 +341,17 @@
           <http://model.geneontology.org/reaction_CHORPYRLY-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_BFO_0000066_reaction_RXN3O-1120_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29888_4-COUMARATE--COA-LIGASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -350,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -364,23 +375,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57945_RXN3O-1120_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-1116_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -388,11 +388,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" , "Provides Input For Rule. The relation '4-coumarate + ATP + coenzyme A &rarr; (<i>E</i>)-4-coumaroyl-CoA + AMP + diphosphate' 'null' '(<i>E</i>)-4-coumaroyl-CoA + coenzyme A + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; 4-hydroxybenzoyl-CoA + acetyl-CoA + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002413_RXN3O-1120_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002413_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,15 +403,26 @@
           <http://model.geneontology.org/RXN3O-1120>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1118_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_15499_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_15499_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -439,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -450,25 +461,14 @@
 <http://purl.obolibrary.org/obo/GO_0016207>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002234_CHEBI_15377_RXN3O-1118_SGD_YeastPathways_PWY3O-1109>
+<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002233_CHEBI_29748_CHORPYRLY-RXN_SGD_PWY_YeastPathways_PWY3O-1109>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002234_CHEBI_30763_CHORPYRLY-RXN_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -479,11 +479,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1121_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1121_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,11 +504,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002233_CHEBI_58315_RXN3O-1116_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002233_CHEBI_58315_RXN3O-1116_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,14 +522,14 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002413_RXN3O-1120_SGD_YeastPathways_PWY3O-1109>
+<http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002413_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -542,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -550,25 +550,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1121_BFO_0000066_reaction_RXN3O-1121_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1109>
+<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002411_RXN3O-1121_SGD_PWY_YeastPathways_PWY3O-1109>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002233_CHEBI_57356_RXN3O-1120_SGD_YeastPathways_PWY3O-1109>
+<http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002234_CHEBI_15377_RXN3O-1118_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_15378_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -581,7 +592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -606,7 +617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -618,11 +629,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30616_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30616_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -637,11 +648,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002234_CHEBI_15377_RXN3O-1118_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002234_CHEBI_15377_RXN3O-1118_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -652,6 +663,17 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-1118>
 ] .
 
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002413_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -659,11 +681,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002234_CHEBI_30763_CHORPYRLY-RXN_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002234_CHEBI_30763_CHORPYRLY-RXN_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -683,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -700,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "p-hydroxybenzoate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -715,11 +737,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_15378_RXN3O-1120_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_15378_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -730,26 +752,15 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-1120>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_12876_RXN3O-1118_SGD_YeastPathways_PWY3O-1109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002234_CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002234_CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,12 +779,45 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16134>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1116_BFO_0000066_reaction_RXN3O-1116_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002413_RXN3O-1118_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_29888_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -787,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -795,26 +839,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_15377_RXN3O-1120_SGD_YeastPathways_PWY3O-1109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002233_CHEBI_57356_RXN3O-1120_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002233_CHEBI_57356_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -829,11 +862,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" , "Provides Input For Rule. The relation 'L-tyrosine &rarr; 3-(4-hydroxyphenyl)pyruvate + ammonia' 'null' '(R)-3-(4-hydroxyphenyl)lactate + NAD<sup>+</sup> &larr; 3-(4-hydroxyphenyl)pyruvate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002413_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002413_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -843,28 +876,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002233_CHEBI_57288_RXN3O-1120_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002233_CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -878,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -895,7 +906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -903,15 +914,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002413_RXN3O-1121_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_29888_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_29888_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,11 +948,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_BFO_0000066_reaction_RXN3O-1120_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_BFO_0000066_reaction_RXN3O-1120_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -950,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -967,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -979,11 +1001,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_BFO_0000066_reaction_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_BFO_0000066_reaction_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -993,6 +1015,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57356_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002234_CHEBI_57540_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30763>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1014,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1027,7 +1071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1040,13 +1084,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY3O-1109" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002233_CHEBI_58315_RXN3O-1116_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1060,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1068,15 +1123,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_BFO_0000066_reaction_4-COUMARATE--COA-LIGASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57945_RXN3O-1120_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57945_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1096,7 +1162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1104,26 +1170,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002233_CHEBI_29748_CHORPYRLY-RXN_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1116_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1116_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1133,6 +1188,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109>
 ] .
+
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_BFO_0000066_reaction_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1149,7 +1215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1172,7 +1238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1180,19 +1246,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_BFO_0000066_reaction_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_15499_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1204,11 +1270,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_BFO_0000066_reaction_4-COUMARATE--COA-LIGASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_BFO_0000066_reaction_4-COUMARATE--COA-LIGASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1223,11 +1289,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002233_CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002233_CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1245,11 +1311,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002233_CHEBI_29748_CHORPYRLY-RXN_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002233_CHEBI_29748_CHORPYRLY-RXN_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1263,65 +1329,32 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002413_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-1109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1121_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_YeastPathways_PWY3O-1109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_YeastPathways_PWY3O-1109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_57540_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57356>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_29888_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_57287_RXN3O-1120_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_57287_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1336,11 +1369,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_36242_RXN3O-1116_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_36242_RXN3O-1116_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1351,17 +1384,6 @@
           <http://model.geneontology.org/CHEBI_36242_RXN3O-1116>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_BFO_0000066_reaction_CHORPYRLY-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_10980> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1371,7 +1393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1394,7 +1416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1402,25 +1424,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_57945_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-1109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_15378_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-1109>
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_36242_RXN3O-1116_SGD_PWY_YeastPathways_PWY3O-1109>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1431,11 +1442,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1121_BFO_0000066_reaction_RXN3O-1121_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1121_BFO_0000066_reaction_RXN3O-1121_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1450,11 +1461,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002234_CHEBI_16134_RXN3O-1116_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002234_CHEBI_16134_RXN3O-1116_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1465,69 +1476,25 @@
           <http://model.geneontology.org/CHEBI_16134_RXN3O-1116>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_BFO_0000066_reaction_RXN3O-1120_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1109>
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002234_CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_57287_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_BFO_0000066_reaction_4-COUMARATE--COA-LIGASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1109>
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_PWY_YeastPathways_PWY3O-1109>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002234_CHEBI_12876_RXN3O-1118_SGD_YeastPathways_PWY3O-1109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002234_CHEBI_16134_RXN3O-1116_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1535,11 +1502,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_57287_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_57287_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1554,11 +1521,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" , "Provides Input For Rule. The relation '(R)-3-(4-hydroxyphenyl)lactate &rarr; 4-coumarate + H<sub>2</sub>O' 'null' '4-coumarate + ATP + coenzyme A &rarr; (<i>E</i>)-4-coumaroyl-CoA + AMP + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002413_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002413_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1573,11 +1540,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002411_RXN3O-1121_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002411_RXN3O-1121_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1590,28 +1557,6 @@
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_57287_RXN3O-1120_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1118_BFO_0000066_reaction_RXN3O-1118_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHORPYRLY-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0008813> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1630,7 +1575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1655,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1672,7 +1617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1680,14 +1625,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57288_RXN3O-1120_SGD_YeastPathways_PWY3O-1109>
+<http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002234_CHEBI_12876_RXN3O-1118_SGD_PWY_YeastPathways_PWY3O-1109>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1696,7 +1641,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_12876_RXN3O-1118_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1704,11 +1660,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57288_RXN3O-1120_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57288_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1723,11 +1679,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002234_CHEBI_57540_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002234_CHEBI_57540_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1744,6 +1700,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_57288>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002233_CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1756,7 +1734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1764,15 +1742,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1121_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002234_CHEBI_30763_RXN3O-1121_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002234_CHEBI_30763_RXN3O-1121_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1787,11 +1776,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1118_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1118_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1806,11 +1795,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1821,28 +1810,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002234_CHEBI_15361_CHORPYRLY-RXN_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002413_RXN3O-1118_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57540_RXN3O-1120>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1852,7 +1819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1860,25 +1827,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1118_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_YeastPathways_PWY3O-1109>
+<http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002233_CHEBI_57356_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002234_CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-1109>
+<http://model.geneontology.org/ev_w_id_RXN3O-1121_BFO_0000066_reaction_RXN3O-1121_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1109>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1886,11 +1853,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_456215_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_456215_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1910,7 +1877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1922,11 +1889,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_15377_RXN3O-1120_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_15377_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1937,26 +1904,15 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-1120>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002234_CHEBI_36242_RXN3O-1116_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_15378_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_15378_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1976,7 +1932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1984,14 +1940,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_15378_RXN3O-1120_SGD_YeastPathways_PWY3O-1109>
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30616_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002234_CHEBI_30763_CHORPYRLY-RXN_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2004,7 +1982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2012,14 +1990,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1116_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_15377_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2027,11 +2005,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" , "Provides Input For Rule. The relation '(<i>E</i>)-4-coumaroyl-CoA + coenzyme A + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; 4-hydroxybenzoyl-CoA + acetyl-CoA + NADH + H<SUP>+</SUP>' 'null' '4-hydroxybenzoyl-CoA + acetyl-CoA &rarr; 4-hydroxybenzoate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002413_RXN3O-1121_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002413_RXN3O-1121_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2046,11 +2024,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1116_BFO_0000066_reaction_RXN3O-1116_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1116_BFO_0000066_reaction_RXN3O-1116_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2069,18 +2047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1116_BFO_0000066_reaction_RXN3O-1116_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2090,14 +2057,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_12876>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_15499_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-1109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-1116_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2105,11 +2072,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_12876_RXN3O-1118_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_12876_RXN3O-1118_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2124,11 +2091,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002234_CHEBI_12876_RXN3O-1118_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002234_CHEBI_12876_RXN3O-1118_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2139,15 +2106,26 @@
           <http://model.geneontology.org/CHEBI_12876_RXN3O-1118>
 ] .
 
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_456215_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002234_CHEBI_15361_CHORPYRLY-RXN_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002234_CHEBI_15361_CHORPYRLY-RXN_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2158,39 +2136,39 @@
           <http://model.geneontology.org/CHEBI_15361_CHORPYRLY-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_15499_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_29748>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002234_CHEBI_57540_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-1109>
+<http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002233_CHEBI_57288_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002234_CHEBI_30763_RXN3O-1121_SGD_YeastPathways_PWY3O-1109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_57287_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002413_RXN3O-1121_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2198,11 +2176,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_57540_RXN3O-1120_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_57540_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2213,15 +2191,26 @@
           <http://model.geneontology.org/CHEBI_57540_RXN3O-1120>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_57945_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_57945_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2232,17 +2221,6 @@
           <http://model.geneontology.org/CHEBI_57945_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_57540_RXN3O-1120_SGD_YeastPathways_PWY3O-1109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15361_CHORPYRLY-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15361> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2252,7 +2230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2260,14 +2238,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_BFO_0000050_YeastPathways_PWY3O-1109/YeastPathways_PWY3O-1109_SGD_YeastPathways_PWY3O-1109>
+<http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002234_CHEBI_36242_RXN3O-1116_SGD_PWY_YeastPathways_PWY3O-1109>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2275,11 +2253,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002233_CHEBI_57288_RXN3O-1120_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002233_CHEBI_57288_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2290,15 +2268,26 @@
           <http://model.geneontology.org/CHEBI_57288_RXN3O-1120>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002234_CHEBI_16134_RXN3O-1116_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002234_CHEBI_36242_RXN3O-1116_SGD_YeastPathways_PWY3O-1109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002234_CHEBI_36242_RXN3O-1116_SGD_PWY_YeastPathways_PWY3O-1109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2314,7 +2303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2324,14 +2313,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57356_RXN3O-1120_SGD_YeastPathways_PWY3O-1109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_57945_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1109" ;
+                "SGD_PWY:PWY3O-1109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_BFO_0000066_reaction_CHORPYRLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2344,7 +2344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-114.ttl
+++ b/models/YeastPathways_PWY3O-114.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_83813_RXN-6601_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_83813_RXN-6601_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,11 +24,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_15378_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_15378_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,25 +39,14 @@
           <http://model.geneontology.org/CHEBI_15378_GLUTATHIONE-SYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_30616_GLUTCYSLIG-RXN_SGD_YeastPathways_PWY3O-114>
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000050_YeastPathways_PWY3O-114/YeastPathways_PWY3O-114_SGD_PWY_YeastPathways_PWY3O-114>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000066_reaction_RXN-6601_location_lociGO_0005829_SGD_YeastPathways_PWY3O-114>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
+                "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -70,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -93,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -101,36 +90,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_43474_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_PWY3O-114>
+<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_15377_RXN-6622_SGD_PWY_YeastPathways_PWY3O-114>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002413_GLUTCYSLIG-RXN_SGD_YeastPathways_PWY3O-114>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_43474_GLUTCYSLIG-RXN_SGD_YeastPathways_PWY3O-114>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
+                "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -138,11 +105,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_61694_RXN-6601_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_61694_RXN-6601_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,15 +120,37 @@
           <http://model.geneontology.org/CHEBI_61694_RXN-6601>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000066_reaction_RXN-6601_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002413_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000066_reaction_GLUTCYSLIG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000066_reaction_GLUTCYSLIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -184,7 +173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of glutathione metabolism (truncated &gamma;-glutamyl cycle) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -212,33 +201,28 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002333_YLR299W-MONOMER_RXN-6601_controller_SGD_YeastPathways_PWY3O-114>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_456216_GLUTCYSLIG-RXN_SGD_YeastPathways_PWY3O-114>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/fd717b5e-f0ad-4abe-acad-d1e1a7263676_RXN-6601>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an &alpha;-(&gamma;-L-glutamyl)-L-amino acid" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-114SmallMolecule62339> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_GLUTATHIONE-SYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -249,24 +233,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-114SmallMolecule62494> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_58173_GLUTCYSLIG-RXN_SGD_YeastPathways_PWY3O-114>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001940>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -275,11 +248,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002333_YJL101C-MONOMER_GLUTCYSLIG-RXN_controller_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002333_YJL101C-MONOMER_GLUTCYSLIG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -299,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -314,11 +287,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000050_YeastPathways_PWY3O-114/YeastPathways_PWY3O-114_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000050_YeastPathways_PWY3O-114/YeastPathways_PWY3O-114_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -332,14 +305,14 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000066_reaction_GLUTATHIONE-SYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-114>
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000066_reaction_GLUTCYSLIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-114>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
+                "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -351,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -362,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -374,11 +347,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002333_YLR299W-MONOMER_RXN-6601_controller_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002333_YLR299W-MONOMER_RXN-6601_controller_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -389,17 +362,6 @@
           <http://model.geneontology.org/YLR299W-MONOMER_RXN-6601_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_83813_RXN-6601_SGD_YeastPathways_PWY3O-114>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_35235_RXN-6622>
         a       <http://purl.obolibrary.org/obo/CHEBI_35235> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -409,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -424,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -432,14 +394,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002333_CPLX3O-5_RXN-6622_controller_SGD_YeastPathways_PWY3O-114>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/reaction_RXN-6622_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -447,11 +407,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002333_CPLX3O-5_RXN-6622_controller_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002333_CPLX3O-5_RXN-6622_controller_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -462,27 +422,29 @@
           <http://model.geneontology.org/CPLX3O-5_RXN-6622_controller>
 ] .
 
-<http://model.geneontology.org/reaction_RXN-6622_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_57925_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_35235_RXN-6622_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_35235_RXN-6622_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -533,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -541,47 +503,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_PWY3O-114>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_35235_RXN-6622_SGD_YeastPathways_PWY3O-114>
+<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_57305_RXN-6622_SGD_PWY_YeastPathways_PWY3O-114>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_57305_RXN-6622_SGD_YeastPathways_PWY3O-114>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_397e0b88-3a52-4f0f-8772-155bc2c6a87e_RXN-6601_SGD_YeastPathways_PWY3O-114>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
+                "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -589,11 +518,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000066_reaction_RXN-6601_location_lociGO_0005829_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000066_reaction_RXN-6601_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,29 +533,29 @@
           <http://model.geneontology.org/reaction_RXN-6601_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000066_reaction_GLUTCYSLIG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-114>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002413_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
+                "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_57305_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_57305_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -646,24 +575,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-114SmallMolecule62509> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002413_RXN-6622_SGD_YeastPathways_PWY3O-114>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_GLUTCYSLIG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -674,7 +592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -689,11 +607,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000066_reaction_RXN-6622_location_lociGO_0005829_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000066_reaction_RXN-6622_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -708,11 +626,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" , "Provides Input For Rule. The relation 'glycine + &gamma;-L-glutamyl-L-cysteine + ATP &rarr; glutathione + ADP + phosphate + H<SUP>+</SUP>' 'null' 'glutathione + a proteinogenic amino acid &rarr; an &alpha;-(&gamma;-L-glutamyl)-L-amino acid + L-cysteinylglycine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002413_RXN-6601_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002413_RXN-6601_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,28 +640,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN-6601>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_29985_GLUTCYSLIG-RXN_SGD_YeastPathways_PWY3O-114>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_15378_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_PWY3O-114>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -757,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -769,11 +665,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_456216_GLUTCYSLIG-RXN_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_456216_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -807,15 +703,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002333_YOL049W-MONOMER_GLUTATHIONE-SYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_CHEBI_61694_RXN-6601_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_CHEBI_61694_RXN-6601_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -826,14 +733,14 @@
           <http://model.geneontology.org/CHEBI_61694_RXN-6601>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002333_YJL101C-MONOMER_GLUTCYSLIG-RXN_controller_SGD_YeastPathways_PWY3O-114>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_57305_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
+                "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -841,11 +748,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_43474_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_43474_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -856,14 +763,14 @@
           <http://model.geneontology.org/CHEBI_43474_GLUTATHIONE-SYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000050_YeastPathways_PWY3O-114/YeastPathways_PWY3O-114_SGD_YeastPathways_PWY3O-114>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_61694_RXN-6601_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
+                "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -874,11 +781,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_35235_RXN-6622_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_35235_RXN-6622_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -893,11 +800,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_29985_GLUTCYSLIG-RXN_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_29985_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -908,14 +815,14 @@
           <http://model.geneontology.org/CHEBI_29985_GLUTCYSLIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000066_reaction_RXN-6622_location_lociGO_0005829_SGD_YeastPathways_PWY3O-114>
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_29985_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_PWY3O-114>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
+                "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -924,17 +831,6 @@
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_15378_GLUTCYSLIG-RXN_SGD_YeastPathways_PWY3O-114>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -946,11 +842,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" , "Provides Input For Rule. The relation 'L-cysteine + L-glutamate + ATP &rarr; &gamma;-L-glutamyl-L-cysteine + ADP + phosphate + H<SUP>+</SUP>' 'null' 'glycine + &gamma;-L-glutamyl-L-cysteine + ATP &rarr; glutathione + ADP + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002413_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002413_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -970,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -982,11 +878,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000066_reaction_GLUTATHIONE-SYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000066_reaction_GLUTATHIONE-SYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1009,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1017,45 +913,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002333_YOL049W-MONOMER_GLUTATHIONE-SYN-RXN_controller_SGD_YeastPathways_PWY3O-114>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'glutathione + a proteinogenic amino acid &rarr; an &alpha;-(&gamma;-L-glutamyl)-L-amino acid + L-cysteinylglycine' 'null' 'L-cysteinylglycine + H<sub>2</sub>O &rarr; L-cysteine + glycine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002413_RXN-6622_SGD_YeastPathways_PWY3O-114> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6601> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-6622>
-] .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1066,21 +932,106 @@
           <http://model.geneontology.org/CHEBI_57925_GLUTATHIONE-SYN-RXN>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'glutathione + a proteinogenic amino acid &rarr; an &alpha;-(&gamma;-L-glutamyl)-L-amino acid + L-cysteinylglycine' 'null' 'L-cysteinylglycine + H<sub>2</sub>O &rarr; L-cysteine + glycine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002413_RXN-6622_SGD_PWY_YeastPathways_PWY3O-114> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6601> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN-6622>
+] .
+
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_58173_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_58173_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002333_YLR299W-MONOMER_RXN-6601_controller_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_fd717b5e-f0ad-4abe-acad-d1e1a7263676_RXN-6601_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_43474_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" , "Provides Input For Rule. The relation 'L-cysteinylglycine + H<sub>2</sub>O &rarr; L-cysteine + glycine' 'null' 'L-cysteine + L-glutamate + ATP &rarr; &gamma;-L-glutamyl-L-cysteine + ADP + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002413_GLUTCYSLIG-RXN_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002413_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1090,6 +1041,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/GLUTCYSLIG-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_35235_RXN-6622_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0006749>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1103,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1115,11 +1077,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_15378_GLUTCYSLIG-RXN_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_15378_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1130,19 +1092,19 @@
           <http://model.geneontology.org/CHEBI_15378_GLUTCYSLIG-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58173>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_456216_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_PWY3O-114>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_CHEBI_61694_RXN-6601_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
+                "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58173>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_29985_GLUTCYSLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
@@ -1153,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1165,11 +1127,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_57925_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_57925_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1184,11 +1146,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_58173_GLUTCYSLIG-RXN_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_58173_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1205,6 +1167,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000050_YeastPathways_PWY3O-114/YeastPathways_PWY3O-114_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1217,7 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1234,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1245,25 +1218,14 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000050_YeastPathways_PWY3O-114/YeastPathways_PWY3O-114_SGD_YeastPathways_PWY3O-114>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002413_RXN-6601_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_61694_RXN-6601_SGD_YeastPathways_PWY3O-114>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
+                "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1276,7 +1238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1288,11 +1250,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_15377_RXN-6622_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_15377_RXN-6622_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1307,11 +1269,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000050_YeastPathways_PWY3O-114/YeastPathways_PWY3O-114_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000050_YeastPathways_PWY3O-114/YeastPathways_PWY3O-114_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1341,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1360,7 +1322,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57925_GLUTATHIONE-SYN-RXN> , <http://model.geneontology.org/CHEBI_83813_RXN-6601> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/397e0b88-3a52-4f0f-8772-155bc2c6a87e_RXN-6601> , <http://model.geneontology.org/CHEBI_61694_RXN-6601> ;
+                <http://model.geneontology.org/fd717b5e-f0ad-4abe-acad-d1e1a7263676_RXN-6601> , <http://model.geneontology.org/CHEBI_61694_RXN-6601> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR299W-MONOMER_RXN-6601_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1368,7 +1330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1376,51 +1338,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_30616_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_15377_RXN-6622_SGD_YeastPathways_PWY3O-114>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002413_RXN-6601_SGD_YeastPathways_PWY3O-114>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_35235_RXN-6622_SGD_YeastPathways_PWY3O-114>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_58173_GLUTCYSLIG-RXN_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_58173_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1436,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1444,11 +1384,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-5_RXN-6622_controller_BFO_0000051_SGD_S000001940_CPLX3O-5_component_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-5_RXN-6622_controller_BFO_0000051_SGD_S000001940_CPLX3O-5_component_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1459,50 +1399,39 @@
           <http://model.geneontology.org/SGD_S000001940_CPLX3O-5_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-5_RXN-6622_controller_BFO_0000051_SGD_S000001940_CPLX3O-5_component_SGD_YeastPathways_PWY3O-114>
+<http://model.geneontology.org/ev_w_id_CPLX3O-5_RXN-6622_controller_BFO_0000051_SGD_S000001940_CPLX3O-5_component_SGD_PWY_YeastPathways_PWY3O-114>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
+                "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000050_YeastPathways_PWY3O-114/YeastPathways_PWY3O-114_SGD_YeastPathways_PWY3O-114>
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_456216_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_PWY3O-114>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_CHEBI_61694_RXN-6601_SGD_YeastPathways_PWY3O-114>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
+                "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002413_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_PWY3O-114>
+<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002413_RXN-6622_SGD_PWY_YeastPathways_PWY3O-114>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
+                "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1510,11 +1439,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_397e0b88-3a52-4f0f-8772-155bc2c6a87e_RXN-6601_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_fd717b5e-f0ad-4abe-acad-d1e1a7263676_RXN-6601_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1522,18 +1451,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/397e0b88-3a52-4f0f-8772-155bc2c6a87e_RXN-6601>
+          <http://model.geneontology.org/fd717b5e-f0ad-4abe-acad-d1e1a7263676_RXN-6601>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_456216_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_456216_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1547,6 +1476,17 @@
 <http://purl.obolibrary.org/obo/GO_0004357>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000050_YeastPathways_PWY3O-114/YeastPathways_PWY3O-114_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000005409>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1554,11 +1494,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_57305_RXN-6622_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_57305_RXN-6622_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1573,11 +1513,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_30616_GLUTCYSLIG-RXN_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_30616_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1605,50 +1545,55 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_35235_RXN-6622_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000066_reaction_RXN-6622_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57925>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_57305_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_PWY3O-114>
+<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002333_CPLX3O-5_RXN-6622_controller_SGD_PWY_YeastPathways_PWY3O-114>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
+                "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/397e0b88-3a52-4f0f-8772-155bc2c6a87e_RXN-6601>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an &alpha;-(&gamma;-L-glutamyl)-L-amino acid" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-114SmallMolecule62339> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000050_YeastPathways_PWY3O-114/YeastPathways_PWY3O-114_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000050_YeastPathways_PWY3O-114/YeastPathways_PWY3O-114_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1658,17 +1603,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-114/YeastPathways_PWY3O-114>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000050_YeastPathways_PWY3O-114/YeastPathways_PWY3O-114_SGD_YeastPathways_PWY3O-114>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GLUTCYSLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004357> ;
@@ -1689,7 +1623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1701,11 +1635,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_30616_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_30616_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1716,6 +1650,61 @@
           <http://model.geneontology.org/CHEBI_30616_GLUTATHIONE-SYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_15378_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_43474_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_BFO_0000066_reaction_GLUTATHIONE-SYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_83813_RXN-6601_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_456216_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57925_GLUTATHIONE-SYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57925> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1725,7 +1714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1737,11 +1726,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000050_YeastPathways_PWY3O-114/YeastPathways_PWY3O-114_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000050_YeastPathways_PWY3O-114/YeastPathways_PWY3O-114_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1756,11 +1745,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002333_YOL049W-MONOMER_GLUTATHIONE-SYN-RXN_controller_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002333_YOL049W-MONOMER_GLUTATHIONE-SYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1776,7 +1765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1789,7 +1778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1797,40 +1786,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000004290>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_58173_GLUTCYSLIG-RXN_SGD_YeastPathways_PWY3O-114>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_30616_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_PWY3O-114>
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_15378_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-114>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
+                "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002333_YJL101C-MONOMER_GLUTCYSLIG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002233_CHEBI_30616_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004290>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_43474_GLUTCYSLIG-RXN_SGD_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_43474_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1841,13 +1841,13 @@
           <http://model.geneontology.org/CHEBI_43474_GLUTCYSLIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_57925_GLUTATHIONE-SYN-RXN_SGD_YeastPathways_PWY3O-114>
+<http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000050_YeastPathways_PWY3O-114/YeastPathways_PWY3O-114_SGD_PWY_YeastPathways_PWY3O-114>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
+                "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-123.ttl
+++ b/models/YeastPathways_PWY3O-123.ttl
@@ -1,11 +1,11 @@
-<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002233_CHEBI_15378_MANNPGUANYLTRANGDP-RXN_SGD_YeastPathways_PWY3O-123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_RO_0002234_CHEBI_58409_PHOSMANMUT-RXN_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
+                "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -18,24 +18,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "dolichyl phosphate D-mannose biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002234_CHEBI_48066_MANNPISOM-RXN_SGD_YeastPathways_PWY3O-123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MANNPISOM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004476> ;
@@ -56,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -64,36 +53,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002233_CHEBI_57527_MANNPGUANYLTRANGDP-RXN_SGD_YeastPathways_PWY3O-123>
+<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002413_PHOSMANMUT-RXN_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002233_CHEBI_58189_MANNPGUANYLTRANGDP-RXN_SGD_PWY_YeastPathways_PWY3O-123>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
+                "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_CHEBI_58189_2.4.1.83-RXN_SGD_YeastPathways_PWY3O-123>
+<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002333_YER003C-MONOMER_MANNPISOM-RXN_controller_SGD_PWY_YeastPathways_PWY3O-123>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_BFO_0000050_YeastPathways_PWY3O-123/YeastPathways_PWY3O-123_SGD_YeastPathways_PWY3O-123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
+                "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -101,11 +90,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-mannopyranose 6-phosphate &harr; &beta;-D-fructofuranose 6-phosphate' 'null' '&alpha;-D-mannose 1-phosphate &larr; D-mannopyranose 6-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002413_PHOSMANMUT-RXN_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002413_PHOSMANMUT-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -120,11 +109,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002233_CHEBI_58409_PHOSMANMUT-RXN_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002233_CHEBI_58409_PHOSMANMUT-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -138,18 +127,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002333_YPR183W-MONOMER_2.4.1.83-RXN_controller_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002333_YPR183W-MONOMER_2.4.1.83-RXN_controller_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -167,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,16 +161,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002234_CHEBI_57527_MANNPGUANYLTRANGDP-RXN_SGD_YeastPathways_PWY3O-123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58409_PHOSMANMUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58409> ;
@@ -195,7 +173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -203,14 +181,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_BFO_0000066_reaction_2.4.1.83-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002233_CHEBI_15378_MANNPGUANYLTRANGDP-RXN_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
+                "SGD_PWY:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_BFO_0000050_YeastPathways_PWY3O-123/YeastPathways_PWY3O-123_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_PHOSMANMUT-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -218,11 +216,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_BFO_0000050_YeastPathways_PWY3O-123/YeastPathways_PWY3O-123_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_BFO_0000050_YeastPathways_PWY3O-123/YeastPathways_PWY3O-123_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,26 +231,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-123/YeastPathways_PWY3O-123>
 ] .
 
-<http://model.geneontology.org/reaction_PHOSMANMUT-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_RO_0002333_YFL045C-MONOMER_PHOSMANMUT-RXN_controller_SGD_YeastPathways_PWY3O-123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57634_MANNPISOM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57634> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -262,7 +240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -270,19 +248,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002333_YER003C-MONOMER_MANNPISOM-RXN_controller_SGD_YeastPathways_PWY3O-123>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002234_CHEBI_57527_MANNPGUANYLTRANGDP-RXN_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
+                "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/PHOSMANMUT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004615> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -303,24 +281,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-123BiochemicalReaction29681> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002233_CHEBI_58409_PHOSMANMUT-RXN_SGD_YeastPathways_PWY3O-123>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004615>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -337,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -345,37 +312,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002233_CHEBI_16214_2.4.1.83-RXN_SGD_YeastPathways_PWY3O-123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_BFO_0000066_reaction_MANNPISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002333_YER003C-MONOMER_MANNPISOM-RXN_controller_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002333_YER003C-MONOMER_MANNPISOM-RXN_controller_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,26 +331,15 @@
           <http://model.geneontology.org/YER003C-MONOMER_MANNPISOM-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002233_CHEBI_57634_MANNPISOM-RXN_SGD_YeastPathways_PWY3O-123>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002233_CHEBI_58189_MANNPGUANYLTRANGDP-RXN_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002233_CHEBI_58189_MANNPGUANYLTRANGDP-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -420,11 +354,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_3fdc690e-fbd9-4a56-9e33-8e08ded32003_2.4.1.83-RXN_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_f8ffea68-6992-44d0-a655-a989defc8e1e_2.4.1.83-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -432,7 +366,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.83-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3fdc690e-fbd9-4a56-9e33-8e08ded32003_2.4.1.83-RXN>
+          <http://model.geneontology.org/f8ffea68-6992-44d0-a655-a989defc8e1e_2.4.1.83-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58189>
@@ -444,14 +378,14 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002413_PHOSMANMUT-RXN_SGD_YeastPathways_PWY3O-123>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_CHEBI_58189_2.4.1.83-RXN_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
+                "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -464,7 +398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -478,14 +412,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002233_CHEBI_58189_MANNPGUANYLTRANGDP-RXN_SGD_YeastPathways_PWY3O-123>
+<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_f8ffea68-6992-44d0-a655-a989defc8e1e_2.4.1.83-RXN_SGD_PWY_YeastPathways_PWY3O-123>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
+                "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -500,13 +434,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16214_2.4.1.83-RXN> , <http://model.geneontology.org/CHEBI_57527_MANNPGUANYLTRANGDP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58189_2.4.1.83-RXN> , <http://model.geneontology.org/3fdc690e-fbd9-4a56-9e33-8e08ded32003_2.4.1.83-RXN> ;
+                <http://model.geneontology.org/CHEBI_58189_2.4.1.83-RXN> , <http://model.geneontology.org/f8ffea68-6992-44d0-a655-a989defc8e1e_2.4.1.83-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YPR183W-MONOMER_2.4.1.83-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -517,6 +451,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_57527>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002234_CHEBI_48066_MANNPISOM-RXN_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -524,11 +469,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" , "Provides Input For Rule. The relation '&alpha;-D-mannose 1-phosphate &larr; D-mannopyranose 6-phosphate' 'null' '&alpha;-D-mannose 1-phosphate + GDP + H<SUP>+</SUP> &rarr; GDP-&alpha;-D-mannose + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_RO_0002413_MANNPGUANYLTRANGDP-RXN_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_RO_0002413_MANNPGUANYLTRANGDP-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,6 +484,17 @@
           <http://model.geneontology.org/MANNPGUANYLTRANGDP-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002333_YDL055C-MONOMER_MANNPGUANYLTRANGDP-RXN_controller_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57527_MANNPGUANYLTRANGDP-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57527> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -548,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -566,11 +522,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_RO_0002234_CHEBI_58409_PHOSMANMUT-RXN_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_RO_0002234_CHEBI_58409_PHOSMANMUT-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -588,11 +544,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" , "Provides Input For Rule. The relation '&alpha;-D-mannose 1-phosphate + GDP + H<SUP>+</SUP> &rarr; GDP-&alpha;-D-mannose + phosphate' 'null' 'a dolichyl phosphate + GDP-&alpha;-D-mannose &rarr; a dolichyl &beta;-D-mannosyl phosphate + GDP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002413_2.4.1.83-RXN_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002413_2.4.1.83-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -630,11 +586,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002234_CHEBI_48066_MANNPISOM-RXN_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002234_CHEBI_48066_MANNPISOM-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -649,11 +605,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002233_CHEBI_15378_MANNPGUANYLTRANGDP-RXN_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002233_CHEBI_15378_MANNPGUANYLTRANGDP-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,11 +627,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_CHEBI_58189_2.4.1.83-RXN_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_CHEBI_58189_2.4.1.83-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -686,40 +642,18 @@
           <http://model.geneontology.org/CHEBI_58189_2.4.1.83-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_RO_0002234_CHEBI_58409_PHOSMANMUT-RXN_SGD_YeastPathways_PWY3O-123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_BFO_0000050_YeastPathways_PWY3O-123/YeastPathways_PWY3O-123_SGD_YeastPathways_PWY3O-123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_MANNPGUANYLTRANGDP-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -727,11 +661,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_RO_0002333_YFL045C-MONOMER_PHOSMANMUT-RXN_controller_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_RO_0002333_YFL045C-MONOMER_PHOSMANMUT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -742,12 +676,34 @@
           <http://model.geneontology.org/YFL045C-MONOMER_PHOSMANMUT-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_BFO_0000066_reaction_MANNPISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_BFO_0000066_reaction_2.4.1.83-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_MANNPISOM-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -758,11 +714,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_RO_0002233_CHEBI_48066_MANNPISOM-RXN_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_RO_0002233_CHEBI_48066_MANNPISOM-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,11 +733,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002333_YDL055C-MONOMER_MANNPGUANYLTRANGDP-RXN_controller_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002333_YDL055C-MONOMER_MANNPGUANYLTRANGDP-RXN_controller_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,17 +747,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YDL055C-MONOMER_MANNPGUANYLTRANGDP-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002413_2.4.1.83-RXN_SGD_YeastPathways_PWY3O-123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004582>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -815,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -823,15 +768,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_RO_0002233_CHEBI_48066_MANNPISOM-RXN_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002233_CHEBI_57634_MANNPISOM-RXN_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002233_CHEBI_57634_MANNPISOM-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -842,26 +798,15 @@
           <http://model.geneontology.org/CHEBI_57634_MANNPISOM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002234_CHEBI_43474_MANNPGUANYLTRANGDP-RXN_SGD_YeastPathways_PWY3O-123>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_BFO_0000066_reaction_MANNPGUANYLTRANGDP-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_BFO_0000066_reaction_MANNPGUANYLTRANGDP-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -877,7 +822,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002234_CHEBI_43474_MANNPGUANYLTRANGDP-RXN_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -885,11 +841,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002233_CHEBI_57527_MANNPGUANYLTRANGDP-RXN_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002233_CHEBI_57527_MANNPGUANYLTRANGDP-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,6 +855,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57527_MANNPGUANYLTRANGDP-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002413_2.4.1.83-RXN_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MANNPGUANYLTRANGDP-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0008928> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -919,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -927,11 +894,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_RO_0002413_MANNPGUANYLTRANGDP-RXN_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_48066>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002333_YPR183W-MONOMER_2.4.1.83-RXN_controller_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_MANNPGUANYLTRANGDP-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -942,16 +931,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-123SmallMolecule29671> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YPR183W-MONOMER_2.4.1.83-RXN_controller>
         a       <http://identifiers.org/sgd/S000006387> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -960,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -968,26 +954,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_RO_0002233_CHEBI_48066_MANNPISOM-RXN_SGD_YeastPathways_PWY3O-123>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_BFO_0000066_reaction_PHOSMANMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_BFO_0000066_reaction_PHOSMANMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -998,37 +976,15 @@
           <http://model.geneontology.org/reaction_PHOSMANMUT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002333_YPR183W-MONOMER_2.4.1.83-RXN_controller_SGD_YeastPathways_PWY3O-123>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_BFO_0000050_YeastPathways_PWY3O-123/YeastPathways_PWY3O-123_SGD_YeastPathways_PWY3O-123>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002234_CHEBI_57527_MANNPGUANYLTRANGDP-RXN_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002234_CHEBI_57527_MANNPGUANYLTRANGDP-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1042,9 +998,6 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/CHEBI_15378_MANNPGUANYLTRANGDP-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1054,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1062,57 +1015,65 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_3fdc690e-fbd9-4a56-9e33-8e08ded32003_2.4.1.83-RXN_SGD_YeastPathways_PWY3O-123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_BFO_0000066_reaction_PHOSMANMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
+                "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002333_YDL055C-MONOMER_MANNPGUANYLTRANGDP-RXN_controller_SGD_YeastPathways_PWY3O-123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/3fdc690e-fbd9-4a56-9e33-8e08ded32003_2.4.1.83-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl &beta;-D-mannosyl phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-123SmallMolecule29606> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000001849>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002233_CHEBI_16214_2.4.1.83-RXN_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002233_CHEBI_57634_MANNPISOM-RXN_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_BFO_0000050_YeastPathways_PWY3O-123/YeastPathways_PWY3O-123_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_BFO_0000066_reaction_MANNPISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_BFO_0000066_reaction_MANNPISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1123,6 +1084,17 @@
           <http://model.geneontology.org/reaction_MANNPISOM-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_BFO_0000050_YeastPathways_PWY3O-123/YeastPathways_PWY3O-123_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0006013>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1130,11 +1102,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_BFO_0000050_YeastPathways_PWY3O-123/YeastPathways_PWY3O-123_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_BFO_0000050_YeastPathways_PWY3O-123/YeastPathways_PWY3O-123_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1152,11 +1124,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002233_CHEBI_16214_2.4.1.83-RXN_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002233_CHEBI_16214_2.4.1.83-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1170,14 +1142,14 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_BFO_0000066_reaction_PHOSMANMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_BFO_0000050_YeastPathways_PWY3O-123/YeastPathways_PWY3O-123_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
+                "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1193,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1201,8 +1173,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002233_CHEBI_58409_PHOSMANMUT-RXN_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_BFO_0000066_reaction_MANNPGUANYLTRANGDP-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YDL055C-MONOMER_MANNPGUANYLTRANGDP-RXN_controller>
         a       <http://identifiers.org/sgd/S000002213> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1211,7 +1205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1222,14 +1216,31 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_BFO_0000050_YeastPathways_PWY3O-123/YeastPathways_PWY3O-123_SGD_YeastPathways_PWY3O-123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/f8ffea68-6992-44d0-a655-a989defc8e1e_2.4.1.83-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a dolichyl &beta;-D-mannosyl phosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-123SmallMolecule29606> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_RO_0002333_YFL045C-MONOMER_PHOSMANMUT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
+                "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1237,11 +1248,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_BFO_0000050_YeastPathways_PWY3O-123/YeastPathways_PWY3O-123_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_BFO_0000050_YeastPathways_PWY3O-123/YeastPathways_PWY3O-123_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1259,11 +1270,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002234_CHEBI_43474_MANNPGUANYLTRANGDP-RXN_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002234_CHEBI_43474_MANNPGUANYLTRANGDP-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1274,14 +1285,14 @@
           <http://model.geneontology.org/CHEBI_43474_MANNPGUANYLTRANGDP-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_RO_0002413_MANNPGUANYLTRANGDP-RXN_SGD_YeastPathways_PWY3O-123>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002233_CHEBI_57527_MANNPGUANYLTRANGDP-RXN_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
+                "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1295,7 +1306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1307,11 +1318,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_BFO_0000050_YeastPathways_PWY3O-123/YeastPathways_PWY3O-123_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_BFO_0000050_YeastPathways_PWY3O-123/YeastPathways_PWY3O-123_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1329,11 +1340,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_BFO_0000066_reaction_2.4.1.83-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_BFO_0000066_reaction_2.4.1.83-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1346,14 +1357,3 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_BFO_0000066_reaction_MANNPGUANYLTRANGDP-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-123>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-13.ttl
+++ b/models/YeastPathways_PWY3O-13.ttl
@@ -1,11 +1,11 @@
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_57945_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_15377_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
+                "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13,11 +13,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_15377_GLUTDEHYD-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_15377_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -52,11 +52,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002234_CHEBI_29985_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002234_CHEBI_29985_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -67,19 +67,19 @@
           <http://model.geneontology.org/CHEBI_29985_GLUTAMATE-SYNTHASE-NADH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002333_YPR035W-MONOMER_GLUTAMINESYN-RXN_controller_SGD_YeastPathways_PWY3O-13>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://identifiers.org/sgd/S000004164>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002233_CHEBI_15562_ISOCITDEH-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
+                "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000004164>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -108,11 +108,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002233_CHEBI_58349_ISOCITDEH-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002233_CHEBI_58349_ISOCITDEH-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -142,11 +142,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_30616_GLUTAMINESYN-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_30616_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -160,6 +160,17 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_16810_ISOCITDEH-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -172,13 +183,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-13SmallMolecule62973> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_BFO_0000050_YeastPathways_PWY3O-13/YeastPathways_PWY3O-13_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_GLUTAMINESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -189,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -201,11 +223,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_BFO_0000066_reaction_GLUTDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_BFO_0000066_reaction_GLUTDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -228,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -243,11 +265,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_BFO_0000066_reaction_GLUTAMATE-SYNTHASE-NADH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_BFO_0000066_reaction_GLUTAMATE-SYNTHASE-NADH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -284,7 +306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -292,20 +314,42 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002234_CHEBI_57783_ISOCITDEH-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/GO_0004450>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002333_YAL062W-MONOMER_GLUTDEHYD-RXN_controller_SGD_YeastPathways_PWY3O-13>
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_15378_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002234_CHEBI_16810_ISOCITDEH-RXN_SGD_PWY_YeastPathways_PWY3O-13>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
+                "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -313,11 +357,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002333_YAL062W-MONOMER_GLUTDEHYD-RXN_controller_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002333_YAL062W-MONOMER_GLUTDEHYD-RXN_controller_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,14 +372,36 @@
           <http://model.geneontology.org/YAL062W-MONOMER_GLUTDEHYD-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_16810_ISOCITDEH-RXN_SGD_YeastPathways_PWY3O-13>
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_58359_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_29985_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_PWY3O-13>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_30616_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -348,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -356,25 +422,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_28938_GLUTDEHYD-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002413_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_58359_GLUTAMINESYN-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
+                "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -382,11 +437,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002234_CHEBI_57783_ISOCITDEH-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002234_CHEBI_57783_ISOCITDEH-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -397,17 +452,6 @@
           <http://model.geneontology.org/CHEBI_57783_ISOCITDEH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_29985_GLUTDEHYD-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -415,11 +459,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_456216_GLUTAMINESYN-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_456216_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -433,17 +477,6 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_BFO_0000066_reaction_GLUTAMATE-SYNTHASE-NADH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-13>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_GLUTAMATE-SYNTHASE-NADH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -453,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -468,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -476,26 +509,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002234_CHEBI_16810_ISOCITDEH-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_28938_GLUTDEHYD-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_28938_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -512,26 +534,15 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_57783_GLUTDEHYD-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_57945_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_57945_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,13 +562,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-13SmallMolecule62804> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_43474_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_GLUTDEHYD-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -568,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -583,11 +605,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_BFO_0000066_reaction_ISOCITDEH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_BFO_0000066_reaction_ISOCITDEH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -602,11 +624,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_28938_GLUTAMINESYN-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_28938_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -617,19 +639,30 @@
           <http://model.geneontology.org/CHEBI_28938_GLUTAMINESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002333_YDL171C-MONOMER_GLUTAMATE-SYNTHASE-NADH-RXN_controller_SGD_YeastPathways_PWY3O-13>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002233_CHEBI_58349_ISOCITDEH-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
+                "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_15378_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -641,11 +674,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002333_YNL009W-MONOMER_ISOCITDEH-RXN_controller_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002333_YNL009W-MONOMER_ISOCITDEH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -656,15 +689,26 @@
           <http://model.geneontology.org/YNL009W-MONOMER_ISOCITDEH-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002333_YDL171C-MONOMER_GLUTAMATE-SYNTHASE-NADH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" , "Provides Input For Rule. The relation 'ammonium + L-glutamate + ATP &rarr; L-glutamine + ADP + phosphate + H<SUP>+</SUP>' 'null' '2 L-glutamate + NAD<sup>+</sup> &larr; L-glutamine + 2-oxoglutarate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002413_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002413_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -675,14 +719,14 @@
           <http://model.geneontology.org/GLUTAMATE-SYNTHASE-NADH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002234_CHEBI_16526_ISOCITDEH-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002333_YAL062W-MONOMER_GLUTDEHYD-RXN_controller_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
+                "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -695,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -709,25 +753,36 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002333_YLR174W-MONOMER_ISOCITDEH-RXN_controller_SGD_YeastPathways_PWY3O-13>
+<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002333_YNL009W-MONOMER_ISOCITDEH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-13>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
+                "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002333_YOR375C-MONOMER_GLUTDEHYD-RXN_controller_SGD_YeastPathways_PWY3O-13>
+<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002333_YDL066W-MONOMER_ISOCITDEH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-13>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_57783_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -735,11 +790,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_29985_GLUTDEHYD-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_29985_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,6 +808,17 @@
 <http://identifiers.org/sgd/S000004954>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_BFO_0000066_reaction_ISOCITDEH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16810_ISOCITDEH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16810> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -762,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -774,11 +840,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002234_CHEBI_57540_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002234_CHEBI_57540_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -792,32 +858,32 @@
 <http://purl.obolibrary.org/obo/GO_0004356>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002333_YPR035W-MONOMER_GLUTAMINESYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15562>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_BFO_0000050_YeastPathways_PWY3O-13/YeastPathways_PWY3O-13_SGD_YeastPathways_PWY3O-13>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002234_CHEBI_16526_ISOCITDEH-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002234_CHEBI_16526_ISOCITDEH-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,7 +901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -847,11 +913,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_15378_GLUTAMINESYN-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_15378_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -869,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -877,41 +943,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002333_YDL066W-MONOMER_ISOCITDEH-RXN_controller_SGD_YeastPathways_PWY3O-13>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_BFO_0000066_reaction_ISOCITDEH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-13>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002233_CHEBI_15562_ISOCITDEH-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -925,17 +958,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_BFO_0000050_YeastPathways_PWY3O-13/YeastPathways_PWY3O-13_SGD_YeastPathways_PWY3O-13>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -946,11 +968,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_15378_GLUTDEHYD-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_15378_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -961,37 +983,15 @@
           <http://model.geneontology.org/CHEBI_15378_GLUTDEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_456216_GLUTAMINESYN-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002413_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_15378_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_15378_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1005,17 +1005,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002413_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1026,30 +1015,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_BFO_0000050_YeastPathways_PWY3O-13/YeastPathways_PWY3O-13_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002333_YOR375C-MONOMER_GLUTDEHYD-RXN_controller_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUTAMINESYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY3O-13/YeastPathways_PWY3O-13>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002333_YOR375C-MONOMER_GLUTDEHYD-RXN_controller_SGD_YeastPathways_PWY3O-13> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1060,16 +1030,24 @@
           <http://model.geneontology.org/YOR375C-MONOMER_GLUTDEHYD-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_15377_GLUTDEHYD-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_BFO_0000050_YeastPathways_PWY3O-13/YeastPathways_PWY3O-13_SGD_PWY_YeastPathways_PWY3O-13> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLUTAMINESYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY3O-13/YeastPathways_PWY3O-13>
+] .
 
 <http://model.geneontology.org/ISOCITDEH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004450> ;
@@ -1090,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1107,13 +1085,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-13SmallMolecule62789> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_15378_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_28938_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_GLUTDEHYD-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1124,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1139,11 +1139,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002333_YDL066W-MONOMER_ISOCITDEH-RXN_controller_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002333_YDL066W-MONOMER_ISOCITDEH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1158,11 +1158,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_58359_GLUTAMINESYN-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_58359_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1173,25 +1173,14 @@
           <http://model.geneontology.org/CHEBI_58359_GLUTAMINESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_BFO_0000066_reaction_GLUTDEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-13>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_58359_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_28938_GLUTAMINESYN-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
+                "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1199,11 +1188,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_57783_GLUTDEHYD-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_57783_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1218,11 +1207,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_58359_GLUTAMINESYN-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_58359_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1249,13 +1238,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-13Protein62825> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002234_CHEBI_57540_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GLUTDEHYD-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004354> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1274,7 +1274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1286,11 +1286,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002233_CHEBI_15562_ISOCITDEH-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002233_CHEBI_15562_ISOCITDEH-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1301,15 +1301,26 @@
           <http://model.geneontology.org/CHEBI_15562_ISOCITDEH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_28938_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_29985_GLUTAMINESYN-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_29985_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1320,25 +1331,14 @@
           <http://model.geneontology.org/CHEBI_29985_GLUTAMINESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_16810_GLUTDEHYD-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002413_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002234_CHEBI_29985_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
+                "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1348,25 +1348,14 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002233_CHEBI_58349_ISOCITDEH-RXN_SGD_YeastPathways_PWY3O-13>
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_29985_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-13>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_BFO_0000066_reaction_GLUTAMINESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-13>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
+                "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1387,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1399,11 +1388,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" , "Provides Input For Rule. The relation 'D-<i>threo</i>-isocitrate + NADP<sup>+</sup> &harr; 2-oxoglutarate + CO<SUB>2</SUB> + NADPH' 'null' '2 L-glutamate + NAD<sup>+</sup> &larr; L-glutamine + 2-oxoglutarate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002413_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002413_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1418,11 +1407,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_BFO_0000050_YeastPathways_PWY3O-13/YeastPathways_PWY3O-13_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_BFO_0000050_YeastPathways_PWY3O-13/YeastPathways_PWY3O-13_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1437,11 +1426,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_BFO_0000050_YeastPathways_PWY3O-13/YeastPathways_PWY3O-13_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_BFO_0000050_YeastPathways_PWY3O-13/YeastPathways_PWY3O-13_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1452,25 +1441,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-13/YeastPathways_PWY3O-13>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002333_YNL009W-MONOMER_ISOCITDEH-RXN_controller_SGD_YeastPathways_PWY3O-13>
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_456216_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-13>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_29985_GLUTAMINESYN-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
+                "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1479,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1502,7 +1480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1514,11 +1492,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_58349_GLUTDEHYD-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_58349_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1533,11 +1511,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002333_YDL171C-MONOMER_GLUTAMATE-SYNTHASE-NADH-RXN_controller_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002333_YDL171C-MONOMER_GLUTAMATE-SYNTHASE-NADH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1548,17 +1526,6 @@
           <http://model.geneontology.org/YDL171C-MONOMER_GLUTAMATE-SYNTHASE-NADH-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002234_CHEBI_57783_ISOCITDEH-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57783_ISOCITDEH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1568,13 +1535,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-13SmallMolecule62886> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_BFO_0000050_YeastPathways_PWY3O-13/YeastPathways_PWY3O-13_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002234_CHEBI_29985_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YOR375C-MONOMER_GLUTDEHYD-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005902> ;
@@ -1583,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1591,26 +1580,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_15378_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002234_CHEBI_16810_ISOCITDEH-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002234_CHEBI_16810_ISOCITDEH-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1628,11 +1606,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_43474_GLUTAMINESYN-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_43474_GLUTAMINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1646,26 +1624,48 @@
 <http://identifiers.org/sgd/S000002330>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_15378_GLUTDEHYD-RXN_SGD_YeastPathways_PWY3O-13>
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002333_YOR375C-MONOMER_GLUTDEHYD-RXN_controller_SGD_PWY_YeastPathways_PWY3O-13>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
+                "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_BFO_0000050_YeastPathways_PWY3O-13/YeastPathways_PWY3O-13_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002333_YLR174W-MONOMER_ISOCITDEH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/reaction_GLUTAMATE-SYNTHASE-NADH-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1678,7 +1678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1701,7 +1701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1709,15 +1709,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002234_CHEBI_16526_ISOCITDEH-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_16810_GLUTDEHYD-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_16810_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1732,11 +1743,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_16810_ISOCITDEH-RXN_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_16810_ISOCITDEH-RXN_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1750,14 +1761,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_58359_GLUTAMINESYN-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_BFO_0000050_YeastPathways_PWY3O-13/YeastPathways_PWY3O-13_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
+                "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1765,11 +1776,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_BFO_0000050_YeastPathways_PWY3O-13/YeastPathways_PWY3O-13_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_BFO_0000050_YeastPathways_PWY3O-13/YeastPathways_PWY3O-13_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1780,14 +1791,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-13/YeastPathways_PWY3O-13>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_BFO_0000050_YeastPathways_PWY3O-13/YeastPathways_PWY3O-13_SGD_YeastPathways_PWY3O-13>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_BFO_0000066_reaction_GLUTAMATE-SYNTHASE-NADH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
+                "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1795,11 +1806,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_BFO_0000066_reaction_GLUTAMINESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_BFO_0000066_reaction_GLUTAMINESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1819,7 +1830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1827,36 +1838,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_BFO_0000050_YeastPathways_PWY3O-13/YeastPathways_PWY3O-13_SGD_YeastPathways_PWY3O-13>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002233_CHEBI_30616_GLUTAMINESYN-RXN_SGD_YeastPathways_PWY3O-13>
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_BFO_0000066_reaction_GLUTDEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-13>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
+                "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_43474_GLUTAMINESYN-RXN_SGD_YeastPathways_PWY3O-13>
+<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_BFO_0000066_reaction_GLUTAMINESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-13>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002233_CHEBI_16810_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1869,24 +1880,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-13SmallMolecule62886> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002234_CHEBI_15378_GLUTAMINESYN-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0097054>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1896,7 +1896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1904,11 +1904,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002333_YLR174W-MONOMER_ISOCITDEH-RXN_controller_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITDEH-RXN_RO_0002333_YLR174W-MONOMER_ISOCITDEH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1919,17 +1919,6 @@
           <http://model.geneontology.org/YLR174W-MONOMER_ISOCITDEH-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002234_CHEBI_57540_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YDL066W-MONOMER_ISOCITDEH-RXN_controller>
         a       <http://identifiers.org/sgd/S000002224> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1937,7 +1926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1954,7 +1943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1966,11 +1955,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002333_YPR035W-MONOMER_GLUTAMINESYN-RXN_controller_SGD_YeastPathways_PWY3O-13> ;
+          <http://model.geneontology.org/ev_w_id_GLUTAMINESYN-RXN_RO_0002333_YPR035W-MONOMER_GLUTAMINESYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-13> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1990,13 +1979,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of glutamate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMATE-SYNTHASE-NADH-RXN_RO_0002233_CHEBI_57945_GLUTAMATE-SYNTHASE-NADH-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58349_ISOCITDEH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
@@ -2007,13 +2007,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-13SmallMolecule62857> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_58349_GLUTDEHYD-RXN_SGD_PWY_YeastPathways_PWY3O-13>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-13" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58359_GLUTAMINESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58359> ;
@@ -2024,7 +2035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2037,18 +2048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTDEHYD-RXN_RO_0002234_CHEBI_58349_GLUTDEHYD-RXN_SGD_YeastPathways_PWY3O-13>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-13" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2061,7 +2061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-15.ttl
+++ b/models/YeastPathways_PWY3O-15.ttl
@@ -8,35 +8,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-15Protein69415> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002333_YBR038W-MONOMER_CHITIN-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY3O-15>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-15" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002234_CHEBI_17029_CHITIN-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-15>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-15" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17029>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -45,11 +23,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002234_CHEBI_17029_CHITIN-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-15> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002234_CHEBI_17029_CHITIN-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-15> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -63,14 +41,14 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002233_CHEBI_17029_CHITIN-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-15>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002233_CHEBI_17029_CHITIN-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-15>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-15" ;
+                "SGD_PWY:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -92,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -129,11 +107,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002233_CHEBI_57705_CHITIN-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-15> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002233_CHEBI_57705_CHITIN-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-15> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -173,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "chitin biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -181,33 +159,11 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002234_CHEBI_58223_CHITIN-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-15>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-15" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://identifiers.org/sgd/S000000242>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-15/YeastPathways_PWY3O-15_SGD_YeastPathways_PWY3O-15>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-15" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000227>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -219,11 +175,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002333_YNL192W-MONOMER_CHITIN-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY3O-15> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002333_YNL192W-MONOMER_CHITIN-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-15> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -234,6 +190,17 @@
           <http://model.geneontology.org/YNL192W-MONOMER_CHITIN-SYNTHASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-15/YeastPathways_PWY3O-15_SGD_PWY_YeastPathways_PWY3O-15>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-15" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YBR023C-MONOMER_CHITIN-SYNTHASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000000227> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -241,7 +208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -258,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -266,18 +233,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_BFO_0000066_reaction_CHITIN-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-15>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-15" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002333_YBR038W-MONOMER_CHITIN-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-15>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-15" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002233_CHEBI_17029_CHITIN-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-15> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002233_CHEBI_17029_CHITIN-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-15> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -291,21 +280,43 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002234_CHEBI_17029_CHITIN-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-15>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-15" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57705>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002333_YBR023C-MONOMER_CHITIN-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-15>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-15" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002333_YBR038W-MONOMER_CHITIN-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY3O-15> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002333_YBR038W-MONOMER_CHITIN-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-15> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -319,26 +330,15 @@
 <http://identifiers.org/sgd/S000005136>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002333_YBR023C-MONOMER_CHITIN-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY3O-15>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-15" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_BFO_0000066_reaction_CHITIN-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-15> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_BFO_0000066_reaction_CHITIN-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-15> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -348,17 +348,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_CHITIN-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002233_CHEBI_57705_CHITIN-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-15>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-15" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004100>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -373,7 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -384,17 +373,6 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002333_YNL192W-MONOMER_CHITIN-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY3O-15>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-15" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -402,11 +380,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002333_YBR023C-MONOMER_CHITIN-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY3O-15> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002333_YBR023C-MONOMER_CHITIN-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-15> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -426,13 +404,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-15SmallMolecule69380> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002234_CHEBI_58223_CHITIN-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-15>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-15" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -441,11 +430,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-15/YeastPathways_PWY3O-15_SGD_YeastPathways_PWY3O-15> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-15/YeastPathways_PWY3O-15_SGD_PWY_YeastPathways_PWY3O-15> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -474,29 +463,29 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_BFO_0000066_reaction_CHITIN-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-15>
+<http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002333_YNL192W-MONOMER_CHITIN-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-15>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-15" ;
+                "SGD_PWY:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002234_CHEBI_58223_CHITIN-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-15> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002234_CHEBI_58223_CHITIN-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-15> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,3 +498,14 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_CHITIN-SYNTHASE-RXN_RO_0002233_CHEBI_57705_CHITIN-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-15>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-15" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-1565.ttl
+++ b/models/YeastPathways_PWY3O-1565.ttl
@@ -1,36 +1,3 @@
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_YeastPathways_PWY3O-1565>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002234_CHEBI_57525_2.4.1.117-RXN_SGD_YeastPathways_PWY3O-1565>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002234_CHEBI_29888_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-1565>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/PHOSPHOGLUCMUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004614> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -50,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -61,6 +28,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_58223>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-1565/YeastPathways_PWY3O-1565_SGD_PWY_YeastPathways_PWY3O-1565>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1565>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_46398>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -68,11 +57,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -90,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -102,11 +91,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -123,17 +112,6 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002233_CHEBI_16214_2.4.1.117-RXN_SGD_YeastPathways_PWY3O-1565>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57525_2.4.1.117-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57525> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -143,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -160,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -171,27 +149,49 @@
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002234_CHEBI_58885_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-1565>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_2.4.1.117-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58601>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_PWY3O-1565>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002234_CHEBI_57525_2.4.1.117-RXN_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002234_CHEBI_57525_2.4.1.117-RXN_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -202,19 +202,19 @@
           <http://model.geneontology.org/CHEBI_57525_2.4.1.117-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0034637>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002333_YKL035W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller_SGD_YeastPathways_PWY3O-1565>
+<http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002234_CHEBI_58223_2.4.1.117-RXN_SGD_PWY_YeastPathways_PWY3O-1565>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
+                "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0034637>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -231,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "dolichyl glucosyl phosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -239,47 +239,14 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1565>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_YeastPathways_PWY3O-1565/YeastPathways_PWY3O-1565_SGD_YeastPathways_PWY3O-1565>
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1565>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002413_2.4.1.117-RXN_SGD_YeastPathways_PWY3O-1565>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_PWY3O-1565>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
+                "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -295,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -310,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -322,11 +289,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -341,11 +308,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_46398_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_46398_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -371,55 +338,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_BFO_0000050_YeastPathways_PWY3O-1565/YeastPathways_PWY3O-1565_SGD_YeastPathways_PWY3O-1565>
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_BFO_0000066_reaction_GLUC1PURIDYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1565>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
+                "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_46398_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-1565>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-1565/YeastPathways_PWY3O-1565_SGD_YeastPathways_PWY3O-1565>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_PWY3O-1565>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -433,7 +367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -441,26 +375,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_YeastPathways_PWY3O-1565>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002233_CHEBI_58885_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002233_CHEBI_58885_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -471,19 +394,19 @@
           <http://model.geneontology.org/CHEBI_58885_GLUC1PURIDYLTRANS-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004614>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002233_CHEBI_58885_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-1565>
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_YeastPathways_PWY3O-1565/YeastPathways_PWY3O-1565_SGD_PWY_YeastPathways_PWY3O-1565>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
+                "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004614>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0003983>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -492,11 +415,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_BFO_0000066_reaction_2.4.1.117-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_BFO_0000066_reaction_2.4.1.117-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -510,15 +433,26 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_46398_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-1565>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002333_YKL035W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002333_YKL035W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -529,12 +463,23 @@
           <http://model.geneontology.org/YKL035W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002333_YKL035W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1565>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -548,11 +493,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,11 +512,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_15378_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_15378_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -582,33 +527,22 @@
           <http://model.geneontology.org/CHEBI_15378_GLUC1PURIDYLTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002413_2.4.1.117-RXN_SGD_PWY_YeastPathways_PWY3O-1565>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16214>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002333_YPL227C-MONOMER_2.4.1.117-RXN_controller_SGD_YeastPathways_PWY3O-1565>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_BFO_0000066_reaction_2.4.1.117-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1565>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -617,11 +551,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002233_CHEBI_16214_2.4.1.117-RXN_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002233_CHEBI_16214_2.4.1.117-RXN_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,13 +573,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1565Protein28785> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002333_YHL012W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1565>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_PWY3O-1565>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GLUC1PURIDYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003983> ;
@@ -666,13 +622,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1565BiochemicalReaction28698> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_BFO_0000066_reaction_2.4.1.117-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1565>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -694,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -706,11 +673,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_BFO_0000050_YeastPathways_PWY3O-1565/YeastPathways_PWY3O-1565_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_BFO_0000050_YeastPathways_PWY3O-1565/YeastPathways_PWY3O-1565_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -721,26 +688,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-1565/YeastPathways_PWY3O-1565>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_PWY3O-1565>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002333_YHL012W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002333_YHL012W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -751,6 +707,17 @@
           <http://model.geneontology.org/YHL012W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002333_YPL227C-MONOMER_2.4.1.117-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1565>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YHL012W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller>
         a       <http://identifiers.org/sgd/S000001004> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -758,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -766,15 +733,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_15378_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-1565>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -785,6 +763,17 @@
           <http://model.geneontology.org/reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_PWY3O-1565>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_4170_PHOSPHOGLUCMUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_4170> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -794,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -806,11 +795,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_BFO_0000066_reaction_GLUC1PURIDYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_BFO_0000066_reaction_GLUC1PURIDYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -827,35 +816,57 @@
 <http://identifiers.org/sgd/S000006148>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002413_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-1565>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57525>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002234_CHEBI_29888_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-1565>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_BFO_0000066_reaction_GLUC1PURIDYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1565>
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002234_CHEBI_57525_2.4.1.117-RXN_SGD_PWY_YeastPathways_PWY3O-1565>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
+                "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" , "Provides Input For Rule. The relation '&alpha;-D-glucopyranose 1-phosphate &harr; D-glucopyranose 6-phosphate' 'null' '&alpha;-D-glucopyranose 1-phosphate + UTP + H<SUP>+</SUP> &rarr; UDP-&alpha;-D-glucose + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002413_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002413_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -873,11 +884,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002234_CHEBI_58885_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002234_CHEBI_58885_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -903,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -926,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -938,11 +949,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_YeastPathways_PWY3O-1565/YeastPathways_PWY3O-1565_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_YeastPathways_PWY3O-1565/YeastPathways_PWY3O-1565_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,6 +964,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-1565/YeastPathways_PWY3O-1565>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002233_CHEBI_16214_2.4.1.117-RXN_SGD_PWY_YeastPathways_PWY3O-1565>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000001610>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -960,11 +982,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-1565/YeastPathways_PWY3O-1565_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-1565/YeastPathways_PWY3O-1565_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -984,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -996,11 +1018,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002333_YPL227C-MONOMER_2.4.1.117-RXN_controller_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002333_YPL227C-MONOMER_2.4.1.117-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1014,45 +1036,34 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_15378_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-1565>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002413_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-1565>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002234_CHEBI_58223_2.4.1.117-RXN_SGD_YeastPathways_PWY3O-1565>
+<http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002233_CHEBI_58885_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-1565>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1565>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
+                "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1065,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1073,26 +1084,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002234_CHEBI_58885_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-1565>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1107,11 +1107,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002234_CHEBI_29888_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002234_CHEBI_29888_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1122,44 +1122,25 @@
           <http://model.geneontology.org/CHEBI_29888_GLUC1PURIDYLTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_BFO_0000050_YeastPathways_PWY3O-1565/YeastPathways_PWY3O-1565_SGD_PWY_YeastPathways_PWY3O-1565>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_GLUC1PURIDYLTRANS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002333_YHL012W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller_SGD_YeastPathways_PWY3O-1565>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '&alpha;-D-glucopyranose 1-phosphate + UTP + H<SUP>+</SUP> &rarr; UDP-&alpha;-D-glucose + diphosphate' 'null' 'UDP-&alpha;-D-glucose + a dolichyl phosphate &rarr; a dolichyl &beta;-D-glucosyl phosphate + UDP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002413_2.4.1.117-RXN_SGD_YeastPathways_PWY3O-1565> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUC1PURIDYLTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.4.1.117-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_58885_GLUC1PURIDYLTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58885> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1170,13 +1151,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1565SmallMolecule28651> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '&alpha;-D-glucopyranose 1-phosphate + UTP + H<SUP>+</SUP> &rarr; UDP-&alpha;-D-glucose + diphosphate' 'null' 'UDP-&alpha;-D-glucose + a dolichyl phosphate &rarr; a dolichyl &beta;-D-glucosyl phosphate + UDP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002413_2.4.1.117-RXN_SGD_PWY_YeastPathways_PWY3O-1565> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLUC1PURIDYLTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/2.4.1.117-RXN>
+] .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1185,11 +1185,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002234_CHEBI_58223_2.4.1.117-RXN_SGD_YeastPathways_PWY3O-1565> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.117-RXN_RO_0002234_CHEBI_58223_2.4.1.117-RXN_SGD_PWY_YeastPathways_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-17.ttl
+++ b/models/YeastPathways_PWY3O-17.ttl
@@ -1,23 +1,12 @@
-<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002413_THI-P-SYN-RXN_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4191_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4191_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,7 +26,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,11 +38,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002333_CPLX3O-80_PYRIMSYN3-RXN_controller_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002333_CPLX3O-80_PYRIMSYN3-RXN_controller_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -64,17 +53,6 @@
           <http://model.geneontology.org/CPLX3O-80_PYRIMSYN3-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXNQT-4301_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CPLX3O-9180_THI-P-SYN-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -84,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -96,11 +74,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-80_PYRIMSYN3-RXN_controller_BFO_0000051_SGD_S000005416_CPLX3O-80_component_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-80_PYRIMSYN3-RXN_controller_BFO_0000051_SGD_S000005416_CPLX3O-80_component_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -120,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -137,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -148,14 +126,39 @@
 <http://purl.obolibrary.org/obo/GO_0008902>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002333_CPLX3O-25_THIAMIN-PYROPHOSPHOKINASE-RXN_controller_SGD_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002233_CHEBI_57595_RXN3O-9804_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-401_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002413_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -171,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -179,18 +182,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002233_CHEBI_30616_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002233_CHEBI_30616_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -204,6 +204,17 @@
 <http://identifiers.org/sgd/S000006179>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_15378_THI-P-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_RXNQT-4301>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -213,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -225,11 +236,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_BFO_0000066_reaction_RXNQT-4301_location_lociGO_0005829_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_BFO_0000066_reaction_RXNQT-4301_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -247,11 +258,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CHEBI_139151_RXN3O-401_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CHEBI_139151_RXN3O-401_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -262,15 +273,26 @@
           <http://model.geneontology.org/CHEBI_139151_RXN3O-401>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CHEBI_57305_RXN3O-401_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002233_CHEBI_30616_OHMETPYRKIN-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002233_CHEBI_30616_OHMETPYRKIN-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -281,34 +303,12 @@
           <http://model.geneontology.org/CHEBI_30616_OHMETPYRKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-80_OHMETPYRKIN-RXN_controller_BFO_0000051_SGD_S000005416_CPLX3O-80_component_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000003376_CPLX3O-10511_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003376> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002333_CPLX3O-80_OHMETPYRKIN-RXN_controller_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -317,61 +317,6 @@
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CHEBI_57305_RXN3O-401_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002234_CHEBI_16892_RXN3O-9804_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002234_CHEBI_43474_RXNQT-4191_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-80_PYRIMSYN3-RXN_controller_BFO_0000051_SGD_S000005416_CPLX3O-80_component_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXN3O-401_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-10511_RXNQT-4301_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -382,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -396,14 +341,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_18385>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_BFO_0000066_reaction_OHMETPYRKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002233_CHEBI_58354_OHMETPYRKIN-RXN_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXNQT-4301_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -411,11 +367,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" , "Provides Input For Rule. The relation 'ADP-5-ethyl-4-methylthiazole-2-carboxylate + H<sub>2</sub>O &rarr; AMP + 4-methyl-5-(2-phosphooxyethyl)thiazole + CO<SUB>2</SUB> + H<SUP>+</SUP>' 'null' '4-methyl-5-(2-phosphooxyethyl)thiazole + 4-amino-2-methyl-5-(diphosphooxymethyl)pyrimidine + H<SUP>+</SUP> &rarr; thiamine phosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002413_THI-P-SYN-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002413_THI-P-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -426,15 +382,26 @@
           <http://model.geneontology.org/THI-P-SYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002233_CHEBI_30616_OHMETPYRKIN-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002233_CHEBI_57595_RXN3O-9804_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002233_CHEBI_57595_RXN3O-9804_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -454,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -471,7 +438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -483,11 +450,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_BFO_0000066_reaction_PYRIMSYN3-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_BFO_0000066_reaction_PYRIMSYN3-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -525,11 +492,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXN3O-401_controller_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXN3O-401_controller_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -545,7 +512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -558,24 +525,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule69001> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_456215_RXNQT-4301_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_139151_RXN3O-401>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_139151> ;
@@ -586,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -594,14 +550,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002413_RXNQT-4191_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_456215_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -611,15 +567,37 @@
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002333_MONOMER3O-9145_RXN3O-9804_controller_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002333_CPLX3O-82_PYRIMSYN3-RXN_controller_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002333_CPLX3O-9180_THI-P-SYN-RXN_controller_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002333_CPLX3O-9180_THI-P-SYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -630,15 +608,26 @@
           <http://model.geneontology.org/CPLX3O-9180_THI-P-SYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002233_CHEBI_16892_RXN3O-9804_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002233_CHEBI_37575_THI-P-SYN-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002233_CHEBI_37575_THI-P-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -649,15 +638,37 @@
           <http://model.geneontology.org/CHEBI_37575_THI-P-SYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002234_CHEBI_18385_RXNQT-4191_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002234_CHEBI_43474_RXNQT-4191_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,14 +679,25 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-17/YeastPathways_PWY3O-17>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002233_CHEBI_30616_PYRIMSYN3-RXN_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXNQT-4301_controller_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002413_RXNQT-4191_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -688,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -701,18 +723,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-25_THIAMIN-PYROPHOSPHOKINASE-RXN_controller_BFO_0000051_SGD_S000005669_CPLX3O-25_component_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -720,11 +742,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_58937_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_58937_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,18 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9804_BFO_0000066_reaction_RXN3O-9804_location_lociGO_0005829_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -762,11 +773,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_15378_RXNQT-4301_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_15378_RXNQT-4301_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,6 +788,17 @@
           <http://model.geneontology.org/CHEBI_15378_RXNQT-4301>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXNQT-4191_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -784,11 +806,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002333_CPLX3O-10511_RXN3O-401_controller_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002333_CPLX3O-10511_RXN3O-401_controller_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,15 +821,29 @@
           <http://model.geneontology.org/CPLX3O-10511_RXN3O-401_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-9180_THI-P-SYN-RXN_controller_BFO_0000051_SGD_S000006135_CPLX3O-9180_component_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_58354_OHMETPYRKIN-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_58354_OHMETPYRKIN-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -817,20 +853,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58354_OHMETPYRKIN-RXN>
 ] .
-
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002233_CHEBI_15377_RXNQT-4301_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/OHMETPYRKIN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0008902> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -851,7 +873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -859,30 +881,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_15378_THI-P-SYN-RXN_SGD_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXN3O-401_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_58354_OHMETPYRKIN-RXN_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_597326>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002234_CHEBI_456216_PYRIMSYN3-RXN_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-82_OHMETPYRKIN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -893,7 +915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -901,15 +923,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002234_CHEBI_16892_RXN3O-9804_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_15378_THI-P-SYN-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_15378_THI-P-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -924,11 +957,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002333_MONOMER3O-9145_RXN3O-9804_controller_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002333_MONOMER3O-9145_RXN3O-9804_controller_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -939,26 +972,15 @@
           <http://model.geneontology.org/MONOMER3O-9145_RXN3O-9804_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002233_CHEBI_139151_RXN3O-401_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002234_CHEBI_456216_PYRIMSYN3-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002234_CHEBI_456216_PYRIMSYN3-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -976,11 +998,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-362_RXN3O-401_BFO_0000051_SGD_S000003376_CPLX3O-362_component_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-362_RXN3O-401_BFO_0000051_SGD_S000003376_CPLX3O-362_component_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -991,17 +1013,6 @@
           <http://model.geneontology.org/SGD_S000003376_CPLX3O-362_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXNQT-4301_controller_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CPLX3O-362_RXN3O-401>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1011,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1019,36 +1030,58 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002234_CHEBI_18385_RXNQT-4191_SGD_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_58296_RXNQT-4301_SGD_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_CPLX3O-80_PYRIMSYN3-RXN_controller_BFO_0000051_SGD_S000005416_CPLX3O-80_component_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-80_OHMETPYRKIN-RXN_controller_BFO_0000051_SGD_S000005416_CPLX3O-80_component_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002333_CPLX3O-82_OHMETPYRKIN-RXN_controller_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002233_CHEBI_30616_PYRIMSYN3-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002233_CHEBI_18385_RXNQT-4191_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1056,11 +1089,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_BFO_0000066_reaction_THIAMIN-PYROPHOSPHOKINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_BFO_0000066_reaction_THIAMIN-PYROPHOSPHOKINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1075,11 +1108,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" , "Provides Input For Rule. The relation 'thiamine phosphate + H<sub>2</sub>O &rarr; thiamine + phosphate' 'null' 'thiamine + ATP &rarr; thiamine diphosphate + AMP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002413_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002413_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1090,18 +1123,40 @@
           <http://model.geneontology.org/THIAMIN-PYROPHOSPHOKINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_BFO_0000066_reaction_OHMETPYRKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002413_OHMETPYRKIN-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CHEBI_57540_RXN3O-401_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CHEBI_57540_RXN3O-401_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1119,11 +1174,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_BFO_0000066_reaction_OHMETPYRKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_BFO_0000066_reaction_OHMETPYRKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1133,17 +1188,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_OHMETPYRKIN-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXNQT-4301_BFO_0000066_reaction_RXNQT-4301_location_lociGO_0005829_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-401>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1166,7 +1210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1174,34 +1218,45 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_58937_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-401_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_57841_PYRIMSYN3-RXN_SGD_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_57841_PYRIMSYN3-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002413_PYRIMSYN3-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-82_OHMETPYRKIN-RXN_controller_BFO_0000051_SGD_S000006179_CPLX3O-82_component_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1212,11 +1267,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_58296_RXNQT-4301_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_58296_RXNQT-4301_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1236,7 +1291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1248,11 +1303,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9804_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9804_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1272,7 +1327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1280,15 +1335,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" , "Provides Input For Rule. The relation 'ATP + 4-amino-2-methyl-5-pyrimidinemethanol &rarr; ADP + 4-amino-2-methyl-5-(phosphooxymethyl)pyrimidine + H<SUP>+</SUP>' 'null' '4-amino-2-methyl-5-(phosphooxymethyl)pyrimidine + ATP &rarr; 4-amino-2-methyl-5-(diphosphooxymethyl)pyrimidine + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002413_PYRIMSYN3-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002413_PYRIMSYN3-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1299,25 +1365,36 @@
           <http://model.geneontology.org/PYRIMSYN3-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXNQT-4191_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_RXN3O-401_BFO_0000066_reaction_RXN3O-401_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002233_CHEBI_30616_OHMETPYRKIN-RXN_SGD_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002234_CHEBI_456216_PYRIMSYN3-RXN_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_58296_RXNQT-4301_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1330,24 +1407,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17Complex69190> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXN3O-401_controller_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57841_PYRIMSYN3-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57841> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1358,7 +1424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1366,32 +1432,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002234_CHEBI_29888_THI-P-SYN-RXN_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9804_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002234_CHEBI_29888_THI-P-SYN-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002234_CHEBI_29888_THI-P-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1405,26 +1471,15 @@
 <http://purl.obolibrary.org/obo/RO_0002629>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CPLX3O-10511_RXN3O-401_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4191_BFO_0000066_reaction_RXNQT-4191_location_lociGO_0005829_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4191_BFO_0000066_reaction_RXNQT-4191_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1442,11 +1497,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002333_CPLX3O-82_PYRIMSYN3-RXN_controller_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002333_CPLX3O-82_PYRIMSYN3-RXN_controller_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1457,26 +1512,15 @@
           <http://model.geneontology.org/CPLX3O-82_PYRIMSYN3-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002333_CPLX3O-82_PYRIMSYN3-RXN_controller_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-82_OHMETPYRKIN-RXN_controller_BFO_0000051_SGD_S000006179_CPLX3O-82_component_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-82_OHMETPYRKIN-RXN_controller_BFO_0000051_SGD_S000006179_CPLX3O-82_component_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1487,33 +1531,22 @@
           <http://model.geneontology.org/SGD_S000006179_CPLX3O-82_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-9180_THI-P-SYN-RXN_controller_BFO_0000051_SGD_S000006135_CPLX3O-9180_component_SGD_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_CPLX3O-82_PYRIMSYN3-RXN_controller_BFO_0000051_SGD_S000006179_CPLX3O-82_component_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58354>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_57595>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002413_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_58354>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1522,11 +1555,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_15378_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_15378_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1537,15 +1570,18 @@
           <http://model.geneontology.org/CHEBI_15378_THIAMIN-PYROPHOSPHOKINASE-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0009228>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002233_CHEBI_139151_RXN3O-401_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002233_CHEBI_139151_RXN3O-401_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1556,18 +1592,15 @@
           <http://model.geneontology.org/CHEBI_139151_RXN3O-401>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0009228>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CHEBI_17154_RXN3O-401_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CHEBI_17154_RXN3O-401_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1578,6 +1611,28 @@
           <http://model.geneontology.org/CHEBI_17154_RXN3O-401>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_BFO_0000066_reaction_THI-P-SYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CPLX3O-10511_RXN3O-401_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-25_THIAMIN-PYROPHOSPHOKINASE-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1587,7 +1642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1604,7 +1659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1616,11 +1671,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_15378_OHMETPYRKIN-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_15378_OHMETPYRKIN-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1630,17 +1685,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_OHMETPYRKIN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-362_RXN3O-401_BFO_0000051_SGD_S000003376_CPLX3O-362_component_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1656,36 +1700,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_BFO_0000066_reaction_THIAMIN-PYROPHOSPHOKINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005416>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1696,6 +1726,9 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-17/YeastPathways_PWY3O-17>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1703,11 +1736,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002233_CHEBI_597326_RXN3O-9804_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002233_CHEBI_597326_RXN3O-9804_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1718,25 +1751,14 @@
           <http://model.geneontology.org/CHEBI_597326_RXN3O-9804>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_58296_RXNQT-4301_SGD_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002333_CPLX3O-10511_RXNQT-4301_controller_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CHEBI_57540_RXN3O-401_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1744,11 +1766,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002233_CHEBI_30616_PYRIMSYN3-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002233_CHEBI_30616_PYRIMSYN3-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1759,14 +1781,14 @@
           <http://model.geneontology.org/CHEBI_30616_PYRIMSYN3-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002233_CHEBI_58354_OHMETPYRKIN-RXN_SGD_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_15378_OHMETPYRKIN-RXN_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1779,7 +1801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "thiamine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1787,25 +1809,14 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002333_CPLX3O-10511_RXN3O-401_controller_SGD_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_456215_RXNQT-4301_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002233_CHEBI_18385_RXNQT-4191_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1813,11 +1824,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXNQT-4301_controller_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXNQT-4301_controller_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1837,7 +1848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1847,50 +1858,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002333_CPLX3O-9180_THI-P-SYN-RXN_controller_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002233_CHEBI_37575_THI-P-SYN-RXN_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002233_CHEBI_597326_RXN3O-9804_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002333_MONOMER3O-9145_RXN3O-9804_controller_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXNQT-4301>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1911,7 +1878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1928,7 +1895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1940,11 +1907,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '4-methyl-5-(2-phosphooxyethyl)thiazole + 4-amino-2-methyl-5-(diphosphooxymethyl)pyrimidine + H<SUP>+</SUP> &rarr; thiamine phosphate + diphosphate' 'null' 'thiamine phosphate + H<sub>2</sub>O &rarr; thiamine + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002413_RXNQT-4191_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002413_RXNQT-4191_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1955,14 +1922,14 @@
           <http://model.geneontology.org/RXNQT-4191>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_CPLX3O-25_THIAMIN-PYROPHOSPHOKINASE-RXN_controller_BFO_0000051_SGD_S000005669_CPLX3O-25_component_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1970,11 +1937,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002234_CHEBI_18385_RXNQT-4191_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002234_CHEBI_18385_RXNQT-4191_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1990,19 +1957,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_BFO_0000066_reaction_RXN3O-401_location_lociGO_0005829_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_BFO_0000066_reaction_RXN3O-401_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2013,18 +1983,37 @@
           <http://model.geneontology.org/reaction_RXN3O-401_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002233_CHEBI_15377_RXNQT-4191_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002233_CHEBI_597326_RXN3O-9804_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-9180_THI-P-SYN-RXN_controller_BFO_0000051_SGD_S000006135_CPLX3O-9180_component_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-9180_THI-P-SYN-RXN_controller_BFO_0000051_SGD_S000006135_CPLX3O-9180_component_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2035,14 +2024,25 @@
           <http://model.geneontology.org/SGD_S000006135_CPLX3O-9180_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9804_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002629_RXNQT-4301_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-362_RXN3O-401_BFO_0000051_SGD_S000003376_CPLX3O-362_component_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2058,7 +2058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2075,7 +2075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2083,8 +2083,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/CHEBI_456216>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://identifiers.org/sgd/S000002403>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_456216_OHMETPYRKIN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ADP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule69169> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/PYRIMSYN3-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0008972> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2105,7 +2125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2113,32 +2133,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/CHEBI_456216_OHMETPYRKIN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ADP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule69169> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002333_CPLX3O-25_THIAMIN-PYROPHOSPHOKINASE-RXN_controller_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002333_CPLX3O-25_THIAMIN-PYROPHOSPHOKINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2149,18 +2152,26 @@
           <http://model.geneontology.org/CPLX3O-25_THIAMIN-PYROPHOSPHOKINASE-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_456216>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002233_CHEBI_139151_RXN3O-401_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_16526_RXNQT-4301_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_16526_RXNQT-4301_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2171,6 +2182,17 @@
           <http://model.geneontology.org/CHEBI_16526_RXNQT-4301>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXN3O-401_controller_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_THIAMIN-PYROPHOSPHOKINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2180,13 +2202,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule69055> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002333_CPLX3O-80_PYRIMSYN3-RXN_controller_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-10511_RXN3O-401_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2197,7 +2230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2205,26 +2238,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_15378_RXNQT-4301_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'thiazole synthase + glycine + NAD<sup>+</sup> &rarr; ADP-5-ethyl-4-methylthiazole-2-carboxylate + nicotinamide + thiazole synthase - dehydroalanine<sub>205</sub>' 'null' 'ADP-5-ethyl-4-methylthiazole-2-carboxylate + H<sub>2</sub>O &rarr; AMP + 4-methyl-5-(2-phosphooxyethyl)thiazole + CO<SUB>2</SUB> + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002413_RXNQT-4301_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002413_RXNQT-4301_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2239,11 +2261,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002333_CPLX3O-80_OHMETPYRKIN-RXN_controller_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002333_CPLX3O-80_OHMETPYRKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2259,32 +2281,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17154>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-401_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002233_CHEBI_37575_THI-P-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CHEBI_139151_RXN3O-401_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2292,11 +2314,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_57841_PYRIMSYN3-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_57841_PYRIMSYN3-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2307,17 +2329,6 @@
           <http://model.geneontology.org/CHEBI_57841_PYRIMSYN3-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002413_THI-P-SYN-RXN_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CPLX3O-80_PYRIMSYN3-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2327,13 +2338,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17Complex69203> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
+
+<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_456216_OHMETPYRKIN-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_RXNQT-4191>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2344,7 +2366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2356,11 +2378,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'pyridoxal 5'-phosphate + L-histidine &rarr; 4-amino-2-methyl-5-pyrimidinemethanol' 'null' 'ATP + 4-amino-2-methyl-5-pyrimidinemethanol &rarr; ADP + 4-amino-2-methyl-5-(phosphooxymethyl)pyrimidine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002413_OHMETPYRKIN-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002413_OHMETPYRKIN-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2375,11 +2397,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002234_CHEBI_57841_PYRIMSYN3-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002234_CHEBI_57841_PYRIMSYN3-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2390,23 +2412,23 @@
           <http://model.geneontology.org/CHEBI_57841_PYRIMSYN3-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002333_CPLX3O-9180_THI-P-SYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-9804_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_58354_OHMETPYRKIN-RXN_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2419,7 +2441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2431,11 +2453,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-80_OHMETPYRKIN-RXN_controller_BFO_0000051_SGD_S000005416_CPLX3O-80_component_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-80_OHMETPYRKIN-RXN_controller_BFO_0000051_SGD_S000005416_CPLX3O-80_component_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2457,29 +2479,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CHEBI_17154_RXN3O-401_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002413_THI-P-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002233_CHEBI_30616_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2500,7 +2511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2527,7 +2538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2535,26 +2546,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-401_BFO_0000066_reaction_RXN3O-401_location_lociGO_0005829_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0042131>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002233_CHEBI_18385_RXNQT-4191_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002233_CHEBI_18385_RXNQT-4191_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2568,18 +2571,18 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0042131>
+<http://purl.obolibrary.org/obo/GO_0004788>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2590,18 +2593,37 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-17/YeastPathways_PWY3O-17>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004788>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002233_CHEBI_30616_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002234_CHEBI_37575_THI-P-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CPLX3O-10511_RXN3O-401_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CPLX3O-10511_RXN3O-401_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2616,11 +2638,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002233_CHEBI_16892_RXN3O-9804_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002233_CHEBI_16892_RXN3O-9804_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2630,6 +2652,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16892_RXN3O-9804>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002333_CPLX3O-10511_RXN3O-401_controller_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008972>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2643,7 +2676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2651,14 +2684,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002234_CHEBI_37575_THI-P-SYN-RXN_SGD_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_RXN3O-9804_BFO_0000066_reaction_RXN3O-9804_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXNQT-4301_BFO_0000066_reaction_RXNQT-4301_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2674,7 +2718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2685,48 +2729,15 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002333_CPLX3O-10511_RXNQT-4301_controller_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_456216_OHMETPYRKIN-RXN_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_15378_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002333_CPLX3O-10511_RXNQT-4301_controller_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002333_CPLX3O-10511_RXNQT-4301_controller_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2741,11 +2752,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9804_BFO_0000066_reaction_RXN3O-9804_location_lociGO_0005829_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9804_BFO_0000066_reaction_RXN3O-9804_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2760,11 +2771,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2775,26 +2786,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-17/YeastPathways_PWY3O-17>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-82_PYRIMSYN3-RXN_controller_BFO_0000051_SGD_S000006179_CPLX3O-82_component_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXN3O-401_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXN3O-401_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2822,13 +2822,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17BiochemicalReaction69122> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002413_RXNQT-4301_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_16526_RXNQT-4301_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002333_CPLX3O-25_THIAMIN-PYROPHOSPHOKINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -2838,7 +2871,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_15378_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2846,11 +2890,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002234_CHEBI_37575_THI-P-SYN-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002234_CHEBI_37575_THI-P-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2861,15 +2905,37 @@
           <http://model.geneontology.org/CHEBI_37575_THI-P-SYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_BFO_0000066_reaction_THIAMIN-PYROPHOSPHOKINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXNQT-4191_BFO_0000066_reaction_RXNQT-4191_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002233_CHEBI_15377_RXNQT-4191_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002233_CHEBI_15377_RXNQT-4191_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2880,14 +2946,14 @@
           <http://model.geneontology.org/CHEBI_15377_RXNQT-4191>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002413_PYRIMSYN3-RXN_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2895,11 +2961,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '4-amino-2-methyl-5-(phosphooxymethyl)pyrimidine + ATP &rarr; 4-amino-2-methyl-5-(diphosphooxymethyl)pyrimidine + ADP' 'null' '4-methyl-5-(2-phosphooxyethyl)thiazole + 4-amino-2-methyl-5-(diphosphooxymethyl)pyrimidine + H<SUP>+</SUP> &rarr; thiamine phosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002413_THI-P-SYN-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002413_THI-P-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2910,26 +2976,15 @@
           <http://model.geneontology.org/THI-P-SYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002234_CHEBI_57841_PYRIMSYN3-RXN_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-82_PYRIMSYN3-RXN_controller_BFO_0000051_SGD_S000006179_CPLX3O-82_component_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-82_PYRIMSYN3-RXN_controller_BFO_0000051_SGD_S000006179_CPLX3O-82_component_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2940,25 +2995,25 @@
           <http://model.geneontology.org/SGD_S000006179_CPLX3O-82_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002629_RXNQT-4301_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_15378_RXNQT-4301_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_15378_OHMETPYRKIN-RXN_SGD_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CHEBI_57540_RXN3O-401_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2966,11 +3021,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_456215_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_456215_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2981,37 +3036,15 @@
           <http://model.geneontology.org/CHEBI_456215_THIAMIN-PYROPHOSPHOKINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_16526_RXNQT-4301_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002333_CPLX3O-80_PYRIMSYN3-RXN_controller_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002233_CHEBI_15377_RXNQT-4301_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002233_CHEBI_15377_RXNQT-4301_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3022,14 +3055,14 @@
           <http://model.geneontology.org/CHEBI_15377_RXNQT-4301>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_BFO_0000066_reaction_THI-P-SYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002413_THI-P-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3037,11 +3070,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CPLX3O-362_RXN3O-401_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CPLX3O-362_RXN3O-401_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3052,15 +3085,26 @@
           <http://model.geneontology.org/CPLX3O-362_RXN3O-401>
 ] .
 
+<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002333_CPLX3O-80_OHMETPYRKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_456216_OHMETPYRKIN-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002234_CHEBI_456216_OHMETPYRKIN-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3076,23 +3120,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002233_CHEBI_15377_RXNQT-4191_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3109,7 +3142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3121,11 +3154,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_BFO_0000066_reaction_THI-P-SYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_BFO_0000066_reaction_THI-P-SYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3140,11 +3173,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002234_CHEBI_16892_RXN3O-9804_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002234_CHEBI_16892_RXN3O-9804_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3159,11 +3192,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002233_CHEBI_58354_OHMETPYRKIN-RXN_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002233_CHEBI_58354_OHMETPYRKIN-RXN_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3179,7 +3212,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002333_CPLX3O-82_OHMETPYRKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3187,11 +3231,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-25_THIAMIN-PYROPHOSPHOKINASE-RXN_controller_BFO_0000051_SGD_S000005669_CPLX3O-25_component_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-25_THIAMIN-PYROPHOSPHOKINASE-RXN_controller_BFO_0000051_SGD_S000005669_CPLX3O-25_component_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3202,45 +3246,12 @@
           <http://model.geneontology.org/SGD_S000005669_CPLX3O-25_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CHEBI_139151_RXN3O-401_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_THIAMIN-PYROPHOSPHOKINASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002413_OHMETPYRKIN-RXN_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3253,13 +3264,54 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule68874> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002234_CHEBI_43474_RXNQT-4191_SGD_PWY_YeastPathways_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXNQT-4191> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_RXNQT-4191>
+] .
+
+<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002234_CHEBI_29888_THI-P-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002234_CHEBI_57841_PYRIMSYN3-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXNQT-4301>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3270,7 +3322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3297,7 +3349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3309,11 +3361,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3324,24 +3376,38 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-17/YeastPathways_PWY3O-17>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002234_CHEBI_43474_RXNQT-4191_SGD_YeastPathways_PWY3O-17> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXNQT-4191> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_RXNQT-4191>
-] .
+<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_58296_RXNQT-4301_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_BFO_0000066_reaction_PYRIMSYN3-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_58937_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-80_OHMETPYRKIN-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3352,7 +3418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3369,7 +3435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3381,11 +3447,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CHEBI_57305_RXN3O-401_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CHEBI_57305_RXN3O-401_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3396,26 +3462,15 @@
           <http://model.geneontology.org/CHEBI_57305_RXN3O-401>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002413_RXNQT-4301_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3426,17 +3481,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-17/YeastPathways_PWY3O-17>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002233_CHEBI_57595_RXN3O-9804_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/MONOMER3O-9145_RXN3O-9804_controller>
         a       <http://identifiers.org/sgd/S000002403> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3444,7 +3488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3455,14 +3499,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_57841>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_BFO_0000066_reaction_PYRIMSYN3-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CHEBI_17154_RXN3O-401_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3470,11 +3514,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_456215_RXNQT-4301_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_456215_RXNQT-4301_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3485,25 +3529,14 @@
           <http://model.geneontology.org/CHEBI_456215_RXNQT-4301>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002233_CHEBI_16892_RXN3O-9804_SGD_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002233_CHEBI_15377_RXNQT-4301_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
+                "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3511,11 +3544,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" , "Entity Regulation Rule 3. The relation 'thiazole synthase + glycine + NAD<sup>+</sup> &rarr; ADP-5-ethyl-4-methylthiazole-2-carboxylate + nicotinamide + thiazole synthase - dehydroalanine<sub>205</sub>' 'null' 'ADP-5-ethyl-4-methylthiazole-2-carboxylate + H<sub>2</sub>O &rarr; AMP + 4-methyl-5-(2-phosphooxyethyl)thiazole + CO<SUB>2</SUB> + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is the enabler of reaction 2." ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002629_RXNQT-4301_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002629_RXNQT-4301_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3529,37 +3562,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_37575>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXNQT-4191_BFO_0000066_reaction_RXNQT-4191_location_lociGO_0005829_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CPLX3O-362_RXN3O-401_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002333_CPLX3O-82_OHMETPYRKIN-RXN_controller_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002333_CPLX3O-82_OHMETPYRKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3569,28 +3580,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CPLX3O-82_OHMETPYRKIN-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-82_OHMETPYRKIN-RXN_controller_BFO_0000051_SGD_S000006179_CPLX3O-82_component_SGD_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_456215_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003376>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3607,7 +3596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3624,7 +3613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3632,15 +3621,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CPLX3O-362_RXN3O-401_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_58296_RXNQT-4301_SGD_YeastPathways_PWY3O-17> ;
+          <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_58296_RXNQT-4301_SGD_PWY_YeastPathways_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-1743.ttl
+++ b/models/YeastPathways_PWY3O-1743.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13,14 +13,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002413_MANNPISOM-RXN_SGD_YeastPathways_PWY3O-1743>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002234_CHEBI_456216_RXN3O-9791_SGD_PWY_YeastPathways_PWY3O-1743>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1743" ;
+                "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -66,26 +66,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002234_CHEBI_48066_RXN3O-9791_SGD_YeastPathways_PWY3O-1743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002333_YGL253W-MONOMER_RXN3O-9791_controller_SGD_YeastPathways_PWY3O-1743> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002333_YGL253W-MONOMER_RXN3O-9791_controller_SGD_PWY_YeastPathways_PWY3O-1743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -103,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,11 +104,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002333_YER003C-MONOMER_MANNPISOM-RXN_controller_SGD_YeastPathways_PWY3O-1743> ;
+          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002333_YER003C-MONOMER_MANNPISOM-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,6 +122,9 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/YER003C-MONOMER_MANNPISOM-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000805> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -140,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -148,8 +140,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_BFO_0000066_reaction_MANNPISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002333_YCL040W-MONOMER_RXN3O-9791_controller_SGD_PWY_YeastPathways_PWY3O-1743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57634_MANNPISOM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57634> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -160,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -168,43 +179,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002233_CHEBI_4208_RXN3O-9791_SGD_YeastPathways_PWY3O-1743>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_BFO_0000066_reaction_MANNPISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002233_CHEBI_48066_RXN3O-9791_SGD_PWY_YeastPathways_PWY3O-1743>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002333_YFR053C-MONOMER_RXN3O-9791_controller_SGD_YeastPathways_PWY3O-1743> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002333_YFR053C-MONOMER_RXN3O-9791_controller_SGD_PWY_YeastPathways_PWY3O-1743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -219,11 +219,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002234_CHEBI_57634_MANNPISOM-RXN_SGD_YeastPathways_PWY3O-1743> ;
+          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002234_CHEBI_57634_MANNPISOM-RXN_SGD_PWY_YeastPathways_PWY3O-1743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -249,14 +249,14 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002234_CHEBI_456216_RXN3O-9791_SGD_YeastPathways_PWY3O-1743>
+<http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002233_CHEBI_4208_RXN3O-9791_SGD_PWY_YeastPathways_PWY3O-1743>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1743" ;
+                "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -272,6 +272,17 @@
 <http://purl.obolibrary.org/obo/GO_0004476>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002333_YFR053C-MONOMER_RXN3O-9791_controller_SGD_PWY_YeastPathways_PWY3O-1743>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -279,11 +290,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002233_CHEBI_4208_RXN3O-9791_SGD_YeastPathways_PWY3O-1743> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002233_CHEBI_4208_RXN3O-9791_SGD_PWY_YeastPathways_PWY3O-1743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "mannose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -323,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -338,11 +349,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002333_YCL040W-MONOMER_RXN3O-9791_controller_SGD_YeastPathways_PWY3O-1743> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002333_YCL040W-MONOMER_RXN3O-9791_controller_SGD_PWY_YeastPathways_PWY3O-1743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,11 +368,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002233_CHEBI_48066_RXN3O-9791_SGD_YeastPathways_PWY3O-1743> ;
+          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002233_CHEBI_48066_RXN3O-9791_SGD_PWY_YeastPathways_PWY3O-1743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -381,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -389,43 +400,54 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002233_CHEBI_48066_RXN3O-9791_SGD_YeastPathways_PWY3O-1743>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0004396>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9791_BFO_0000050_YeastPathways_PWY3O-1743/YeastPathways_PWY3O-1743_SGD_YeastPathways_PWY3O-1743>
+<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002234_CHEBI_57634_MANNPISOM-RXN_SGD_PWY_YeastPathways_PWY3O-1743>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1743" ;
+                "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002333_YGL253W-MONOMER_RXN3O-9791_controller_SGD_PWY_YeastPathways_PWY3O-1743>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9791_BFO_0000066_reaction_RXN3O-9791_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004396>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_MANNPISOM-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -444,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -452,15 +474,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9791_BFO_0000050_YeastPathways_PWY3O-1743/YeastPathways_PWY3O-1743_SGD_PWY_YeastPathways_PWY3O-1743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002233_CHEBI_30616_RXN3O-9791_SGD_YeastPathways_PWY3O-1743> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002233_CHEBI_30616_RXN3O-9791_SGD_PWY_YeastPathways_PWY3O-1743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -474,26 +507,15 @@
 <http://purl.obolibrary.org/obo/GO_0019309>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002333_YCL040W-MONOMER_RXN3O-9791_controller_SGD_YeastPathways_PWY3O-1743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002234_CHEBI_48066_RXN3O-9791_SGD_YeastPathways_PWY3O-1743> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002234_CHEBI_48066_RXN3O-9791_SGD_PWY_YeastPathways_PWY3O-1743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -508,11 +530,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_BFO_0000066_reaction_MANNPISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1743> ;
+          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_BFO_0000066_reaction_MANNPISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -530,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -538,22 +560,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002333_YGL253W-MONOMER_RXN3O-9791_controller_SGD_YeastPathways_PWY3O-1743>
+<http://purl.obolibrary.org/obo/CHEBI_48066>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002234_CHEBI_15378_RXN3O-9791_SGD_PWY_YeastPathways_PWY3O-1743>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002233_CHEBI_30616_RXN3O-9791_SGD_PWY_YeastPathways_PWY3O-1743>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1743" ;
+                "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_48066>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://identifiers.org/sgd/S000000545>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -577,7 +610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -585,24 +618,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002333_YER003C-MONOMER_MANNPISOM-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://identifiers.org/sgd/S000001949>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9791_BFO_0000066_reaction_RXN3O-9791_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1743> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9791_BFO_0000066_reaction_RXN3O-9791_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,28 +654,20 @@
           <http://model.geneontology.org/reaction_RXN3O-9791_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002234_CHEBI_15378_RXN3O-9791_SGD_YeastPathways_PWY3O-1743>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000001949>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002333_YFR053C-MONOMER_RXN3O-9791_controller_SGD_YeastPathways_PWY3O-1743>
+<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_BFO_0000050_YeastPathways_PWY3O-1743/YeastPathways_PWY3O-1743_SGD_PWY_YeastPathways_PWY3O-1743>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1743" ;
+                "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -647,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -655,26 +688,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002234_CHEBI_57634_MANNPISOM-RXN_SGD_YeastPathways_PWY3O-1743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002234_CHEBI_456216_RXN3O-9791_SGD_YeastPathways_PWY3O-1743> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002234_CHEBI_456216_RXN3O-9791_SGD_PWY_YeastPathways_PWY3O-1743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -685,26 +707,15 @@
           <http://model.geneontology.org/CHEBI_456216_RXN3O-9791>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9791_BFO_0000066_reaction_RXN3O-9791_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1743>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_BFO_0000050_YeastPathways_PWY3O-1743/YeastPathways_PWY3O-1743_SGD_YeastPathways_PWY3O-1743> ;
+          <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_BFO_0000050_YeastPathways_PWY3O-1743/YeastPathways_PWY3O-1743_SGD_PWY_YeastPathways_PWY3O-1743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -721,14 +732,14 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_BFO_0000050_YeastPathways_PWY3O-1743/YeastPathways_PWY3O-1743_SGD_YeastPathways_PWY3O-1743>
+<http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002234_CHEBI_48066_RXN3O-9791_SGD_PWY_YeastPathways_PWY3O-1743>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1743" ;
+                "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -750,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -762,11 +773,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" , "Provides Input For Rule. The relation 'D-mannose + ATP &rarr; D-mannopyranose 6-phosphate + ADP + H<SUP>+</SUP>' 'null' 'D-mannopyranose 6-phosphate &harr; &beta;-D-fructofuranose 6-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002413_MANNPISOM-RXN_SGD_YeastPathways_PWY3O-1743> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002413_MANNPISOM-RXN_SGD_PWY_YeastPathways_PWY3O-1743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -784,11 +795,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9791_BFO_0000050_YeastPathways_PWY3O-1743/YeastPathways_PWY3O-1743_SGD_YeastPathways_PWY3O-1743> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9791_BFO_0000050_YeastPathways_PWY3O-1743/YeastPathways_PWY3O-1743_SGD_PWY_YeastPathways_PWY3O-1743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,37 +810,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-1743/YeastPathways_PWY3O-1743>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002233_CHEBI_30616_RXN3O-9791_SGD_YeastPathways_PWY3O-1743>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002333_YER003C-MONOMER_MANNPISOM-RXN_controller_SGD_YeastPathways_PWY3O-1743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002234_CHEBI_15378_RXN3O-9791_SGD_YeastPathways_PWY3O-1743> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002234_CHEBI_15378_RXN3O-9791_SGD_PWY_YeastPathways_PWY3O-1743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -842,3 +831,14 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002413_MANNPISOM-RXN_SGD_PWY_YeastPathways_PWY3O-1743>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-1801.ttl
+++ b/models/YeastPathways_PWY3O-1801.ttl
@@ -1,34 +1,12 @@
-<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_61540_RXN-10664_SGD_YeastPathways_PWY3O-1801>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1801" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000066_reaction_RXN-10664_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1801>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1801" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_61540_RXN-10664_SGD_YeastPathways_PWY3O-1801> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_61540_RXN-10664_SGD_PWY_YeastPathways_PWY3O-1801> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -43,11 +21,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_15378_RXN-10662_SGD_YeastPathways_PWY3O-1801> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_15378_RXN-10662_SGD_PWY_YeastPathways_PWY3O-1801> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -57,17 +35,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_RXN-10662>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15378_RXN-10664_SGD_YeastPathways_PWY3O-1801>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1801" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -84,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,34 +62,67 @@
 <http://purl.obolibrary.org/obo/CHEBI_61540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0006636>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_FERROCYTOCHROME-B5_RXN-10664_SGD_YeastPathways_PWY3O-1801>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_15377_RXN-10662_SGD_PWY_YeastPathways_PWY3O-1801>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1801" ;
+                "SGD_PWY:PWY3O-1801" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0006636>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000066_reaction_RXN-10664_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1801>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_32372_RXN-10662_SGD_PWY_YeastPathways_PWY3O-1801>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1801" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_FERRICYTOCHROME-B5_RXN-10664_SGD_YeastPathways_PWY3O-1801>
+<http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000066_reaction_RXN-10662_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1801>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1801" ;
+                "SGD_PWY:PWY3O-1801" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_57379_RXN-10664_SGD_PWY_YeastPathways_PWY3O-1801>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -130,11 +130,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_15377_RXN-10664_SGD_YeastPathways_PWY3O-1801> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_15377_RXN-10664_SGD_PWY_YeastPathways_PWY3O-1801> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -149,11 +149,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_61540_RXN-10664_SGD_YeastPathways_PWY3O-1801> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_61540_RXN-10664_SGD_PWY_YeastPathways_PWY3O-1801> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -163,6 +163,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_61540_RXN-10664>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_61540_RXN-10664_SGD_PWY_YeastPathways_PWY3O-1801>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1801" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -185,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -193,14 +204,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000050_YeastPathways_PWY3O-1801/YeastPathways_PWY3O-1801_SGD_YeastPathways_PWY3O-1801>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_FERRICYTOCHROME-B5_RXN-10664_SGD_PWY_YeastPathways_PWY3O-1801>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1801" ;
+                "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -214,11 +225,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000066_reaction_RXN-10664_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1801> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000066_reaction_RXN-10664_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1801> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -229,14 +240,14 @@
           <http://model.geneontology.org/reaction_RXN-10664_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000050_YeastPathways_PWY3O-1801/YeastPathways_PWY3O-1801_SGD_YeastPathways_PWY3O-1801>
+<http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000050_YeastPathways_PWY3O-1801/YeastPathways_PWY3O-1801_SGD_PWY_YeastPathways_PWY3O-1801>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1801" ;
+                "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -249,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -269,13 +280,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1801Protein17141> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000050_YeastPathways_PWY3O-1801/YeastPathways_PWY3O-1801_SGD_PWY_YeastPathways_PWY3O-1801>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1801" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN-10664>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -286,7 +308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -301,11 +323,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_FERROCYTOCHROME-B5_RXN-10664_SGD_YeastPathways_PWY3O-1801> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_FERROCYTOCHROME-B5_RXN-10664_SGD_PWY_YeastPathways_PWY3O-1801> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -320,11 +342,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_15377_RXN-10662_SGD_YeastPathways_PWY3O-1801> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_15377_RXN-10662_SGD_PWY_YeastPathways_PWY3O-1801> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -335,25 +357,14 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-10662>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_15377_RXN-10664_SGD_YeastPathways_PWY3O-1801>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1801" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002333_YGL055W-MONOMER_RXN-10664_controller_SGD_YeastPathways_PWY3O-1801>
+<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15378_RXN-10664_SGD_PWY_YeastPathways_PWY3O-1801>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1801" ;
+                "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -369,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -389,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -406,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "palmitoleate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -414,14 +425,14 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_15378_RXN-10662_SGD_YeastPathways_PWY3O-1801>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002413_RXN-10662_SGD_PWY_YeastPathways_PWY3O-1801>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1801" ;
+                "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -432,11 +443,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'palmitoyl-CoA + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; palmitoleoyl-CoA + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' 'null' 'palmitoleoyl-CoA + H<sub>2</sub>O &rarr; palmitoleate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002413_RXN-10662_SGD_YeastPathways_PWY3O-1801> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002413_RXN-10662_SGD_PWY_YeastPathways_PWY3O-1801> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -451,11 +462,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000050_YeastPathways_PWY3O-1801/YeastPathways_PWY3O-1801_SGD_YeastPathways_PWY3O-1801> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000050_YeastPathways_PWY3O-1801/YeastPathways_PWY3O-1801_SGD_PWY_YeastPathways_PWY3O-1801> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -493,26 +504,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_15377_RXN-10662_SGD_YeastPathways_PWY3O-1801>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1801" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_57379_RXN-10664_SGD_YeastPathways_PWY3O-1801> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_57379_RXN-10664_SGD_PWY_YeastPathways_PWY3O-1801> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -527,11 +527,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000066_reaction_RXN-10662_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1801> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000066_reaction_RXN-10662_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1801> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,6 +542,17 @@
           <http://model.geneontology.org/reaction_RXN-10662_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_61540_RXN-10664_SGD_PWY_YeastPathways_PWY3O-1801>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1801" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-1801/YeastPathways_PWY3O-1801>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0006636> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -551,7 +562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -568,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -585,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -595,28 +606,6 @@
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_57287_RXN-10662_SGD_YeastPathways_PWY3O-1801>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1801" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002413_RXN-10662_SGD_YeastPathways_PWY3O-1801>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1801" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -628,11 +617,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002333_YGL055W-MONOMER_RXN-10664_controller_SGD_YeastPathways_PWY3O-1801> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002333_YGL055W-MONOMER_RXN-10664_controller_SGD_PWY_YeastPathways_PWY3O-1801> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,11 +636,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_57287_RXN-10662_SGD_YeastPathways_PWY3O-1801> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_57287_RXN-10662_SGD_PWY_YeastPathways_PWY3O-1801> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,14 +660,14 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15379_RXN-10664_SGD_YeastPathways_PWY3O-1801>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_15377_RXN-10664_SGD_PWY_YeastPathways_PWY3O-1801>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1801" ;
+                "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -691,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -704,7 +693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -715,11 +704,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15379_RXN-10664_SGD_YeastPathways_PWY3O-1801> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15379_RXN-10664_SGD_PWY_YeastPathways_PWY3O-1801> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,11 +723,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000050_YeastPathways_PWY3O-1801/YeastPathways_PWY3O-1801_SGD_YeastPathways_PWY3O-1801> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000050_YeastPathways_PWY3O-1801/YeastPathways_PWY3O-1801_SGD_PWY_YeastPathways_PWY3O-1801> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -752,6 +741,39 @@
 <http://identifiers.org/sgd/S000003023>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_FERROCYTOCHROME-B5_RXN-10664_SGD_PWY_YeastPathways_PWY3O-1801>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1801" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_57287_RXN-10662_SGD_PWY_YeastPathways_PWY3O-1801>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1801" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15379_RXN-10664_SGD_PWY_YeastPathways_PWY3O-1801>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1801" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -760,37 +782,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000066_reaction_RXN-10662_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1801>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1801" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_57379_RXN-10664_SGD_YeastPathways_PWY3O-1801>
+<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002333_YGL055W-MONOMER_RXN-10664_controller_SGD_PWY_YeastPathways_PWY3O-1801>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1801" ;
+                "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_15378_RXN-10662_SGD_PWY_YeastPathways_PWY3O-1801>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1801" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -804,7 +826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -816,11 +838,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_FERRICYTOCHROME-B5_RXN-10664_SGD_YeastPathways_PWY3O-1801> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_FERRICYTOCHROME-B5_RXN-10664_SGD_PWY_YeastPathways_PWY3O-1801> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,11 +857,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_32372_RXN-10662_SGD_YeastPathways_PWY3O-1801> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_32372_RXN-10662_SGD_PWY_YeastPathways_PWY3O-1801> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -852,17 +874,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_61540_RXN-10664_SGD_YeastPathways_PWY3O-1801>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1801" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-10662>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
@@ -879,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -894,11 +905,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15378_RXN-10664_SGD_YeastPathways_PWY3O-1801> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15378_RXN-10664_SGD_PWY_YeastPathways_PWY3O-1801> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -912,17 +923,6 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_32372_RXN-10662_SGD_YeastPathways_PWY3O-1801>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1801" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YGL055W-MONOMER_RXN-10664_controller>
         a       <http://identifiers.org/sgd/S000003023> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -930,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-1874.ttl
+++ b/models/YeastPathways_PWY3O-1874.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -13,26 +13,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_YeastPathways_PWY3O-1874>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1874" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" , "Provides Input For Rule. The relation 'L-glutamine + chorismate &harr; 4-amino-4-deoxychorismate + L-glutamate' 'null' '4-amino-4-deoxychorismate &rarr; 4-aminobenzoate + pyruvate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_YeastPathways_PWY3O-1874> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_PWY_YeastPathways_PWY3O-1874> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -47,11 +36,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_YeastPathways_PWY3O-1874> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_PWY_YeastPathways_PWY3O-1874> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,7 +66,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,14 +74,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_YeastPathways_PWY3O-1874>
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1874>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1874" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_PWY_YeastPathways_PWY3O-1874>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1874" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1874>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1874" ;
+                "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -124,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -132,26 +143,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_PWY3O-1874/YeastPathways_PWY3O-1874_SGD_YeastPathways_PWY3O-1874>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1874" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_YeastPathways_PWY3O-1874> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1874> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -166,11 +166,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_YeastPathways_PWY3O-1874> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_PWY_YeastPathways_PWY3O-1874> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,7 +188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,17 +199,6 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_PWY3O-1874/YeastPathways_PWY3O-1874_SGD_YeastPathways_PWY3O-1874>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1874" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -219,19 +208,41 @@
 <http://purl.obolibrary.org/obo/CHEBI_58406>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0019438>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_YeastPathways_PWY3O-1874>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1874>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1874" ;
+                "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1874>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1874" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_PWY3O-1874/YeastPathways_PWY3O-1874_SGD_PWY_YeastPathways_PWY3O-1874>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1874" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0019438>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58359_PABASYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58359> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -242,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -257,11 +268,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1874> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1874> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -278,14 +289,25 @@
 <http://identifiers.org/sgd/S000005316>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_YeastPathways_PWY3O-1874>
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_PWY_YeastPathways_PWY3O-1874>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1874" ;
+                "SGD_PWY:PWY3O-1874" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-1874>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -296,11 +318,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_PWY3O-1874> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-1874> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,11 +337,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_PWY3O-1874> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-1874> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -345,7 +367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -356,6 +378,17 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_PWY_YeastPathways_PWY3O-1874>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1874" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58406_PABASYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58406> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -365,24 +398,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1874SmallMolecule54191> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_YeastPathways_PWY3O-1874>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1874" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -391,11 +413,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_PWY3O-1874/YeastPathways_PWY3O-1874_SGD_YeastPathways_PWY3O-1874> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_PWY3O-1874/YeastPathways_PWY3O-1874_SGD_PWY_YeastPathways_PWY3O-1874> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,17 +428,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-1874/YeastPathways_PWY3O-1874>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_YeastPathways_PWY3O-1874>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1874" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -425,7 +436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -438,13 +449,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1874SmallMolecule54230> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_PWY_YeastPathways_PWY3O-1874>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1874" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -466,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -478,11 +500,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_YeastPathways_PWY3O-1874> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-1874> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -497,11 +519,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1874> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-1874> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -512,17 +534,6 @@
           <http://model.geneontology.org/reaction_ADCLY-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_YeastPathways_PWY3O-1874>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1874" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_17836_ADCLY-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17836> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -532,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -540,31 +551,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_YeastPathways_PWY3O-1874>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-1874>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1874" ;
+                "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_PWY3O-1874>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-1874>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1874" ;
+                "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -572,11 +583,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_YeastPathways_PWY3O-1874> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_PWY_YeastPathways_PWY3O-1874> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -593,23 +604,12 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_PWY3O-1874>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1874" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_PABASYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -617,11 +617,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_YeastPathways_PWY3O-1874> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-1874> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,11 +639,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_PWY3O-1874/YeastPathways_PWY3O-1874_SGD_YeastPathways_PWY3O-1874> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_PWY3O-1874/YeastPathways_PWY3O-1874_SGD_PWY_YeastPathways_PWY3O-1874> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -666,7 +666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "p-aminobenzoate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -681,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -692,22 +692,22 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-1874>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1874" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_17836>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1874>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1874" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15361_ADCLY-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
@@ -718,7 +718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -726,14 +726,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-1874>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-1874>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1874" ;
+                "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -744,11 +744,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_YeastPathways_PWY3O-1874> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_PWY_YeastPathways_PWY3O-1874> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,17 +759,6 @@
           <http://model.geneontology.org/CHEBI_17836_ADCLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_YeastPathways_PWY3O-1874>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1874" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_29748>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -777,11 +766,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_YeastPathways_PWY3O-1874> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-1874> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,3 +783,14 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_PWY3O-1874/YeastPathways_PWY3O-1874_SGD_PWY_YeastPathways_PWY3O-1874>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1874" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-188.ttl
+++ b/models/YeastPathways_PWY3O-188.ttl
@@ -1,23 +1,12 @@
-<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002234_CHEBI_57540_RXN3O-165_SGD_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 oxidized cytochrome c + ubiquinol-6 &rarr; 2 reduced cytochrome c + ubiquinone-<i>6</i>' 'null' 'succinate + ubiquinone-<i>6</i> &rarr; fumarate + ubiquinol-6' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_SUCC-FUM-OXRED-UBI-RXN_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -32,11 +21,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000001631_CPLX3O-742_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000001631_CPLX3O-742_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -51,11 +40,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000003702_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000003702_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -66,23 +55,12 @@
           <http://model.geneontology.org/SGD_S000003702_CPLX3O-109_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002233_CHEBI_52971_RXN3O-168_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000001093_CPLX3O-117_component>
         a       <http://identifiers.org/sgd/S000001093> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -91,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -109,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -117,11 +95,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002411_RXN3O-168_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002411_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -132,14 +110,14 @@
           <http://model.geneontology.org/RXN3O-168>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_BFO_0000066_reaction_SUCC-FUM-OXRED-UBI-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000005591_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -147,11 +125,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002234_CHEBI_57540_RXN3O-165_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002234_CHEBI_57540_RXN3O-165_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -166,11 +144,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000003159_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000003159_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -181,32 +159,32 @@
           <http://model.geneontology.org/SGD_S000003159_CPLX3O-117_component>
 ] .
 
-<http://model.geneontology.org/SGD_S000001631_CPLX3O-742_component>
-        a       <http://identifiers.org/sgd/S000001631> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000003159_CPLX3O-117_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003159> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004387_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188>
+<http://model.geneontology.org/SGD_S000001631_CPLX3O-742_component>
+        a       <http://identifiers.org/sgd/S000001631> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-742_component_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -215,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -224,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -237,23 +215,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002234_CHEBI_29806_SUCC-FUM-OXRED-UBI-RXN_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000004028_CPLX3O-117_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004028> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -266,23 +233,12 @@
 <http://identifiers.org/sgd/S000004869>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000005591_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_SUCC-FUM-OXRED-UBI-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -291,33 +247,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001093>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002333_YML120C-MONOMER_RXN3O-165_controller_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002333_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002333_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -331,15 +276,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_52971>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_BFO_0000066_reaction_RXN3O-9794_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_CHEBI_52971_RXN3O-168_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_CHEBI_52971_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -350,37 +306,15 @@
           <http://model.geneontology.org/CHEBI_52971_RXN3O-168>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000000750_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000002937_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-44_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-44_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,6 +325,17 @@
           <http://model.geneontology.org/SGD_S000001624_CPLX3O-44_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000003415_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -398,11 +343,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000000750_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000000750_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -412,39 +357,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/SGD_S000000750_CPLX3O-109_component>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004028_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000003159_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_BFO_0000066_reaction_RXN3O-9794_location_lociGO_0005829_SGD_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -458,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -478,9 +390,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9794_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15379_RXN3O-9794> , <http://model.geneontology.org/c795a63d-5d58-47b8-8ee3-035deeef80ba_RXN3O-168> ;
+                <http://model.geneontology.org/CHEBI_15379_RXN3O-9794> , <http://model.geneontology.org/e214ca17-aa73-49b3-95c2-9e1c04266f60_RXN3O-168> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/fd25e927-ea75-4f78-ab42-e40544cd7155_RXN3O-9794> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9794> ;
+                <http://model.geneontology.org/d27b514c-4676-4735-9db6-e034f6124fce_RXN3O-9794> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9794> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -488,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -500,11 +412,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_CHEBI_15379_RXN3O-9794_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_CHEBI_15379_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -519,11 +431,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-165_BFO_0000050_YeastPathways_PWY3O-188/YeastPathways_PWY3O-188_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-165_BFO_0000050_YeastPathways_PWY3O-188/YeastPathways_PWY3O-188_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,55 +446,16 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-188/YeastPathways_PWY3O-188>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004869_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002413_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002234_CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_721c30dd-16ef-4b5b-ae5b-51aec9f3846d_RXN3O-9794_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/fd25e927-ea75-4f78-ab42-e40544cd7155_RXN3O-9794>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "oxidized cytochrome c" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17279> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_52970_RXN3O-165>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_52970> ;
@@ -593,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -604,6 +477,28 @@
 <http://identifiers.org/sgd/S000006395>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002333_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-188/YeastPathways_PWY3O-188>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0019646> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -613,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -625,11 +520,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002233_CHEBI_30031_SUCC-FUM-OXRED-UBI-RXN_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002233_CHEBI_30031_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -644,11 +539,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" , "Provides Input For Rule. The relation 'NADH + ubiquinone-<i>6</i> &rarr; NAD<sup>+</sup> + ubiquinol-6' 'null' '2 oxidized cytochrome c + ubiquinol-6 &rarr; 2 reduced cytochrome c + ubiquinone-<i>6</i>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002413_RXN3O-168_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002413_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -666,11 +561,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004869_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004869_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -684,14 +579,14 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003581_CPLX3O-44_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_CHEBI_15377_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -704,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -715,43 +610,21 @@
 <http://identifiers.org/sgd/S000000750>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/SGD_S000003415_CPLX3O-109_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003415> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000002937_CPLX3O-109_component>
         a       <http://identifiers.org/sgd/S000002937> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002234_CHEBI_52970_RXN3O-165_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/SGD_S000003415_CPLX3O-109_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003415> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002411_RXN3O-9794_SGD_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -764,7 +637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "aerobic respiration, electron transport chain - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -776,11 +649,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002411_RXN3O-9794_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002411_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -798,11 +671,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -816,23 +689,12 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-168_BFO_0000050_YeastPathways_PWY3O-188/YeastPathways_PWY3O-188_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000004997_CPLX3O-117_component>
         a       <http://identifiers.org/sgd/S000004997> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -840,11 +702,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000003415_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000003415_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -855,25 +717,47 @@
           <http://model.geneontology.org/SGD_S000003415_CPLX3O-109_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-742_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000007281_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188>
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-44_component_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002233_CHEBI_52971_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002233_CHEBI_30031_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000002937_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -881,11 +765,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_fd25e927-ea75-4f78-ab42-e40544cd7155_RXN3O-9794_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_d27b514c-4676-4735-9db6-e034f6124fce_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -893,32 +777,21 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9794> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fd25e927-ea75-4f78-ab42-e40544cd7155_RXN3O-9794>
+          <http://model.geneontology.org/d27b514c-4676-4735-9db6-e034f6124fce_RXN3O-9794>
 ] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_CHEBI_52971_RXN3O-168_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002233_CHEBI_57945_RXN3O-165_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002233_CHEBI_57945_RXN3O-165_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -936,11 +809,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000002225_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000002225_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -951,17 +824,50 @@
           <http://model.geneontology.org/SGD_S000002225_CPLX3O-117_component>
 ] .
 
-<http://identifiers.org/sgd/S000004028>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000000141_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188>
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000007281_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004028>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002333_YML120C-MONOMER_RXN3O-165_controller_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-165_BFO_0000066_reaction_RXN3O-165_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000000141_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -970,18 +876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002411_SUCC-FUM-OXRED-UBI-RXN_SGD_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -992,11 +887,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002234_CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002234_CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1011,11 +906,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1030,11 +925,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000007281_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000007281_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1050,7 +945,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-165_BFO_0000050_YeastPathways_PWY3O-188/YeastPathways_PWY3O-188_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1066,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,11 +984,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_BFO_0000050_YeastPathways_PWY3O-188/YeastPathways_PWY3O-188_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_BFO_0000050_YeastPathways_PWY3O-188/YeastPathways_PWY3O-188_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1093,26 +999,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-188/YeastPathways_PWY3O-188>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-742_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-742_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-742_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1123,25 +1018,25 @@
           <http://model.geneontology.org/SGD_S000002585_CPLX3O-742_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_BFO_0000050_YeastPathways_PWY3O-188/YeastPathways_PWY3O-188_SGD_YeastPathways_PWY3O-188>
+<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002234_CHEBI_52970_RXN3O-165_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-742_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000007260_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1149,11 +1044,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000005591_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000005591_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1164,14 +1059,28 @@
           <http://model.geneontology.org/SGD_S000005591_CPLX3O-109_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000007270_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000003581_CPLX3O-44_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003581> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0008177>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_30031_SUCC-FUM-OXRED-UBI-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30031> ;
@@ -1182,16 +1091,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17376> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/GO_0008177>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1200,11 +1106,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_BFO_0000050_YeastPathways_PWY3O-188/YeastPathways_PWY3O-188_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_BFO_0000050_YeastPathways_PWY3O-188/YeastPathways_PWY3O-188_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1219,11 +1125,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002333_YML120C-MONOMER_RXN3O-165_controller_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002333_YML120C-MONOMER_RXN3O-165_controller_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1234,26 +1140,15 @@
           <http://model.geneontology.org/YML120C-MONOMER_RXN3O-165_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004028_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004028_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1264,56 +1159,51 @@
           <http://model.geneontology.org/SGD_S000004028_CPLX3O-117_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_CHEBI_15379_RXN3O-9794_SGD_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002233_CHEBI_57945_RXN3O-165_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002333_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_SGD_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000003702_CPLX3O-109_component>
         a       <http://identifiers.org/sgd/S000003702> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/dfce4873-fa27-4563-83f2-e7f05b7b63c1_RXN3O-168>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "reduced cytochrome c" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17257> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002333_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1322,11 +1212,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'succinate + ubiquinone-<i>6</i> &rarr; fumarate + ubiquinol-6' 'null' '2 oxidized cytochrome c + ubiquinol-6 &rarr; 2 reduced cytochrome c + ubiquinone-<i>6</i>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002413_RXN3O-168_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002413_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1343,14 +1233,14 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002411_RXN3O-168_SGD_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000006395_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1358,11 +1248,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_dae5d737-39b9-404f-94cc-6dbc0e1f39ef_RXN3O-168_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_dfce4873-fa27-4563-83f2-e7f05b7b63c1_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1370,7 +1260,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-168> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/dae5d737-39b9-404f-94cc-6dbc0e1f39ef_RXN3O-168>
+          <http://model.geneontology.org/dfce4873-fa27-4563-83f2-e7f05b7b63c1_RXN3O-168>
 ] .
 
 <http://identifiers.org/sgd/S000007260>
@@ -1383,11 +1273,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-44_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-44_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1406,7 +1296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1415,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1423,11 +1313,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000001929_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000001929_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1438,26 +1328,12 @@
           <http://model.geneontology.org/SGD_S000001929_CPLX3O-109_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004997_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/c795a63d-5d58-47b8-8ee3-035deeef80ba_RXN3O-168>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/SGD_S000000750_CPLX3O-109_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000750> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1480,7 +1356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1488,16 +1364,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000003155_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_e214ca17-aa73-49b3-95c2-9e1c04266f60_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9794> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/e214ca17-aa73-49b3-95c2-9e1c04266f60_RXN3O-168>
+] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9794>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -1508,7 +1392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1516,33 +1400,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_c795a63d-5d58-47b8-8ee3-035deeef80ba_RXN3O-168_SGD_YeastPathways_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9794> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c795a63d-5d58-47b8-8ee3-035deeef80ba_RXN3O-168>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002333_CPLX3O-109_RXN3O-168_controller_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-168_BFO_0000050_YeastPathways_PWY3O-188/YeastPathways_PWY3O-188_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1550,11 +1415,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-165_BFO_0000066_reaction_RXN3O-165_location_lociGO_0005829_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-165_BFO_0000066_reaction_RXN3O-165_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1572,11 +1437,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000007270_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000007270_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1599,7 +1464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1607,24 +1472,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002233_CHEBI_52971_RXN3O-168_SGD_YeastPathways_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_52971_RXN3O-168>
-] .
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000001929_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/e214ca17-aa73-49b3-95c2-9e1c04266f60_RXN3O-168>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_CHEBI_15379_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_52971_RXN3O-168>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_52971> ;
@@ -1635,7 +1506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1643,15 +1514,59 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-44_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_BFO_0000050_YeastPathways_PWY3O-188/YeastPathways_PWY3O-188_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002233_CHEBI_52971_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_52971_RXN3O-168>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002333_CPLX3O-109_RXN3O-168_controller_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/6ec260f6-7a26-4c0d-8757-473a4913a040_RXN3O-9794>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_BFO_0000050_YeastPathways_PWY3O-188/YeastPathways_PWY3O-188_SGD_PWY_YeastPathways_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1662,6 +1577,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-188/YeastPathways_PWY3O-188>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000001631_CPLX3O-742_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YML120C-MONOMER_RXN3O-165_controller>
         a       <http://identifiers.org/sgd/S000004589> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1669,7 +1595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1681,11 +1607,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004997_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004997_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1696,36 +1622,53 @@
           <http://model.geneontology.org/SGD_S000004997_CPLX3O-117_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-44_component_SGD_YeastPathways_PWY3O-188>
+<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002234_CHEBI_57540_RXN3O-165_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000007283_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188>
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002234_CHEBI_29806_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000001631_CPLX3O-742_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://identifiers.org/sgd/S000001631>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000002937>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000003159_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1750,7 +1693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1758,11 +1701,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://identifiers.org/sgd/S000001631>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/d27b514c-4676-4735-9db6-e034f6124fce_RXN3O-9794>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "oxidized cytochrome c" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17279> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000002937>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_BFO_0000050_YeastPathways_PWY3O-188/YeastPathways_PWY3O-188_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29806_SUCC-FUM-OXRED-UBI-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29806> ;
@@ -1773,7 +1738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1785,11 +1750,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 oxidized cytochrome c + ubiquinol-6 &rarr; 2 reduced cytochrome c + ubiquinone-<i>6</i>' 'null' 'NADH + ubiquinone-<i>6</i> &rarr; NAD<sup>+</sup> + ubiquinol-6' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_RXN3O-165_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_RXN3O-165_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1804,11 +1769,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-742_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-742_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1826,11 +1791,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000003529_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000003529_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1841,28 +1806,17 @@
           <http://model.geneontology.org/SGD_S000003529_CPLX3O-109_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000003702_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000002225_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188>
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_CHEBI_52971_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1871,34 +1825,34 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_c795a63d-5d58-47b8-8ee3-035deeef80ba_RXN3O-168_SGD_YeastPathways_PWY3O-188>
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004869_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_RXN3O-165_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000141>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-165_BFO_0000050_YeastPathways_PWY3O-188/YeastPathways_PWY3O-188_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1907,11 +1861,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002333_CPLX3O-117_RXN3O-9794_controller_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002333_CPLX3O-117_RXN3O-9794_controller_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1926,11 +1880,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002234_CHEBI_52970_RXN3O-165_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002234_CHEBI_52970_RXN3O-165_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1941,26 +1895,15 @@
           <http://model.geneontology.org/CHEBI_52970_RXN3O-165>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-165_BFO_0000066_reaction_RXN3O-165_location_lociGO_0005829_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000003155_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000003155_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1971,51 +1914,62 @@
           <http://model.geneontology.org/SGD_S000003155_CPLX3O-117_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_SUCC-FUM-OXRED-UBI-RXN_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-742_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-44_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000007283_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_RXN3O-165_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_BFO_0000066_reaction_SUCC-FUM-OXRED-UBI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002234_CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002333_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002333_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2033,11 +1987,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_721c30dd-16ef-4b5b-ae5b-51aec9f3846d_RXN3O-9794_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_6ec260f6-7a26-4c0d-8757-473a4913a040_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2045,18 +1999,51 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-168> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/721c30dd-16ef-4b5b-ae5b-51aec9f3846d_RXN3O-9794>
+          <http://model.geneontology.org/6ec260f6-7a26-4c0d-8757-473a4913a040_RXN3O-9794>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000003702_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004028_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002411_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000007283_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000007283_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2067,15 +2054,26 @@
           <http://model.geneontology.org/SGD_S000007283_CPLX3O-117_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000000750_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000000141_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000000141_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2086,25 +2084,14 @@
           <http://model.geneontology.org/SGD_S000000141_CPLX3O-109_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002233_CHEBI_52971_RXN3O-168_SGD_YeastPathways_PWY3O-188>
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002411_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002413_RXN3O-168_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2120,9 +2107,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-168_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/721c30dd-16ef-4b5b-ae5b-51aec9f3846d_RXN3O-9794> , <http://model.geneontology.org/CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN> ;
+                <http://model.geneontology.org/CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN> , <http://model.geneontology.org/6ec260f6-7a26-4c0d-8757-473a4913a040_RXN3O-9794> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_52971_RXN3O-168> , <http://model.geneontology.org/dae5d737-39b9-404f-94cc-6dbc0e1f39ef_RXN3O-168> ;
+                <http://model.geneontology.org/CHEBI_52971_RXN3O-168> , <http://model.geneontology.org/dfce4873-fa27-4563-83f2-e7f05b7b63c1_RXN3O-168> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-109_RXN3O-168_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2132,24 +2119,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188BiochemicalReaction17459> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-168_BFO_0000066_reaction_RXN3O-168_location_lociGO_0005829_SGD_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004997>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2158,11 +2134,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_BFO_0000066_reaction_RXN3O-9794_location_lociGO_0005829_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_BFO_0000066_reaction_RXN3O-9794_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2177,11 +2153,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-742_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-742_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2192,23 +2168,12 @@
           <http://model.geneontology.org/SGD_S000003964_CPLX3O-742_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002333_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-165_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2216,11 +2181,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000006395_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000006395_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2234,14 +2199,14 @@
 <http://identifiers.org/sgd/S000003415>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_6ec260f6-7a26-4c0d-8757-473a4913a040_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2257,7 +2222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2269,11 +2234,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_BFO_0000066_reaction_SUCC-FUM-OXRED-UBI-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_BFO_0000066_reaction_SUCC-FUM-OXRED-UBI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2284,14 +2249,25 @@
           <http://model.geneontology.org/reaction_SUCC-FUM-OXRED-UBI-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000003415_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188>
+<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002233_CHEBI_57945_RXN3O-165_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002413_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2299,11 +2275,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002411_SUCC-FUM-OXRED-UBI-RXN_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002411_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2314,15 +2290,26 @@
           <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000003155_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004387_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004387_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2333,17 +2320,6 @@
           <http://model.geneontology.org/SGD_S000004387_CPLX3O-117_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000001093_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CPLX3O-109_RXN3O-168_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2353,7 +2329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2364,56 +2340,45 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://identifiers.org/sgd/S000004387>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_dae5d737-39b9-404f-94cc-6dbc0e1f39ef_RXN3O-168_SGD_YeastPathways_PWY3O-188>
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002411_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004387>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_BFO_0000050_YeastPathways_PWY3O-188/YeastPathways_PWY3O-188_SGD_YeastPathways_PWY3O-188>
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003581_CPLX3O-44_component_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/SGD_S000007281_CPLX3O-117_component>
         a       <http://identifiers.org/sgd/S000007281> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_CHEBI_15377_RXN3O-9794_SGD_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2423,7 +2388,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000001093_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2432,7 +2408,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004387_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2441,7 +2428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2449,11 +2436,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002333_CPLX3O-109_RXN3O-168_controller_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002333_CPLX3O-109_RXN3O-168_controller_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2468,11 +2455,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003581_CPLX3O-44_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003581_CPLX3O-44_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2488,18 +2475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000003529_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2507,11 +2483,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000002937_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000002937_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2522,14 +2498,14 @@
           <http://model.geneontology.org/SGD_S000002937_CPLX3O-109_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000007260_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-168_BFO_0000066_reaction_RXN3O-168_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2538,7 +2514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2548,15 +2524,18 @@
 <http://identifiers.org/sgd/S000003702>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_29806>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_CHEBI_15377_RXN3O-9794_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_CHEBI_15377_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2567,25 +2546,23 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-9794>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000007270_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/SGD_S000005591_CPLX3O-109_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005591> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000006395_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188>
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-742_component_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2593,11 +2570,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002233_CHEBI_52971_RXN3O-168_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002233_CHEBI_52971_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2608,18 +2585,26 @@
           <http://model.geneontology.org/CHEBI_52971_RXN3O-168>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_29806>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_e214ca17-aa73-49b3-95c2-9e1c04266f60_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000001093_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000001093_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2633,34 +2618,25 @@
 <http://identifiers.org/sgd/S000001929>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/SGD_S000005591_CPLX3O-109_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005591> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002413_RXN3O-168_SGD_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002333_CPLX3O-117_RXN3O-9794_controller_SGD_YeastPathways_PWY3O-188>
+<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002233_CHEBI_52971_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2669,7 +2645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2678,7 +2654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2687,12 +2663,34 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003581>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000002225_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000003529_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001624>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2706,16 +2704,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188Complex17298> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
-
-<http://model.geneontology.org/721c30dd-16ef-4b5b-ae5b-51aec9f3846d_RXN3O-9794>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://identifiers.org/sgd/S000003155>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2724,11 +2719,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002234_CHEBI_29806_SUCC-FUM-OXRED-UBI-RXN_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002234_CHEBI_29806_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2739,15 +2734,26 @@
           <http://model.geneontology.org/CHEBI_29806_SUCC-FUM-OXRED-UBI-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_d27b514c-4676-4735-9db6-e034f6124fce_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_BFO_0000066_reaction_RXN3O-168_location_lociGO_0005829_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_BFO_0000066_reaction_RXN3O-168_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2767,7 +2773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2775,15 +2781,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000004997_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000007260_CPLX3O-117_component_SGD_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000007260_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2794,53 +2811,14 @@
           <http://model.geneontology.org/SGD_S000007260_CPLX3O-117_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000001929_CPLX3O-109_component_SGD_YeastPathways_PWY3O-188>
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002333_CPLX3O-117_RXN3O-9794_controller_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002233_CHEBI_30031_SUCC-FUM-OXRED-UBI-RXN_SGD_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/dae5d737-39b9-404f-94cc-6dbc0e1f39ef_RXN3O-168>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "reduced cytochrome c" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17257> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_fd25e927-ea75-4f78-ab42-e40544cd7155_RXN3O-9794_SGD_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2849,6 +2827,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_BFO_0000050_YeastPathways_PWY3O-188/YeastPathways_PWY3O-188_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_dfce4873-fa27-4563-83f2-e7f05b7b63c1_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-19.ttl
+++ b/models/YeastPathways_PWY3O-19.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,6 +17,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-19/YeastPathways_PWY3O-19>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002413_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_2.1.1.114-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -26,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,11 +49,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" , "Provides Input For Rule. The relation '2-hexaprenyl-6-methoxyphenol + NADPH + oxygen + H<SUP>+</SUP> &rarr; 2-methoxy-6-<i>all trans</i>-hexaprenyl-1,4-benzoquinol + NADP<sup>+</sup> + H<sub>2</sub>O' 'null' '<i>S</i>-adenosyl-L-methionine + 2-methoxy-6-<i>all trans</i>-hexaprenyl-1,4-benzoquinol &rarr; 6-methoxy-3-methyl-2-<i>all-trans</i>-hexaprenyl-1,4-benzoquinol + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002413_RXN3O-54_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002413_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,25 +64,14 @@
           <http://model.geneontology.org/RXN3O-54>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002233_CHEBI_57916_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-75_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_15377_RXN3O-12_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -79,11 +79,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002333_YNR041C-MONOMER_RXN-9003_controller_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002333_YNR041C-MONOMER_RXN-9003_controller_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -93,39 +93,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YNR041C-MONOMER_RXN-9003_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002234_CHEBI_1109_RXN3O-73_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-75_BFO_0000066_reaction_RXN3O-75_location_lociGO_0005829_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_57916_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -142,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -154,11 +121,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_BFO_0000066_reaction_RXN3O-75_location_lociGO_0005829_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_BFO_0000066_reaction_RXN3O-75_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,15 +136,26 @@
           <http://model.geneontology.org/reaction_RXN3O-75_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002233_CHEBI_61472_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002333_YML110C-MONOMER_RXN3O-54_controller_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002333_YML110C-MONOMER_RXN3O-54_controller_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -192,11 +170,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_52970_RXN3O-102_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_52970_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -207,14 +185,14 @@
           <http://model.geneontology.org/CHEBI_52970_RXN3O-102>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002413_RXN3O-102_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_15378_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -227,24 +205,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41561> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_61473_RXN3O-54_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -258,15 +225,48 @@
 <http://purl.obolibrary.org/obo/GO_0008689>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002413_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_15379_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002333_YGR255C-MONOMER_RXN3O-58_controller_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '6-methoxy-3-methyl-2-<i>all-trans</i>-hexaprenyl-1,4-benzoquinol + a reduced electron acceptor + oxygen &rarr; 3-demethylubiquinol-6 + an oxidized electron acceptor + H<sub>2</sub>O' 'null' '<i>S</i>-adenosyl-L-methionine + 3-demethylubiquinol-6 &rarr; <i>S</i>-adenosyl-L-homocysteine + ubiquinol-6 + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002413_RXN3O-102_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002413_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -281,11 +281,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_15377_RXN3O-58_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_15377_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -300,11 +300,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_57783_RXN3O-12_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_57783_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -322,11 +322,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9003_BFO_0000066_reaction_RXN-9003_location_lociGO_0005829_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9003_BFO_0000066_reaction_RXN-9003_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -336,6 +336,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN-9003_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000066_reaction_2.1.1.114-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-58_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0043333>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -349,13 +371,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41423> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_61473_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_30763_RXN-9003_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -367,11 +411,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002333_YOL096C-MONOMER_2.1.1.114-RXN_controller_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002333_YOL096C-MONOMER_2.1.1.114-RXN_controller_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,11 +430,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002233_CHEBI_57916_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002233_CHEBI_57916_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -401,25 +445,14 @@
           <http://model.geneontology.org/CHEBI_57916_2.1.1.114-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002413_RXN3O-12_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9003_BFO_0000066_reaction_RXN-9003_location_lociGO_0005829_SGD_YeastPathways_PWY3O-19>
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_Apo-Ferredoxins_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-19>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -427,11 +460,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002233_CHEBI_59789_RXN3O-54_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002233_CHEBI_59789_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -442,25 +475,14 @@
           <http://model.geneontology.org/CHEBI_59789_RXN3O-54>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_15339_RXN3O-75_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_58179_RXN-9003_SGD_YeastPathways_PWY3O-19>
+<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_58349_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-19>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -473,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -490,13 +512,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41546> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_58179_RXN-9003_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-75_BFO_0000066_reaction_RXN3O-75_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YNR041C-MONOMER_RXN-9003_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005324> ;
@@ -505,13 +560,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19Protein41386> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_52970_RXN3O-102>
         a       <http://purl.obolibrary.org/obo/CHEBI_52970> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -522,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,26 +596,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002413_RXN3O-75_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_61473_RXN3O-54_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_61473_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -560,15 +615,21 @@
           <http://model.geneontology.org/CHEBI_61473_RXN3O-54>
 ] .
 
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://identifiers.org/sgd/S000003487>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_BFO_0000066_reaction_RXN3O-58_location_lociGO_0005829_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_BFO_0000066_reaction_RXN3O-58_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -579,21 +640,18 @@
           <http://model.geneontology.org/reaction_RXN3O-58_location_lociGO_0005829>
 ] .
 
-<http://identifiers.org/sgd/S000003487>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,28 +662,36 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-19/YeastPathways_PWY3O-19>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_15379_RXN3O-75_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002413_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-54_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_YeastPathways_PWY3O-19>
+<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002413_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_57783_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-19>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -638,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -646,59 +712,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_57856_RXN3O-54_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_52970_RXN3O-102_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_58349_RXN3O-12_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002233_CHEBI_61472_RXN3O-12_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002233_CHEBI_58373_RXN3O-58_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002233_CHEBI_58373_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,11 +735,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002333_YGR255C-MONOMER_RXN3O-58_controller_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002333_YGR255C-MONOMER_RXN3O-58_controller_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -737,7 +759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -749,11 +771,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_61472_RXN3O-12_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_61472_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -764,6 +786,17 @@
           <http://model.geneontology.org/CHEBI_61472_RXN3O-12>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-54_BFO_0000066_reaction_RXN3O-54_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -772,7 +805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -785,7 +818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "ubiquinol-6 biosynthesis from 4-hydroxybenzoate (eukaryotic) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -798,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -806,11 +839,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002234_CHEBI_29888_RXN-9003_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002234_CHEBI_29888_RXN-9003_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -826,18 +859,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9003_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_YeastPathways_PWY3O-19>
+<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_61473_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-19>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -846,55 +879,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002233_CHEBI_59789_RXN3O-54_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_84492>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_30763_RXN-9003_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" , "Provides Input For Rule. The relation '3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + H<SUP>+</SUP> &rarr; 2-hexaprenyl-6-methoxyphenol + CO<SUB>2</SUB>' 'null' '2-hexaprenyl-6-methoxyphenol + NADPH + oxygen + H<SUP>+</SUP> &rarr; 2-methoxy-6-<i>all trans</i>-hexaprenyl-1,4-benzoquinol + NADP<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002413_RXN3O-12_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002413_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -905,8 +905,41 @@
           <http://model.geneontology.org/RXN3O-12>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002233_CHEBI_59789_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002413_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_57856_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9003>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008412> ;
@@ -927,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -939,11 +972,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_57856_RXN3O-54_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_57856_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -954,15 +987,26 @@
           <http://model.geneontology.org/CHEBI_57856_RXN3O-54>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_15379_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002233_CHEBI_64253_RXN3O-75_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002233_CHEBI_64253_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -973,28 +1017,6 @@
           <http://model.geneontology.org/CHEBI_64253_RXN3O-75>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002234_CHEBI_16526_RXN3O-73_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_61472_RXN3O-12_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_64253_RXN3O-75>
         a       <http://purl.obolibrary.org/obo/CHEBI_64253> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1004,7 +1026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1019,11 +1041,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_64253_RXN3O-75_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_64253_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1038,11 +1060,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15379_RXN3O-58_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15379_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1053,15 +1075,26 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-58>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-12_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_15378_RXN3O-12_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_15378_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1072,25 +1105,14 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-12>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002413_RXN3O-73_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002234_CHEBI_29888_RXN-9003_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002233_CHEBI_59789_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1103,7 +1125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1114,14 +1136,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_57856_RXN3O-102_SGD_YeastPathways_PWY3O-19>
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_Reduced-ferredoxins_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-19>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_15378_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1135,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1147,11 +1180,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_57856_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_57856_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1171,7 +1204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1183,11 +1216,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000066_reaction_RXN3O-73_location_lociGO_0005829_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000066_reaction_RXN3O-73_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1202,11 +1235,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-54_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-54_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1217,14 +1250,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-19/YeastPathways_PWY3O-19>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_57783_RXN3O-12_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_57856_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1232,11 +1265,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'all-<i>trans</i>-hexaprenyl diphosphate + 4-hydroxybenzoate &rarr; 3-hexaprenyl-4-hydroxybenzoate + diphosphate' 'null' '3-hexaprenyl-4-hydroxybenzoate + 2 a reduced ferredoxin [iron-sulfur] cluster + oxygen + 2 H<SUP>+</SUP> &rarr; 3,4-dihydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + 2 an oxidized ferredoxin [iron-sulfur] cluster + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002413_RXN3O-58_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002413_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1253,23 +1286,34 @@
 <http://purl.obolibrary.org/obo/CHEBI_61472>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://purl.obolibrary.org/obo/GO_0008682>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_57916>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_YeastPathways_PWY3O-19>
+<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002233_CHEBI_59789_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-19>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9003_BFO_0000066_reaction_RXN-9003_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1277,11 +1321,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_15379_RXN3O-75_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_15379_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1296,11 +1340,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + 2-methoxy-6-<i>all trans</i>-hexaprenyl-1,4-benzoquinol &rarr; 6-methoxy-3-methyl-2-<i>all-trans</i>-hexaprenyl-1,4-benzoquinol + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' '6-methoxy-3-methyl-2-<i>all-trans</i>-hexaprenyl-1,4-benzoquinol + a reduced electron acceptor + oxygen &rarr; 3-demethylubiquinol-6 + an oxidized electron acceptor + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002413_RXN3O-75_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002413_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1330,7 +1374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1357,7 +1401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1369,11 +1413,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_57856_RXN3O-102_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_57856_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1383,6 +1427,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57856_RXN3O-102>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000066_reaction_RXN3O-73_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004578>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1406,7 +1461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1414,19 +1469,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002333_YML110C-MONOMER_RXN3O-54_controller_SGD_YeastPathways_PWY3O-19>
+<http://model.geneontology.org/ev_w_id_RXN-9003_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_PWY_YeastPathways_PWY3O-19>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-54_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YOL096C-MONOMER_2.1.1.114-RXN_controller>
         a       <http://identifiers.org/sgd/S000005456> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1435,7 +1501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1449,16 +1515,19 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_17499_RXN3O-75_SGD_YeastPathways_PWY3O-19>
+<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002333_MONOMER3O-164_RXN3O-75_controller_SGD_PWY_YeastPathways_PWY3O-19>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_59789>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1467,11 +1536,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1491,7 +1560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1503,11 +1572,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_58373_RXN3O-58_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_58373_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1527,7 +1596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1535,18 +1604,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_59789>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_15377_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_61472_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_15377_RXN3O-12_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_15377_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1566,7 +1654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1578,11 +1666,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_30763_RXN-9003_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_30763_RXN-9003_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1593,14 +1681,14 @@
           <http://model.geneontology.org/CHEBI_30763_RXN-9003>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15379_RXN3O-58_SGD_YeastPathways_PWY3O-19>
+<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_52970_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-19>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1616,7 +1704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1624,25 +1712,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-58_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15379_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-12_BFO_0000066_reaction_RXN3O-12_location_lociGO_0005829_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1652,26 +1729,15 @@
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-58_BFO_0000066_reaction_RXN3O-58_location_lociGO_0005829_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" , "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + 3,4-dihydroxy-5-<i>all-trans</i>-hexaprenylbenzoate &rarr; <i>S</i>-adenosyl-L-homocysteine + 3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + H<SUP>+</SUP>' 'null' '3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + H<SUP>+</SUP> &rarr; 2-hexaprenyl-6-methoxyphenol + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002413_RXN3O-73_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002413_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1686,11 +1752,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002234_CHEBI_1109_RXN3O-73_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002234_CHEBI_1109_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1701,14 +1767,14 @@
           <http://model.geneontology.org/CHEBI_1109_RXN3O-73>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002413_RXN3O-58_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_57916_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1716,11 +1782,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002233_CHEBI_61472_RXN3O-12_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002233_CHEBI_61472_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1738,11 +1804,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-102_BFO_0000066_reaction_RXN3O-102_location_lociGO_0005829_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-102_BFO_0000066_reaction_RXN3O-102_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1752,28 +1818,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN3O-102_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-102_BFO_0000066_reaction_RXN3O-102_location_lociGO_0005829_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002233_CHEBI_58373_RXN3O-58_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_64253>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1797,7 +1841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1805,45 +1849,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002234_CHEBI_84492_RXN-9003_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-73_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002333_YOL096C-MONOMER_RXN3O-102_controller_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_15379_RXN3O-12_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002333_YOL096C-MONOMER_2.1.1.114-RXN_controller_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1851,11 +1873,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_15339_RXN3O-75_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_15339_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1866,26 +1888,15 @@
           <http://model.geneontology.org/CHEBI_15339_RXN3O-75>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_1109_RXN3O-73_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_Apo-Ferredoxins_RXN3O-58_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_Apo-Ferredoxins_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1896,26 +1907,15 @@
           <http://model.geneontology.org/Apo-Ferredoxins_RXN3O-58>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_15378_RXN3O-102_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_BFO_0000066_reaction_RXN3O-12_location_lociGO_0005829_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_BFO_0000066_reaction_RXN3O-12_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1935,24 +1935,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41334> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_Reduced-ferredoxins_RXN3O-58_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30763_RXN-9003>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30763> ;
@@ -1963,7 +1952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1978,13 +1967,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19Protein41516> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002233_CHEBI_15378_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-54>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1995,11 +1995,39 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41423> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-102_BFO_0000066_reaction_RXN3O-102_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_29888_RXN-9003>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41377> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2012,28 +2040,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41423> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_29888_RXN-9003>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41377> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2046,7 +2057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2054,15 +2065,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-102_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002233_CHEBI_59789_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002233_CHEBI_59789_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2071,25 +2093,6 @@
           <http://model.geneontology.org/2.1.1.114-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_59789_2.1.1.114-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '3-hexaprenyl-4-hydroxybenzoate + 2 a reduced ferredoxin [iron-sulfur] cluster + oxygen + 2 H<SUP>+</SUP> &rarr; 3,4-dihydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + 2 an oxidized ferredoxin [iron-sulfur] cluster + H<sub>2</sub>O' 'null' '<i>S</i>-adenosyl-L-methionine + 3,4-dihydroxy-5-<i>all-trans</i>-hexaprenylbenzoate &rarr; <i>S</i>-adenosyl-L-homocysteine + 3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002413_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-19> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-58> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.1.1.114-RXN>
 ] .
 
 <http://model.geneontology.org/RXN3O-102>
@@ -2109,7 +2112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2117,14 +2120,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002333_MONOMER3O-164_RXN3O-75_controller_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '3-hexaprenyl-4-hydroxybenzoate + 2 a reduced ferredoxin [iron-sulfur] cluster + oxygen + 2 H<SUP>+</SUP> &rarr; 3,4-dihydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + 2 an oxidized ferredoxin [iron-sulfur] cluster + H<sub>2</sub>O' 'null' '<i>S</i>-adenosyl-L-methionine + 3,4-dihydroxy-5-<i>all-trans</i>-hexaprenylbenzoate &rarr; <i>S</i>-adenosyl-L-homocysteine + 3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002413_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-19> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-58> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/2.1.1.114-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002413_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2132,11 +2154,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002333_YGR255C-MONOMER_RXN3O-12_controller_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002333_YGR255C-MONOMER_RXN3O-12_controller_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2150,15 +2172,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_57856>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002413_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002234_CHEBI_84492_RXN-9003_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002234_CHEBI_84492_RXN-9003_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2169,6 +2202,17 @@
           <http://model.geneontology.org/CHEBI_84492_RXN-9003>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002333_YML110C-MONOMER_RXN3O-54_controller_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_17499_RXN3O-75>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2178,7 +2222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2199,35 +2243,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19Protein41533> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_15377_RXN3O-75_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002234_CHEBI_84492_RXN-9003_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2236,11 +2258,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2251,16 +2273,24 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-19/YeastPathways_PWY3O-19>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_64253_RXN3O-75_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_61473_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-19> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-54> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_61473_RXN3O-54>
+] .
 
 <http://model.geneontology.org/RXN3O-73>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
@@ -2279,7 +2309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2287,34 +2317,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_61473_RXN3O-54_SGD_YeastPathways_PWY3O-19> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-54> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61473_RXN3O-54>
-] .
+<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_15378_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_15378_RXN3O-102_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_15378_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2332,7 +2354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2340,14 +2362,58 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-12_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_YeastPathways_PWY3O-19>
+<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_57856_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002234_CHEBI_16526_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_15377_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-19>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_84492_RXN-9003_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_15339_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2360,7 +2426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2370,17 +2436,6 @@
 
 <http://identifiers.org/sgd/S000005456>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-75_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -2394,7 +2449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2411,7 +2466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2423,11 +2478,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002333_MONOMER3O-164_RXN3O-75_controller_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002333_MONOMER3O-164_RXN3O-75_controller_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2441,15 +2496,24 @@
 <http://purl.obolibrary.org/obo/CHEBI_52970>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/reaction_RXN3O-58_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_84492_RXN-9003_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_84492_RXN-9003_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2460,12 +2524,25 @@
           <http://model.geneontology.org/CHEBI_84492_RXN-9003>
 ] .
 
-<http://model.geneontology.org/reaction_RXN3O-58_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-58_BFO_0000066_reaction_RXN3O-58_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_1109_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2473,11 +2550,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_15379_RXN3O-12_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_15379_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2488,14 +2565,14 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-12>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002233_CHEBI_59789_RXN3O-102_SGD_YeastPathways_PWY3O-19>
+<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002234_CHEBI_1109_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-19>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2503,11 +2580,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9003_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9003_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2517,6 +2594,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-19/YeastPathways_PWY3O-19>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002233_CHEBI_59789_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008412>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2530,7 +2618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2538,25 +2626,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002333_YGR255C-MONOMER_RXN3O-12_controller_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_57856_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-19>
+<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002333_YOL096C-MONOMER_RXN3O-102_controller_SGD_PWY_YeastPathways_PWY3O-19>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2565,7 +2642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2573,11 +2650,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_57916_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_57916_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2588,14 +2665,14 @@
           <http://model.geneontology.org/CHEBI_57916_2.1.1.114-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002233_CHEBI_64253_RXN3O-75_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_58373_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2603,11 +2680,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002233_CHEBI_15378_RXN3O-73_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002233_CHEBI_15378_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2627,7 +2704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2635,15 +2712,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_17499_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-54_BFO_0000066_reaction_RXN3O-54_location_lociGO_0005829_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-54_BFO_0000066_reaction_RXN3O-54_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2658,11 +2746,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-102_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-102_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2673,14 +2761,25 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-19/YeastPathways_PWY3O-19>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_15378_RXN3O-54_SGD_YeastPathways_PWY3O-19>
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15378_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-19>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002333_YNR041C-MONOMER_RXN-9003_controller_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2696,7 +2795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2713,7 +2812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2721,18 +2820,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0009058>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_17499_RXN3O-75_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_17499_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2743,37 +2839,18 @@
           <http://model.geneontology.org/CHEBI_17499_RXN3O-75>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000066_reaction_2.1.1.114-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_84492_RXN-9003_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0009058>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2784,18 +2861,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-19/YeastPathways_PWY3O-19>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002333_YOL096C-MONOMER_RXN3O-102_controller_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002333_YOL096C-MONOMER_RXN3O-102_controller_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2806,44 +2880,22 @@
           <http://model.geneontology.org/YOL096C-MONOMER_RXN3O-102_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002333_YGR255C-MONOMER_RXN3O-58_controller_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002413_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000005651>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_Apo-Ferredoxins_RXN3O-58_SGD_YeastPathways_PWY3O-19>
+<http://model.geneontology.org/ev_w_id_RXN3O-12_BFO_0000066_reaction_RXN3O-12_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-19>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-73>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2854,7 +2906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2862,8 +2914,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://identifiers.org/sgd/S000005651>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57856_2.1.1.114-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57856> ;
@@ -2874,7 +2926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2882,61 +2934,20 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002233_CHEBI_15378_RXN3O-73_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-102_BFO_0000050_YeastPathways_PWY3O-19/YeastPathways_PWY3O-19_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_61473_RXN3O-54_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-54_BFO_0000066_reaction_RXN3O-54_location_lociGO_0005829_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15378_RXN3O-58_SGD_YeastPathways_PWY3O-19>
+<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_15378_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-19>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2944,11 +2955,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000066_reaction_2.1.1.114-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000066_reaction_2.1.1.114-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2963,11 +2974,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_Reduced-ferredoxins_RXN3O-58_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_Reduced-ferredoxins_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2978,15 +2989,26 @@
           <http://model.geneontology.org/Reduced-ferredoxins_RXN3O-58>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002233_CHEBI_57916_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_58349_RXN3O-12_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_58349_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2997,26 +3019,15 @@
           <http://model.geneontology.org/CHEBI_58349_RXN3O-12>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002333_YNR041C-MONOMER_RXN-9003_controller_SGD_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_58179_RXN-9003_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_58179_RXN-9003_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3041,7 +3052,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_15377_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3049,11 +3071,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002234_CHEBI_16526_RXN3O-73_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002234_CHEBI_16526_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3064,26 +3086,15 @@
           <http://model.geneontology.org/CHEBI_16526_RXN3O-73>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002413_RXN3O-54_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_15378_RXN3O-54_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_15378_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3098,11 +3109,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002233_CHEBI_59789_RXN3O-102_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002233_CHEBI_59789_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3113,25 +3124,14 @@
           <http://model.geneontology.org/CHEBI_59789_RXN3O-102>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_15378_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-19>
+<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002233_CHEBI_64253_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-19>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_15378_RXN3O-12_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3142,13 +3142,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19Protein41455> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002333_YOL096C-MONOMER_2.1.1.114-RXN_controller_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57916_2.1.1.114-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57916> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3159,24 +3170,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41596> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_58373_RXN3O-58_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_84492_RXN-9003>
         a       <http://purl.obolibrary.org/obo/CHEBI_84492> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3187,7 +3187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3195,14 +3195,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_15377_RXN3O-58_SGD_YeastPathways_PWY3O-19>
+<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002333_YGR255C-MONOMER_RXN3O-12_controller_SGD_PWY_YeastPathways_PWY3O-19>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3215,7 +3215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3227,11 +3227,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_15377_RXN3O-75_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_15377_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3246,11 +3246,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15378_RXN3O-58_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15378_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3270,13 +3270,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41480> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002233_CHEBI_58373_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-58>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3297,7 +3308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3309,11 +3320,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_1109_RXN3O-73_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_1109_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3324,25 +3335,14 @@
           <http://model.geneontology.org/CHEBI_1109_RXN3O-73>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000066_reaction_RXN3O-73_location_lociGO_0005829_SGD_YeastPathways_PWY3O-19>
+<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_64253_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-19>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002234_CHEBI_29888_RXN-9003_SGD_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3353,7 +3353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3365,11 +3365,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_15378_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-19> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_15378_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-2.ttl
+++ b/models/YeastPathways_PWY3O-2.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_15378_RXN-5781_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_15378_RXN-5781_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,14 +17,40 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-5781>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_30616_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/CHEBI_57856_RXN3O-349>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57856> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "SAH" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31991> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_CHEBI_59789_RXN4FS-2_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -35,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,41 +69,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+<http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_57856_RXN3O-349>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57856> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "SAH" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31991> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -88,14 +99,36 @@
           <http://model.geneontology.org/reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_58779_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_60377_RXN-5781_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_57876_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -103,11 +136,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -127,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -135,11 +168,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/22d50d35-3560-4ce1-9549-c9cd4e31c81a_2.1.1.17-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_58779_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002333_YGR007W-MONOMER_2.7.7.14-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -150,24 +202,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32004> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_PHOSPHASERDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -178,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -186,14 +227,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN3O-349_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -206,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -218,11 +259,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002333_YJR073C-MONOMER_2.1.1.71-RXN_controller_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002333_YJR073C-MONOMER_2.1.1.71-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -237,11 +278,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_BFO_0000066_reaction_RXN4FS-2_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_BFO_0000066_reaction_RXN4FS-2_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -252,15 +293,37 @@
           <http://model.geneontology.org/reaction_RXN4FS-2_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,14 +337,14 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_15378_RXN4FS-2_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -289,11 +352,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ethanolamine + ATP &rarr; <i>O</i>-phosphoethanolamine + ADP + H<SUP>+</SUP>' 'null' '<i>O</i>-phosphoethanolamine + CTP + H<SUP>+</SUP> &rarr; CDP-ethanolamine + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002413_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002413_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,14 +367,25 @@
           <http://model.geneontology.org/2.7.7.14-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000066_reaction_RXN-5781_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002333_YHR123W-MONOMER_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_30616_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -324,7 +398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -332,29 +406,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_29888>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -365,15 +436,18 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-2/YeastPathways_PWY3O-2>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_29888>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -388,11 +462,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,6 +480,17 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_2.7.8.11-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -415,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -427,11 +512,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002333_YER026C-MONOMER_PHOSPHASERSYN-RXN_controller_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002333_YER026C-MONOMER_PHOSPHASERSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,7 +537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -460,26 +545,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_CHEBI_15377_PGPPHOSPHA-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_CHEBI_15377_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,11 +568,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000066_reaction_2.7.7.15-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000066_reaction_2.7.7.15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,36 +583,25 @@
           <http://model.geneontology.org/reaction_2.7.7.15-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_3bfd29ef-6918-4601-a9b4-08626968ceb6_2.1.1.71-RXN_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_15378_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_7a1e665b-8169-4d07-bd90-16a17ef0994c_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000066_reaction_2.1.1.17-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -554,7 +617,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN4FS-2_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/3bfd29ef-6918-4601-a9b4-08626968ceb6_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_RXN4FS-2> ;
+                <http://model.geneontology.org/6cc940da-a3c6-4702-9b79-1e12cd712579_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_RXN4FS-2> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16110_RXN4FS-2> , <http://model.geneontology.org/CHEBI_15378_RXN4FS-2> , <http://model.geneontology.org/CHEBI_57856_RXN4FS-2> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -562,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -570,15 +633,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/52eef56e-e533-4cef-9686-29752adf932a_2.1.1.17-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32435> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,25 +669,36 @@
           <http://model.geneontology.org/CHEBI_59789_RXN3O-349>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000066_reaction_2.1.1.17-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002333_YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002333_YJR073C-MONOMER_2.1.1.71-RXN_controller_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002333_YGR202C-MONOMER_2.7.7.15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_CHEBI_17268_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -615,11 +706,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002333_YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002333_YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -634,11 +725,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_15378_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_15378_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -649,6 +740,17 @@
           <http://model.geneontology.org/CHEBI_15378_2.7.8.11-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002413_CARDIOLIPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58190_ETHANOLAMINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58190> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -658,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -670,11 +772,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_30616_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_30616_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -689,11 +791,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_59789_2.1.1.71-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_59789_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -721,31 +823,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/a9550c4e-e6ec-48a6-8684-eedebb9bd574_2.1.1.17-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_57856_RXN3O-349_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32435> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000066_reaction_PGPPHOSPHA-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_17815_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_15378_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -758,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of phospholipid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -773,7 +880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -788,7 +895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -796,14 +903,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_BFO_0000066_reaction_RXN4FS-2_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -816,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -824,17 +931,20 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/f000c9df-a660-49c4-8de6-f1d7e0ec1e76_PHOSPHAGLYPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002333_YGR007W-MONOMER_2.7.7.14-RXN_controller_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -842,11 +952,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -861,11 +971,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -876,22 +986,44 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-2/YeastPathways_PWY3O-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_456216_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_295975>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000003402>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_90ffafe2-e7ff-4d73-a6f5-be762ff2e55c_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000066_reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -900,11 +1032,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -920,7 +1052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -928,11 +1060,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -943,23 +1075,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-2/YeastPathways_PWY3O-2>
 ] .
 
-<http://model.geneontology.org/e03ff9d1-cff1-4c19-b8bf-10988c1de099_2.1.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31967> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://identifiers.org/sgd/S000003389>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -967,11 +1082,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_60377_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_60377_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -982,14 +1097,14 @@
           <http://model.geneontology.org/CHEBI_60377_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002333_YJR073C-MONOMER_RXN3O-349_controller_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_59789_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -998,7 +1113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1011,7 +1126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1023,11 +1138,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002333_YGR202C-MONOMER_2.7.7.15-RXN_controller_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002333_YGR202C-MONOMER_2.7.7.15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1047,7 +1162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1058,26 +1173,29 @@
 <http://purl.obolibrary.org/obo/GO_0004608>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_16110_RXN4FS-2_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_456216_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/c3861b5e-c8ac-47c8-a89e-e5be95ee1fd4_2.1.1.71-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_16110_RXN-5781_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_16110_RXN-5781_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1105,7 +1223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1122,7 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1135,7 +1253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1143,11 +1261,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1177,7 +1295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1194,7 +1312,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/025b688b-56dd-4f1e-8f10-60de6b9417ce_PHOSPHASERSYN-RXN> ;
+                <http://model.geneontology.org/093c51e3-893d-4c78-b541-0ad1d2e1eabe_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1204,7 +1322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1212,25 +1330,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000066_reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1238,11 +1345,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_456216_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_456216_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1260,11 +1367,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN3O-349_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN3O-349_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1275,15 +1382,26 @@
           <http://model.geneontology.org/RXN3O-349>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_16110_RXN-5781_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_CHEBI_59789_RXN4FS-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_CHEBI_59789_RXN4FS-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1304,7 +1422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1312,14 +1430,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002333_YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1330,7 +1448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1338,26 +1456,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002333_YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1368,6 +1475,17 @@
           <http://model.geneontology.org/CHEBI_16526_PHOSPHASERDECARB-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_CHEBI_15377_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_ETHANOLAMINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1377,7 +1495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1392,7 +1510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1400,43 +1518,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/7a1e665b-8169-4d07-bd90-16a17ef0994c_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32319> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_15378_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1447,29 +1537,40 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-2/YeastPathways_PWY3O-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002411_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1477,11 +1578,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_a9550c4e-e6ec-48a6-8684-eedebb9bd574_2.1.1.17-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_52eef56e-e533-4cef-9686-29752adf932a_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1489,40 +1590,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.17-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a9550c4e-e6ec-48a6-8684-eedebb9bd574_2.1.1.17-RXN>
+          <http://model.geneontology.org/52eef56e-e533-4cef-9686-29752adf932a_2.1.1.17-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002333_YJR073C-MONOMER_RXN4FS-2_controller_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000066_reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000066_reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1533,26 +1612,15 @@
           <http://model.geneontology.org/reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000066_reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a CDP-diacylglycerol + L-serine &harr; CMP + a 3-<i>O</i>-<i>sn</i>-phosphatidyl-L-serine + H<SUP>+</SUP>' 'null' 'a 3-<i>O</i>-<i>sn</i>-phosphatidyl-L-serine + H<SUP>+</SUP> &rarr; an L-1-phosphatidylethanolamine + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002413_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002413_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1563,48 +1631,37 @@
           <http://model.geneontology.org/PHOSPHASERDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_58779_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_29888_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/3bfd29ef-6918-4601-a9b4-08626968ceb6_2.1.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_16110_RXN4FS-2_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_7819c2a0-a945-428e-a57f-a3936c0122ac_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_15378_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PGPPHOSPHA-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7819c2a0-a945-428e-a57f-a3936c0122ac_PHOSPHAGLYPSYN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_15378_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-2> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1615,6 +1672,53 @@
           <http://model.geneontology.org/CHEBI_15378_2.7.7.15-RXN>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_f000c9df-a660-49c4-8de6-f1d7e0ec1e76_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PGPPHOSPHA-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/f000c9df-a660-49c4-8de6-f1d7e0ec1e76_PHOSPHAGLYPSYN-RXN>
+] .
+
+<http://model.geneontology.org/90ffafe2-e7ff-4d73-a6f5-be762ff2e55c_2.7.8.11-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_17815_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17815> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1624,7 +1728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1632,27 +1736,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002333_YLR133W-MONOMER_CHOLINE-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000066_reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_17754>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-5781>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -1663,7 +1748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1671,22 +1756,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_60377_RXN-5781_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000066_reaction_2.7.7.14-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_17754>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003239>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/2.7.7.15-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004105> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1707,7 +1811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1721,15 +1825,40 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002413_RXN-5781_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_BFO_0000066_reaction_RXN4FS-2_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_e0ada35d-cb03-4a21-bf05-2d5d15d6f200_2.1.1.71-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_c3861b5e-c8ac-47c8-a89e-e5be95ee1fd4_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1737,31 +1866,22 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-349> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e0ada35d-cb03-4a21-bf05-2d5d15d6f200_2.1.1.71-RXN>
+          <http://model.geneontology.org/c3861b5e-c8ac-47c8-a89e-e5be95ee1fd4_2.1.1.71-RXN>
 ] .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ae341aa5-4eb8-4d1b-aa66-ee909613dd75_PHOSPHAGLYPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57880>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57603_ETHANOLAMINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57603> ;
@@ -1772,24 +1892,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32299> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_62237_CARDIOLIPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_62237> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1800,7 +1909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1808,15 +1917,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PGPPHOSPHA-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1831,11 +1951,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_57880_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_57880_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1849,9 +1969,6 @@
 <http://purl.obolibrary.org/obo/GO_0008654>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/e0ada35d-cb03-4a21-bf05-2d5d15d6f200_2.1.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59789> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1861,7 +1978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1869,25 +1986,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_17815_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_57880_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002413_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1895,11 +2012,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_57603_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_57603_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1914,11 +2031,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_22d50d35-3560-4ce1-9549-c9cd4e31c81a_2.1.1.17-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_ed277332-e99e-4c6d-aca2-1ee6c76245c6_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1926,18 +2043,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/22d50d35-3560-4ce1-9549-c9cd4e31c81a_2.1.1.17-RXN>
+          <http://model.geneontology.org/ed277332-e99e-4c6d-aca2-1ee6c76245c6_2.1.1.17-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_16110_RXN3O-349_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_16110_RXN3O-349_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1948,6 +2065,23 @@
           <http://model.geneontology.org/CHEBI_16110_RXN3O-349>
 ] .
 
+<http://model.geneontology.org/e5a3ffbf-ec76-4a39-9756-e53236540eb5_PHOSPHAGLYPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/YLR133W-MONOMER_CHOLINE-KINASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000004123> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1955,7 +2089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1963,26 +2097,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2002,26 +2125,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_37563>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2035,37 +2147,15 @@
 <http://identifiers.org/sgd/S000001165>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_17815_RXN-5781_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_29888_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_29888_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2080,11 +2170,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000066_reaction_2.1.1.17-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000066_reaction_2.1.1.17-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2102,11 +2192,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_025b688b-56dd-4f1e-8f10-60de6b9417ce_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_093c51e3-893d-4c78-b541-0ad1d2e1eabe_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2114,18 +2204,29 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/025b688b-56dd-4f1e-8f10-60de6b9417ce_PHOSPHASERSYN-RXN>
+          <http://model.geneontology.org/093c51e3-893d-4c78-b541-0ad1d2e1eabe_PHOSPHASERSYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002413_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000066_reaction_CHOLINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000066_reaction_CHOLINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2145,7 +2246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2161,7 +2262,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_43474_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2169,11 +2281,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002333_YHR123W-MONOMER_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002333_YHR123W-MONOMER_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2183,6 +2295,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YHR123W-MONOMER_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000066_reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/2.1.1.17-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004608> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2195,7 +2318,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/a9550c4e-e6ec-48a6-8684-eedebb9bd574_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
+                <http://model.geneontology.org/52eef56e-e533-4cef-9686-29752adf932a_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR157W-MONOMER_2.1.1.17-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2203,7 +2326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2215,11 +2338,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'CTP + phosphocholine + H<SUP>+</SUP> &rarr; CDP-choline + diphosphate' 'null' 'a 1,2-diacyl-<i>sn</i>-glycerol + CDP-choline &harr; a phosphatidylcholine + CMP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002413_RXN-5781_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002413_RXN-5781_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2230,23 +2353,45 @@
           <http://model.geneontology.org/RXN-5781>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_57603_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000066_reaction_RXN-5781_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_PGPPHOSPHA-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002333_YGR157W-MONOMER_2.1.1.17-RXN_controller_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2259,7 +2404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2274,11 +2419,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_60377_RXN-5781_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_60377_RXN-5781_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2292,19 +2437,30 @@
 <http://purl.obolibrary.org/obo/CHEBI_57603>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/CHEBI_17815>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002333_YJR073C-MONOMER_RXN4FS-2_controller_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_17815>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_60377> ;
@@ -2315,7 +2471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2323,26 +2479,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002233_CHEBI_64716_PGPPHOSPHA-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_ae341aa5-4eb8-4d1b-aa66-ee909613dd75_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_e5a3ffbf-ec76-4a39-9756-e53236540eb5_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2350,7 +2495,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ae341aa5-4eb8-4d1b-aa66-ee909613dd75_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/e5a3ffbf-ec76-4a39-9756-e53236540eb5_PHOSPHAGLYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_2.7.7.15-RXN_location_lociGO_0005829>
@@ -2358,29 +2503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_60377_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2388,11 +2511,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002333_YLR133W-MONOMER_CHOLINE-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002333_YLR133W-MONOMER_CHOLINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2403,77 +2526,22 @@
           <http://model.geneontology.org/YLR133W-MONOMER_CHOLINE-KINASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_CHEBI_17268_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57856>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002333_YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_43474_PGPPHOSPHA-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_CHEBI_15377_PGPPHOSPHA-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002413_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004103>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2482,11 +2550,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN4FS-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN4FS-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2501,11 +2569,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_3bfd29ef-6918-4601-a9b4-08626968ceb6_2.1.1.71-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_6cc940da-a3c6-4702-9b79-1e12cd712579_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2513,18 +2581,29 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN4FS-2> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3bfd29ef-6918-4601-a9b4-08626968ceb6_2.1.1.71-RXN>
+          <http://model.geneontology.org/6cc940da-a3c6-4702-9b79-1e12cd712579_2.1.1.71-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_cd6ff8d2-bac9-482a-9e28-6d5985e511fd_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2535,25 +2614,25 @@
           <http://model.geneontology.org/YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000066_reaction_2.7.7.14-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_c3861b5e-c8ac-47c8-a89e-e5be95ee1fd4_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2561,11 +2640,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000066_reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000066_reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2580,11 +2659,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2594,17 +2673,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-2/YeastPathways_PWY3O-2>
 ] .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000828>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2616,7 +2684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2624,51 +2692,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002411_2.1.1.71-RXN_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000066_reaction_PGPPHOSPHA-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002333_YER026C-MONOMER_PHOSPHASERSYN-RXN_controller_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002333_YGR157W-MONOMER_2.1.1.17-RXN_controller_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002333_YGR157W-MONOMER_2.1.1.17-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2679,14 +2725,14 @@
           <http://model.geneontology.org/YGR157W-MONOMER_2.1.1.17-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_16110_RXN3O-349_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_58779_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2694,11 +2740,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002233_CHEBI_64716_PGPPHOSPHA-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002233_CHEBI_64716_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2709,31 +2755,25 @@
           <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN>
 ] .
 
-<http://model.geneontology.org/7a194d35-a2aa-473a-86da-8dbba3625553_2.7.8.11-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_57876_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2741,11 +2781,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2756,25 +2796,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-2/YeastPathways_PWY3O-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_15378_RXN4FS-2_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002333_YNL130C-MONOMER_RXN-5781_controller_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002333_YHR123W-MONOMER_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2787,7 +2816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2795,15 +2824,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_16110_RXN3O-349_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_43474_PGPPHOSPHA-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_43474_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2818,11 +2858,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2833,8 +2873,52 @@
           <http://model.geneontology.org/CHEBI_295975_CHOLINE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_64716_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_60377_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17268> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2845,63 +2929,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32207> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/025b688b-56dd-4f1e-8f10-60de6b9417ce_PHOSPHASERSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002413_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_30616_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YHR123W-MONOMER_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000001165> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2910,7 +2944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2927,24 +2961,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32345> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-5781>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004142> ;
@@ -2963,7 +2986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2971,14 +2994,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_15354_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_17815_RXN-5781_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2991,7 +3014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3003,11 +3026,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_60377_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_60377_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3018,29 +3041,40 @@
           <http://model.geneontology.org/CHEBI_60377_2.7.8.11-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000066_reaction_2.7.8.11-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_57856_RXN4FS-2_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008444>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000066_reaction_2.7.7.15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_15378_2.1.1.71-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_15378_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3055,11 +3089,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_57856_RXN3O-349_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_57856_RXN3O-349_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3079,7 +3113,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/e0ada35d-cb03-4a21-bf05-2d5d15d6f200_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
+                <http://model.geneontology.org/c3861b5e-c8ac-47c8-a89e-e5be95ee1fd4_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_57856_RXN3O-349> , <http://model.geneontology.org/CHEBI_16110_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -3087,7 +3121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3095,26 +3129,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000066_reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000066_reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3125,17 +3148,6 @@
           <http://model.geneontology.org/reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_57876_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY3O-2/YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008654> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3145,13 +3157,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY3O-2" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_456216_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005074>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3163,11 +3186,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_456216_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_456216_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3178,9 +3201,6 @@
           <http://model.geneontology.org/CHEBI_456216_ETHANOLAMINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/7819c2a0-a945-428e-a57f-a3936c0122ac_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/CHEBI_16038_PHOSPHASERDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16038> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3190,7 +3210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3198,31 +3218,42 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_37563_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002333_YER026C-MONOMER_PHOSPHASERSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003434>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002413_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58779>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000003434>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002413_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3230,11 +3261,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_57876_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_57876_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3249,11 +3280,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3271,24 +3302,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2Protein32306> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000066_reaction_RXN3O-349_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16110_RXN-5781>
         a       <http://purl.obolibrary.org/obo/CHEBI_16110> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3299,24 +3319,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31977> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN4FS-2_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0008444> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3327,9 +3336,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/ae341aa5-4eb8-4d1b-aa66-ee909613dd75_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/e5a3ffbf-ec76-4a39-9756-e53236540eb5_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/7a1e665b-8169-4d07-bd90-16a17ef0994c_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/70cf2286-7ad4-451d-9d37-247359225729_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3337,7 +3346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3345,26 +3354,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_025b688b-56dd-4f1e-8f10-60de6b9417ce_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3394,7 +3392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3411,7 +3409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3423,11 +3421,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_15354_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_15354_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3438,15 +3436,37 @@
           <http://model.geneontology.org/CHEBI_15354_CHOLINE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_e5a3ffbf-ec76-4a39-9756-e53236540eb5_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_6cc940da-a3c6-4702-9b79-1e12cd712579_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a 1,2-diacyl-<i>sn</i>-glycerol + CDP-ethanolamine &rarr; an L-1-phosphatidylethanolamine + CMP + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + an L-1-phosphatidylethanolamine &rarr; a phosphatidyl-<i>N</i>-methylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002413_2.1.1.17-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002413_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3457,14 +3477,14 @@
           <http://model.geneontology.org/2.1.1.17-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_15378_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002333_YPR113W-MONOMER_2.7.8.11-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3474,14 +3494,14 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3489,11 +3509,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3504,50 +3524,61 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-2/YeastPathways_PWY3O-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002233_CHEBI_64716_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_60377_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000066_reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002413_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003881>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_a9550c4e-e6ec-48a6-8684-eedebb9bd574_2.1.1.17-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_57856_RXN3O-349_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN4FS-2_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002333_YJR073C-MONOMER_2.1.1.71-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3555,11 +3586,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002333_YNL130C-MONOMER_RXN-5781_controller_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002333_YNL130C-MONOMER_RXN-5781_controller_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3570,6 +3601,17 @@
           <http://model.geneontology.org/YNL130C-MONOMER_RXN-5781_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_29888_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_37563_2.7.7.15-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_37563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3579,7 +3621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3587,25 +3629,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN3O-349_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_30616_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_59789_2.1.1.71-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3613,11 +3644,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3631,6 +3662,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_64716>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29888_2.7.7.15-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3640,7 +3682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3648,48 +3690,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_7819c2a0-a945-428e-a57f-a3936c0122ac_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_37563_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'choline + ATP &rarr; phosphocholine + ADP + H<SUP>+</SUP>' 'null' 'CTP + phosphocholine + H<SUP>+</SUP> &rarr; CDP-choline + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002413_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002413_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3712,7 +3721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3720,25 +3729,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PGPPHOSPHA-RXN_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000066_reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_17754_CARDIOLIPSYN-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3754,7 +3752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3766,11 +3764,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_15378_RXN4FS-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_15378_RXN4FS-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3781,6 +3779,39 @@
           <http://model.geneontology.org/CHEBI_15378_RXN4FS-2>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000066_reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002413_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_17815_RXN-5781>
         a       <http://purl.obolibrary.org/obo/CHEBI_17815> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3790,7 +3821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3802,11 +3833,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3817,39 +3848,17 @@
           <http://model.geneontology.org/YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000002554>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_57880_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_62237_CARDIOLIPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_15378_2.1.1.71-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3857,11 +3866,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_17815_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_17815_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3876,11 +3885,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000066_reaction_2.7.7.14-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000066_reaction_2.7.7.14-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3900,7 +3909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3908,14 +3917,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_7a194d35-a2aa-473a-86da-8dbba3625553_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3926,11 +3935,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002411_2.1.1.71-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002411_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3945,11 +3954,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_17754_CARDIOLIPSYN-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_17754_CARDIOLIPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3969,7 +3978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3977,15 +3986,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_15378_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000066_reaction_RXN-5781_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000066_reaction_RXN-5781_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3999,25 +4030,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_16110>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_57876_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_093c51e3-893d-4c78-b541-0ad1d2e1eabe_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002413_2.1.1.17-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4028,11 +4048,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_64716_PGPPHOSPHA-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_64716_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4047,11 +4067,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_37563_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_37563_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4071,7 +4091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4082,6 +4102,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_11750>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000066_reaction_2.7.8.11-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_60377_RXN-5781>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_60377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4091,7 +4122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4103,11 +4134,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_17815_RXN-5781_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_17815_RXN-5781_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4118,6 +4149,28 @@
           <http://model.geneontology.org/CHEBI_17815_RXN-5781>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002333_YJR073C-MONOMER_RXN3O-349_controller_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_17754_CARDIOLIPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -4125,11 +4178,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" , "Provides Input For Rule. The relation '1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate + H<sub>2</sub>O &rarr; an L-1-phosphatidyl-<i>sn</i>-glycerol + phosphate' 'null' '2 an L-1-phosphatidyl-<i>sn</i>-glycerol &rarr; a cardiolipin + glycerol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002413_CARDIOLIPSYN-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002413_CARDIOLIPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4147,7 +4200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4155,26 +4208,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_30616_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_30616_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4185,26 +4227,15 @@
           <http://model.geneontology.org/CHEBI_30616_CHOLINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_16110_RXN-5781_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002333_YPR113W-MONOMER_2.7.8.11-RXN_controller_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002333_YPR113W-MONOMER_2.7.8.11-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4215,17 +4246,6 @@
           <http://model.geneontology.org/YPR113W-MONOMER_2.7.8.11-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002333_YGR202C-MONOMER_2.7.7.15-RXN_controller_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15354_CHOLINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15354> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4235,7 +4255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4243,15 +4263,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4266,11 +4297,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002333_YJR073C-MONOMER_RXN3O-349_controller_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002333_YJR073C-MONOMER_RXN3O-349_controller_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4300,7 +4331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4318,7 +4349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4333,11 +4364,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4348,39 +4379,17 @@
           <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002413_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000066_reaction_RXN3O-349_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4388,11 +4397,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4403,17 +4412,6 @@
           <http://model.geneontology.org/CHEBI_58190_ETHANOLAMINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_64716_PGPPHOSPHA-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_60377_2.7.8.11-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_60377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4423,7 +4421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4431,25 +4429,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_e0ada35d-cb03-4a21-bf05-2d5d15d6f200_2.1.1.71-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15378_2.1.1.17-RXN_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4457,11 +4444,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002333_YGR007W-MONOMER_2.7.7.14-RXN_controller_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002333_YGR007W-MONOMER_2.7.7.14-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4476,11 +4463,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4494,6 +4481,17 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_CHOLINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4503,7 +4501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4518,7 +4516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4530,11 +4528,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4545,6 +4543,17 @@
           <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000066_reaction_2.1.1.71-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29888_2.7.7.14-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4554,7 +4563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4567,7 +4576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4575,11 +4584,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4593,12 +4602,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_57876>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_15378_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4606,11 +4626,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000066_reaction_2.7.8.11-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000066_reaction_2.7.8.11-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4621,14 +4641,14 @@
           <http://model.geneontology.org/reaction_2.7.8.11-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4641,7 +4661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4652,25 +4672,14 @@
 <http://purl.obolibrary.org/obo/GO_0003882>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_37563_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4678,11 +4687,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4693,14 +4702,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-2/YeastPathways_PWY3O-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4713,7 +4722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4724,26 +4733,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_58190>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4758,11 +4756,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_CHEBI_17268_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_CHEBI_17268_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4777,11 +4775,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4796,11 +4794,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4811,54 +4809,32 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-2/YeastPathways_PWY3O-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_456216_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004123>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000066_reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004105>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_e03ff9d1-cff1-4c19-b8bf-10988c1de099_2.1.1.71-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_16110_RXN4FS-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_16110_RXN4FS-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4869,15 +4845,26 @@
           <http://model.geneontology.org/CHEBI_16110_RXN4FS-2>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002333_YLR133W-MONOMER_CHOLINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" , "Provides Input For Rule. The relation 'a 3-<i>O</i>-<i>sn</i>-phosphatidyl-L-serine + H<SUP>+</SUP> &rarr; an L-1-phosphatidylethanolamine + CO<SUB>2</SUB>' 'null' '<i>S</i>-adenosyl-L-methionine + an L-1-phosphatidylethanolamine &rarr; a phosphatidyl-<i>N</i>-methylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002413_2.1.1.17-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002413_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4888,14 +4875,14 @@
           <http://model.geneontology.org/2.1.1.17-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000066_reaction_2.7.7.15-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4903,11 +4890,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_57876_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_57876_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4918,15 +4905,26 @@
           <http://model.geneontology.org/CHEBI_57876_2.7.7.14-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_37563_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_15378_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_15378_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4937,17 +4935,6 @@
           <http://model.geneontology.org/CHEBI_15378_2.7.7.14-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002413_2.1.1.17-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_59789> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4957,7 +4944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4965,8 +4952,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_60377_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_17268>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_2.7.7.15-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -4977,7 +4986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4985,26 +4994,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002333_YNL130C-MONOMER_RXN-5781_controller_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_62237_CARDIOLIPSYN-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_62237_CARDIOLIPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5024,7 +5022,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.7.8.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/7a194d35-a2aa-473a-86da-8dbba3625553_2.7.8.11-RXN> ;
+                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/90ffafe2-e7ff-4d73-a6f5-be762ff2e55c_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_60377_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_57880_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -5032,7 +5030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5045,12 +5043,51 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_15354_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/093c51e3-893d-4c78-b541-0ad1d2e1eabe_PHOSPHASERSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YJR073C-MONOMER_2.1.1.71-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003834> ;
@@ -5059,7 +5096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5070,6 +5107,17 @@
 <http://identifiers.org/sgd/S000003834>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_70cf2286-7ad4-451d-9d37-247359225729_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16038> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5079,7 +5127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5091,11 +5139,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_29888_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_29888_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5111,55 +5159,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_22d50d35-3560-4ce1-9549-c9cd4e31c81a_2.1.1.17-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_58779_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_58779_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5170,23 +5185,12 @@
           <http://model.geneontology.org/CHEBI_58779_2.7.7.15-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000066_reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5194,11 +5198,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5212,17 +5216,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_16038>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_29888_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -5230,11 +5223,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_15378_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_15378_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5245,15 +5238,37 @@
           <http://model.geneontology.org/CHEBI_15378_CHOLINE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_15378_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_e03ff9d1-cff1-4c19-b8bf-10988c1de099_2.1.1.71-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_cd6ff8d2-bac9-482a-9e28-6d5985e511fd_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5261,18 +5276,29 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e03ff9d1-cff1-4c19-b8bf-10988c1de099_2.1.1.71-RXN>
+          <http://model.geneontology.org/cd6ff8d2-bac9-482a-9e28-6d5985e511fd_2.1.1.71-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002333_YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5283,6 +5309,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-2/YeastPathways_PWY3O-2>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_f000c9df-a660-49c4-8de6-f1d7e0ec1e76_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/2.1.1.71-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -5292,9 +5329,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.1.1.71-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/22d50d35-3560-4ce1-9549-c9cd4e31c81a_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> , <http://model.geneontology.org/ed277332-e99e-4c6d-aca2-1ee6c76245c6_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> , <http://model.geneontology.org/e03ff9d1-cff1-4c19-b8bf-10988c1de099_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/cd6ff8d2-bac9-482a-9e28-6d5985e511fd_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YJR073C-MONOMER_2.1.1.71-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -5302,7 +5339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5313,26 +5350,15 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5352,7 +5378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5369,7 +5395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5377,24 +5403,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002333_YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-2> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ETHANOLAMINE-KINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller>
-] .
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000066_reaction_CHOLINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_ed277332-e99e-4c6d-aca2-1ee6c76245c6_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5405,7 +5434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5413,19 +5442,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002333_YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ETHANOLAMINE-KINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller>
+] .
+
 <http://purl.obolibrary.org/obo/GO_0004142>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000066_reaction_2.1.1.71-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33384> ;
@@ -5436,7 +5473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5449,7 +5486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5457,11 +5494,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>O</i>-phosphoethanolamine + CTP + H<SUP>+</SUP> &rarr; CDP-ethanolamine + diphosphate' 'null' 'a 1,2-diacyl-<i>sn</i>-glycerol + CDP-ethanolamine &rarr; an L-1-phosphatidylethanolamine + CMP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002413_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002413_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5476,11 +5513,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15378_2.1.1.17-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15378_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5491,26 +5528,15 @@
           <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_57603_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5521,23 +5547,29 @@
           <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN>
 ] .
 
+<http://model.geneontology.org/70cf2286-7ad4-451d-9d37-247359225729_PHOSPHAGLYPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32319> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/reaction_2.7.7.14-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_29888_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5545,11 +5577,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000066_reaction_PGPPHOSPHA-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000066_reaction_PGPPHOSPHA-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5569,35 +5601,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32004> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000066_reaction_CHOLINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_ae341aa5-4eb8-4d1b-aa66-ee909613dd75_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57876_2.7.7.14-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57876> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5608,7 +5618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5632,35 +5642,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2Protein32225> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_15378_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_15378_RXN-5781_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004305>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5669,11 +5657,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000066_reaction_RXN3O-349_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000066_reaction_RXN3O-349_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5684,17 +5672,6 @@
           <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_62237_CARDIOLIPSYN-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16110_RXN3O-349>
         a       <http://purl.obolibrary.org/obo/CHEBI_16110> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5704,7 +5681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5715,14 +5692,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002333_YPR113W-MONOMER_2.7.8.11-RXN_controller_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15378_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5730,11 +5707,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_7a1e665b-8169-4d07-bd90-16a17ef0994c_PHOSPHAGLYPSYN-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_70cf2286-7ad4-451d-9d37-247359225729_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5742,18 +5719,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7a1e665b-8169-4d07-bd90-16a17ef0994c_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/70cf2286-7ad4-451d-9d37-247359225729_PHOSPHAGLYPSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_7a194d35-a2aa-473a-86da-8dbba3625553_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_90ffafe2-e7ff-4d73-a6f5-be762ff2e55c_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5761,17 +5738,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.8.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7a194d35-a2aa-473a-86da-8dbba3625553_2.7.8.11-RXN>
+          <http://model.geneontology.org/90ffafe2-e7ff-4d73-a6f5-be762ff2e55c_2.7.8.11-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002413_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5779,11 +5756,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000066_reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000066_reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5798,11 +5775,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000066_reaction_2.1.1.71-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000066_reaction_2.1.1.71-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5813,17 +5790,6 @@
           <http://model.geneontology.org/reaction_2.1.1.71-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002413_CARDIOLIPSYN-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_2.7.7.14-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5833,7 +5799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5850,7 +5816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5862,11 +5828,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_57856_RXN4FS-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_57856_RXN4FS-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5877,15 +5843,46 @@
           <http://model.geneontology.org/CHEBI_57856_RXN4FS-2>
 ] .
 
+<http://model.geneontology.org/cd6ff8d2-bac9-482a-9e28-6d5985e511fd_2.1.1.71-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31967> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ed277332-e99e-4c6d-aca2-1ee6c76245c6_2.1.1.17-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5915,32 +5912,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2BiochemicalReaction32228> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002333_YJR073C-MONOMER_RXN4FS-2_controller_SGD_YeastPathways_PWY3O-2> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN4FS-2> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YJR073C-MONOMER_RXN4FS-2_controller>
-] .
 
 <http://model.geneontology.org/PHOSPHASERDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004609> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5961,7 +5939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5973,11 +5951,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5992,11 +5970,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_37563_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_37563_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6007,67 +5985,31 @@
           <http://model.geneontology.org/CHEBI_37563_2.7.7.14-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002413_RXN-5781_SGD_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_57856_RXN4FS-2_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_15378_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002333_YJR073C-MONOMER_RXN4FS-2_controller_SGD_PWY_YeastPathways_PWY3O-2> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN4FS-2> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YJR073C-MONOMER_RXN4FS-2_controller>
+] .
 
 <http://model.geneontology.org/reaction_RXN4FS-2_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6075,11 +6017,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000066_reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000066_reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6090,29 +6032,29 @@
           <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_CHEBI_59789_RXN4FS-2_SGD_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_52eef56e-e533-4cef-9686-29752adf932a_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002333_YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002333_YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6121,42 +6063,6 @@
           <http://model.geneontology.org/CARDIOLIPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller>
-] .
-
-<http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32004> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-2> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ETHANOLAMINEPHOSPHOTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
 ] .
 
 <http://model.geneontology.org/PGPPHOSPHA-RXN>
@@ -6168,7 +6074,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PGPPHOSPHA-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> , <http://model.geneontology.org/7819c2a0-a945-428e-a57f-a3936c0122ac_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/f000c9df-a660-49c4-8de6-f1d7e0ec1e76_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -6176,13 +6082,93 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2BiochemicalReaction32309> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32004> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002333_YGR157W-MONOMER_2.1.1.17-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ETHANOLAMINEPHOSPHOTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002333_YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_PHOSPHASERDECARB-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -6193,7 +6179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6204,15 +6190,18 @@
 <http://purl.obolibrary.org/obo/CHEBI_59789>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/6cc940da-a3c6-4702-9b79-1e12cd712579_2.1.1.71-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_58779_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_58779_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6222,3 +6211,14 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58779_2.7.7.15-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_15378_RXN-5781_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-20.ttl
+++ b/models/YeastPathways_PWY3O-20.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002333_YOR241W-MONOMER_RXN0-2921_controller_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002333_YOR241W-MONOMER_RXN0-2921_controller_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,15 +23,26 @@
 <http://purl.obolibrary.org/obo/GO_0004372>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,17 +56,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -65,11 +65,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64853> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/de830213-55de-4583-b599-b76262ddfbd0_RXN3O-681>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -80,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -88,26 +105,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -121,14 +127,14 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_CHEBI_30616_RXN0-2921_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN0-2921_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -136,11 +142,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_CHEBI_29985_RXN3O-681_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_CHEBI_29985_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -151,15 +157,26 @@
           <http://model.geneontology.org/CHEBI_29985_RXN3O-681>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_CHEBI_43474_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,17 +186,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -191,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,15 +205,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_15378_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -218,64 +235,25 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-20/YeastPathways_PWY3O-20>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YGL125W-MONOMER_1.5.1.20-RXN_controller_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_15378_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/4a975ce2-f4c2-4f4d-a5e9-3198ab9cca31_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_8022fc70-9a93-4181-96ab-c520478babfe_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_RXN0-2921_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -283,11 +261,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57540_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57540_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -302,11 +280,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -333,11 +311,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_CHEBI_29985_RXN0-2921_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_CHEBI_29985_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -351,37 +329,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_CHEBI_30616_FORMYLTHFGLUSYNTH-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -401,15 +357,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/55ecaa80-fb16-48cb-b4a7-2c803d69bcbf_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/5790e7ba-4d59-43ea-8c6c-c4e757e138d9_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/01456ff2-c692-42f5-af7d-aec1a606be1e_RXN3O-22> , <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/bb6b777d-b509-4ab1-8772-e0d88f2d12fc_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -417,20 +373,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/55ef8059-b6d4-457a-97c2-61656e001a2e_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002333_YOR241W-MONOMER_RXN0-2921_controller_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_781c4fdc-2da0-4ba4-a6db-eadd9c3cafa3_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_CHEBI_456216_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -438,11 +402,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -453,15 +417,37 @@
           <http://model.geneontology.org/CHEBI_43474_RXN3O-22>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_a08cde20-b525-45e4-9459-cb3a138cd26e_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_3b5b08e1-b00c-4648-8131-4ed6535d59db_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_bd5286c0-88e4-4025-9a61-ffb082eee8fe_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -469,19 +455,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFGLUSYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3b5b08e1-b00c-4648-8131-4ed6535d59db_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/bd5286c0-88e4-4025-9a61-ffb082eee8fe_FORMATETHFLIG-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005767> ;
@@ -490,13 +465,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20Protein64828> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -505,11 +491,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -520,14 +506,36 @@
           <http://model.geneontology.org/CHEBI_43474_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_0effdf57-b46a-4601-9d03-fcb3d29a9480_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -536,7 +544,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_CHEBI_30616_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -549,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -557,18 +587,7 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_fe86d01e-0014-4a3d-892f-20c7c9a2728b_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/55ecaa80-fb16-48cb-b4a7-2c803d69bcbf_1.5.1.20-RXN>
+<http://model.geneontology.org/5790e7ba-4d59-43ea-8c6c-c4e757e138d9_1.5.1.20-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/CHEBI_456216_FOLYLPOLYGLUTAMATESYNTH-RXN>
@@ -580,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -588,29 +607,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_CHEBI_456216_RXN3O-681_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_CHEBI_456216_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_456216_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -621,18 +651,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-20/YeastPathways_PWY3O-20>
 ] .
 
-<http://model.geneontology.org/781c4fdc-2da0-4ba4-a6db-eadd9c3cafa3_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -655,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -663,26 +690,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_04e09e6e-48fe-4d8d-9f1a-4d4ebfd3fe6e_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_fe86d01e-0014-4a3d-892f-20c7c9a2728b_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_c298a070-ec3a-4344-ab47-344123226f90_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -690,30 +706,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fe86d01e-0014-4a3d-892f-20c7c9a2728b_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/c298a070-ec3a-4344-ab47-344123226f90_DIHYDROFOLATEREDUCT-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN0-2921_BFO_0000066_reaction_RXN0-2921_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-681_BFO_0000066_reaction_RXN3O-681_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000288> ;
@@ -722,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -734,11 +728,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_04e09e6e-48fe-4d8d-9f1a-4d4ebfd3fe6e_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_43dc3a7d-11db-4338-8adb-c808bf7be6c3_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -746,19 +740,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FOLYLPOLYGLUTAMATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/04e09e6e-48fe-4d8d-9f1a-4d4ebfd3fe6e_FOLYLPOLYGLUTAMATESYNTH-RXN>
+          <http://model.geneontology.org/43dc3a7d-11db-4338-8adb-c808bf7be6c3_FOLYLPOLYGLUTAMATESYNTH-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57451>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -767,11 +750,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,7 +774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -799,48 +782,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_53867e94-7473-4efd-8271-23c60a9c141a_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_FORMYLTHFGLUSYNTH-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -851,15 +801,37 @@
           <http://model.geneontology.org/FORMYLTHFGLUSYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -870,14 +842,47 @@
           <http://model.geneontology.org/reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YPL023C-MONOMER_1.5.1.20-RXN_controller_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_11f07e7c-fb49-4320-8d08-c4bb78b31666_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -890,9 +895,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/55ef8059-b6d4-457a-97c2-61656e001a2e_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/0effdf57-b46a-4601-9d03-fcb3d29a9480_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/4a975ce2-f4c2-4f4d-a5e9-3198ab9cca31_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/a08cde20-b525-45e4-9459-cb3a138cd26e_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -900,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -911,6 +916,9 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -920,7 +928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -932,11 +940,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_CHEBI_30616_RXN3O-681_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_CHEBI_30616_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,21 +955,43 @@
           <http://model.geneontology.org/CHEBI_30616_RXN3O-681>
 ] .
 
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_RXN3O-681_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/11f07e7c-fb49-4320-8d08-c4bb78b31666_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -972,29 +1002,29 @@
           <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_55ef8059-b6d4-457a-97c2-61656e001a2e_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/GO_0008841>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0008841>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_BFO_0000066_reaction_FOLYLPOLYGLUTAMATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_BFO_0000066_reaction_FOLYLPOLYGLUTAMATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1005,36 +1035,19 @@
           <http://model.geneontology.org/reaction_FOLYLPOLYGLUTAMATESYNTH-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-20>
+<http://purl.obolibrary.org/obo/CHEBI_15740>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_5790e7ba-4d59-43ea-8c6c-c4e757e138d9_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/252c99cd-e3f0-45d9-bfc3-e3216940d38c_FORMYLTHFGLUSYNTH-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_15740>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1042,15 +1055,26 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_380dfae7-a36e-4bd6-9914-7c94d3a39252_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_94b46370-0999-4886-8712-14de8b6e4c34_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1058,18 +1082,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/380dfae7-a36e-4bd6-9914-7c94d3a39252_1.5.1.20-RXN>
+          <http://model.geneontology.org/94b46370-0999-4886-8712-14de8b6e4c34_1.5.1.20-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1080,18 +1104,32 @@
           <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/3b5b08e1-b00c-4648-8131-4ed6535d59db_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/bb6b777d-b509-4ab1-8772-e0d88f2d12fc_RXN3O-22>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64931> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_CHEBI_30616_RXN0-2921_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_CHEBI_30616_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1102,28 +1140,45 @@
           <http://model.geneontology.org/CHEBI_30616_RXN0-2921>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_CHEBI_30616_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/94b46370-0999-4886-8712-14de8b6e4c34_1.5.1.20-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64931> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1131,11 +1186,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_55ef8059-b6d4-457a-97c2-61656e001a2e_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_0effdf57-b46a-4601-9d03-fcb3d29a9480_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1143,28 +1198,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/55ef8059-b6d4-457a-97c2-61656e001a2e_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/0effdf57-b46a-4601-9d03-fcb3d29a9480_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_CHEBI_29985_RXN3O-681_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002333_YOR241W-MONOMER_RXN3O-681_controller_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1177,24 +1221,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64805> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_RXN3O-22_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
@@ -1205,7 +1238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1216,26 +1249,15 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_BFO_0000066_reaction_FORMYLTHFGLUSYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1250,11 +1272,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_CHEBI_43474_FORMYLTHFGLUSYNTH-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_CHEBI_43474_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1269,11 +1291,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1288,11 +1310,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_01456ff2-c692-42f5-af7d-aec1a606be1e_RXN3O-22_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_bb6b777d-b509-4ab1-8772-e0d88f2d12fc_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1300,40 +1322,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/01456ff2-c692-42f5-af7d-aec1a606be1e_RXN3O-22>
+          <http://model.geneontology.org/bb6b777d-b509-4ab1-8772-e0d88f2d12fc_RXN3O-22>
 ] .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_252c99cd-e3f0-45d9-bfc3-e3216940d38c_FORMYLTHFGLUSYNTH-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_CHEBI_456216_FORMYLTHFGLUSYNTH-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_CHEBI_456216_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1344,6 +1344,28 @@
           <http://model.geneontology.org/CHEBI_456216_FORMYLTHFGLUSYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-681_BFO_0000066_reaction_RXN3O-681_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/FOLYLPOLYGLUTAMATESYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004326> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1353,15 +1375,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FOLYLPOLYGLUTAMATESYNTH-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/27cdda9e-8100-4c64-aa70-d22b01f45db0_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_29985_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/CHEBI_30616_FOLYLPOLYGLUTAMATESYNTH-RXN> ;
+                <http://model.geneontology.org/CHEBI_29985_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/eb654138-4915-429b-add9-a9e49f8fadcd_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_30616_FOLYLPOLYGLUTAMATESYNTH-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/04e09e6e-48fe-4d8d-9f1a-4d4ebfd3fe6e_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/CHEBI_43474_FOLYLPOLYGLUTAMATESYNTH-RXN> ;
+                <http://model.geneontology.org/CHEBI_456216_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/43dc3a7d-11db-4338-8adb-c808bf7be6c3_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/CHEBI_43474_FOLYLPOLYGLUTAMATESYNTH-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_FOLYLPOLYGLUTAMATESYNTH-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1369,14 +1391,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_CHEBI_456216_FORMYLTHFGLUSYNTH-RXN_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1384,11 +1406,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1408,7 +1430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1416,26 +1438,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2921_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/43dc3a7d-11db-4338-8adb-c808bf7be6c3_FOLYLPOLYGLUTAMATESYNTH-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1446,6 +1474,17 @@
           <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29985_RXN0-2921>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1455,7 +1494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1463,15 +1502,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_33debf0a-0ea7-43b0-960a-b1628e581db6_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_RXN0-2921_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1486,11 +1536,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1501,29 +1551,32 @@
           <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_456216>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/bd5286c0-88e4-4025-9a61-ffb082eee8fe_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://purl.obolibrary.org/obo/CHEBI_456216>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002333_YOR241W-MONOMER_FOLYLPOLYGLUTAMATESYNTH-RXN_controller_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002333_YOR241W-MONOMER_FOLYLPOLYGLUTAMATESYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1534,58 +1587,25 @@
           <http://model.geneontology.org/YOR241W-MONOMER_FOLYLPOLYGLUTAMATESYNTH-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57540_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_c298a070-ec3a-4344-ab47-344123226f90_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_CHEBI_29985_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1593,11 +1613,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1608,26 +1628,15 @@
           <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_CHEBI_43474_RXN3O-681_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1647,7 +1656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1655,14 +1664,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_43474_RXN0-2921_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_36ebaeaf-e94f-4c49-890e-caa2a4d73625_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1670,11 +1690,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1685,22 +1705,16 @@
           <http://model.geneontology.org/CHEBI_17839_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/380dfae7-a36e-4bd6-9914-7c94d3a39252_1.5.1.20-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002411_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64931> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1709,11 +1723,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_dab5e2d8-dc4f-41cb-8ab4-cf7012326baa_RXN3O-681_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_de830213-55de-4583-b599-b76262ddfbd0_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1721,17 +1735,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-681> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/dab5e2d8-dc4f-41cb-8ab4-cf7012326baa_RXN3O-681>
+          <http://model.geneontology.org/de830213-55de-4583-b599-b76262ddfbd0_RXN3O-681>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1744,15 +1758,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-681_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-681> , <http://model.geneontology.org/dab5e2d8-dc4f-41cb-8ab4-cf7012326baa_RXN3O-681> , <http://model.geneontology.org/CHEBI_29985_RXN3O-681> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-681> , <http://model.geneontology.org/de830213-55de-4583-b599-b76262ddfbd0_RXN3O-681> , <http://model.geneontology.org/CHEBI_29985_RXN3O-681> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/5272da76-d1f3-4afc-8e4e-be7ee2ab13c5_RXN3O-681> , <http://model.geneontology.org/CHEBI_43474_RXN3O-681> , <http://model.geneontology.org/CHEBI_456216_RXN3O-681> ;
+                <http://model.geneontology.org/36ebaeaf-e94f-4c49-890e-caa2a4d73625_RXN3O-681> , <http://model.geneontology.org/CHEBI_43474_RXN3O-681> , <http://model.geneontology.org/CHEBI_456216_RXN3O-681> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-681_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1764,11 +1778,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_781c4fdc-2da0-4ba4-a6db-eadd9c3cafa3_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_11f07e7c-fb49-4320-8d08-c4bb78b31666_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1776,7 +1790,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/781c4fdc-2da0-4ba4-a6db-eadd9c3cafa3_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/11f07e7c-fb49-4320-8d08-c4bb78b31666_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000005767>
@@ -1791,15 +1805,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-2921_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/e697630c-9da3-4d78-b3a0-827eb3c148f4_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_29985_RXN0-2921> , <http://model.geneontology.org/CHEBI_30616_RXN0-2921> ;
+                <http://model.geneontology.org/CHEBI_29985_RXN0-2921> , <http://model.geneontology.org/33debf0a-0ea7-43b0-960a-b1628e581db6_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_30616_RXN0-2921> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN0-2921> , <http://model.geneontology.org/CHEBI_456216_RXN0-2921> , <http://model.geneontology.org/8fc89d6f-d7be-47d3-bbe4-c248cfbea8af_RXN0-2921> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN0-2921> , <http://model.geneontology.org/6bb5f630-6661-4d97-97df-84b8ee79c9be_RXN0-2921> , <http://model.geneontology.org/CHEBI_456216_RXN0-2921> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN0-2921_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1807,15 +1821,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_285f2105-f945-4241-8980-bbdfdc802cb9_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_CHEBI_29985_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_CHEBI_29985_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1826,16 +1851,8 @@
           <http://model.geneontology.org/CHEBI_29985_FOLYLPOLYGLUTAMATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/eb654138-4915-429b-add9-a9e49f8fadcd_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://identifiers.org/sgd/S000004048>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1850,11 +1867,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YGL125W-MONOMER_1.5.1.20-RXN_controller_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YGL125W-MONOMER_1.5.1.20-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1865,14 +1882,14 @@
           <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1880,11 +1897,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1898,6 +1915,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_17839>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/a08cde20-b525-45e4-9459-cb3a138cd26e_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_456216_RXN3O-681>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1907,7 +1941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1922,7 +1956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1934,11 +1968,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_e697630c-9da3-4d78-b3a0-827eb3c148f4_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_33debf0a-0ea7-43b0-960a-b1628e581db6_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1946,18 +1980,32 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2921> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e697630c-9da3-4d78-b3a0-827eb3c148f4_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/33debf0a-0ea7-43b0-960a-b1628e581db6_GLYOHMETRANS-RXN>
 ] .
+
+<http://model.geneontology.org/0effdf57-b46a-4601-9d03-fcb3d29a9480_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_43474_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1967,6 +2015,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57540_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1980,15 +2039,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMYLTHFGLUSYNTH-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_29985_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/3b5b08e1-b00c-4648-8131-4ed6535d59db_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_29985_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/bd5286c0-88e4-4025-9a61-ffb082eee8fe_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/252c99cd-e3f0-45d9-bfc3-e3216940d38c_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMYLTHFGLUSYNTH-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/0c468d99-723f-4e44-bc2f-33d54e854cd5_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMYLTHFGLUSYNTH-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_FORMYLTHFGLUSYNTH-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1996,34 +2055,54 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002333_YOR241W-MONOMER_FOLYLPOLYGLUTAMATESYNTH-RXN_controller_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_CHEBI_30616_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/0c468d99-723f-4e44-bc2f-33d54e854cd5_FORMYLTHFGLUSYNTH-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_CHEBI_456216_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/be6dec46-4c5b-46e5-a44c-38a2fa594f24_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2034,7 +2113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2042,36 +2121,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_CHEBI_456216_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_FORMYLTHFGLUSYNTH-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2084,7 +2141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2092,26 +2149,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2129,7 +2175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2146,7 +2192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2154,26 +2200,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_252c99cd-e3f0-45d9-bfc3-e3216940d38c_FORMYLTHFGLUSYNTH-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_0c468d99-723f-4e44-bc2f-33d54e854cd5_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2181,11 +2216,22 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFGLUSYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/252c99cd-e3f0-45d9-bfc3-e3216940d38c_FORMYLTHFGLUSYNTH-RXN>
+          <http://model.geneontology.org/0c468d99-723f-4e44-bc2f-33d54e854cd5_FORMYLTHFGLUSYNTH-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000005762>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-681_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005767> ;
@@ -2194,7 +2240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2206,11 +2252,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2221,14 +2267,14 @@
           <http://model.geneontology.org/YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2241,7 +2287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2249,14 +2295,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_3b5b08e1-b00c-4648-8131-4ed6535d59db_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_CHEBI_29985_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2264,11 +2310,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_15378_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_15378_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2288,9 +2334,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/781c4fdc-2da0-4ba4-a6db-eadd9c3cafa3_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/11f07e7c-fb49-4320-8d08-c4bb78b31666_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/d14ac62c-e681-4101-8a36-58645e97b3f9_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/e4b3190f-90ae-487b-a78a-052553392514_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2298,7 +2344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2306,15 +2352,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_43dc3a7d-11db-4338-8adb-c808bf7be6c3_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_be6dec46-4c5b-46e5-a44c-38a2fa594f24_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2325,48 +2404,15 @@
           <http://model.geneontology.org/1.5.1.20-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002333_YOR241W-MONOMER_RXN0-2921_controller_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_CHEBI_29985_RXN0-2921_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2380,26 +2426,15 @@
 <http://purl.obolibrary.org/obo/GO_0004489>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_e697630c-9da3-4d78-b3a0-827eb3c148f4_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2410,32 +2445,49 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-20/YeastPathways_PWY3O-20>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_27cdda9e-8100-4c64-aa70-d22b01f45db0_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/c298a070-ec3a-4344-ab47-344123226f90_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002333_YOR241W-MONOMER_FOLYLPOLYGLUTAMATESYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2446,26 +2498,15 @@
           <http://model.geneontology.org/CHEBI_29985_RXN3O-22>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_BFO_0000066_reaction_FORMYLTHFGLUSYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_BFO_0000066_reaction_FORMYLTHFGLUSYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2476,6 +2517,28 @@
           <http://model.geneontology.org/reaction_FORMYLTHFGLUSYNTH-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_bd5286c0-88e4-4025-9a61-ffb082eee8fe_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_FORMYLTHFGLUSYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2485,7 +2548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2502,7 +2565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2514,11 +2577,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2529,6 +2592,17 @@
           <http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_bb6b777d-b509-4ab1-8772-e0d88f2d12fc_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2538,7 +2612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2555,7 +2629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2572,7 +2646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2584,11 +2658,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_CHEBI_43474_RXN3O-681_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_CHEBI_43474_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2599,15 +2673,26 @@
           <http://model.geneontology.org/CHEBI_43474_RXN3O-681>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_eb654138-4915-429b-add9-a9e49f8fadcd_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2621,6 +2706,45 @@
 <http://identifiers.org/sgd/S000000467>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_CHEBI_29985_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/6bb5f630-6661-4d97-97df-84b8ee79c9be_RXN0-2921>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003093> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2628,7 +2752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2640,11 +2764,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_CHEBI_30616_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_CHEBI_30616_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2658,37 +2782,15 @@
 <http://purl.obolibrary.org/obo/GO_0004146>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_CHEBI_43474_FORMYLTHFGLUSYNTH-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_380dfae7-a36e-4bd6-9914-7c94d3a39252_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YPL023C-MONOMER_1.5.1.20-RXN_controller_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YPL023C-MONOMER_1.5.1.20-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2703,11 +2805,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2718,15 +2820,32 @@
           <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/285f2105-f945-4241-8980-bbdfdc802cb9_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_43474_RXN0-2921_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_43474_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2742,12 +2861,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/27cdda9e-8100-4c64-aa70-d22b01f45db0_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/CHEBI_43474_RXN3O-22>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -2758,7 +2874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2775,13 +2891,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64820> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005944> ;
@@ -2790,7 +2917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2802,11 +2929,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2826,7 +2953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "folate polyglutamylation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2841,11 +2968,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_456216_RXN0-2921_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_456216_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2863,7 +2990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2880,7 +3007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2897,7 +3024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2912,11 +3039,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_4a975ce2-f4c2-4f4d-a5e9-3198ab9cca31_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_a08cde20-b525-45e4-9459-cb3a138cd26e_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2924,29 +3051,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4a975ce2-f4c2-4f4d-a5e9-3198ab9cca31_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/a08cde20-b525-45e4-9459-cb3a138cd26e_FORMATETHFLIG-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2957,22 +3073,19 @@
           <http://model.geneontology.org/FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/5272da76-d1f3-4afc-8e4e-be7ee2ab13c5_RXN3O-681>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
+<http://model.geneontology.org/33debf0a-0ea7-43b0-960a-b1628e581db6_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-2921_BFO_0000066_reaction_RXN0-2921_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57305> ;
@@ -2983,7 +3096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2995,11 +3108,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-681_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-681_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3010,19 +3123,30 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-20/YeastPathways_PWY3O-20>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_0c468d99-723f-4e44-bc2f-33d54e854cd5_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3031,11 +3155,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002333_YOR241W-MONOMER_FORMYLTHFGLUSYNTH-RXN_controller_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002333_YOR241W-MONOMER_FORMYLTHFGLUSYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3049,17 +3173,6 @@
 <http://identifiers.org/sgd/S000005944>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002333_YOR241W-MONOMER_FORMYLTHFGLUSYNTH-RXN_controller_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3069,7 +3182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3081,11 +3194,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002411_RXN3O-681_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002411_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3096,25 +3209,14 @@
           <http://model.geneontology.org/RXN3O-681>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_4a975ce2-f4c2-4f4d-a5e9-3198ab9cca31_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3123,7 +3225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3131,11 +3233,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3149,32 +3251,26 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/8fc89d6f-d7be-47d3-bbe4-c248cfbea8af_RXN0-2921>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_BFO_0000066_reaction_FOLYLPOLYGLUTAMATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2921_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2921_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3194,7 +3290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3206,11 +3302,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3221,53 +3317,31 @@
           <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_8fc89d6f-d7be-47d3-bbe4-c248cfbea8af_RXN0-2921_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/01456ff2-c692-42f5-af7d-aec1a606be1e_RXN3O-22>
+<http://model.geneontology.org/36ebaeaf-e94f-4c49-890e-caa2a4d73625_RXN3O-681>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
+                "a 7,8-dihydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64931> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3275,11 +3349,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3290,32 +3364,26 @@
           <http://model.geneontology.org/CHEBI_30616_RXN3O-22>
 ] .
 
-<http://model.geneontology.org/04e09e6e-48fe-4d8d-9f1a-4d4ebfd3fe6e_FOLYLPOLYGLUTAMATESYNTH-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_CHEBI_30616_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_CHEBI_29985_FORMYLTHFGLUSYNTH-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_CHEBI_29985_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3326,17 +3394,6 @@
           <http://model.geneontology.org/CHEBI_29985_FORMYLTHFGLUSYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000467> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3344,7 +3401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3361,7 +3418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3369,51 +3426,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/8022fc70-9a93-4181-96ab-c520478babfe_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DIHYDROFOLATESYNTH-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_RXN3O-22_SGD_YeastPathways_PWY3O-20> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3424,14 +3445,44 @@
           <http://model.geneontology.org/RXN3O-22>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_5272da76-d1f3-4afc-8e4e-be7ee2ab13c5_RXN3O-681_SGD_YeastPathways_PWY3O-20>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_DIHYDROFOLATESYNTH-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YPL023C-MONOMER_1.5.1.20-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3442,7 +3493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3450,26 +3501,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_CHEBI_29985_FORMYLTHFGLUSYNTH-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_CHEBI_456216_RXN3O-681_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_CHEBI_456216_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3480,17 +3520,6 @@
           <http://model.geneontology.org/CHEBI_456216_RXN3O-681>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0046655>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3498,11 +3527,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3513,25 +3542,14 @@
           <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_e4b3190f-90ae-487b-a78a-052553392514_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_CHEBI_30616_RXN3O-681_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3539,11 +3557,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_27cdda9e-8100-4c64-aa70-d22b01f45db0_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_eb654138-4915-429b-add9-a9e49f8fadcd_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3551,17 +3569,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FOLYLPOLYGLUTAMATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/27cdda9e-8100-4c64-aa70-d22b01f45db0_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/eb654138-4915-429b-add9-a9e49f8fadcd_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3570,7 +3588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3578,11 +3596,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_8022fc70-9a93-4181-96ab-c520478babfe_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_285f2105-f945-4241-8980-bbdfdc802cb9_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3590,19 +3608,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8022fc70-9a93-4181-96ab-c520478babfe_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/285f2105-f945-4241-8980-bbdfdc802cb9_DIHYDROFOLATEREDUCT-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_d14ac62c-e681-4101-8a36-58645e97b3f9_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_FOLYLPOLYGLUTAMATESYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3613,16 +3620,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64767> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
@@ -3633,7 +3637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3641,64 +3645,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_BFO_0000066_reaction_FOLYLPOLYGLUTAMATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20>
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YGL125W-MONOMER_1.5.1.20-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_6bb5f630-6661-4d97-97df-84b8ee79c9be_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_CHEBI_43474_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/d14ac62c-e681-4101-8a36-58645e97b3f9_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3711,7 +3679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3719,42 +3687,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_CHEBI_30616_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/e697630c-9da3-4d78-b3a0-827eb3c148f4_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002333_YOR241W-MONOMER_FORMYLTHFGLUSYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_CHEBI_43474_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3762,11 +3727,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_8fc89d6f-d7be-47d3-bbe4-c248cfbea8af_RXN0-2921_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_6bb5f630-6661-4d97-97df-84b8ee79c9be_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3774,8 +3739,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2921> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8fc89d6f-d7be-47d3-bbe4-c248cfbea8af_RXN0-2921>
+          <http://model.geneontology.org/6bb5f630-6661-4d97-97df-84b8ee79c9be_RXN0-2921>
 ] .
+
+<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_BFO_0000066_reaction_FORMYLTHFGLUSYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_RXN3O-681>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -3786,7 +3762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3798,11 +3774,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3818,7 +3794,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3829,11 +3816,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3853,9 +3840,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/8022fc70-9a93-4181-96ab-c520478babfe_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/285f2105-f945-4241-8980-bbdfdc802cb9_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/fe86d01e-0014-4a3d-892f-20c7c9a2728b_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/c298a070-ec3a-4344-ab47-344123226f90_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3863,7 +3850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3880,7 +3867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3888,26 +3875,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_456216_RXN0-2921_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-681_BFO_0000066_reaction_RXN3O-681_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-681_BFO_0000066_reaction_RXN3O-681_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3918,40 +3894,40 @@
           <http://model.geneontology.org/reaction_RXN3O-681_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_dab5e2d8-dc4f-41cb-8ab4-cf7012326baa_RXN3O-681_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3962,14 +3938,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-20/YeastPathways_PWY3O-20>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_01456ff2-c692-42f5-af7d-aec1a606be1e_RXN3O-22_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3977,11 +3953,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-glutamate + 7,8-dihydropteroate + ATP &rarr; ADP + 7,8-dihydrofolate monoglutamate + phosphate + H<SUP>+</SUP>' 'null' 'a tetrahydrofolate + NADP<sup>+</sup> &larr; a 7,8-dihydrofolate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3992,29 +3968,57 @@
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/e4b3190f-90ae-487b-a78a-052553392514_GLYOHMETRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003436>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_53867e94-7473-4efd-8271-23c60a9c141a_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_be6dec46-4c5b-46e5-a44c-38a2fa594f24_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4022,11 +4026,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/53867e94-7473-4efd-8271-23c60a9c141a_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/be6dec46-4c5b-46e5-a44c-38a2fa594f24_GLYOHMETRANS-RXN>
 ] .
-
-<http://model.geneontology.org/53867e94-7473-4efd-8271-23c60a9c141a_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/1.5.1.20-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004489> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4037,9 +4038,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> , <http://model.geneontology.org/53867e94-7473-4efd-8271-23c60a9c141a_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> , <http://model.geneontology.org/be6dec46-4c5b-46e5-a44c-38a2fa594f24_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/380dfae7-a36e-4bd6-9914-7c94d3a39252_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/94b46370-0999-4886-8712-14de8b6e4c34_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller> , <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -4047,7 +4048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4059,11 +4060,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2921_BFO_0000066_reaction_RXN0-2921_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2921_BFO_0000066_reaction_RXN0-2921_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4083,7 +4084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4091,26 +4092,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4121,14 +4111,14 @@
           <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_CHEBI_43474_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4140,7 +4130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4149,7 +4139,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_94b46370-0999-4886-8712-14de8b6e4c34_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4161,7 +4173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4174,28 +4186,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64805> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/dab5e2d8-dc4f-41cb-8ab4-cf7012326baa_RXN3O-681>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -4208,7 +4203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4216,26 +4211,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_55ecaa80-fb16-48cb-b4a7-2c803d69bcbf_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_5790e7ba-4d59-43ea-8c6c-c4e757e138d9_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4243,32 +4227,21 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/55ecaa80-fb16-48cb-b4a7-2c803d69bcbf_1.5.1.20-RXN>
+          <http://model.geneontology.org/5790e7ba-4d59-43ea-8c6c-c4e757e138d9_1.5.1.20-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_CHEBI_30616_FORMYLTHFGLUSYNTH-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_CHEBI_30616_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4300,7 +4273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4312,11 +4285,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4327,14 +4300,14 @@
           <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002333_YOR241W-MONOMER_RXN3O-681_controller_SGD_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4342,11 +4315,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_5272da76-d1f3-4afc-8e4e-be7ee2ab13c5_RXN3O-681_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_36ebaeaf-e94f-4c49-890e-caa2a4d73625_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4354,7 +4327,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-681> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5272da76-d1f3-4afc-8e4e-be7ee2ab13c5_RXN3O-681>
+          <http://model.geneontology.org/36ebaeaf-e94f-4c49-890e-caa2a4d73625_RXN3O-681>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_DIHYDROFOLATESYNTH-RXN>
@@ -4366,13 +4339,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64820> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000000288>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15740> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4383,7 +4359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4391,18 +4367,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000000288>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_d14ac62c-e681-4101-8a36-58645e97b3f9_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_e4b3190f-90ae-487b-a78a-052553392514_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4410,35 +4394,29 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d14ac62c-e681-4101-8a36-58645e97b3f9_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/e4b3190f-90ae-487b-a78a-052553392514_GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/fe86d01e-0014-4a3d-892f-20c7c9a2728b_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_CHEBI_43474_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_CHEBI_43474_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4453,11 +4431,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002333_YOR241W-MONOMER_RXN3O-681_controller_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002333_YOR241W-MONOMER_RXN3O-681_controller_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4468,14 +4446,14 @@
           <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-681_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-681_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_CHEBI_29985_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4488,7 +4466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4496,18 +4474,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_CHEBI_29985_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004329>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4525,11 +4525,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4540,37 +4540,15 @@
           <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_55ecaa80-fb16-48cb-b4a7-2c803d69bcbf_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_CHEBI_456216_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_CHEBI_456216_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4581,6 +4559,28 @@
           <http://model.geneontology.org/CHEBI_456216_FOLYLPOLYGLUTAMATESYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-20/YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0046655> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4590,24 +4590,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY3O-20" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002411_RXN3O-681_SGD_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33384> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4618,10 +4607,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule65023> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_de830213-55de-4583-b599-b76262ddfbd0_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-214.ttl
+++ b/models/YeastPathways_PWY3O-214.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15,23 +15,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YMR083W-MONOMER_1.1.1.190-RXN_controller_SGD_YeastPathways_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_2.6.1.28-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -39,11 +28,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_BFO_0000050_YeastPathways_PWY3O-214/YeastPathways_PWY3O-214_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_BFO_0000050_YeastPathways_PWY3O-214/YeastPathways_PWY3O-214_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,11 +50,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TRYPTOPHAN-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TRYPTOPHAN-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -76,47 +65,14 @@
           <http://model.geneontology.org/reaction_TRYPTOPHAN-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_BFO_0000050_YeastPathways_PWY3O-214/YeastPathways_PWY3O-214_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX-9432_TRYPTOPHAN-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YBR145W-MONOMER_1.1.1.190-RXN_controller_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_BFO_0000050_YeastPathways_PWY3O-214/YeastPathways_PWY3O-214_SGD_YeastPathways_PWY3O-214>
+<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_BFO_0000050_YeastPathways_PWY3O-214/YeastPathways_PWY3O-214_SGD_PWY_YeastPathways_PWY3O-214>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
+                "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -126,15 +82,26 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_29985_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" , "Provides Input For Rule. The relation 'L-tryptophan + 3-phenyl-2-oxopropanoate &harr; (indol-3-yl)pyruvate + L-phenylalanine' 'null' '(indol-3-yl)pyruvate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + (indol-3-yl)acetaldehyde' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002413_4.1.1.74-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002413_4.1.1.74-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -149,11 +116,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_BFO_0000050_YeastPathways_PWY3O-214/YeastPathways_PWY3O-214_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_BFO_0000050_YeastPathways_PWY3O-214/YeastPathways_PWY3O-214_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -164,6 +131,28 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-214/YeastPathways_PWY3O-214>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-214/YeastPathways_PWY3O-214_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YMR083W-MONOMER_1.1.1.190-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -172,18 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002234_CHEBI_57540_1.1.1.190-RXN_SGD_YeastPathways_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -196,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "tryptophan degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -209,7 +187,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002233_CHEBI_57945_1.1.1.190-RXN_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -217,11 +206,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-58_4.1.1.74-RXN_controller_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-58_4.1.1.74-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,15 +221,26 @@
           <http://model.geneontology.org/CPLX3O-58_4.1.1.74-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YDL168W-MONOMER_1.1.1.190-RXN_controller_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YDL168W-MONOMER_1.1.1.190-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,17 +251,6 @@
           <http://model.geneontology.org/YDL168W-MONOMER_1.1.1.190-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_BFO_0000050_YeastPathways_PWY3O-214/YeastPathways_PWY3O-214_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -269,11 +258,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-118_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -283,17 +272,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
 ] .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YMR303C-MONOMER_1.1.1.190-RXN_controller_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -307,24 +285,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-214Complex42103> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-71_4.1.1.74-RXN_controller_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16810_TRYPTOPHAN-AMINOTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16810> ;
@@ -335,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -355,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -370,11 +337,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002233_CHEBI_57912_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002233_CHEBI_57912_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -385,17 +352,6 @@
           <http://model.geneontology.org/CHEBI_57912_TRYPTOPHAN-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_57912_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YOL086C-MONOMER_1.1.1.190-RXN_controller>
         a       <http://identifiers.org/sgd/S000005446> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -403,57 +359,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-214Protein41977> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-67_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002233_CHEBI_15378_1.1.1.190-RXN_SGD_YeastPathways_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002233_CHEBI_18086_4.1.1.74-RXN_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-67_4.1.1.74-RXN_controller_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_1.1.1.190-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -464,7 +376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -476,11 +388,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002233_CHEBI_15378_4.1.1.74-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002233_CHEBI_15378_4.1.1.74-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -498,11 +410,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002233_CHEBI_18086_4.1.1.74-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002233_CHEBI_18086_4.1.1.74-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,36 +428,14 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-214/YeastPathways_PWY3O-214_SGD_YeastPathways_PWY3O-214>
+<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_BFO_0000066_reaction_2.6.1.28-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-214>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002413_1.1.1.190-RXN_SGD_YeastPathways_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002234_CHEBI_16526_4.1.1.74-RXN_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
+                "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -568,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -576,15 +466,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002413_4.1.1.74-RXN_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" , "Provides Input For Rule. The relation '(indol-3-yl)pyruvate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + (indol-3-yl)acetaldehyde' 'null' 'indole-3-ethanol + NAD<sup>+</sup> &larr; (indol-3-yl)acetaldehyde + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002413_1.1.1.190-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002413_1.1.1.190-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,11 +500,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YMR303C-MONOMER_1.1.1.190-RXN_controller_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YMR303C-MONOMER_1.1.1.190-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -622,7 +523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -630,11 +531,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-71_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-71_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -645,30 +546,30 @@
           <http://model.geneontology.org/SGD_S000002788_CPLX3O-71_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002413_4.1.1.74-RXN_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YBR145W-MONOMER_1.1.1.190-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002413_2.6.1.28-RXN_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004688>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002234_CHEBI_58095_2.6.1.28-RXN_SGD_YeastPathways_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003319>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -680,11 +581,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.28-RXN_controller_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.28-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,11 +600,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TRYPTOPHAN-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TRYPTOPHAN-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -714,36 +615,25 @@
           <http://model.geneontology.org/CPLX-9432_TRYPTOPHAN-AMINOTRANSFERASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002233_CHEBI_57945_1.1.1.190-RXN_SGD_YeastPathways_PWY3O-214>
+<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002233_CHEBI_18005_2.6.1.28-RXN_SGD_PWY_YeastPathways_PWY3O-214>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
+                "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_BFO_0000066_reaction_1.1.1.190-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-214>
+<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002233_CHEBI_18086_4.1.1.74-RXN_SGD_PWY_YeastPathways_PWY3O-214>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-118_4.1.1.74-RXN_controller_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
+                "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -757,11 +647,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002234_CHEBI_18086_4.1.1.74-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002234_CHEBI_18086_4.1.1.74-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -772,26 +662,15 @@
           <http://model.geneontology.org/CHEBI_18086_4.1.1.74-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_BFO_0000066_reaction_4.1.1.74-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002234_CHEBI_57540_1.1.1.190-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002234_CHEBI_57540_1.1.1.190-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -801,6 +680,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57540_1.1.1.190-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_BFO_0000066_reaction_1.1.1.190-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0050362>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -823,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -831,48 +721,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_17640_2.6.1.28-RXN_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002233_CHEBI_57912_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YDL168W-MONOMER_1.1.1.190-RXN_controller_SGD_YeastPathways_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_BFO_0000066_reaction_2.6.1.28-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_BFO_0000066_reaction_2.6.1.28-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -892,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -904,11 +761,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_17640_2.6.1.28-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_17640_2.6.1.28-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -918,6 +775,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_17640_2.6.1.28-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YDL168W-MONOMER_1.1.1.190-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_18086>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -929,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -944,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -964,7 +832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -976,11 +844,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_BFO_0000050_YeastPathways_PWY3O-214/YeastPathways_PWY3O-214_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_BFO_0000050_YeastPathways_PWY3O-214/YeastPathways_PWY3O-214_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -996,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1004,11 +872,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_BFO_0000066_reaction_1.1.1.190-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_BFO_0000066_reaction_1.1.1.190-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1022,19 +890,19 @@
 <http://purl.obolibrary.org/obo/CHEBI_17890>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002234_CHEBI_17640_2.6.1.28-RXN_SGD_YeastPathways_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-118_4.1.1.74-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
+                "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1051,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1062,8 +930,52 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002413_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-71_4.1.1.74-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_16810_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002234_CHEBI_58095_2.6.1.28-RXN_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1072,11 +984,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-67_4.1.1.74-RXN_controller_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-67_4.1.1.74-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1087,15 +999,26 @@
           <http://model.geneontology.org/CPLX3O-67_4.1.1.74-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_BFO_0000066_reaction_4.1.1.74-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YGL256W-MONOMER_1.1.1.190-RXN_controller_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YGL256W-MONOMER_1.1.1.190-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1115,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1127,11 +1050,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-58_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1142,15 +1065,37 @@
           <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002234_CHEBI_18086_4.1.1.74-RXN_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002233_CHEBI_15378_1.1.1.190-RXN_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002234_CHEBI_17640_2.6.1.28-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002234_CHEBI_17640_2.6.1.28-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1164,26 +1109,15 @@
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YOL086C-MONOMER_1.1.1.190-RXN_controller_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_16810_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_16810_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1194,39 +1128,17 @@
           <http://model.geneontology.org/CHEBI_16810_TRYPTOPHAN-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.28-RXN_controller_SGD_YeastPathways_PWY3O-214>
+<http://identifiers.org/sgd/S000003225>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002234_CHEBI_17640_2.6.1.28-RXN_SGD_PWY_YeastPathways_PWY3O-214>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TRYPTOPHAN-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000003225>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_16810_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
+                "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1239,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1256,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1267,37 +1179,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_18005>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002233_CHEBI_18005_2.6.1.28-RXN_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002233_CHEBI_15378_4.1.1.74-RXN_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002233_CHEBI_17640_2.6.1.28-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002233_CHEBI_17640_2.6.1.28-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1312,11 +1202,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002233_CHEBI_57945_1.1.1.190-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002233_CHEBI_57945_1.1.1.190-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1339,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1347,14 +1237,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_29985_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_17640_2.6.1.28-RXN_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
+                "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1367,7 +1257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1375,15 +1265,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-67_4.1.1.74-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YOL086C-MONOMER_1.1.1.190-RXN_controller_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YOL086C-MONOMER_1.1.1.190-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1394,15 +1295,26 @@
           <http://model.geneontology.org/YOL086C-MONOMER_1.1.1.190-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YOL086C-MONOMER_1.1.1.190-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-214/YeastPathways_PWY3O-214_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-214/YeastPathways_PWY3O-214_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1413,6 +1325,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-214/YeastPathways_PWY3O-214>
 ] .
 
+<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002233_CHEBI_15378_4.1.1.74-RXN_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-214/YeastPathways_PWY3O-214>
         a       <http://purl.obolibrary.org/obo/GO_0006569> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1422,7 +1345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1430,28 +1353,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TRYPTOPHAN-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-214>
+<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_BFO_0000050_YeastPathways_PWY3O-214/YeastPathways_PWY3O-214_SGD_PWY_YeastPathways_PWY3O-214>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
+                "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002234_CHEBI_18086_4.1.1.74-RXN_SGD_YeastPathways_PWY3O-214>
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_CPLX-9432_TRYPTOPHAN-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_PWY3O-214>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002233_CHEBI_57912_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1467,7 +1401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1479,11 +1413,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" , "Provides Input For Rule. The relation 'L-tryptophan + 3-phenyl-2-oxopropanoate &harr; (indol-3-yl)pyruvate + L-phenylalanine' 'null' '2-oxoglutarate + L-tryptophan &harr; L-glutamate + (indol-3-yl)pyruvate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002413_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002413_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1499,7 +1433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1507,11 +1441,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2-oxoglutarate + L-tryptophan &harr; L-glutamate + (indol-3-yl)pyruvate' 'null' 'L-tryptophan + 3-phenyl-2-oxopropanoate &harr; (indol-3-yl)pyruvate + L-phenylalanine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002413_2.6.1.28-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002413_2.6.1.28-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1547,13 +1481,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-214BiochemicalReaction42055> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-58_4.1.1.74-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1562,11 +1507,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-118_4.1.1.74-RXN_controller_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-118_4.1.1.74-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1581,11 +1526,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YBR145W-MONOMER_1.1.1.190-RXN_controller_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YBR145W-MONOMER_1.1.1.190-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1596,6 +1541,17 @@
           <http://model.geneontology.org/YBR145W-MONOMER_1.1.1.190-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TRYPTOPHAN-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_4.1.1.74-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1605,7 +1561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1617,11 +1573,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX-9432_TRYPTOPHAN-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_TRYPTOPHAN-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1632,25 +1588,14 @@
           <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002233_CHEBI_17640_2.6.1.28-RXN_SGD_YeastPathways_PWY3O-214>
+<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TRYPTOPHAN-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-58_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-214>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
+                "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1671,7 +1616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1679,14 +1624,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002413_2.6.1.28-RXN_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002233_CHEBI_17640_2.6.1.28-RXN_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
+                "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1703,24 +1648,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-214Protein41995> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-118_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/2.6.1.28-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0047299> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1741,7 +1675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1753,11 +1687,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002233_CHEBI_18005_2.6.1.28-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002233_CHEBI_18005_2.6.1.28-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1772,11 +1706,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_29985_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_29985_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1790,17 +1724,6 @@
 <http://identifiers.org/sgd/S000001179>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-58_4.1.1.74-RXN_controller_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YHR137W-MONOMER_2.6.1.28-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001179> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1808,7 +1731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1819,15 +1742,26 @@
 <http://identifiers.org/sgd/S000004124>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_57912_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_BFO_0000066_reaction_4.1.1.74-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_BFO_0000066_reaction_4.1.1.74-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1842,11 +1776,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002233_CHEBI_15378_1.1.1.190-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002233_CHEBI_15378_1.1.1.190-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1869,23 +1803,12 @@
 <http://purl.obolibrary.org/obo/GO_0047299>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002234_CHEBI_17890_1.1.1.190-RXN_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_1.1.1.190-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1893,11 +1816,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-71_4.1.1.74-RXN_controller_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-71_4.1.1.74-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1917,7 +1840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1929,11 +1852,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YMR083W-MONOMER_1.1.1.190-RXN_controller_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YMR083W-MONOMER_1.1.1.190-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1949,7 +1872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1957,11 +1880,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-67_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1977,36 +1900,69 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_BFO_0000066_reaction_2.6.1.28-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002234_CHEBI_17890_1.1.1.190-RXN_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
+                "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005446>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57912>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002234_CHEBI_57540_1.1.1.190-RXN_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002234_CHEBI_58095_2.6.1.28-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002234_CHEBI_58095_2.6.1.28-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2021,11 +1977,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_57912_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_57912_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2036,17 +1992,6 @@
           <http://model.geneontology.org/CHEBI_57912_TRYPTOPHAN-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002413_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YBR145W-MONOMER_1.1.1.190-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000349> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2054,7 +1999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2069,7 +2014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2077,14 +2022,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-71_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_YeastPathways_PWY3O-214>
+<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002234_CHEBI_16526_4.1.1.74-RXN_SGD_PWY_YeastPathways_PWY3O-214>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
+                "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2097,7 +2042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2105,15 +2050,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.28-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002234_CHEBI_16526_4.1.1.74-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002234_CHEBI_16526_4.1.1.74-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2124,14 +2080,14 @@
           <http://model.geneontology.org/CHEBI_16526_4.1.1.74-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YGL256W-MONOMER_1.1.1.190-RXN_controller_SGD_YeastPathways_PWY3O-214>
+<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YGL256W-MONOMER_1.1.1.190-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
+                "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2139,11 +2095,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002234_CHEBI_17890_1.1.1.190-RXN_SGD_YeastPathways_PWY3O-214> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002234_CHEBI_17890_1.1.1.190-RXN_SGD_PWY_YeastPathways_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2159,6 +2115,50 @@
 
 <http://purl.obolibrary.org/obo/GO_0047018>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_BFO_0000050_YeastPathways_PWY3O-214/YeastPathways_PWY3O-214_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-71_4.1.1.74-RXN_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002413_1.1.1.190-RXN_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.190-RXN_RO_0002333_YMR303C-MONOMER_1.1.1.190-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002788>
         a       <http://www.w3.org/2002/07/owl#Class> .

--- a/models/YeastPathways_PWY3O-2220.ttl
+++ b/models/YeastPathways_PWY3O-2220.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_17368_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_17368_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,11 +21,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002411_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002411_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,14 +36,14 @@
           <http://model.geneontology.org/ADENINE-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_YeastPathways_PWY3O-2220>
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_PWY_YeastPathways_PWY3O-2220>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -51,11 +51,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -66,6 +66,17 @@
           <http://model.geneontology.org/CHEBI_28938_ADENINE-DEAMINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0043101> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -75,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -92,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -113,11 +124,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_58053_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_58053_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -128,15 +139,26 @@
           <http://model.geneontology.org/CHEBI_58053_AMP-DEAMINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000066_reaction_AMP-DEAMINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_15378_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_15378_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -147,11 +169,55 @@
           <http://model.geneontology.org/CHEBI_15378_ADENOSINE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_28938_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000066_reaction_ADENINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000005085> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -160,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -177,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -189,11 +255,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -204,15 +270,26 @@
           <http://model.geneontology.org/YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_16335_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -230,11 +307,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000066_reaction_ADENINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000066_reaction_ADENINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of adenine, hypoxanthine and their nucleosides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -268,26 +345,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'inosine + phosphate &rarr; &alpha;-D-ribose-1-phosphate + hypoxanthine' 'null' 'IMP + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + hypoxanthine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -305,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -317,11 +383,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000066_reaction_AMP-DEAMINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000066_reaction_AMP-DEAMINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -332,30 +398,30 @@
           <http://model.geneontology.org/reaction_AMP-DEAMINASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_58053_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_15378_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000002849>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_30616_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58017_ADENPRIBOSYLTRAN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58017> ;
@@ -366,13 +432,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2220SmallMolecule48190> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YML022W-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_16708_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002807>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -382,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -395,13 +483,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2220SmallMolecule48175> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002333_YJR105W-MONOMER_ADENOSINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -410,11 +509,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_HYPOXANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_HYPOXANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -425,17 +524,6 @@
           <http://model.geneontology.org/reaction_HYPOXANPRIBOSYLTRAN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_43474_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -443,11 +531,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002333_YJR105W-MONOMER_ADENOSINE-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002333_YJR105W-MONOMER_ADENOSINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -460,17 +548,6 @@
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_15378_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ADENINE-DEAMINASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0000034> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -491,35 +568,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2220BiochemicalReaction48309> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000066_reaction_INOPHOSPHOR-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -530,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -547,7 +602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -559,11 +614,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_17596_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_17596_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,6 +629,17 @@
           <http://model.geneontology.org/CHEBI_17596_INOPHOSPHOR-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_17596_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0003999>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -581,11 +647,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -596,29 +662,29 @@
           <http://model.geneontology.org/YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15377_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16708_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_16708_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_16708_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -638,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -658,24 +724,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2220SmallMolecule48091> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000066_reaction_ADENOSINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003866>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -687,11 +742,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -702,26 +757,15 @@
           <http://model.geneontology.org/CHEBI_456215_ADENPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_57720_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_16335_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_16335_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -741,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -749,14 +793,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002333_YLR209C-MONOMER_INOPHOSPHOR-RXN_controller_SGD_YeastPathways_PWY3O-2220>
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_17368_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -769,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -777,14 +821,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000066_reaction_AMP-DEAMINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -800,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -815,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -827,11 +871,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,7 +891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -855,11 +899,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000066_reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000066_reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -888,7 +932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -896,47 +940,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220>
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17368_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -945,18 +956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -967,7 +967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -979,11 +979,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_57720_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_57720_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -994,37 +994,15 @@
           <http://model.geneontology.org/CHEBI_57720_INOPHOSPHOR-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_28938_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" , "Provides Input For Rule. The relation 'AMP + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + adenine' 'null' 'AMP + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; IMP + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1044,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1052,15 +1030,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/GO_0004001>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002333_YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002333_YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1071,97 +1052,39 @@
           <http://model.geneontology.org/YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004001>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000066_reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2220>
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_PWY_YeastPathways_PWY3O-2220>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-2220>
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2220>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16708_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1169,11 +1092,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002333_YML035C-MONOMER_AMP-DEAMINASE-RXN_controller_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002333_YML035C-MONOMER_AMP-DEAMINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1188,11 +1111,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456215_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456215_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1202,17 +1125,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_456215_ADENOSINE-KINASE-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002333_YML035C-MONOMER_AMP-DEAMINASE-RXN_controller_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/INOPHOSPHOR-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004731> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1233,13 +1145,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2220BiochemicalReaction48216> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002333_YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1249,17 +1194,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YML022W-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1287,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1302,11 +1236,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1321,11 +1255,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1348,7 +1282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1360,11 +1294,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1378,25 +1312,36 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_HYPOXANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2220>
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_HYPOXANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2220>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000066_reaction_ADENINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000066_reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15377_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1404,11 +1349,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15377_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15377_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1423,11 +1368,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1438,14 +1383,36 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002333_YJR105W-MONOMER_ADENOSINE-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-2220>
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456216_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1459,11 +1426,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17368_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17368_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1474,26 +1441,15 @@
           <http://model.geneontology.org/CHEBI_17368_INOPHOSPHOR-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_17368_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'adenosine + ATP &rarr; AMP + ADP + H<SUP>+</SUP>' 'null' 'AMP + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; IMP + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1513,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1521,14 +1477,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15378_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1541,7 +1497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1553,11 +1509,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_43474_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_43474_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1568,26 +1524,15 @@
           <http://model.geneontology.org/CHEBI_43474_INOPHOSPHOR-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YML022W-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YML022W-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1602,11 +1547,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_17368_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_17368_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1623,17 +1568,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_17368_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000005085>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1649,7 +1583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1661,11 +1595,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_28938_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_28938_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1680,11 +1614,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_30616_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_30616_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1695,28 +1629,6 @@
           <http://model.geneontology.org/CHEBI_30616_ADENOSINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456215_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002333_YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_17368_INOPHOSPHOR-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17368> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1726,7 +1638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1749,7 +1661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1757,15 +1669,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1780,11 +1703,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16708_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16708_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1795,14 +1718,14 @@
           <http://model.geneontology.org/CHEBI_16708_ADENPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_16335_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_30616_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1810,11 +1733,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1824,6 +1747,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_57720_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16335>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1837,7 +1782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1854,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1862,15 +1807,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002333_YLR209C-MONOMER_INOPHOSPHOR-RXN_controller_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002333_YLR209C-MONOMER_INOPHOSPHOR-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1890,7 +1846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1902,11 +1858,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1921,11 +1877,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" , "Provides Input For Rule. The relation 'adenine + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; ammonium + hypoxanthine' 'null' 'IMP + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + hypoxanthine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1936,14 +1892,14 @@
           <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1951,11 +1907,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1966,15 +1922,26 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220>
 ] .
 
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_43474_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456216_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456216_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1988,6 +1955,17 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15378_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1998,7 +1976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2013,7 +1991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2021,41 +1999,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_17596_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17368_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456216_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_AMP-DEAMINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2066,7 +2011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2079,7 +2024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2088,7 +2033,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002333_YML035C-MONOMER_AMP-DEAMINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2096,11 +2052,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000066_reaction_INOPHOSPHOR-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000066_reaction_INOPHOSPHOR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2110,17 +2066,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_INOPHOSPHOR-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ADENOSINE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004001> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2141,7 +2086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2153,11 +2098,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2168,14 +2113,14 @@
           <http://model.geneontology.org/CHEBI_456215_ADENPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2184,7 +2129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2192,11 +2137,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2207,6 +2152,28 @@
           <http://model.geneontology.org/CHEBI_15378_ADENINE-DEAMINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000066_reaction_ADENOSINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002411_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57720_INOPHOSPHOR-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57720> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2216,7 +2183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2231,7 +2198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2239,19 +2206,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_YeastPathways_PWY3O-2220>
+<http://purl.obolibrary.org/obo/GO_0043101>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000066_reaction_INOPHOSPHOR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2220>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0043101>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_57720>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2260,11 +2227,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15378_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15378_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2279,11 +2246,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000066_reaction_ADENOSINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000066_reaction_ADENOSINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2294,25 +2261,36 @@
           <http://model.geneontology.org/reaction_ADENOSINE-KINASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002411_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220>
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_16708_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456215_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2325,7 +2303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2350,7 +2328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2362,11 +2340,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2380,14 +2358,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_17368>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_58053_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-2220>
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_17368_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002333_YLR209C-MONOMER_INOPHOSPHOR-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2395,11 +2384,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_YeastPathways_PWY3O-2220> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_PWY_YeastPathways_PWY3O-2220> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2410,20 +2399,31 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004731>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_58053>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_YeastPathways_PWY3O-2220>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
+                "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2448,7 +2448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-224.ttl
+++ b/models/YeastPathways_PWY3O-224.ttl
@@ -3,7 +3,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8443_BFO_0000050_YeastPathways_PWY3O-224/YeastPathways_PWY3O-224_SGD_PWY_YeastPathways_PWY3O-224>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11,11 +22,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_15378_RXN-8443_SGD_YeastPathways_PWY3O-224> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_15378_RXN-8443_SGD_PWY_YeastPathways_PWY3O-224> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,6 +46,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_57502>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-8443_BFO_0000066_reaction_RXN-8443_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-224>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-224" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -53,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -61,15 +83,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002233_CHEBI_58527_RXN-8443_SGD_PWY_YeastPathways_PWY3O-224>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-224" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002233_CHEBI_58527_RXN-8443_SGD_YeastPathways_PWY3O-224> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002233_CHEBI_58527_RXN-8443_SGD_PWY_YeastPathways_PWY3O-224> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -89,30 +122,19 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002333_MONOMER3O-4139_RXN-8443_controller_SGD_YeastPathways_PWY3O-224>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-224" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8443_BFO_0000066_reaction_RXN-8443_location_lociGO_0005829_SGD_YeastPathways_PWY3O-224>
+<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002233_CHEBI_30616_RXN-8443_SGD_PWY_YeastPathways_PWY3O-224>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-224" ;
+                "SGD_PWY:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -121,11 +143,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002233_CHEBI_30616_RXN-8443_SGD_YeastPathways_PWY3O-224> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002233_CHEBI_30616_RXN-8443_SGD_PWY_YeastPathways_PWY3O-224> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -135,6 +157,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30616_RXN-8443>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_15378_RXN-8443_SGD_PWY_YeastPathways_PWY3O-224>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-224" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -148,13 +181,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-224SmallMolecule40879> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_456216_RXN-8443_SGD_PWY_YeastPathways_PWY3O-224>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-224" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -168,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -183,11 +227,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002333_MONOMER3O-4139_RXN-8443_controller_SGD_YeastPathways_PWY3O-224> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002333_MONOMER3O-4139_RXN-8443_controller_SGD_PWY_YeastPathways_PWY3O-224> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -207,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -215,37 +259,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_456216_RXN-8443_SGD_YeastPathways_PWY3O-224>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-224" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8443_BFO_0000050_YeastPathways_PWY3O-224/YeastPathways_PWY3O-224_SGD_YeastPathways_PWY3O-224>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-224" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8443_BFO_0000066_reaction_RXN-8443_location_lociGO_0005829_SGD_YeastPathways_PWY3O-224> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8443_BFO_0000066_reaction_RXN-8443_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-224> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -256,14 +278,14 @@
           <http://model.geneontology.org/reaction_RXN-8443_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002233_CHEBI_30616_RXN-8443_SGD_YeastPathways_PWY3O-224>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002333_MONOMER3O-4139_RXN-8443_controller_SGD_PWY_YeastPathways_PWY3O-224>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-224" ;
+                "SGD_PWY:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -280,11 +302,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_57502_RXN-8443_SGD_YeastPathways_PWY3O-224> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_57502_RXN-8443_SGD_PWY_YeastPathways_PWY3O-224> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -313,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -325,11 +347,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8443_BFO_0000050_YeastPathways_PWY3O-224/YeastPathways_PWY3O-224_SGD_YeastPathways_PWY3O-224> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8443_BFO_0000050_YeastPathways_PWY3O-224/YeastPathways_PWY3O-224_SGD_PWY_YeastPathways_PWY3O-224> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -355,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "nicotinate riboside salvage pathway I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -370,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -398,24 +420,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-224BiochemicalReaction40865> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_57502_RXN-8443_SGD_YeastPathways_PWY3O-224>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-224" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -429,24 +440,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-224SmallMolecule40922> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002233_CHEBI_58527_RXN-8443_SGD_YeastPathways_PWY3O-224>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-224" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -455,11 +455,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_456216_RXN-8443_SGD_YeastPathways_PWY3O-224> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_456216_RXN-8443_SGD_PWY_YeastPathways_PWY3O-224> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -470,16 +470,16 @@
           <http://model.geneontology.org/CHEBI_456216_RXN-8443>
 ] .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_15378_RXN-8443_SGD_YeastPathways_PWY3O-224>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_57502_RXN-8443_SGD_PWY_YeastPathways_PWY3O-224>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-224" ;
+                "SGD_PWY:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .

--- a/models/YeastPathways_PWY3O-230.ttl
+++ b/models/YeastPathways_PWY3O-230.ttl
@@ -1,20 +1,3 @@
-<http://model.geneontology.org/f88842ed-46f6-4792-8ee9-23541642fb6b_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-230SmallMolecule50230> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/YeastPathways_PWY3O-230>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -24,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "serine biosynthesis from glyoxylate - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -39,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,11 +34,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_435693b6-b897-4940-b008-e9aa9037280c_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-230> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_55306618-cacd-44d7-8188-3895cd99a63e_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -63,7 +46,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/435693b6-b897-4940-b008-e9aa9037280c_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/55306618-cacd-44d7-8188-3895cd99a63e_GLYOHMETRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004372>
@@ -72,14 +55,36 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY3O-230>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-230>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-230" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-230>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-230" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_defca0b5-12f8-42b5-be2d-478df964f4a9_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-230" ;
+                "SGD_PWY:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -92,14 +97,14 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_f88842ed-46f6-4792-8ee9-23541642fb6b_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-230>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-230" ;
+                "SGD_PWY:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -107,11 +112,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_57305_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-230> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -129,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,22 +148,22 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_57305_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-230>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-230" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_55306618-cacd-44d7-8188-3895cd99a63e_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-230" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-230/YeastPathways_PWY3O-230>
         a       <http://purl.obolibrary.org/obo/GO_0006564> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -169,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -177,29 +182,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_15377_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-230>
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-230" ;
+                "SGD_PWY:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY3O-230> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-230> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -210,33 +215,33 @@
           <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/435693b6-b897-4940-b008-e9aa9037280c_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-230SmallMolecule50253> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY3O-230>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-230" ;
+                "SGD_PWY:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/defca0b5-12f8-42b5-be2d-478df964f4a9_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-230SmallMolecule50230> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -245,11 +250,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_15377_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-230> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -281,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -293,11 +298,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY3O-230> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-230> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,11 +317,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-230> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-230> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -327,30 +332,19 @@
           <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY3O-230/YeastPathways_PWY3O-230_SGD_PWY_YeastPathways_PWY3O-230>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-230" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY3O-230/YeastPathways_PWY3O-230_SGD_YeastPathways_PWY3O-230>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-230" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_435693b6-b897-4940-b008-e9aa9037280c_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-230>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-230" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -362,11 +356,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_f88842ed-46f6-4792-8ee9-23541642fb6b_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-230> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_defca0b5-12f8-42b5-be2d-478df964f4a9_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -374,7 +368,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f88842ed-46f6-4792-8ee9-23541642fb6b_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/defca0b5-12f8-42b5-be2d-478df964f4a9_GLYOHMETRANS-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -392,15 +386,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/435693b6-b897-4940-b008-e9aa9037280c_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/55306618-cacd-44d7-8188-3895cd99a63e_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/f88842ed-46f6-4792-8ee9-23541642fb6b_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/defca0b5-12f8-42b5-be2d-478df964f4a9_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -412,11 +406,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY3O-230/YeastPathways_PWY3O-230_SGD_YeastPathways_PWY3O-230> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY3O-230/YeastPathways_PWY3O-230_SGD_PWY_YeastPathways_PWY3O-230> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -433,19 +427,36 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-230>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-230>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-230" ;
+                "SGD_PWY:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/55306618-cacd-44d7-8188-3895cd99a63e_GLYOHMETRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-230SmallMolecule50253> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -457,11 +468,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_33384_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-230> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -484,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -497,18 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_33384_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-230>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-230" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -521,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-236.ttl
+++ b/models/YeastPathways_PWY3O-236.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "nicotinate riboside salvage pathway II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -19,11 +19,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002333_YDR400W-MONOMER_RXN3O-214_controller_SGD_YeastPathways_PWY3O-236> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002333_YDR400W-MONOMER_RXN3O-214_controller_SGD_PWY_YeastPathways_PWY3O-236> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,11 +38,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002234_CHEBI_32544_RXN3O-205_SGD_YeastPathways_PWY3O-236> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002234_CHEBI_32544_RXN3O-205_SGD_PWY_YeastPathways_PWY3O-236> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,6 +56,9 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-236/YeastPathways_PWY3O-236>
         a       <http://purl.obolibrary.org/obo/GO_0034355> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -65,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -82,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -90,8 +93,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002233_CHEBI_15377_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-236>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-236" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -105,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,17 +127,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_58527>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-205_BFO_0000066_reaction_RXN3O-205_location_lociGO_0005829_SGD_YeastPathways_PWY3O-236>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-236" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58527_RXN3O-214>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58527> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -144,25 +144,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-214_BFO_0000050_YeastPathways_PWY3O-236/YeastPathways_PWY3O-236_SGD_YeastPathways_PWY3O-236>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-236" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002233_CHEBI_58527_RXN3O-205_SGD_YeastPathways_PWY3O-236>
+<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002233_CHEBI_43474_RXN3O-205_SGD_PWY_YeastPathways_PWY3O-236>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-236" ;
+                "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -175,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -192,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -204,11 +193,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_32544_RXN3O-214_SGD_YeastPathways_PWY3O-236> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_32544_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-236> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -223,11 +212,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002233_CHEBI_58527_RXN3O-205_SGD_YeastPathways_PWY3O-236> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002233_CHEBI_58527_RXN3O-205_SGD_PWY_YeastPathways_PWY3O-236> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -241,17 +230,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_16988_RXN3O-214_SGD_YeastPathways_PWY3O-236>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-236" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -264,14 +242,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_32544>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002333_YLR209C-MONOMER_RXN3O-205_controller_SGD_YeastPathways_PWY3O-236>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002411_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-236>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-236" ;
+                "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -280,33 +258,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002234_CHEBI_32544_RXN3O-205_SGD_YeastPathways_PWY3O-236>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-236" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002333_YDR400W-MONOMER_RXN3O-214_controller_SGD_PWY_YeastPathways_PWY3O-236>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-236" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-214_BFO_0000050_YeastPathways_PWY3O-236/YeastPathways_PWY3O-236_SGD_YeastPathways_PWY3O-236> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-214_BFO_0000050_YeastPathways_PWY3O-236/YeastPathways_PWY3O-236_SGD_PWY_YeastPathways_PWY3O-236> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -317,6 +295,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-236/YeastPathways_PWY3O-236>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-214_BFO_0000066_reaction_RXN3O-214_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-236>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-236" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -324,11 +313,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_16988_RXN3O-214_SGD_YeastPathways_PWY3O-236> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_16988_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-236> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,11 +335,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002233_CHEBI_43474_RXN3O-205_SGD_YeastPathways_PWY3O-236> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002233_CHEBI_43474_RXN3O-205_SGD_PWY_YeastPathways_PWY3O-236> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -367,6 +356,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_57720>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-205_BFO_0000066_reaction_RXN3O-205_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-236>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-236" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58527_RXN3O-205>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58527> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -376,7 +376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -401,18 +401,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002234_CHEBI_32544_RXN3O-205_SGD_PWY_YeastPathways_PWY3O-236>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-236" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-205_BFO_0000050_YeastPathways_PWY3O-236/YeastPathways_PWY3O-236_SGD_PWY_YeastPathways_PWY3O-236>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-236" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_32544_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-236>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-236" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002411_RXN3O-214_SGD_YeastPathways_PWY3O-236> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002411_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-236> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -423,15 +456,37 @@
           <http://model.geneontology.org/RXN3O-214>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002234_CHEBI_57720_RXN3O-205_SGD_PWY_YeastPathways_PWY3O-236>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-236" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002333_YLR209C-MONOMER_RXN3O-205_controller_SGD_PWY_YeastPathways_PWY3O-236>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-236" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002233_CHEBI_58527_RXN3O-214_SGD_YeastPathways_PWY3O-236> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002233_CHEBI_58527_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-236> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -449,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -461,11 +516,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-205_BFO_0000066_reaction_RXN3O-205_location_lociGO_0005829_SGD_YeastPathways_PWY3O-236> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-205_BFO_0000066_reaction_RXN3O-205_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-236> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -489,24 +544,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-236Protein69797> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002411_RXN3O-214_SGD_YeastPathways_PWY3O-236>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-236" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-214>
         a       <http://purl.obolibrary.org/obo/GO_0045437> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -525,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -546,11 +590,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002333_YLR209C-MONOMER_RXN3O-205_controller_SGD_YeastPathways_PWY3O-236> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002333_YLR209C-MONOMER_RXN3O-205_controller_SGD_PWY_YeastPathways_PWY3O-236> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,15 +611,26 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002233_CHEBI_58527_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-236>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-236" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002233_CHEBI_15377_RXN3O-214_SGD_YeastPathways_PWY3O-236> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002233_CHEBI_15377_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-236> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -586,26 +641,15 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-214>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-214_BFO_0000066_reaction_RXN3O-214_location_lociGO_0005829_SGD_YeastPathways_PWY3O-236>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-236" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-205_BFO_0000050_YeastPathways_PWY3O-236/YeastPathways_PWY3O-236_SGD_YeastPathways_PWY3O-236> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-205_BFO_0000050_YeastPathways_PWY3O-236/YeastPathways_PWY3O-236_SGD_PWY_YeastPathways_PWY3O-236> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -621,51 +665,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-205_BFO_0000050_YeastPathways_PWY3O-236/YeastPathways_PWY3O-236_SGD_YeastPathways_PWY3O-236>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-236" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002233_CHEBI_15377_RXN3O-214_SGD_YeastPathways_PWY3O-236>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-236" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_32544_RXN3O-214_SGD_YeastPathways_PWY3O-236>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_16988_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-236>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-236" ;
+                "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -674,11 +696,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002234_CHEBI_57720_RXN3O-205_SGD_YeastPathways_PWY3O-236> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002234_CHEBI_57720_RXN3O-205_SGD_PWY_YeastPathways_PWY3O-236> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -689,25 +711,14 @@
           <http://model.geneontology.org/CHEBI_57720_RXN3O-205>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002333_YDR400W-MONOMER_RXN3O-214_controller_SGD_YeastPathways_PWY3O-236>
+<http://model.geneontology.org/ev_w_id_RXN3O-214_BFO_0000050_YeastPathways_PWY3O-236/YeastPathways_PWY3O-236_SGD_PWY_YeastPathways_PWY3O-236>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-236" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002234_CHEBI_57720_RXN3O-205_SGD_YeastPathways_PWY3O-236>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-236" ;
+                "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -717,18 +728,15 @@
 <http://purl.obolibrary.org/obo/GO_0045437>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-214_BFO_0000066_reaction_RXN3O-214_location_lociGO_0005829_SGD_YeastPathways_PWY3O-236> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-214_BFO_0000066_reaction_RXN3O-214_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-236> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -738,6 +746,9 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN3O-214_location_lociGO_0005829>
 ] .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/RXN3O-205>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004731> ;
@@ -758,24 +769,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-236BiochemicalReaction69695> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002233_CHEBI_43474_RXN3O-205_SGD_YeastPathways_PWY3O-236>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-236" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_32544_RXN3O-214>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_32544> ;
@@ -786,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -797,13 +797,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002233_CHEBI_58527_RXN3O-214_SGD_YeastPathways_PWY3O-236>
+<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002233_CHEBI_58527_RXN3O-205_SGD_PWY_YeastPathways_PWY3O-236>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-236" ;
+                "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-238.ttl
+++ b/models/YeastPathways_PWY3O-238.ttl
@@ -1,14 +1,3 @@
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_YeastPathways_PWY3O-238>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58207_HOMOCYSMET-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58207> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -18,45 +7,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42907> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/a10ae3a1-c79a-4d3f-a446-f8c5bba41e88_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42808> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_57844_HOMOCYSMET-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57844> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "met" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42921> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -69,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -77,15 +32,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/CHEBI_57844_HOMOCYSMET-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57844> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "met" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42921> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_8b1d00f3-b2fd-42af-aab5-69c7ec588c4d_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-238" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_YeastPathways_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -96,14 +79,14 @@
           <http://model.geneontology.org/CHEBI_456216_RXN3O-22>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_a10ae3a1-c79a-4d3f-a446-f8c5bba41e88_RXN3O-22_SGD_YeastPathways_PWY3O-238>
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_PWY3O-238/YeastPathways_PWY3O-238_SGD_PWY_YeastPathways_PWY3O-238>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
+                "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -111,11 +94,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -138,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -148,6 +131,17 @@
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-238>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-238" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -161,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,14 +169,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_58207>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_YeastPathways_PWY3O-238>
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-238>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
+                "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -190,11 +184,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_YeastPathways_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -205,15 +199,26 @@
           <http://model.geneontology.org/CHEBI_43474_RXN3O-22>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-238>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-238" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -229,7 +234,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002411_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -245,15 +261,26 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-238>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-238" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_PWY3O-238/YeastPathways_PWY3O-238_SGD_YeastPathways_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_PWY3O-238/YeastPathways_PWY3O-238_SGD_PWY_YeastPathways_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,13 +298,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238Protein42879> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-238>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-238" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_RXN3O-22>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -288,11 +326,50 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42871> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-238" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_PWY3O-238/YeastPathways_PWY3O-238_SGD_PWY_YeastPathways_PWY3O-238>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-238" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/633b0d9b-6ca1-4876-8277-f67e6cdd666f_RXN3O-22>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42808> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -303,11 +380,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_253ccbcc-f0f6-4271-86f2-1e56d47f036c_RXN3O-22_SGD_YeastPathways_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_8b1d00f3-b2fd-42af-aab5-69c7ec588c4d_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,29 +392,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/253ccbcc-f0f6-4271-86f2-1e56d47f036c_RXN3O-22>
+          <http://model.geneontology.org/8b1d00f3-b2fd-42af-aab5-69c7ec588c4d_RXN3O-22>
 ] .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-238>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -351,54 +417,49 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_30616>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_YeastPathways_PWY3O-238>
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
+                "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/8b1d00f3-b2fd-42af-aab5-69c7ec588c4d_RXN3O-22>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42808> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_30616>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_YeastPathways_PWY3O-238>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_253ccbcc-f0f6-4271-86f2-1e56d47f036c_RXN3O-22_SGD_YeastPathways_PWY3O-238>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,26 +470,15 @@
           <http://model.geneontology.org/HOMOCYSMET-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-238>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002411_RXN3O-22_SGD_YeastPathways_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002411_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -439,51 +489,40 @@
           <http://model.geneontology.org/RXN3O-22>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_YeastPathways_PWY3O-238>
+<http://purl.obolibrary.org/obo/CHEBI_29985>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_633b0d9b-6ca1-4876-8277-f67e6cdd666f_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
+                "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-238>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
+                "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002411_RXN3O-22_SGD_YeastPathways_PWY3O-238>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_29985>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_YeastPathways_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,32 +533,15 @@
           <http://model.geneontology.org/CHEBI_30616_RXN3O-22>
 ] .
 
-<http://model.geneontology.org/253ccbcc-f0f6-4271-86f2-1e56d47f036c_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42808> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -530,33 +552,19 @@
           <http://model.geneontology.org/reaction_HOMOCYSMET-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-238>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
+                "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-238>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004326>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-238>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -567,7 +575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "methionine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -575,16 +583,8 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_PWY3O-238/YeastPathways_PWY3O-238_SGD_YeastPathways_PWY3O-238>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004326>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_58140>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -592,14 +592,25 @@
 <http://identifiers.org/sgd/S000000893>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_PWY3O-238/YeastPathways_PWY3O-238_SGD_YeastPathways_PWY3O-238>
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-238>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-238" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-238>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
+                "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -614,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -622,11 +633,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_YeastPathways_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY_YeastPathways_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -641,11 +652,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_YeastPathways_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_PWY_YeastPathways_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,13 +685,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42856> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-22> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29985_RXN3O-22>
+] .
 
 <http://model.geneontology.org/YER091C-MONOMER_HOMOCYSMET-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000893> ;
@@ -689,7 +719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -701,30 +731,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_YeastPathways_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_PWY3O-238/YeastPathways_PWY3O-238_SGD_PWY_YeastPathways_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-22> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_RXN3O-22>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_PWY3O-238/YeastPathways_PWY3O-238_SGD_YeastPathways_PWY3O-238> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -747,7 +758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -780,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -794,30 +805,19 @@
 <http://purl.obolibrary.org/obo/CHEBI_57844>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_YeastPathways_PWY3O-238>
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY_YeastPathways_PWY3O-238>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
+                "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-238>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/RXN3O-22>
         a       <http://purl.obolibrary.org/obo/GO_0004326> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -828,9 +828,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/253ccbcc-f0f6-4271-86f2-1e56d47f036c_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> , <http://model.geneontology.org/8b1d00f3-b2fd-42af-aab5-69c7ec588c4d_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/a10ae3a1-c79a-4d3f-a446-f8c5bba41e88_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
+                <http://model.geneontology.org/633b0d9b-6ca1-4876-8277-f67e6cdd666f_RXN3O-22> , <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -838,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -858,7 +858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -873,11 +873,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_a10ae3a1-c79a-4d3f-a446-f8c5bba41e88_RXN3O-22_SGD_YeastPathways_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_633b0d9b-6ca1-4876-8277-f67e6cdd666f_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -885,18 +885,29 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a10ae3a1-c79a-4d3f-a446-f8c5bba41e88_RXN3O-22>
+          <http://model.geneontology.org/633b0d9b-6ca1-4876-8277-f67e6cdd666f_RXN3O-22>
 ] .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_PWY_YeastPathways_PWY3O-238>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-238" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -911,11 +922,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_YeastPathways_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -931,14 +942,3 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_YeastPathways_PWY3O-238>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-242.ttl
+++ b/models/YeastPathways_PWY3O-242.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_BFO_0000066_reaction_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_BFO_0000066_reaction_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,11 +21,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002233_CHEBI_15377_RXN-10961_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002233_CHEBI_15377_RXN-10961_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,28 +36,17 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-10961>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002333_MONOMER3O-352_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-242>
+<http://purl.obolibrary.org/obo/CHEBI_17526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002234_CHEBI_17283_RXN-10938_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_17526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002234_CHEBI_456216_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -68,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -80,11 +69,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002333_MONOMER3O-107_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002333_MONOMER3O-107_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -95,25 +84,14 @@
           <http://model.geneontology.org/MONOMER3O-107_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002333_MONOMER3O-55_RXN-10961_controller_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-72_RXN3O-364_controller_SGD_YeastPathways_PWY3O-242>
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002333_MONOMER3O-107_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -126,7 +104,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-10938_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_RXN-10938> , <http://model.geneontology.org/787276f7-befe-40bf-bb31-96e93290f738_2.7.1.150-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN-10938> , <http://model.geneontology.org/05cd8bbc-1054-4d6a-8aab-934e060b85a4_2.7.1.150-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_17283_RXN-10938> , <http://model.geneontology.org/CHEBI_43474_RXN-10938> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -136,13 +114,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242BiochemicalReaction43053> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002413_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -154,11 +143,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002411_RXN-10938_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002411_RXN-10938_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,17 +158,6 @@
           <http://model.geneontology.org/RXN-10938>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002233_CHEBI_57880_RXN3O-364_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_2.7.1.150-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -189,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -206,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -214,15 +192,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002234_CHEBI_17283_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/c7389b94-d9e8-46e3-8bc4-dadc71f2ab9b_2.7.1.68-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43085> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" , "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-<i>myo</i>-inositol + ATP &rarr; a 1-phosphatidyl-1D-myo-inositol 3-phosphate + ADP + H<SUP>+</SUP>' 'null' 'a 1-phosphatidyl-1D-myo-inositol 3-phosphate + ATP &rarr; 1-phosphatidyl-1D-myo-inositol 3,5-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002413_2.7.1.150-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002413_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,26 +239,15 @@
           <http://model.geneontology.org/2.7.1.150-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002234_CHEBI_57880_RXN3O-364_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol + phosphate' 'null' 'a 1-phosphatidyl-1D-<i>myo</i>-inositol + ATP &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002413_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002413_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,11 +262,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10938_BFO_0000066_reaction_RXN-10938_location_lociGO_0005829_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10938_BFO_0000066_reaction_RXN-10938_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -289,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -304,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -312,36 +307,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002233_CHEBI_17283_RXN-10938_SGD_YeastPathways_PWY3O-242>
+<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002333_MONOMER3O-69_RXN-10961_controller_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_8c60868f-f5ab-4122-9bcd-5e7f76d5c6c4_2.7.1.68-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-76_RXN3O-364_controller_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -354,14 +327,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002234_CHEBI_17526_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002333_MONOMER3O-111_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002233_CHEBI_57880_RXN3O-364_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -369,11 +353,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002333_YDR208W-MONOMER_2.7.1.68-RXN_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002333_YDR208W-MONOMER_2.7.1.68-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -388,11 +372,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002333_MONOMER3O-352_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002333_MONOMER3O-352_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,26 +387,15 @@
           <http://model.geneontology.org/MONOMER3O-352_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10961_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-69_RXN3O-364_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-69_RXN3O-364_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,11 +410,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-86_RXN-10938_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-86_RXN-10938_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -465,7 +438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -473,15 +446,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN-10961_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_BFO_0000066_reaction_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_BFO_0000066_reaction_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,7 +487,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_17283_RXN-10938> , <http://model.geneontology.org/CHEBI_30616_2.7.1.150-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_2.7.1.150-RXN> , <http://model.geneontology.org/50163510-7e59-4f8c-98b6-0addbb4f8841_2.7.1.150-RXN> , <http://model.geneontology.org/CHEBI_15378_2.7.1.150-RXN> ;
+                <http://model.geneontology.org/CHEBI_456216_2.7.1.150-RXN> , <http://model.geneontology.org/944d6cc3-d88b-4f77-aa3a-585381b1d16c_2.7.1.150-RXN> , <http://model.geneontology.org/CHEBI_15378_2.7.1.150-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YFR019W-MONOMER_2.7.1.150-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -511,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -519,40 +503,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002333_YLR240W-MONOMER_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002413_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002413_RXN-10961_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002233_CHEBI_30616_2.7.1.150-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002233_CHEBI_30616_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,11 +540,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002234_CHEBI_15378_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002234_CHEBI_15378_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -586,11 +559,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002234_CHEBI_57880_RXN-10961_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002234_CHEBI_57880_RXN-10961_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -601,14 +574,36 @@
           <http://model.geneontology.org/CHEBI_57880_RXN-10961>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002413_2.7.1.150-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002233_CHEBI_30616_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002234_CHEBI_15378_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-55_RXN3O-364_controller_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -619,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -636,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -644,19 +639,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-72_RXN-10938_controller_SGD_YeastPathways_PWY3O-242>
+<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002233_CHEBI_15377_RXN-10961_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://identifiers.org/sgd/S000003871>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_CHEBI_456216_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_1-PHOSPHATIDYLINOSITOL-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -667,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -675,40 +678,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002413_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000003871>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0046854>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002233_CHEBI_30616_2.7.1.68-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002233_CHEBI_17526_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002233_CHEBI_17526_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -726,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -734,15 +718,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/reaction_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002233_CHEBI_30616_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002233_CHEBI_30616_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -762,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,24 +763,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002233_CHEBI_15377_RXN3O-364_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002233_CHEBI_15377_RXN3O-364_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -798,9 +782,6 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-364>
 ] .
 
-<http://model.geneontology.org/148272af-90cf-47f0-9b9e-d9fc98b896d1_2.7.1.68-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -808,11 +789,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002234_CHEBI_17283_RXN-10938_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002234_CHEBI_17283_RXN-10938_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -826,25 +807,25 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002333_MONOMER3O-69_RXN-10961_controller_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002413_RXN-10961_SGD_YeastPathways_PWY3O-242>
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002413_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002233_CHEBI_17526_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -855,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -872,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -887,11 +868,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-<i>myo</i>-inositol + ATP &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + ADP + H<SUP>+</SUP>' 'null' 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002413_RXN-10961_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002413_RXN-10961_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -902,37 +883,15 @@
           <http://model.geneontology.org/RXN-10961>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002234_CHEBI_17526_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002234_CHEBI_43474_RXN-10938_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" , "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-myo-inositol 3-phosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol + phosphate' 'null' 'a 1-phosphatidyl-1D-<i>myo</i>-inositol + ATP &rarr; a 1-phosphatidyl-1D-myo-inositol 3-phosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002413_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002413_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,11 +906,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10961_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10961_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -962,17 +921,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-242/YeastPathways_PWY3O-242>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_BFO_0000066_reaction_2.7.1.68-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -981,7 +929,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-72_RXN-10938_controller_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -989,11 +948,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002234_CHEBI_17526_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002234_CHEBI_17526_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1023,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1031,14 +990,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002234_CHEBI_15378_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002233_CHEBI_57880_RXN-10961_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1047,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1055,11 +1014,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_50163510-7e59-4f8c-98b6-0addbb4f8841_2.7.1.150-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_944d6cc3-d88b-4f77-aa3a-585381b1d16c_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1067,38 +1026,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.1.150-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/50163510-7e59-4f8c-98b6-0addbb4f8841_2.7.1.150-RXN>
+          <http://model.geneontology.org/944d6cc3-d88b-4f77-aa3a-585381b1d16c_2.7.1.150-RXN>
 ] .
-
-<http://model.geneontology.org/50163510-7e59-4f8c-98b6-0addbb4f8841_2.7.1.150-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-phosphatidyl-1D-myo-inositol 3,5-bisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43060> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002333_YLR240W-MONOMER_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002333_YLR240W-MONOMER_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1109,26 +1048,18 @@
           <http://model.geneontology.org/YLR240W-MONOMER_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_BFO_0000066_reaction_2.7.1.150-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002333_MONOMER3O-72_RXN-10961_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002333_MONOMER3O-72_RXN-10961_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1139,24 +1070,16 @@
           <http://model.geneontology.org/MONOMER3O-72_RXN-10961_controller>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" , "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + phosphate' 'null' 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + ATP &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002413_2.7.1.68-RXN_SGD_YeastPathways_PWY3O-242> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.7.1.68-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57880_RXN-10961>
         a       <http://purl.obolibrary.org/obo/CHEBI_57880> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1167,7 +1090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1175,16 +1098,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_CHEBI_15377_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" , "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + phosphate' 'null' 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + ATP &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002413_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/2.7.1.68-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_43474_RXN3O-364>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -1195,7 +1126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1210,7 +1141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1218,14 +1149,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002413_2.7.1.150-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002234_CHEBI_456216_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002333_MONOMER3O-72_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1234,18 +1176,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002233_CHEBI_30616_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_YeastPathways_PWY3O-242>
+<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_944d6cc3-d88b-4f77-aa3a-585381b1d16c_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1253,11 +1195,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_CHEBI_456216_2.7.1.68-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_CHEBI_456216_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1278,11 +1220,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002234_CHEBI_17526_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002234_CHEBI_17526_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1300,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1312,11 +1254,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002234_CHEBI_57880_RXN3O-364_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002234_CHEBI_57880_RXN3O-364_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1327,14 +1269,14 @@
           <http://model.geneontology.org/CHEBI_57880_RXN3O-364>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002333_YFR019W-MONOMER_2.7.1.150-RXN_controller_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002411_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1342,11 +1284,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-69_RXN-10938_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-69_RXN-10938_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1357,25 +1299,14 @@
           <http://model.geneontology.org/MONOMER3O-69_RXN-10938_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_CHEBI_456216_2.7.1.68-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002413_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-86_RXN-10938_controller_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1391,7 +1322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1408,7 +1339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1416,14 +1347,47 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-55_RXN-10938_controller_SGD_YeastPathways_PWY3O-242>
+<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002333_YDR208W-MONOMER_2.7.1.68-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002234_CHEBI_43474_RXN-10938_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002234_CHEBI_43474_RXN3O-364_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002233_CHEBI_30616_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1431,11 +1395,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_BFO_0000066_reaction_2.7.1.150-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_BFO_0000066_reaction_2.7.1.150-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1446,15 +1410,26 @@
           <http://model.geneontology.org/reaction_2.7.1.150-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_BFO_0000066_reaction_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002233_CHEBI_30616_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002233_CHEBI_30616_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1465,26 +1440,15 @@
           <http://model.geneontology.org/CHEBI_30616_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002333_MONOMER3O-72_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002233_CHEBI_17526_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002233_CHEBI_17526_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1502,7 +1466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1517,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1529,11 +1493,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002333_MONOMER3O-111_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002333_MONOMER3O-111_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1544,28 +1508,6 @@
           <http://model.geneontology.org/MONOMER3O-111_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002233_CHEBI_57880_RXN-10961_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002234_CHEBI_15378_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_2.7.1.68-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1575,7 +1517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1583,25 +1525,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_787276f7-befe-40bf-bb31-96e93290f738_2.7.1.150-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002413_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002234_CHEBI_17283_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_YeastPathways_PWY3O-242>
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_BFO_0000066_reaction_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1612,11 +1554,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1627,26 +1569,18 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-242/YeastPathways_PWY3O-242>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-69_RXN3O-364_controller_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/3a47746a-d7d9-4249-bff7-1de5afe74932_2.7.1.68-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1666,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1674,15 +1608,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002411_RXN-10938_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-364_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-364_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1697,11 +1642,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_CHEBI_15377_RXN-10938_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_CHEBI_15377_RXN-10938_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1712,28 +1657,6 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-10938>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_CHEBI_15377_RXN-10938_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1743,22 +1666,16 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/CHEBI_15378_1-PHOSPHATIDYLINOSITOL-KINASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
+<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_c7389b94-d9e8-46e3-8bc4-dadc71f2ab9b_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43149> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/1-PHOSPHATIDYLINOSITOL-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004430> ;
@@ -1779,7 +1696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1791,11 +1708,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002411_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002411_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1806,37 +1723,32 @@
           <http://model.geneontology.org/PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002413_2.7.1.68-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/CHEBI_15378_1-PHOSPHATIDYLINOSITOL-KINASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43149> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002333_MONOMER3O-365_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002333_MONOMER3O-365_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1854,11 +1766,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-72_RXN3O-364_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-72_RXN3O-364_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1869,26 +1781,15 @@
           <http://model.geneontology.org/MONOMER3O-72_RXN3O-364_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10938_BFO_0000066_reaction_RXN-10938_location_lociGO_0005829_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '1-phosphatidyl-1D-myo-inositol 3,5-bisphosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-myo-inositol 3-phosphate + phosphate' 'null' 'a 1-phosphatidyl-1D-myo-inositol 3-phosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002413_RXN3O-364_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002413_RXN3O-364_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1906,11 +1807,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_CHEBI_15377_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_CHEBI_15377_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1924,6 +1825,39 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-76_RXN3O-364_controller_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002333_MONOMER3O-352_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002233_CHEBI_30616_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YFR019W-MONOMER_2.7.1.150-RXN_controller>
         a       <http://identifiers.org/sgd/S000001915> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1931,13 +1865,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242Protein43201> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002233_CHEBI_30616_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-364_BFO_0000066_reaction_RXN3O-364_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-72_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -1946,7 +1902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1954,18 +1910,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/GO_0004430>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002333_YNL267W-MONOMER_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_CHEBI_15378_2.7.1.150-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_CHEBI_15378_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1976,37 +1940,21 @@
           <http://model.geneontology.org/CHEBI_15378_2.7.1.150-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002233_CHEBI_17526_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000005211>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002413_RXN3O-364_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004430>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002234_CHEBI_17283_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002234_CHEBI_17283_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2017,18 +1965,26 @@
           <http://model.geneontology.org/CHEBI_17283_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000005211>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-69_RXN-10938_controller_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002333_MONOMER3O-55_RXN-10961_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002333_MONOMER3O-55_RXN-10961_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2046,11 +2002,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002333_MONOMER3O-72_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002333_MONOMER3O-72_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2070,7 +2026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2078,14 +2034,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_CHEBI_15378_2.7.1.68-RXN_SGD_YeastPathways_PWY3O-242>
+<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002413_RXN3O-364_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-69_RXN3O-364_controller_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2095,6 +2062,21 @@
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/MONOMER3O-86_RXN-10938_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005269> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphatidylinositol 3,5-bisphosphate 5-phosphatase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242Protein43069> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 <http://purl.obolibrary.org/obo/GO_0004438>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2102,11 +2084,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002233_CHEBI_30616_2.7.1.68-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002233_CHEBI_30616_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2117,32 +2099,6 @@
           <http://model.geneontology.org/CHEBI_30616_2.7.1.68-RXN>
 ] .
 
-<http://model.geneontology.org/MONOMER3O-86_RXN-10938_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005269> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphatidylinositol 3,5-bisphosphate 5-phosphatase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242Protein43069> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002333_YNL267W-MONOMER_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/MONOMER3O-72_RXN-10938_controller>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2150,24 +2106,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242Protein43019> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-69_RXN-10938_controller_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_2.7.1.150-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2178,7 +2123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2190,11 +2135,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002233_CHEBI_57880_RXN-10961_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002233_CHEBI_57880_RXN-10961_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2205,15 +2150,37 @@
           <http://model.geneontology.org/CHEBI_57880_RXN-10961>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002234_CHEBI_15378_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002233_CHEBI_17283_RXN-10938_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002233_CHEBI_17283_RXN-10938_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2246,7 +2213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2258,11 +2225,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002234_CHEBI_43474_RXN-10938_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002234_CHEBI_43474_RXN-10938_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2285,7 +2252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2302,7 +2269,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/148272af-90cf-47f0-9b9e-d9fc98b896d1_2.7.1.68-RXN> , <http://model.geneontology.org/CHEBI_15377_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> , <http://model.geneontology.org/3a47746a-d7d9-4249-bff7-1de5afe74932_2.7.1.68-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_43474_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> , <http://model.geneontology.org/CHEBI_17526_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -2312,46 +2279,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242BiochemicalReaction43078> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002233_CHEBI_15377_RXN-10961_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-364_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_CHEBI_15378_2.7.1.150-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005269>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2365,7 +2299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2373,37 +2307,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002233_CHEBI_30616_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002233_CHEBI_17526_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" , "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-<i>myo</i>-inositol + ATP &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + ADP + H<SUP>+</SUP>' 'null' 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + ATP &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002413_2.7.1.68-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002413_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2414,14 +2326,14 @@
           <http://model.geneontology.org/2.7.1.68-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002333_MONOMER3O-69_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_BFO_0000066_reaction_2.7.1.68-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2429,11 +2341,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2448,11 +2360,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10961_BFO_0000066_reaction_RXN-10961_location_lociGO_0005829_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10961_BFO_0000066_reaction_RXN-10961_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2467,11 +2379,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002234_CHEBI_43474_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002234_CHEBI_43474_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2491,7 +2403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2505,19 +2417,30 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_17283>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002333_MONOMER3O-107_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002234_CHEBI_17526_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-86_RXN-10938_controller_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_17283>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-69_RXN-10938_controller>
         a       <http://identifiers.org/sgd/S000005050> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2526,7 +2449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2541,7 +2464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2556,7 +2479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2568,11 +2491,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002333_YFR019W-MONOMER_2.7.1.150-RXN_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002333_YFR019W-MONOMER_2.7.1.150-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2595,7 +2518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2607,11 +2530,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" , "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-<i>myo</i>-inositol + ATP &rarr; a 1-phosphatidyl-1D-myo-inositol 3-phosphate + ADP + H<SUP>+</SUP>' 'null' 'a 1-phosphatidyl-1D-myo-inositol 3-phosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002413_RXN3O-364_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002413_RXN3O-364_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2622,14 +2545,25 @@
           <http://model.geneontology.org/RXN3O-364>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002234_CHEBI_43474_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002333_MONOMER3O-55_RXN-10961_controller_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2637,11 +2571,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" , "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol + phosphate' 'null' 'a 1-phosphatidyl-1D-<i>myo</i>-inositol + ATP &rarr; a 1-phosphatidyl-1D-myo-inositol 3-phosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002413_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002413_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2652,15 +2586,18 @@
           <http://model.geneontology.org/1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0016303>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10938_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10938_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2671,17 +2608,39 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-242/YeastPathways_PWY3O-242>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0016303>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-55_RXN3O-364_controller_SGD_YeastPathways_PWY3O-242>
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002234_CHEBI_456216_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/05cd8bbc-1054-4d6a-8aab-934e060b85a4_2.7.1.150-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-55_RXN-10938_controller_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002413_RXN3O-364_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2694,13 +2653,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43043> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_CHEBI_15378_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/2.7.1.68-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0016308> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2713,7 +2683,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_17526_1-PHOSPHATIDYLINOSITOL-KINASE-RXN> , <http://model.geneontology.org/CHEBI_30616_2.7.1.68-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/8c60868f-f5ab-4122-9bcd-5e7f76d5c6c4_2.7.1.68-RXN> , <http://model.geneontology.org/CHEBI_15378_2.7.1.68-RXN> , <http://model.geneontology.org/CHEBI_456216_2.7.1.68-RXN> ;
+                <http://model.geneontology.org/c7389b94-d9e8-46e3-8bc4-dadc71f2ab9b_2.7.1.68-RXN> , <http://model.geneontology.org/CHEBI_15378_2.7.1.68-RXN> , <http://model.geneontology.org/CHEBI_456216_2.7.1.68-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR208W-MONOMER_2.7.1.68-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2721,7 +2691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2732,28 +2702,6 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002234_CHEBI_17283_RXN-10938_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002413_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/MONOMER3O-69_RXN-10961_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005050> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2761,13 +2709,54 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242Protein43025> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10938_BFO_0000066_reaction_RXN-10938_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002413_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_c7389b94-d9e8-46e3-8bc4-dadc71f2ab9b_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.7.1.68-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/c7389b94-d9e8-46e3-8bc4-dadc71f2ab9b_2.7.1.68-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_15378_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2778,7 +2767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2790,41 +2779,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_8c60868f-f5ab-4122-9bcd-5e7f76d5c6c4_2.7.1.68-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002234_CHEBI_456216_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.7.1.68-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8c60868f-f5ab-4122-9bcd-5e7f76d5c6c4_2.7.1.68-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002234_CHEBI_57880_RXN-10961_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002234_CHEBI_456216_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_YeastPathways_PWY3O-242> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2839,11 +2798,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-55_RXN3O-364_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-55_RXN3O-364_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2854,26 +2813,15 @@
           <http://model.geneontology.org/MONOMER3O-55_RXN3O-364_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-72_RXN-10938_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-72_RXN-10938_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2884,14 +2832,25 @@
           <http://model.geneontology.org/MONOMER3O-72_RXN-10938_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002413_RXN3O-364_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-72_RXN3O-364_controller_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_BFO_0000066_reaction_2.7.1.150-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2904,7 +2863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2912,26 +2871,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002234_CHEBI_43474_RXN3O-364_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2942,8 +2890,38 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-242/YeastPathways_PWY3O-242>
 ] .
 
-<http://model.geneontology.org/787276f7-befe-40bf-bb31-96e93290f738_2.7.1.150-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002333_YFR019W-MONOMER_2.7.1.150-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002233_CHEBI_17283_RXN-10938_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-364_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -2954,7 +2932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidylinositol phosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2962,82 +2940,15 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_RXN-10938_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_BFO_0000066_reaction_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002413_2.7.1.68-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/YeastPathways_PWY3O-242/YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/GO_0046854> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "The phosphorylated products of phosphatidylinositol (PtdIns, PI), collectively referred to as phosphoinositides or phosphatidylinositol phosphates (PtdInsPs, PIPs), are membrane-bound lipids that function as structural components of membranes, as well as regulators of many cellular processes in eukaryotes, including vesicle-mediated membrane trafficking, cell wall integrity, and actin cytoskeleton organization (reviewed in |CITS:[17382260]| and |CITS:[8599109]|). PtdInsPs are also precursors of the water-soluble inositol phosphates (IPs), an important class of intracellular signaling molecules (reviewed in |CITS:[16781889], [16429326], [17488633]|). The inositol ring of the membrane phospholipids and the water-soluble IPs are readily phosphorylated and dephosphorylated at a number of positions making them well suited as key regulators. PtdIns can be phosphorylated at one or a combination of positions (3', 4', or 5') on the inositol headgroup, generating a set of unique stereoisomers that have specific biological functions (reviewed in |CITS:[17382260]|). These stereoisomers have been shown to be restricted to certain membranes (reviewed in |CITS:[17382260]|). Phosphatidylinositol 4-phosphate (PtdIns4P) is the major PtdInsP species of the Golgi apparatus, where it plays a role in the vesicular trafficking of secretory proteins from the Golgi to the plasma membrane (reviewed in |CITS:[17382260]|). Phosphatidylinositol 4,5-bisphosphate (PtdIns[4,5]P2) is the major species found at the plasma membrane and is involved in the regulation of actin cytoskeleton organization, as well as cell wall integrity, and heat shock response pathways (reviewed in |CITS:[17382260]|). Phosphatidylinositol 3-phosphate (PtdIns3P) is found predominantly at endosomal membranes and in multivesicular bodies (MVB), where it plays a role in endosomal and vacuolar membrane trafficking. Phosphatidylinositol 3,5-bisphosphate (PtdIns[3,5]P2) is found on vacuolar membranes where it plays an important role in the MVB sorting pathway (reviewed in |CITS:[17382260]|). Phosphorylation and dephosphorylation of the inositol headgroups of PtdInsPs at specific membrane locations signals the recruitment of certain proteins essential for vesicular transport (|CITS:[8599109]|, and reviewed in |CITS:[17382260]|). PtdInsPs recruit proteins that contain PtdInsP-specific binding domains, such as the well-studied pleckstrin homology (PH) domain that recognizes the phosphorylation pattern of specific PtdInsP inositol headgroups (reviewed in |CITS:[17382260]|). A number of kinases and phosphatases are involved in the generation and interconversions of PtdInsPs, the majority of which have been well conserved during evolution (reviewed in |CITS:[17382260]|). The PtdInsP kinases, in contrast to the lipid phosphatases, have a higher degree of specificity. While each kinase appears to phosphorylate only one substrate, many of the lipid phosphatases can dephosphorylate a number of substrates." ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphatidylinositol phosphate biosynthesis" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-                "YeastPathways_PWY3O-242" ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/8c60868f-f5ab-4122-9bcd-5e7f76d5c6c4_2.7.1.68-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43085> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002233_CHEBI_17283_RXN-10938_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002233_CHEBI_17283_RXN-10938_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3048,15 +2959,54 @@
           <http://model.geneontology.org/CHEBI_17283_RXN-10938>
 ] .
 
+<http://model.geneontology.org/YeastPathways_PWY3O-242/YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/GO_0046854> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "The phosphorylated products of phosphatidylinositol (PtdIns, PI), collectively referred to as phosphoinositides or phosphatidylinositol phosphates (PtdInsPs, PIPs), are membrane-bound lipids that function as structural components of membranes, as well as regulators of many cellular processes in eukaryotes, including vesicle-mediated membrane trafficking, cell wall integrity, and actin cytoskeleton organization (reviewed in |CITS:[17382260]| and |CITS:[8599109]|). PtdInsPs are also precursors of the water-soluble inositol phosphates (IPs), an important class of intracellular signaling molecules (reviewed in |CITS:[16781889], [16429326], [17488633]|). The inositol ring of the membrane phospholipids and the water-soluble IPs are readily phosphorylated and dephosphorylated at a number of positions making them well suited as key regulators. PtdIns can be phosphorylated at one or a combination of positions (3', 4', or 5') on the inositol headgroup, generating a set of unique stereoisomers that have specific biological functions (reviewed in |CITS:[17382260]|). These stereoisomers have been shown to be restricted to certain membranes (reviewed in |CITS:[17382260]|). Phosphatidylinositol 4-phosphate (PtdIns4P) is the major PtdInsP species of the Golgi apparatus, where it plays a role in the vesicular trafficking of secretory proteins from the Golgi to the plasma membrane (reviewed in |CITS:[17382260]|). Phosphatidylinositol 4,5-bisphosphate (PtdIns[4,5]P2) is the major species found at the plasma membrane and is involved in the regulation of actin cytoskeleton organization, as well as cell wall integrity, and heat shock response pathways (reviewed in |CITS:[17382260]|). Phosphatidylinositol 3-phosphate (PtdIns3P) is found predominantly at endosomal membranes and in multivesicular bodies (MVB), where it plays a role in endosomal and vacuolar membrane trafficking. Phosphatidylinositol 3,5-bisphosphate (PtdIns[3,5]P2) is found on vacuolar membranes where it plays an important role in the MVB sorting pathway (reviewed in |CITS:[17382260]|). Phosphorylation and dephosphorylation of the inositol headgroups of PtdInsPs at specific membrane locations signals the recruitment of certain proteins essential for vesicular transport (|CITS:[8599109]|, and reviewed in |CITS:[17382260]|). PtdInsPs recruit proteins that contain PtdInsP-specific binding domains, such as the well-studied pleckstrin homology (PH) domain that recognizes the phosphorylation pattern of specific PtdInsP inositol headgroups (reviewed in |CITS:[17382260]|). A number of kinases and phosphatases are involved in the generation and interconversions of PtdInsPs, the majority of which have been well conserved during evolution (reviewed in |CITS:[17382260]|). The PtdInsP kinases, in contrast to the lipid phosphatases, have a higher degree of specificity. While each kinase appears to phosphorylate only one substrate, many of the lipid phosphatases can dephosphorylate a number of substrates." ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphatidylinositol phosphate biosynthesis" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+                "YeastPathways_PWY3O-242" ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_CHEBI_15377_RXN-10938_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002233_CHEBI_15377_RXN3O-364_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002233_CHEBI_57880_RXN3O-364_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002233_CHEBI_57880_RXN3O-364_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3074,11 +3024,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002234_CHEBI_43474_RXN-10961_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002234_CHEBI_43474_RXN-10961_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3089,14 +3039,25 @@
           <http://model.geneontology.org/CHEBI_43474_RXN-10961>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002411_RXN-10938_SGD_YeastPathways_PWY3O-242>
+<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002234_CHEBI_43474_RXN-10961_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3105,7 +3066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3113,11 +3074,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002333_MONOMER3O-69_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002333_MONOMER3O-69_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3128,6 +3089,17 @@
           <http://model.geneontology.org/MONOMER3O-69_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-10961_BFO_0000066_reaction_RXN-10961_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57880_RXN3O-364>
         a       <http://purl.obolibrary.org/obo/CHEBI_57880> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3137,7 +3109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3164,7 +3136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3172,14 +3144,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_BFO_0000066_reaction_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-242>
+<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002333_MONOMER3O-72_RXN-10961_controller_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_CHEBI_15378_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002233_CHEBI_17283_RXN-10938_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3187,11 +3181,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_BFO_0000066_reaction_2.7.1.68-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_BFO_0000066_reaction_2.7.1.68-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3205,30 +3199,15 @@
 <http://purl.obolibrary.org/obo/GO_0000285>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/MONOMER3O-69_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller>
-        a       <http://identifiers.org/sgd/S000005050> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphatidylinositol 4,5-bisphosphate 5-phosphatase [multifunctional]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242Protein43025> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_BFO_0000066_reaction_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_BFO_0000066_reaction_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3239,26 +3218,30 @@
           <http://model.geneontology.org/reaction_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002333_MONOMER3O-72_RXN-10961_controller_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/MONOMER3O-69_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller>
+        a       <http://identifiers.org/sgd/S000005050> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphatidylinositol 4,5-bisphosphate 5-phosphatase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242Protein43025> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-364_BFO_0000066_reaction_RXN3O-364_location_lociGO_0005829_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-364_BFO_0000066_reaction_RXN3O-364_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3277,7 +3260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3285,11 +3268,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_787276f7-befe-40bf-bb31-96e93290f738_2.7.1.150-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_05cd8bbc-1054-4d6a-8aab-934e060b85a4_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3297,7 +3280,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10938> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/787276f7-befe-40bf-bb31-96e93290f738_2.7.1.150-RXN>
+          <http://model.geneontology.org/05cd8bbc-1054-4d6a-8aab-934e060b85a4_2.7.1.150-RXN>
 ] .
 
 <http://model.geneontology.org/YLR240W-MONOMER_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_controller>
@@ -3307,7 +3290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3318,75 +3301,42 @@
 <http://identifiers.org/sgd/S000003636>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002333_MONOMER3O-111_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_50163510-7e59-4f8c-98b6-0addbb4f8841_2.7.1.150-RXN_SGD_YeastPathways_PWY3O-242>
+<http://model.geneontology.org/ev_w_id_RXN-10938_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002234_CHEBI_43474_RXN-10961_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002333_MONOMER3O-69_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002233_CHEBI_30616_2.7.1.150-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002413_RXN-10961_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10961_BFO_0000066_reaction_RXN-10961_location_lociGO_0005829_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002233_CHEBI_17283_RXN-10938_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3394,11 +3344,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002333_YNL267W-MONOMER_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002333_YNL267W-MONOMER_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3409,15 +3359,43 @@
           <http://model.geneontology.org/YNL267W-MONOMER_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/944d6cc3-d88b-4f77-aa3a-585381b1d16c_2.7.1.150-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-phosphatidyl-1D-myo-inositol 3,5-bisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43060> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-76_RXN3O-364_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-76_RXN3O-364_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3432,11 +3410,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '1-phosphatidyl-1D-myo-inositol 3,5-bisphosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-myo-inositol 3-phosphate + phosphate' 'null' 'a 1-phosphatidyl-1D-myo-inositol 3-phosphate + ATP &rarr; 1-phosphatidyl-1D-myo-inositol 3,5-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002413_2.7.1.150-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002413_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3447,15 +3425,37 @@
           <http://model.geneontology.org/2.7.1.150-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_BFO_0000066_reaction_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_3a47746a-d7d9-4249-bff7-1de5afe74932_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_148272af-90cf-47f0-9b9e-d9fc98b896d1_2.7.1.68-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_3a47746a-d7d9-4249-bff7-1de5afe74932_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3463,26 +3463,24 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/148272af-90cf-47f0-9b9e-d9fc98b896d1_2.7.1.68-RXN>
+          <http://model.geneontology.org/3a47746a-d7d9-4249-bff7-1de5afe74932_2.7.1.68-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_148272af-90cf-47f0-9b9e-d9fc98b896d1_2.7.1.68-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN-10961_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_2.7.1.150-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3495,7 +3493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3503,35 +3501,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_2.7.1.150-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002333_YDR208W-MONOMER_2.7.1.68-RXN_controller_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_CHEBI_456216_2.7.1.150-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_CHEBI_456216_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3542,15 +3520,26 @@
           <http://model.geneontology.org/CHEBI_456216_2.7.1.150-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_CHEBI_15377_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002234_CHEBI_456216_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002234_CHEBI_456216_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3565,11 +3554,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002333_MONOMER3O-69_RXN-10961_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002333_MONOMER3O-69_RXN-10961_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3584,11 +3573,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + phosphate' 'null' 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002413_RXN-10961_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002413_RXN-10961_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3599,58 +3588,36 @@
           <http://model.geneontology.org/RXN-10961>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_05cd8bbc-1054-4d6a-8aab-934e060b85a4_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002234_CHEBI_456216_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002413_RXN-10961_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_YeastPathways_PWY3O-242>
+<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002234_CHEBI_57880_RXN-10961_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-364_BFO_0000066_reaction_RXN3O-364_location_lociGO_0005829_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002233_CHEBI_15377_RXN3O-364_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3663,24 +3630,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43121> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002333_MONOMER3O-365_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN-10961>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -3691,7 +3647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3699,15 +3655,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002413_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_CHEBI_15378_2.7.1.68-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_CHEBI_15378_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3718,18 +3685,15 @@
           <http://model.geneontology.org/CHEBI_15378_2.7.1.68-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004439>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002234_CHEBI_15378_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002234_CHEBI_15378_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3740,15 +3704,29 @@
           <http://model.geneontology.org/CHEBI_15378_1-PHOSPHATIDYLINOSITOL-KINASE-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0004439>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002234_CHEBI_17526_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002234_CHEBI_43474_RXN3O-364_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002234_CHEBI_43474_RXN3O-364_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3759,25 +3737,14 @@
           <http://model.geneontology.org/CHEBI_43474_RXN3O-364>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002411_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_BFO_0000066_reaction_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-242>
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002333_MONOMER3O-365_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3785,11 +3752,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-55_RXN-10938_controller_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-55_RXN-10938_controller_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3800,25 +3767,58 @@
           <http://model.geneontology.org/MONOMER3O-55_RXN-10938_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_CHEBI_456216_2.7.1.150-RXN_SGD_YeastPathways_PWY3O-242>
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002333_YLR240W-MONOMER_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002233_CHEBI_17526_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002413_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002234_CHEBI_43474_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002234_CHEBI_57880_RXN3O-364_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_CHEBI_456216_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3826,11 +3826,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-246.ttl
+++ b/models/YeastPathways_PWY3O-246.ttl
@@ -1,3 +1,14 @@
+<http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY_YeastPathways_PWY3O-246>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-246" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15686> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15,15 +26,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-246>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-246" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-246> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-246> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,6 +59,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-246>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-246" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -49,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -60,46 +93,46 @@
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-246>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-246" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-246>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-246>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-246" ;
+                "SGD_PWY:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000056>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-246>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-246" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-246> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-246> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -116,6 +149,17 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-246>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-246" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -129,11 +173,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PWY3O-246> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-246> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -144,23 +188,23 @@
           <http://model.geneontology.org/CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-246>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-246" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000056> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-246>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-246" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -174,11 +218,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-246> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-246> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -192,28 +236,6 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-246>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-246" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_YeastPathways_PWY3O-246>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-246" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -223,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -236,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -247,11 +269,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-246> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-246> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,7 +293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "(R,R)-butanediol degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -288,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -296,26 +318,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-246>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-246" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-246/YeastPathways_PWY3O-246_SGD_YeastPathways_PWY3O-246> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-246/YeastPathways_PWY3O-246_SGD_PWY_YeastPathways_PWY3O-246> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -341,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -358,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -369,14 +380,14 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-246/YeastPathways_PWY3O-246_SGD_YeastPathways_PWY3O-246>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-246>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-246" ;
+                "SGD_PWY:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -387,11 +398,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-246> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-246> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -412,11 +423,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_YeastPathways_PWY3O-246> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY_YeastPathways_PWY3O-246> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -426,17 +437,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-246>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-246" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -484,24 +484,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-246BiochemicalReaction26150> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PWY3O-246>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-246" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -513,11 +502,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-246> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-246> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -527,6 +516,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-246/YeastPathways_PWY3O-246_SGD_PWY_YeastPathways_PWY3O-246>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-246" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .

--- a/models/YeastPathways_PWY3O-259.ttl
+++ b/models/YeastPathways_PWY3O-259.ttl
@@ -1,3 +1,36 @@
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_57876_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_57603_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002333_YHR123W-MONOMER_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57603_ETHANOLAMINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57603> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -32,14 +65,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_57876_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-259>
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000066_reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-259>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
+                "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -47,11 +80,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,15 +95,26 @@
           <http://model.geneontology.org/CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -87,17 +131,6 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_17815_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-259>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_2.7.7.14-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -107,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,18 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000066_reaction_2.7.7.14-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-259>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -147,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -158,24 +180,16 @@
 <http://purl.obolibrary.org/obo/CHEBI_57876>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-259> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.7.7.14-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58190_ETHANOLAMINE-KINASE-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_17815_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -186,7 +200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,31 +213,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000066_reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-259>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002413_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-259>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-259> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.7.7.14-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58190_ETHANOLAMINE-KINASE-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_60377_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_60377> ;
@@ -234,13 +245,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-259SmallMolecule20909> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -251,14 +273,25 @@
 <http://identifiers.org/sgd/S000002554>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-259>
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_456216_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000066_reaction_2.7.7.14-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-259>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
+                "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -269,11 +302,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -293,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -320,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -332,11 +365,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_57603_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_57603_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,9 +379,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57603_ETHANOLAMINE-KINASE-RXN>
 ] .
-
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004307> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -367,7 +397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -375,22 +405,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_29888_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-259>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_37563_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_37563>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000050_YeastPathways_PWY3O-259/YeastPathways_PWY3O-259_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -399,11 +443,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_37563_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_37563_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,48 +458,15 @@
           <http://model.geneontology.org/CHEBI_37563_2.7.7.14-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-259>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000050_YeastPathways_PWY3O-259/YeastPathways_PWY3O-259_SGD_YeastPathways_PWY3O-259>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_60377_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-259>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000066_reaction_2.7.7.14-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000066_reaction_2.7.7.14-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -473,11 +484,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ethanolamine + ATP &rarr; <i>O</i>-phosphoethanolamine + ADP + H<SUP>+</SUP>' 'null' '<i>O</i>-phosphoethanolamine + CTP + H<SUP>+</SUP> &rarr; CDP-ethanolamine + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002413_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002413_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -491,17 +502,6 @@
 <http://purl.obolibrary.org/obo/GO_0004307>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002333_YHR123W-MONOMER_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-259>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58190>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -510,18 +510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_30616_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-259>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -532,11 +521,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_57876_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_57876_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,11 +540,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_30616_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_30616_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -566,26 +555,15 @@
           <http://model.geneontology.org/CHEBI_30616_ETHANOLAMINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002333_YGR007W-MONOMER_2.7.7.14-RXN_controller_SGD_YeastPathways_PWY3O-259>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" , "Provides Input For Rule. The relation '<i>O</i>-phosphoethanolamine + CTP + H<SUP>+</SUP> &rarr; CDP-ethanolamine + diphosphate' 'null' 'a 1,2-diacyl-<i>sn</i>-glycerol + CDP-ethanolamine &rarr; an L-1-phosphatidylethanolamine + CMP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002413_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002413_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -606,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -623,13 +601,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-259SmallMolecule21032> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_57876_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16038> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -640,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,40 +637,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_15378_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002333_YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-259>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_57876_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-259>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_15378_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_15378_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -692,43 +681,32 @@
           <http://model.geneontology.org/CHEBI_15378_2.7.7.14-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_456216_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-259>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-259/YeastPathways_PWY3O-259_SGD_YeastPathways_PWY3O-259>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002413_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
+                "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000050_YeastPathways_PWY3O-259/YeastPathways_PWY3O-259_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_BFO_0000050_YeastPathways_PWY3O-259/YeastPathways_PWY3O-259_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,11 +721,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002333_YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002333_YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -773,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phospholipid biosynthesis II (Kennedy pathway) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -781,26 +759,15 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002413_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-259>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_17815_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_17815_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,11 +782,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000066_reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000066_reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -830,15 +797,26 @@
           <http://model.geneontology.org/reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_29888_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002333_YGR007W-MONOMER_2.7.7.14-RXN_controller_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002333_YGR007W-MONOMER_2.7.7.14-RXN_controller_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -849,14 +827,47 @@
           <http://model.geneontology.org/YGR007W-MONOMER_2.7.7.14-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000066_reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-259>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002413_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_30616_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-259/YeastPathways_PWY3O-259_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -872,7 +883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -889,7 +900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -904,11 +915,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002333_YHR123W-MONOMER_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002333_YHR123W-MONOMER_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -929,11 +940,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -956,7 +967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -973,7 +984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -981,19 +992,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_15378_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-259>
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_60377_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-259>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
+                "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000002554> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1002,13 +1013,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-259Protein21039> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_37563_2.7.7.14-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_37563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1019,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1031,11 +1053,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000066_reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000066_reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1050,11 +1072,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-259/YeastPathways_PWY3O-259_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-259/YeastPathways_PWY3O-259_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,26 +1087,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-259/YeastPathways_PWY3O-259>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002333_YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-259>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_57876_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_57876_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1094,17 +1105,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57876_2.7.7.14-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-259>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1125,7 +1125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1136,54 +1136,43 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-259/YeastPathways_PWY3O-259_SGD_YeastPathways_PWY3O-259>
+<http://purl.obolibrary.org/obo/CHEBI_57603>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-259/YeastPathways_PWY3O-259_SGD_PWY_YeastPathways_PWY3O-259>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
+                "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_58190_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-259>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_57603_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-259>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57603>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_60377_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_60377_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1201,11 +1190,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_456216_ETHANOLAMINE-KINASE-RXN_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_456216_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1235,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1243,18 +1232,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000066_reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_17815>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002333_YGR007W-MONOMER_2.7.7.14-RXN_controller_SGD_PWY_YeastPathways_PWY3O-259>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-259" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-259/YeastPathways_PWY3O-259_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-259/YeastPathways_PWY3O-259_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1268,26 +1279,15 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_37563_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-259>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-259" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_29888_2.7.7.14-RXN_SGD_YeastPathways_PWY3O-259> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_29888_2.7.7.14-RXN_SGD_PWY_YeastPathways_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-261.ttl
+++ b/models/YeastPathways_PWY3O-261.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002333_YEL046C-MONOMER_THREONINE-ALDOLASE-RXN_controller_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002333_YEL046C-MONOMER_THREONINE-ALDOLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,26 +17,18 @@
           <http://model.geneontology.org/YEL046C-MONOMER_THREONINE-ALDOLASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_BFO_0000066_reaction_THREONINE-ALDOLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-261>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_29985>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '3-phospho-D-glycerate + NAD<sup>+</sup> &harr; 3-phosphooxypyruvate + NADH + H<SUP>+</SUP>' 'null' '2-oxoglutarate + 3-phospho-L-serine &larr; 3-phosphooxypyruvate + L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002413_PSERTRANSAM-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002413_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -47,8 +39,16 @@
           <http://model.geneontology.org/PSERTRANSAM-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_29985>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002413_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN0-5114>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -67,14 +67,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002234_CHEBI_57524_PSERTRANSAM-RXN_SGD_YeastPathways_PWY3O-261>
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_57945_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-261>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -82,11 +82,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002333_MONOMER3O-372_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002333_MONOMER3O-372_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -97,25 +97,47 @@
           <http://model.geneontology.org/MONOMER3O-372_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002234_CHEBI_16810_PSERTRANSAM-RXN_SGD_YeastPathways_PWY3O-261>
+<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002333_YOR184W-MONOMER_PSERTRANSAM-RXN_controller_SGD_PWY_YeastPathways_PWY3O-261>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002333_YGR208W-MONOMER_RXN0-5114_controller_SGD_YeastPathways_PWY3O-261>
+<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002234_CHEBI_57524_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_BFO_0000066_reaction_PSERTRANSAM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-261>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002233_CHEBI_57926_THREONINE-ALDOLASE-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -125,14 +147,14 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002333_YIL074C-MONOMER_PGLYCDEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-261>
+<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002233_CHEBI_29985_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_PWY3O-261>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -140,11 +162,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" , "Provides Input For Rule. The relation '2-oxoglutarate + 3-phospho-L-serine &larr; 3-phosphooxypyruvate + L-glutamate' 'null' '3-phospho-L-serine + H<sub>2</sub>O &rarr; L-serine + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002413_RXN0-5114_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002413_RXN0-5114_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -159,11 +181,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_33384_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -174,20 +196,6 @@
           <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_33384_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/YOR184W-MONOMER_PSERTRANSAM-RXN_controller>
         a       <http://identifiers.org/sgd/S000005710> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -195,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -203,19 +211,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15377>
+<http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002234_CHEBI_33384_RXN0-5114_SGD_YeastPathways_PWY3O-261>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_PGLYCDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -226,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -237,17 +237,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002234_CHEBI_43474_RXN0-5114_SGD_YeastPathways_PWY3O-261>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16810_PSERTRANSAM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16810> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -257,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -269,11 +258,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -284,15 +273,26 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-261/YeastPathways_PWY3O-261>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_15361_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_15378_PGLYCDEHYDROG-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_15378_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,22 +303,22 @@
           <http://model.geneontology.org/CHEBI_15378_PGLYCDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002233_CHEBI_29985_PSERTRANSAM-RXN_SGD_YeastPathways_PWY3O-261>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002233_CHEBI_57524_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15343_THREONINE-ALDOLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15343> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,11 +341,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -356,14 +356,14 @@
           <http://model.geneontology.org/reaction_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002234_CHEBI_15343_THREONINE-ALDOLASE-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -373,14 +373,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_15343>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_36655_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-261>
+<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002234_CHEBI_33384_RXN0-5114_SGD_PWY_YeastPathways_PWY3O-261>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -388,11 +388,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002233_CHEBI_18110_PGLYCDEHYDROG-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002233_CHEBI_18110_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,14 +403,25 @@
           <http://model.geneontology.org/CHEBI_18110_PGLYCDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002233_CHEBI_57926_THREONINE-ALDOLASE-RXN_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002413_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002234_CHEBI_43474_RXN0-5114_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -423,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -438,7 +449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -465,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -473,26 +484,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002233_CHEBI_57540_PGLYCDEHYDROG-RXN_SGD_YeastPathways_PWY3O-261>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002233_CHEBI_15377_RXN0-5114_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002233_CHEBI_15377_RXN0-5114_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,18 +506,26 @@
           <http://model.geneontology.org/CHEBI_15377_RXN0-5114>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002234_CHEBI_57305_THREONINE-ALDOLASE-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -524,6 +535,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_2aa07cd7-eaf9-4742-9a9d-609643a11892_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -535,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -546,28 +579,28 @@
 <http://identifiers.org/sgd/S000001864>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5114_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57926>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_15377_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-261>
+<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002233_CHEBI_18110_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-261>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -580,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -588,15 +621,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002234_CHEBI_15343_THREONINE-ALDOLASE-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002234_CHEBI_15343_THREONINE-ALDOLASE-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -611,11 +655,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002333_YER081W-MONOMER_PGLYCDEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002333_YER081W-MONOMER_PGLYCDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,11 +683,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_15361_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_15361_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -654,14 +698,14 @@
           <http://model.geneontology.org/CHEBI_15361_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_18110_PGLYCDEHYDROG-RXN_SGD_YeastPathways_PWY3O-261>
+<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_57305_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-261>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -672,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -689,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -706,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -717,9 +761,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://model.geneontology.org/CHEBI_33384_RXN0-5114>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33384> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -729,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -737,26 +778,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_57972_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-261>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002234_CHEBI_57524_PSERTRANSAM-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002234_CHEBI_57524_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -776,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -788,11 +821,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_57305_THREONINE-ALDOLASE-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_57305_THREONINE-ALDOLASE-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -803,30 +836,30 @@
           <http://model.geneontology.org/CHEBI_57305_THREONINE-ALDOLASE-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000003440>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_33cfb850-c936-4a4b-a0af-cf8967d4750f_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-261>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_57305_THREONINE-ALDOLASE-RXN_SGD_PWY_YeastPathways_PWY3O-261>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003440>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_16810>
+<http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57945_PGLYCDEHYDROG-RXN>
@@ -838,11 +871,31 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule41148> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16810>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_29985_PSERTRANSAM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "glu" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule41195> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -865,33 +918,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261BiochemicalReaction41164> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/CHEBI_29985_PSERTRANSAM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glu" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule41195> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57926_THREONINE-ALDOLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57926> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -902,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -910,14 +943,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002234_CHEBI_15343_THREONINE-ALDOLASE-RXN_SGD_YeastPathways_PWY3O-261>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -925,11 +958,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002234_CHEBI_43474_RXN0-5114_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002234_CHEBI_43474_RXN0-5114_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -940,29 +973,15 @@
           <http://model.geneontology.org/CHEBI_43474_RXN0-5114>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002333_YOR184W-MONOMER_PSERTRANSAM-RXN_controller_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0008453>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002233_CHEBI_57540_PGLYCDEHYDROG-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002233_CHEBI_57540_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -973,8 +992,22 @@
           <http://model.geneontology.org/CHEBI_57540_PGLYCDEHYDROG-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0008453>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000467> ;
@@ -983,13 +1016,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261Protein41034> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57524>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0009070>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -998,11 +1034,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" , "Provides Input For Rule. The relation 'L-threonine &rarr; acetaldehyde + glycine' 'null' 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002413_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002413_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1013,18 +1049,26 @@
           <http://model.geneontology.org/GLYOHMETRANS-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57524>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002333_MONOMER3O-372_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1039,11 +1083,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" , "Provides Input For Rule. The relation 'glyoxylate + L-alanine &rarr; glycine + pyruvate' 'null' 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002413_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002413_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1054,33 +1098,33 @@
           <http://model.geneontology.org/GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/33cfb850-c936-4a4b-a0af-cf8967d4750f_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule40983> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_15378_PGLYCDEHYDROG-RXN_SGD_YeastPathways_PWY3O-261>
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_18110_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-261>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/e63b736f-d3a6-4fcb-ab6c-9ff340f2317a_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule41006> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_58272_PGLYCDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58272> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1091,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1099,42 +1143,20 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_YeastPathways_PWY3O-261>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004648>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002233_CHEBI_58272_PGLYCDEHYDROG-RXN_SGD_YeastPathways_PWY3O-261>
+<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_PWY_YeastPathways_PWY3O-261>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1147,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1159,11 +1181,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5114_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5114_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1174,15 +1196,26 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-261/YeastPathways_PWY3O-261>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002333_YEL046C-MONOMER_THREONINE-ALDOLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_33cfb850-c936-4a4b-a0af-cf8967d4750f_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_2aa07cd7-eaf9-4742-9a9d-609643a11892_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1190,7 +1223,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/33cfb850-c936-4a4b-a0af-cf8967d4750f_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/2aa07cd7-eaf9-4742-9a9d-609643a11892_GLYOHMETRANS-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000001336>
@@ -1208,24 +1241,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule41052> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002233_CHEBI_18110_PGLYCDEHYDROG-RXN_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1245,7 +1267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1263,11 +1285,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_BFO_0000066_reaction_THREONINE-ALDOLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_BFO_0000066_reaction_THREONINE-ALDOLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1282,11 +1304,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_18110_PGLYCDEHYDROG-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_18110_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1306,7 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1314,43 +1336,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002333_MONOMER3O-372_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_18110>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0004372>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_BFO_0000066_reaction_PSERTRANSAM-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_36655_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_36655_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1361,25 +1361,25 @@
           <http://model.geneontology.org/CHEBI_36655_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002413_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002413_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002233_CHEBI_58272_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1387,11 +1387,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002233_CHEBI_29985_PSERTRANSAM-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002233_CHEBI_29985_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1402,37 +1402,15 @@
           <http://model.geneontology.org/CHEBI_29985_PSERTRANSAM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5114_BFO_0000066_reaction_RXN0-5114_location_lociGO_0005829_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002413_PSERTRANSAM-RXN_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1443,36 +1421,36 @@
           <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_15361_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-261>
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002333_YIL074C-MONOMER_PGLYCDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-261>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-261>
+<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002234_CHEBI_16810_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002233_CHEBI_15377_RXN0-5114_SGD_PWY_YeastPathways_PWY3O-261>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002413_RXN0-5114_SGD_YeastPathways_PWY3O-261>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1488,15 +1466,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57305_THREONINE-ALDOLASE-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/7dc48176-f514-4e06-9d13-8dcdc98e70b5_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_THREONINE-ALDOLASE-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/e63b736f-d3a6-4fcb-ab6c-9ff340f2317a_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/33cfb850-c936-4a4b-a0af-cf8967d4750f_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/2aa07cd7-eaf9-4742-9a9d-609643a11892_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1508,11 +1486,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002233_CHEBI_57524_PSERTRANSAM-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002233_CHEBI_57524_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1527,11 +1505,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1545,6 +1523,17 @@
 <http://identifiers.org/sgd/S000000772>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002233_CHEBI_57540_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_36655_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36655> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1554,7 +1543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1562,17 +1551,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0004617>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY3O-261>
+<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_36655_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-261>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004617>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-5114_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1583,7 +1583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1591,18 +1591,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://identifiers.org/sgd/S000000467>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002234_CHEBI_57305_THREONINE-ALDOLASE-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002234_CHEBI_57305_THREONINE-ALDOLASE-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1613,25 +1610,17 @@
           <http://model.geneontology.org/CHEBI_57305_THREONINE-ALDOLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_BFO_0000066_reaction_PGLYCDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-261>
+<http://identifiers.org/sgd/S000000467>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002333_YGR208W-MONOMER_RXN0-5114_controller_SGD_PWY_YeastPathways_PWY3O-261>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_57305_THREONINE-ALDOLASE-RXN_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1639,11 +1628,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002333_YIL074C-MONOMER_PGLYCDEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002333_YIL074C-MONOMER_PGLYCDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1654,25 +1643,14 @@
           <http://model.geneontology.org/YIL074C-MONOMER_PGLYCDEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002234_CHEBI_57305_THREONINE-ALDOLASE-RXN_SGD_YeastPathways_PWY3O-261>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002413_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1680,11 +1658,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_57305_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_57305_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1698,17 +1676,28 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_43474>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002333_YER081W-MONOMER_PGLYCDEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_57972_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_43474>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002333_YER081W-MONOMER_PGLYCDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1721,7 +1710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1729,15 +1718,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002413_RXN0-5114_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002333_YOR184W-MONOMER_PSERTRANSAM-RXN_controller_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002333_YOR184W-MONOMER_PSERTRANSAM-RXN_controller_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1748,24 +1748,15 @@
           <http://model.geneontology.org/YOR184W-MONOMER_PSERTRANSAM-RXN_controller>
 ] .
 
-<http://model.geneontology.org/reaction_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_7dc48176-f514-4e06-9d13-8dcdc98e70b5_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_e63b736f-d3a6-4fcb-ab6c-9ff340f2317a_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1773,8 +1764,28 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7dc48176-f514-4e06-9d13-8dcdc98e70b5_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/e63b736f-d3a6-4fcb-ab6c-9ff340f2317a_GLYOHMETRANS-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1782,14 +1793,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_36655>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_7dc48176-f514-4e06-9d13-8dcdc98e70b5_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-261>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_15378_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1800,7 +1811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1808,15 +1819,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002333_YGR208W-MONOMER_RXN0-5114_controller_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002333_YGR208W-MONOMER_RXN0-5114_controller_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1831,11 +1853,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002233_CHEBI_58272_PGLYCDEHYDROG-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002233_CHEBI_58272_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1850,11 +1872,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1867,39 +1889,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_57972>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_57305_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002233_CHEBI_57524_PSERTRANSAM-RXN_SGD_YeastPathways_PWY3O-261>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008453> ;
@@ -1920,7 +1909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1932,11 +1921,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_BFO_0000066_reaction_PSERTRANSAM-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_BFO_0000066_reaction_PSERTRANSAM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1947,15 +1936,37 @@
           <http://model.geneontology.org/reaction_PSERTRANSAM-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_BFO_0000066_reaction_THREONINE-ALDOLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-5114_BFO_0000066_reaction_RXN0-5114_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1965,6 +1976,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-261/YeastPathways_PWY3O-261>
 ] .
+
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000883>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1978,7 +2000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1990,11 +2012,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5114_BFO_0000066_reaction_RXN0-5114_location_lociGO_0005829_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5114_BFO_0000066_reaction_RXN0-5114_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2010,7 +2032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2018,11 +2040,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2055,7 +2077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2071,23 +2093,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002233_CHEBI_15377_RXN0-5114_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN0-5114>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0036424> ;
@@ -2106,7 +2128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2118,11 +2140,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002233_CHEBI_57926_THREONINE-ALDOLASE-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002233_CHEBI_57926_THREONINE-ALDOLASE-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2133,26 +2155,15 @@
           <http://model.geneontology.org/CHEBI_57926_THREONINE-ALDOLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002333_YEL046C-MONOMER_THREONINE-ALDOLASE-RXN_controller_SGD_YeastPathways_PWY3O-261>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_57945_PGLYCDEHYDROG-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_57945_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2167,11 +2178,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_57972_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_57972_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2182,26 +2193,15 @@
           <http://model.geneontology.org/CHEBI_57972_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002234_CHEBI_16810_PSERTRANSAM-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002234_CHEBI_16810_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2212,15 +2212,32 @@
           <http://model.geneontology.org/CHEBI_16810_PSERTRANSAM-RXN>
 ] .
 
+<http://model.geneontology.org/2aa07cd7-eaf9-4742-9a9d-609643a11892_GLYOHMETRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule40983> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_15377_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2234,23 +2251,6 @@
 <http://identifiers.org/sgd/S000004048>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/7dc48176-f514-4e06-9d13-8dcdc98e70b5_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule41006> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/YGR208W-MONOMER_RXN0-5114_controller>
         a       <http://identifiers.org/sgd/S000003440> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2258,7 +2258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2266,23 +2266,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_PSERTRANSAM-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2290,11 +2279,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002234_CHEBI_33384_RXN0-5114_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002234_CHEBI_33384_RXN0-5114_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2305,15 +2294,26 @@
           <http://model.geneontology.org/CHEBI_33384_RXN0-5114>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_BFO_0000066_reaction_PGLYCDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_BFO_0000066_reaction_PGLYCDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_BFO_0000066_reaction_PGLYCDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2324,6 +2324,17 @@
           <http://model.geneontology.org/reaction_PGLYCDEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_e63b736f-d3a6-4fcb-ab6c-9ff340f2317a_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-261>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2333,7 +2344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of serine and glycine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2347,22 +2358,11 @@
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_57945_PGLYCDEHYDROG-RXN_SGD_YeastPathways_PWY3O-261>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN0-5114_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-285.ttl
+++ b/models/YeastPathways_PWY3O-285.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'XMP + diphosphate &larr; xanthine + 5-phospho-&alpha;-D-ribose 1-diphosphate' 'null' 'XMP + ammonium + ATP &rarr; GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002413_GMP-SYN-NH3-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002413_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,34 +17,12 @@
           <http://model.geneontology.org/GMP-SYN-NH3-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -57,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -65,25 +43,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002413_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -106,35 +73,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285BiochemicalReaction34077> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_37565_GDPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_37565> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -145,24 +90,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33393> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58189> ;
@@ -173,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -185,11 +119,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_57720_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_57720_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -200,25 +134,14 @@
           <http://model.geneontology.org/CHEBI_57720_INOPHOSPHOR-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -231,7 +154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -243,11 +166,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,29 +181,29 @@
           <http://model.geneontology.org/CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004385>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004385>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7607_BFO_0000066_reaction_RXN-7607_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7607_BFO_0000066_reaction_RXN-7607_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -290,17 +213,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN-7607_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/AIRS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004641> ;
@@ -321,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -329,14 +241,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -347,11 +259,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,25 +274,36 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -388,11 +311,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -413,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -426,40 +349,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15378_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -467,11 +379,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -491,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -499,15 +411,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -525,11 +448,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -540,26 +463,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -579,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -591,11 +503,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -606,29 +518,30 @@
           <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002807> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "hypoxanthine guanine phosphoribosyltransferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004731>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein34124> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,20 +552,8 @@
           <http://model.geneontology.org/reaction_GDPREDUCT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002807> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "hypoxanthine guanine phosphoribosyltransferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein34124> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+<http://purl.obolibrary.org/obo/GO_0004731>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_30616_GMP-SYN-NH3-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -663,7 +564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -675,11 +576,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -697,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -714,7 +615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -722,34 +623,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000066_reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ADENPRIBOSYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829>
-] .
+<http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ADP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33408> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -769,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -777,32 +676,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ADP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33408> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000066_reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ADENPRIBOSYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,15 +714,26 @@
           <http://model.geneontology.org/CHEBI_61429_RXN0-746>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRS-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_17368_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_17368_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -832,6 +744,17 @@
           <http://model.geneontology.org/CHEBI_17368_ADENINE-DEAMINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58467> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -841,24 +764,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33879> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGR061C-MONOMER_FGAMSYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003293> ;
@@ -867,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -884,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -892,30 +804,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_30616_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004422>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002333_YML035C-MONOMER_AMP-DEAMINASE-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_PRPPAMIDOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -926,7 +816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -942,7 +832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -950,11 +840,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -964,6 +854,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN0-745>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -982,7 +883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -997,11 +898,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1016,11 +917,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1031,37 +932,15 @@
           <http://model.geneontology.org/CHEBI_58017_GUANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1072,26 +951,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15377_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1102,36 +970,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_57464_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1144,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1152,62 +998,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_456215_GMP-SYN-NH3-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16335>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_58053_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_58053_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1222,11 +1035,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1237,15 +1050,26 @@
           <http://model.geneontology.org/CHEBI_61429_DGDPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1265,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1277,11 +1101,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1292,15 +1116,26 @@
           <http://model.geneontology.org/CHEBI_15378_GLYRIBONUCSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_57464_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1318,11 +1153,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' 'null' 'ATP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine &rarr; ADP + 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1333,29 +1168,37 @@
           <http://model.geneontology.org/AIRS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58457>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1368,43 +1211,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1415,25 +1228,36 @@
           <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_5901ac82-b52c-4b16-be94-4f54b16e57f6_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_7b9913d9-cd58-48e3-be0b-8dc40d186116_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1446,7 +1270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1454,27 +1278,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57464>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YLR209C-MONOMER_INOPHOSPHOR-RXN_controller>
         a       <http://identifiers.org/sgd/S000004199> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1483,7 +1288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1491,18 +1296,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57464>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1513,15 +1326,26 @@
           <http://model.geneontology.org/CHEBI_15378_RXN0-746>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1532,14 +1356,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1562,7 +1386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1570,15 +1394,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1589,6 +1424,17 @@
           <http://model.geneontology.org/CHEBI_29888_PRPPAMIDOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1596,11 +1442,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1611,25 +1457,14 @@
           <http://model.geneontology.org/CHEBI_57540_IMP-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1637,11 +1472,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1652,15 +1487,26 @@
           <http://model.geneontology.org/reaction_RXN0-745_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002411_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002411_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1670,6 +1516,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/AICARSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004018> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1690,13 +1547,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285BiochemicalReaction33930> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002233_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_61429_RXN0-746>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_61429> ;
@@ -1707,7 +1575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1719,11 +1587,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1738,11 +1606,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1753,39 +1621,6 @@
           <http://model.geneontology.org/CHEBI_58564_AIRCARBOXY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1795,7 +1630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1810,11 +1645,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1834,7 +1669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1842,15 +1677,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1861,25 +1707,25 @@
           <http://model.geneontology.org/YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1887,11 +1733,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000066_reaction_AMP-DEAMINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000066_reaction_AMP-DEAMINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1911,7 +1757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1923,11 +1769,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1942,11 +1788,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_15378_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_15378_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1957,14 +1803,25 @@
           <http://model.geneontology.org/CHEBI_15378_ADENOSINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_b3ec212c-0a64-4c0d-a72b-50c8106ce8f8_GART-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1972,11 +1829,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1994,7 +1851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2002,15 +1859,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2028,7 +1896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2040,11 +1908,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2055,19 +1923,30 @@
           <http://model.geneontology.org/CHEBI_456216_SAICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_57464_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004637>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002234_CHEBI_43474_RXN-7607_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29888_XANPRIBOSYLTRAN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
@@ -2078,24 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33693> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_29888_GUANPRIBOSYLTRAN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2106,27 +1968,44 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_29888_GUANPRIBOSYLTRAN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33693> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_AIRS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2137,7 +2016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2149,11 +2028,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2164,47 +2043,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2212,11 +2058,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2230,26 +2076,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_17368>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2265,7 +2100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2278,7 +2113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2290,11 +2125,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2305,6 +2140,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-11_RXN-7607_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2314,24 +2160,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Complex33340> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
-
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/AMP-DEAMINASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003876> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2352,7 +2187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2360,25 +2195,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000066_reaction_AMP-DEAMINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2391,7 +2215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2411,7 +2235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2423,11 +2247,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Provides Input For Rule. The relation 'dGDP + an oxidized thioredoxin + H<sub>2</sub>O &larr; GDP + a reduced thioredoxin' 'null' 'dGDP + ATP &rarr; dGTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2436,25 +2260,6 @@
           <http://model.geneontology.org/GDPREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/DGDPKIN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/AICARSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58443_SAICARSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_17596_RXN-7607>
@@ -2466,7 +2271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2474,40 +2279,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_YeastPathways_PWY3O-285>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/AICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58443_SAICARSYN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_61404>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2518,26 +2331,15 @@
           <http://model.geneontology.org/CHEBI_15378_FGAMSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002411_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002411_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2548,26 +2350,15 @@
           <http://model.geneontology.org/ADENINE-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2587,7 +2378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2595,15 +2386,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2614,15 +2416,26 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2636,15 +2449,26 @@
 <http://purl.obolibrary.org/obo/GO_0004001>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2655,15 +2479,37 @@
           <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2674,47 +2520,14 @@
           <http://model.geneontology.org/CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002233_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2727,24 +2540,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33444> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002333_MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -2755,7 +2557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2763,25 +2565,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000066_reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2794,7 +2607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2806,11 +2619,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'IMP + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + hypoxanthine' 'null' 'L-aspartate + IMP + GTP &rarr; adenylo-succinate + GDP + phosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2825,11 +2638,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002233_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002233_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2840,37 +2653,15 @@
           <http://model.geneontology.org/CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002413_RXN-7607_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2888,7 +2679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2899,17 +2690,6 @@
 <http://purl.obolibrary.org/obo/GO_0000310>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2917,11 +2697,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2932,25 +2712,36 @@
           <http://model.geneontology.org/GMP-SYN-GLUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_CPLX3O-11_RXN-7607_controller_BFO_0000051_SGD_S000005681_CPLX3O-11_component_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2963,7 +2754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2975,11 +2766,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2993,6 +2784,58 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_28938_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_28938_GMP-SYN-NH3-RXN>
+] .
+
 <http://model.geneontology.org/CHEBI_15377_ADPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3002,7 +2845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3014,52 +2857,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_28938_GMP-SYN-NH3-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_GMP-SYN-NH3-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_17596_RXN-7607_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_15378_AIRS-RXN_SGD_YeastPathways_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3070,14 +2872,14 @@
           <http://model.geneontology.org/CHEBI_15378_AIRS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3085,11 +2887,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3100,14 +2902,36 @@
           <http://model.geneontology.org/reaction_DADPKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000066_reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002234_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3115,11 +2939,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3134,11 +2958,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3149,6 +2973,17 @@
           <http://model.geneontology.org/Red-Thioredoxin_ADPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_RXN0-745>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3158,7 +2993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3175,7 +3010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3187,11 +3022,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3209,11 +3044,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3228,11 +3063,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3243,15 +3078,26 @@
           <http://model.geneontology.org/reaction_SAICARSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002333_YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002333_YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3271,9 +3117,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> , <http://model.geneontology.org/6d7d69f2-adf8-4861-8da2-c01b28e6a11d_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> , <http://model.geneontology.org/ba471902-4da5-4bd5-93bb-9d6e9d5a8a75_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/b3ec212c-0a64-4c0d-a72b-50c8106ce8f8_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
+                <http://model.geneontology.org/738fc3f5-d409-4335-968b-78914f3bf7fa_GART-RXN> , <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3281,7 +3127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3296,11 +3142,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3311,14 +3157,25 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3329,7 +3186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3337,15 +3194,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3363,24 +3231,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein33886> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58681>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3394,7 +3251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3402,48 +3259,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-NH3-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002411_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002411_DADPKIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002411_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3454,15 +3278,26 @@
           <http://model.geneontology.org/DADPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58115_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58115_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3472,6 +3307,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58115_GUANPRIBOSYLTRAN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3485,7 +3331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3497,11 +3343,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_17596_RXN-7607_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_17596_RXN-7607_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3515,14 +3361,14 @@
 <http://identifiers.org/sgd/S000005085>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58115_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3535,7 +3381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3543,15 +3389,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17368_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17368_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3562,16 +3419,22 @@
           <http://model.geneontology.org/CHEBI_17368_INOPHOSPHOR-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_29806_AICARSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29806> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "fumarate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33834> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_16526_AIRCARBOXY-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -3582,28 +3445,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33472> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_29806_AICARSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29806> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "fumarate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33834> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3626,7 +3472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3638,11 +3484,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_456215_GMP-SYN-NH3-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_456215_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3653,6 +3499,31 @@
           <http://model.geneontology.org/CHEBI_456215_GMP-SYN-NH3-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_28938_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000002807>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_15377_IMPCYCLOHYDROLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3662,7 +3533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3670,17 +3541,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000002807>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3691,7 +3559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3703,11 +3571,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'AMP + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; IMP + ammonium' 'null' 'L-aspartate + IMP + GTP &rarr; adenylo-succinate + GDP + phosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3721,6 +3589,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3730,7 +3609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3745,11 +3624,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3760,14 +3639,14 @@
           <http://model.geneontology.org/CHEBI_456216_GLYRIBONUCSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3775,11 +3654,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_44585cc1-9f35-478b-9bae-cdb9271ff4f3_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_7b9913d9-cd58-48e3-be0b-8dc40d186116_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3787,35 +3666,35 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/44585cc1-9f35-478b-9bae-cdb9271ff4f3_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/7b9913d9-cd58-48e3-be0b-8dc40d186116_AICARTRANSFORM-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3826,25 +3705,12 @@
           <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003412> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3857,7 +3723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3869,11 +3735,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3884,32 +3750,12 @@
           <http://model.geneontology.org/YER170W-MONOMER_ADENYL-KIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003412> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_DGDPKIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_57464_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3917,11 +3763,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3936,11 +3782,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3955,11 +3801,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3982,7 +3828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3997,7 +3843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4005,14 +3851,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002413_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4025,7 +3882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4037,11 +3894,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4052,14 +3909,14 @@
           <http://model.geneontology.org/CHEBI_37565_GDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002333_YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4070,11 +3927,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4094,13 +3951,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33302> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YOR128C-MONOMER_AIRCARBOXY-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005654> ;
@@ -4109,7 +3988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4122,7 +4001,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4135,7 +4025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4147,11 +4037,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4162,17 +4052,6 @@
           <http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_ADENOSINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4182,7 +4061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4190,15 +4069,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4209,25 +4099,14 @@
           <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000066_reaction_GUANINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4235,11 +4114,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4250,15 +4129,48 @@
           <http://model.geneontology.org/CHEBI_15740_RXN0-745>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002333_YJR105W-MONOMER_ADENOSINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002413_RXN-7607_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4288,7 +4200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4296,14 +4208,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_738fc3f5-d409-4335-968b-78914f3bf7fa_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4311,11 +4223,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4326,6 +4238,28 @@
           <http://model.geneontology.org/YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002333_CPLX3O-11_RXN-7607_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000066_reaction_ADENINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_SAICARSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4335,7 +4269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4351,35 +4285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/44585cc1-9f35-478b-9bae-cdb9271ff4f3_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33900> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4392,24 +4298,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33408> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003937> ;
@@ -4430,7 +4325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4442,11 +4337,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4461,11 +4356,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4483,7 +4378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4495,11 +4390,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15378_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15378_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4519,7 +4414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4531,11 +4426,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4546,26 +4441,15 @@
           <http://model.geneontology.org/CHEBI_30616_DGDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456216_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456216_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4576,14 +4460,14 @@
           <http://model.geneontology.org/CHEBI_456216_ADENOSINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002233_CHEBI_15377_RXN-7607_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4592,7 +4476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4600,11 +4484,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4624,7 +4508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4636,11 +4520,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4660,7 +4544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4668,15 +4552,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456216_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_57720_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4687,26 +4593,15 @@
           <http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4721,11 +4616,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4735,6 +4630,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YAR015W-MONOMER_SAICARSYN-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SAICARSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004639> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4755,7 +4661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4763,17 +4669,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57945>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002333_YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57945>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4786,7 +4703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4797,14 +4714,25 @@
 <http://purl.obolibrary.org/obo/GO_0004639>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4815,11 +4743,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4830,18 +4758,62 @@
           <http://model.geneontology.org/YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4859,7 +4831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4872,18 +4844,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_456216_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4891,11 +4874,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4925,24 +4908,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285BiochemicalReaction34165> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_GUANYL-KIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -4953,24 +4925,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33378> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_AIRCARBOXY-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -4981,7 +4942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4993,11 +4954,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5008,17 +4969,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002333_YJR133W-MONOMER_XANPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29985_FGAMSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5028,7 +4978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5048,7 +4998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5059,6 +5009,17 @@
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000004520>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -5066,11 +5027,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5085,11 +5046,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5100,25 +5061,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15377_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_16235_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5126,11 +5076,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5148,7 +5098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5165,7 +5115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5177,11 +5127,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRS-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRS-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5196,11 +5146,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'adenylo-succinate &harr; fumarate + AMP' 'null' 'AMP + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; IMP + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5211,29 +5161,40 @@
           <http://model.geneontology.org/AMP-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_30616_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_15378_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5251,11 +5212,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5285,7 +5246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5298,18 +5259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5317,11 +5267,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5336,11 +5286,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000066_reaction_ADENOSINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000066_reaction_ADENOSINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5351,25 +5301,75 @@
           <http://model.geneontology.org/reaction_ADENOSINE-KINASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/738fc3f5-d409-4335-968b-78914f3bf7fa_GART-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33922> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5377,11 +5377,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5392,58 +5392,58 @@
           <http://model.geneontology.org/CHEBI_58564_AIRCARBOXY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_15377_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_43474_RXN-7607_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5451,11 +5451,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002234_CHEBI_43474_RXN-7607_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002234_CHEBI_43474_RXN-7607_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5466,14 +5466,25 @@
           <http://model.geneontology.org/CHEBI_43474_RXN-7607>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17368_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5481,11 +5492,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_16235_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_16235_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5496,14 +5507,14 @@
           <http://model.geneontology.org/CHEBI_16235_GUANINE-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5512,18 +5523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5531,11 +5531,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5546,28 +5546,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58115_GUANPRIBOSYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58115> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5577,7 +5555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5585,17 +5563,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002411_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5603,11 +5592,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5618,45 +5607,12 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YLR432W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002233_CHEBI_15377_RXN-7607_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5664,11 +5620,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_57464_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_57464_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5688,7 +5644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5700,11 +5656,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5715,17 +5671,6 @@
           <http://model.geneontology.org/CHEBI_456216_AIRS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_FGAMSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5735,7 +5680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5747,11 +5692,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5772,11 +5717,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'dADP + an oxidized thioredoxin + H<sub>2</sub>O &larr; ADP + a reduced thioredoxin' 'null' 'dADP + ATP &rarr; dATP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5787,14 +5732,25 @@
           <http://model.geneontology.org/DADPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5802,11 +5758,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5821,11 +5777,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5840,11 +5796,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5864,7 +5820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5881,7 +5837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5889,35 +5845,45 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Provides Input For Rule. The relation 'ATP + 5-phospho-&beta;-D-ribosylamine + glycine &rarr; ADP + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + phosphate + H<SUP>+</SUP>' 'null' 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Provides Input For Rule. The relation 'ATP + 5-phospho-&beta;-D-ribosylamine + glycine &rarr; ADP + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + phosphate + H<SUP>+</SUP>' 'null' 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5927,6 +5893,26 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/GART-RXN>
 ] .
+
+<http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/DGDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004550> ;
@@ -5945,7 +5931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5953,45 +5939,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YLR028C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6011,7 +5967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6019,26 +5975,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002333_YJR133W-MONOMER_XANPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002333_YJR133W-MONOMER_XANPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6056,35 +6001,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein34257> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_28938_GUANINE-DEAMINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_28938> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6095,7 +6018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6112,7 +6035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6124,11 +6047,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6139,36 +6062,25 @@
           <http://model.geneontology.org/reaction_RXN0-746_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000066_reaction_AMP-DEAMINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_28938_GMP-SYN-NH3-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6176,11 +6088,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_17368_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_17368_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6190,6 +6102,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_17368_INOPHOSPHOR-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003894>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6201,7 +6124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6213,11 +6136,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6228,40 +6151,29 @@
           <http://model.geneontology.org/CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_58053_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000002634>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002333_YNL220W-MONOMER_ADENYLOSUCCINATE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7607_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7607_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6272,39 +6184,28 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58595>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6317,7 +6218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6329,11 +6230,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'XMP + ammonium + ATP &rarr; GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6353,7 +6254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6361,14 +6262,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_ba471902-4da5-4bd5-93bb-9d6e9d5a8a75_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6381,7 +6282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6398,7 +6299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6411,7 +6312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6419,11 +6320,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6437,26 +6338,15 @@
 <http://purl.obolibrary.org/obo/GO_0004748>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_5901ac82-b52c-4b16-be94-4f54b16e57f6_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_aac98237-ee6c-4d3f-8a2a-8e6eb6d0f72a_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6464,30 +6354,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5901ac82-b52c-4b16-be94-4f54b16e57f6_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/aac98237-ee6c-4d3f-8a2a-8e6eb6d0f72a_AICARTRANSFORM-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6497,7 +6365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6505,11 +6373,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_6d7d69f2-adf8-4861-8da2-c01b28e6a11d_GART-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_ba471902-4da5-4bd5-93bb-9d6e9d5a8a75_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6517,17 +6385,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6d7d69f2-adf8-4861-8da2-c01b28e6a11d_GART-RXN>
+          <http://model.geneontology.org/ba471902-4da5-4bd5-93bb-9d6e9d5a8a75_GART-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6535,11 +6403,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6554,11 +6422,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'XMP + L-glutamine + ATP + H<sub>2</sub>O &rarr; L-glutamate + GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6573,11 +6441,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6592,11 +6460,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6607,29 +6475,29 @@
           <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://identifiers.org/sgd/S000005654>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000005654>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6640,17 +6508,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58475>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -6658,11 +6515,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6672,6 +6529,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/Red-Thioredoxin_ADPREDUCT-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002333_YML035C-MONOMER_AMP-DEAMINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58443>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6685,7 +6564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6693,15 +6572,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6721,7 +6611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6729,15 +6619,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_28938_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_16708_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_16708_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6748,14 +6649,14 @@
           <http://model.geneontology.org/CHEBI_16708_ADENINE-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6768,13 +6669,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33302> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57567> ;
@@ -6785,7 +6697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6796,35 +6708,15 @@
 <http://purl.obolibrary.org/obo/GO_0004642>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/reaction_RXN-7607_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6835,39 +6727,37 @@
           <http://model.geneontology.org/CHEBI_57945_IMP-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/reaction_RXN-7607_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002413_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6875,11 +6765,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6894,11 +6784,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16235_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16235_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6909,6 +6799,17 @@
           <http://model.geneontology.org/CHEBI_16235_GUANPRIBOSYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_28938_GMP-SYN-NH3-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_28938> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6918,7 +6819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6935,7 +6836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6952,7 +6853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6964,11 +6865,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'IMP + H<sub>2</sub>O &harr; 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' 'null' 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6978,17 +6879,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/IMP-DEHYDROG-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002411_DADPKIN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ADPREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004748> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7009,7 +6899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7017,14 +6907,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7032,11 +6922,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'dGDP + an oxidized thioredoxin + H<sub>2</sub>O &larr; GDP + a reduced thioredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7050,6 +6940,17 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_17712_GUANINE-DEAMINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17712> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7059,7 +6960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7086,7 +6987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7101,7 +7002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7109,16 +7010,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_28938_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/AMP-DEAMINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_28938_AMP-DEAMINASE-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_456215_GMP-SYN-NH3-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456215> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7129,7 +7038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7141,30 +7050,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_28938_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/AMP-DEAMINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_AMP-DEAMINASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_YeastPathways_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7184,7 +7074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7196,11 +7086,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'adenosine + ATP &rarr; AMP + ADP + H<SUP>+</SUP>' 'null' 'AMP + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; IMP + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7220,7 +7110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7232,11 +7122,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7251,11 +7141,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7266,6 +7156,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_30616_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57945_IMP-DEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7275,7 +7176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7283,15 +7184,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_17368_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7302,24 +7214,15 @@
           <http://model.geneontology.org/YGR061C-MONOMER_FGAMSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/reaction_AIRS-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7330,15 +7233,24 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
+<http://model.geneontology.org/reaction_AIRS-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7352,25 +7264,25 @@
 <http://identifiers.org/sgd/S000005681>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16235_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58115_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-11_RXN-7607_controller_BFO_0000051_SGD_S000005681_CPLX3O-11_component_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7378,11 +7290,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7393,28 +7305,6 @@
           <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_ADENINE-DEAMINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7424,7 +7314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7441,7 +7331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7449,42 +7339,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/5901ac82-b52c-4b16-be94-4f54b16e57f6_AICARTRANSFORM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33922> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_15378_GMP-SYN-NH3-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000066_reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7495,7 +7357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7506,68 +7368,35 @@
 <http://purl.obolibrary.org/obo/CHEBI_29991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58115>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Provides Input For Rule. The relation 'GMP + ATP &harr; GDP + ADP' 'null' 'GDP + ATP &rarr; GTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7597,7 +7426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7605,26 +7434,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7635,25 +7453,14 @@
           <http://model.geneontology.org/CHEBI_58359_PRPPAMIDOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_15378_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7661,11 +7468,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7676,17 +7483,28 @@
           <http://model.geneontology.org/CHEBI_15377_IMP-DEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000002849>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_57540_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7694,11 +7512,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002333_MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002333_MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7709,19 +7527,19 @@
           <http://model.geneontology.org/MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285>
+<http://identifiers.org/sgd/S000002397>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000002397>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/GMP-SYN-NH3-RXN>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7740,7 +7558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7752,11 +7570,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7767,26 +7585,15 @@
           <http://model.geneontology.org/CHEBI_15378_GMP-SYN-GLUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7804,11 +7611,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7828,7 +7635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7836,38 +7643,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002234_CHEBI_17596_RXN-7607_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_YeastPathways_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GDPKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN0-745>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7878,7 +7666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7886,14 +7674,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_43474_RXN-7607_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7901,11 +7689,52 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GDPKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_17596_RXN-7607_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7916,16 +7745,24 @@
           <http://model.geneontology.org/CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/AMP-DEAMINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
+] .
 
 <http://model.geneontology.org/CHEBI_30616_GDPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7936,7 +7773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7948,41 +7785,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/AMP-DEAMINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
-] .
-
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000066_reaction_GUANINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7993,15 +7800,26 @@
           <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_30616_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_30616_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8012,30 +7830,30 @@
           <http://model.geneontology.org/CHEBI_30616_ADENOSINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_YeastPathways_PWY3O-285>
+<http://identifiers.org/sgd/S000005164>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7607_BFO_0000066_reaction_RXN-7607_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000005164>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0003938>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -8059,13 +7877,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285BiochemicalReaction33349> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58359_GMP-SYN-GLUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58359> ;
@@ -8076,7 +7905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8088,11 +7917,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8103,14 +7932,25 @@
           <http://model.geneontology.org/CHEBI_43474_SAICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8123,7 +7963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8133,17 +7973,6 @@
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -8155,7 +7984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8167,11 +7996,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'IMP + H<sub>2</sub>O &rarr; inosine + phosphate' 'null' 'inosine + phosphate &rarr; &alpha;-D-ribose-1-phosphate + hypoxanthine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002413_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002413_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8182,59 +8011,37 @@
           <http://model.geneontology.org/INOPHOSPHOR-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_456216_GDPKIN-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_ADENYL-KIN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8242,11 +8049,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8257,12 +8064,45 @@
           <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_ADPREDUCT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_15378_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_16235_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8270,11 +8110,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8285,14 +8125,25 @@
           <http://model.geneontology.org/CHEBI_30616_GUANYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002333_YJR105W-MONOMER_ADENOSINE-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_456216_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7607_BFO_0000066_reaction_RXN-7607_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8303,11 +8154,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'inosine + phosphate &rarr; &alpha;-D-ribose-1-phosphate + hypoxanthine' 'null' 'IMP + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + hypoxanthine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8318,6 +8169,39 @@
           <http://model.geneontology.org/HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456215_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_aac98237-ee6c-4d3f-8a2a-8e6eb6d0f72a_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57464> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8327,7 +8211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8335,43 +8219,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_29806>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0004018>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002333_CPLX3O-270_GDPREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8382,37 +8255,15 @@
           <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000066_reaction_AICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8423,25 +8274,25 @@
           <http://model.geneontology.org/reaction_AICARSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002413_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8449,11 +8300,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8464,26 +8315,15 @@
           <http://model.geneontology.org/CHEBI_58426_GART-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YML022W-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YML022W-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8494,37 +8334,15 @@
           <http://model.geneontology.org/YML022W-MONOMER_ADENPRIBOSYLTRAN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000066_reaction_ADENOSINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8535,15 +8353,26 @@
           <http://model.geneontology.org/reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide &harr; a tetrahydrofolate + 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' 'null' 'IMP + H<sub>2</sub>O &harr; 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8558,11 +8387,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8573,24 +8402,15 @@
           <http://model.geneontology.org/CHEBI_456215_AMPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_b3ec212c-0a64-4c0d-a72b-50c8106ce8f8_GART-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_738fc3f5-d409-4335-968b-78914f3bf7fa_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8598,28 +8418,15 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b3ec212c-0a64-4c0d-a72b-50c8106ce8f8_GART-RXN>
+          <http://model.geneontology.org/738fc3f5-d409-4335-968b-78914f3bf7fa_GART-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8627,11 +8434,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_37565_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8649,7 +8456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8676,7 +8483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8684,50 +8491,61 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/CHEBI_29985>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_30616_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY3O-285>
+<http://purl.obolibrary.org/obo/CHEBI_29985>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002413_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8735,11 +8553,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002333_YLR209C-MONOMER_INOPHOSPHOR-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002333_YLR209C-MONOMER_INOPHOSPHOR-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8759,7 +8577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8767,47 +8585,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_29985_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_15378_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8815,11 +8611,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8834,11 +8630,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002233_CHEBI_15377_RXN-7607_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002233_CHEBI_15377_RXN-7607_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8849,26 +8645,15 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-7607>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000066_reaction_GUANINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000066_reaction_GUANINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8884,7 +8669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8892,11 +8677,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8907,14 +8692,14 @@
           <http://model.geneontology.org/YML056C-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002411_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8925,7 +8710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8945,13 +8730,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33496> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -8960,11 +8767,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8975,37 +8782,15 @@
           <http://model.geneontology.org/CHEBI_58426_GART-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002233_CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9016,26 +8801,15 @@
           <http://model.geneontology.org/CHEBI_29991_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000066_reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000066_reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9046,15 +8820,26 @@
           <http://model.geneontology.org/reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9074,7 +8859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9086,11 +8871,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9101,17 +8886,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16235_GUANINE-DEAMINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16235> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9121,7 +8895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9133,11 +8907,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9148,25 +8922,14 @@
           <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9174,11 +8937,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9189,28 +8952,17 @@
           <http://model.geneontology.org/CHEBI_57667_ADPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002411_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9223,7 +8975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of purine biosynthesis and salvage pathways - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -9231,45 +8983,15 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9284,11 +9006,30 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16708_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16708_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9299,6 +9040,28 @@
           <http://model.geneontology.org/CHEBI_16708_ADENPRIBOSYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_43474_RXN-7607>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9308,7 +9071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9320,11 +9083,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9335,14 +9098,36 @@
           <http://model.geneontology.org/CHEBI_28938_ADENINE-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_44585cc1-9f35-478b-9bae-cdb9271ff4f3_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9355,7 +9140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9366,15 +9151,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_16235>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9385,41 +9181,41 @@
           <http://model.geneontology.org/CHEBI_58017_XANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004644>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58426_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN0-746>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
@@ -9436,7 +9232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9448,11 +9244,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9470,11 +9266,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9485,17 +9281,6 @@
           <http://model.geneontology.org/CHEBI_29888_GUANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_57720_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58053> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9505,7 +9290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9513,14 +9298,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002333_CPLX3O-11_RXN-7607_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9528,11 +9313,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000066_reaction_INOPHOSPHOR-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000066_reaction_INOPHOSPHOR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9543,6 +9328,17 @@
           <http://model.geneontology.org/reaction_INOPHOSPHOR-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58017_GUANPRIBOSYLTRAN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58017> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9552,24 +9348,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule34067> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29806_AMPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29806> ;
@@ -9580,7 +9365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9592,11 +9377,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_HYPOXANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_HYPOXANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9610,6 +9395,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_17596>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_61429>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -9622,13 +9418,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33693> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000972>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -9637,11 +9444,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_29888_GMP-SYN-NH3-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_29888_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9652,15 +9459,26 @@
           <http://model.geneontology.org/CHEBI_29888_GMP-SYN-NH3-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002333_YML035C-MONOMER_AMP-DEAMINASE-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002333_YML035C-MONOMER_AMP-DEAMINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9676,7 +9494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9689,7 +9507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9697,37 +9515,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_43474_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9742,11 +9538,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9757,6 +9553,17 @@
           <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_GDPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9766,7 +9573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9778,30 +9585,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17712_GUANINE-DEAMINASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9812,26 +9600,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_137981_AIRS-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9851,7 +9628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9863,11 +9640,33 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17712_GUANINE-DEAMINASE-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_137981>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9878,37 +9677,26 @@
           <http://model.geneontology.org/CHEBI_456215_GMP-SYN-GLUT-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_137981>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + 2 H<SUP>+</SUP> &harr; 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + CO<SUB>2</SUB>' 'null' 'ATP + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + L-aspartate &rarr; ADP + 5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/AIRCARBOXY-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SAICARSYN-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9919,28 +9707,69 @@
           <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58426>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + 2 H<SUP>+</SUP> &harr; 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + CO<SUB>2</SUB>' 'null' 'ATP + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + L-aspartate &rarr; ADP + 5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002413_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/AIRCARBOXY-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SAICARSYN-RXN>
+] .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY3O-285>
+<http://purl.obolibrary.org/obo/CHEBI_58426>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000066_reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002413_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15378_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9956,7 +9785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9964,37 +9793,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10005,26 +9812,15 @@
           <http://model.geneontology.org/CHEBI_15740_RXN0-746>
 ] .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000066_reaction_ADENINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000066_reaction_ADENINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10035,14 +9831,14 @@
           <http://model.geneontology.org/reaction_ADENINE-DEAMINASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_15377_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10052,15 +9848,26 @@
 <http://identifiers.org/sgd/S000001550>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YML022W-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10080,7 +9887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10088,14 +9895,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002234_CHEBI_43474_RXN-7607_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10108,7 +9915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10120,11 +9927,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10135,25 +9942,14 @@
           <http://model.geneontology.org/CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002413_AIRS-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10169,7 +9965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10181,11 +9977,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10196,37 +9992,15 @@
           <http://model.geneontology.org/CHEBI_15378_RXN0-745>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Provides Input For Rule. The relation 'guanine + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; ammonium + xanthine' 'null' 'XMP + diphosphate &larr; xanthine + 5-phospho-&alpha;-D-ribose 1-diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002413_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002413_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10237,45 +10011,12 @@
           <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_16335_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_AICARSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002333_YGR061C-MONOMER_FGAMSYN-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10288,7 +10029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10296,14 +10037,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456216_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_16526_RXN0-745_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10311,11 +10052,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10326,14 +10067,14 @@
           <http://model.geneontology.org/CHEBI_29985_GMP-SYN-GLUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10341,11 +10082,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002333_YOR128C-MONOMER_AIRCARBOXY-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10356,18 +10097,40 @@
           <http://model.geneontology.org/YOR128C-MONOMER_AIRCARBOXY-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_456215_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000003563>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10382,11 +10145,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-aspartate + IMP + GTP &rarr; adenylo-succinate + GDP + phosphate + 2 H<SUP>+</SUP>' 'null' 'adenylo-succinate &harr; fumarate + AMP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10402,9 +10165,49 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001328>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller>
+        a       <http://identifiers.org/sgd/S000004727> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "inosine monophosphate cyclohydrolase [multifunctional]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein33886> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_16235_GUANPRIBOSYLTRAN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16235> ;
@@ -10415,7 +10218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10423,18 +10226,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000001328>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002333_YLR359W-MONOMER_AMPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15377_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_15377_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10452,11 +10263,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10467,15 +10278,37 @@
           <http://model.geneontology.org/reaction_DGDPKIN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002333_YLR209C-MONOMER_INOPHOSPHOR-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456215_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456215_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10486,29 +10319,36 @@
           <http://model.geneontology.org/CHEBI_456215_ADENOSINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller>
-        a       <http://identifiers.org/sgd/S000004727> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "inosine monophosphate cyclohydrolase [multifunctional]" ;
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_16335_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein33886> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7607_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002234_CHEBI_17596_RXN-7607_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10516,11 +10356,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000066_reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10531,15 +10371,26 @@
           <http://model.geneontology.org/reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10550,24 +10401,33 @@
           <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58443_SAICARSYN-RXN>
-] .
+<http://model.geneontology.org/7b9913d9-cd58-48e3-be0b-8dc40d186116_AICARTRANSFORM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33900> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58457> ;
@@ -10578,7 +10438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10586,58 +10446,55 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_58189_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58443_SAICARSYN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_17368_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_29888_GMP-SYN-NH3-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10648,7 +10505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10659,37 +10516,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_57667>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_17368_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0003922>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_SAICARSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10697,11 +10532,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10712,25 +10547,25 @@
           <http://model.geneontology.org/CHEBI_58053_IMPCYCLOHYDROLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10739,7 +10574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10748,7 +10583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10756,11 +10591,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10775,11 +10610,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10797,7 +10632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10805,23 +10640,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_HYPOXANPRIBOSYLTRAN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10844,7 +10668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10852,14 +10676,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_15377_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10867,11 +10691,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Provides Input For Rule. The relation 'IMP + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + hypoxanthine' 'null' 'IMP + H<sub>2</sub>O &rarr; inosine + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002413_RXN-7607_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002413_RXN-7607_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10882,58 +10706,47 @@
           <http://model.geneontology.org/RXN-7607>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_RXN-7607_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10941,11 +10754,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10956,14 +10769,14 @@
           <http://model.geneontology.org/CHEBI_18413_FGAMSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10971,11 +10784,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Provides Input For Rule. The relation 'AMP + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + adenine' 'null' 'AMP + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; IMP + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002413_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10984,25 +10797,6 @@
           <http://model.geneontology.org/ADENPRIBOSYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/AMP-DEAMINASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_AIRS-RXN>
@@ -11014,13 +10808,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33378> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
+] .
 
 <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004019> ;
@@ -11041,7 +10854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11049,26 +10862,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_BFO_0000066_reaction_AICARTRANSFORM-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11086,11 +10888,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'adenylo-succinate &harr; fumarate + AMP' 'null' 'AMP + ATP &harr; 2 ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11106,7 +10908,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11115,7 +10939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11123,11 +10947,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a 10-formyltetrahydrofolate + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide &harr; a tetrahydrofolate + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + H<SUP>+</SUP>' 'null' 'ATP + <i>N</i><sup>2</sup>-formyl-<i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + ADP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002413_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11148,11 +10972,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11170,11 +10994,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11189,11 +11013,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11213,7 +11037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11221,22 +11045,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_30616_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58189>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000003203>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000003203> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -11245,7 +11069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11253,42 +11077,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/6d7d69f2-adf8-4861-8da2-c01b28e6a11d_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33900> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002413_AIRCARBOXY-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16708_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11299,7 +11106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11316,7 +11123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11328,11 +11135,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'IMP + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + hypoxanthine' 'null' 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11347,11 +11154,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002234_CHEBI_17596_RXN-7607_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002234_CHEBI_17596_RXN-7607_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11371,7 +11178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11386,11 +11193,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11401,28 +11208,6 @@
           <http://model.geneontology.org/CHEBI_15378_GUANINE-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58359_PRPPAMIDOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58359> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -11432,7 +11217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11444,11 +11229,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'IMP + NAD<sup>+</sup> + H<sub>2</sub>O &harr; XMP + NADH + H<SUP>+</SUP>' 'null' 'XMP + ammonium + ATP &rarr; GMP + AMP + diphosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-NH3-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11464,7 +11249,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11472,11 +11268,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Provides Input For Rule. The relation 'GMP + diphosphate &larr; guanine + 5-phospho-&alpha;-D-ribose 1-diphosphate' 'null' 'GMP + ATP &harr; GDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11490,6 +11286,39 @@
 <http://purl.obolibrary.org/obo/GO_0000034>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YJR133W-MONOMER_XANPRIBOSYLTRAN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003894> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -11497,7 +11326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11509,11 +11338,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_30616_GMP-SYN-NH3-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_30616_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11524,15 +11353,26 @@
           <http://model.geneontology.org/CHEBI_30616_GMP-SYN-NH3-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_43474_AIRS-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11548,7 +11388,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11556,11 +11407,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11580,7 +11431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11597,7 +11448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11614,7 +11465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11626,11 +11477,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_CHEBI_15377_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11641,25 +11492,14 @@
           <http://model.geneontology.org/CHEBI_15377_GDPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456215_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11667,11 +11507,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002333_CPLX3O-270_ADPREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11682,14 +11522,14 @@
           <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_29888_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11702,7 +11542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11710,15 +11550,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16235_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_15377_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11729,15 +11580,26 @@
           <http://model.geneontology.org/CHEBI_15377_FGAMSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11752,11 +11614,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11767,15 +11629,26 @@
           <http://model.geneontology.org/CHEBI_29991_SAICARSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'adenine + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; ammonium + hypoxanthine' 'null' 'IMP + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + hypoxanthine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11795,7 +11668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11803,40 +11676,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_6d7d69f2-adf8-4861-8da2-c01b28e6a11d_GART-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002413_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004199>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11847,14 +11720,25 @@
           <http://model.geneontology.org/reaction_AMPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_HYPOXANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11862,11 +11746,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_57464_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_57464_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11877,6 +11761,23 @@
           <http://model.geneontology.org/CHEBI_57464_XANPRIBOSYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/aac98237-ee6c-4d3f-8a2a-8e6eb6d0f72a_AICARTRANSFORM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33922> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_30616_ADENYL-KIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -11886,13 +11787,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33378> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -11906,13 +11818,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33333> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ADENPRIBOSYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003999> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -11935,7 +11858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11947,11 +11870,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11974,7 +11897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11982,14 +11905,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12002,7 +11925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12022,9 +11945,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/44585cc1-9f35-478b-9bae-cdb9271ff4f3_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
+                <http://model.geneontology.org/7b9913d9-cd58-48e3-be0b-8dc40d186116_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/5901ac82-b52c-4b16-be94-4f54b16e57f6_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/aac98237-ee6c-4d3f-8a2a-8e6eb6d0f72a_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -12032,7 +11955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12044,11 +11967,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_43474_RXN-7607_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_43474_RXN-7607_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12059,14 +11982,36 @@
           <http://model.geneontology.org/CHEBI_43474_RXN-7607>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15378_RXN0-746_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_16708_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12087,7 +12032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12095,14 +12040,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002333_YDR408C-MONOMER_GART-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12110,11 +12055,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12125,25 +12070,14 @@
           <http://model.geneontology.org/CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12151,11 +12085,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Provides Input For Rule. The relation '5-phospho-&beta;-D-ribosylamine + L-glutamate + diphosphate &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + L-glutamine + H<sub>2</sub>O' 'null' 'ATP + 5-phospho-&beta;-D-ribosylamine + glycine &rarr; ADP + <i>N</i><sup>1</sup>-(5-phospho-&beta;-D-ribosyl)glycinamide + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12185,7 +12119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12193,26 +12127,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12223,25 +12146,25 @@
           <http://model.geneontology.org/CHEBI_58115_GMP-SYN-NH3-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002413_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12250,7 +12173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12261,11 +12184,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12276,15 +12199,26 @@
           <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12295,40 +12229,18 @@
           <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12343,11 +12255,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'AMP + ATP &harr; 2 ADP' 'null' 'dADP + an oxidized thioredoxin + H<sub>2</sub>O &larr; ADP + a reduced thioredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12358,14 +12270,14 @@
           <http://model.geneontology.org/ADPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002413_GMP-SYN-NH3-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000066_reaction_INOPHOSPHOR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12373,11 +12285,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12393,7 +12305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12401,11 +12313,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_BFO_0000066_reaction_AIRS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12420,11 +12332,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12435,14 +12347,14 @@
           <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12450,11 +12362,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Provides Input For Rule. The relation 'GDP + ATP &rarr; GTP + ADP' 'null' 'formate + GTP + H<SUP>+</SUP> &rarr; dGTP + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002413_RXN0-746_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12469,11 +12381,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12484,17 +12396,6 @@
           <http://model.geneontology.org/CHEBI_456216_ADENYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_30616_GUANYL-KIN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58189_GUANYL-KIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58189> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -12504,24 +12405,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33363> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17368_INOPHOSPHOR-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17368> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -12532,7 +12422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12540,14 +12430,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_16526_RXN0-746_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12558,7 +12459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12570,11 +12471,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_15377_RXN0-746_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12589,11 +12490,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_ADENINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12604,17 +12505,6 @@
           <http://model.geneontology.org/CHEBI_15378_ADENINE-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58115_GMP-SYN-GLUT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58115> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -12624,7 +12514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12651,7 +12541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12663,11 +12553,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002333_YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12682,11 +12572,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12697,19 +12587,19 @@
           <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/GO_0004641>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004641>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -12718,11 +12608,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_30616_RXN0-745_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12733,15 +12623,37 @@
           <http://model.geneontology.org/CHEBI_30616_RXN0-745>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12752,28 +12664,17 @@
           <http://model.geneontology.org/reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000004351>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000066_reaction_ADENOSINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12781,11 +12682,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'IMP + H<sub>2</sub>O &harr; 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' 'null' 'L-aspartate + IMP + GTP &rarr; adenylo-succinate + GDP + phosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12796,8 +12697,58 @@
           <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ba471902-4da5-4bd5-93bb-9d6e9d5a8a75_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33900> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_15378_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_137981_AIRS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_137981> ;
@@ -12808,7 +12759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12816,15 +12767,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_18413_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12835,26 +12797,15 @@
           <http://model.geneontology.org/YKL067W-MONOMER_GDPKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12865,14 +12816,25 @@
           <http://model.geneontology.org/reaction_ADPREDUCT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_HYPOXANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_15378_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000066_reaction_SAICARSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12883,11 +12845,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12902,11 +12864,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12917,15 +12879,26 @@
           <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_58681_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002333_YJR105W-MONOMER_ADENOSINE-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002333_YJR105W-MONOMER_ADENOSINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12940,11 +12913,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12955,26 +12928,18 @@
           <http://model.geneontology.org/CHEBI_57305_GLYRIBONUCSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000066_reaction_INOPHOSPHOR-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000004484>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Provides Input For Rule. The relation '5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole &harr; fumarate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide' 'null' 'a 10-formyltetrahydrofolate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide &harr; a tetrahydrofolate + 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12990,12 +12955,31 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://identifiers.org/sgd/S000004484>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002333_MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_AIRS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -13006,7 +12990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13014,15 +12998,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_456216_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13033,26 +13028,15 @@
           <http://model.geneontology.org/CHEBI_456216_FGAMSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17368_INOPHOSPHOR-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Provides Input For Rule. The relation 'ATP + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + L-aspartate &rarr; ADP + 5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole + phosphate + H<SUP>+</SUP>' 'null' '5'-phosphoribosyl-4-(N-succinocarboxamide)-5-aminoimidazole &harr; fumarate + 5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13067,11 +13051,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_30616_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13082,47 +13066,36 @@
           <http://model.geneontology.org/CHEBI_30616_ADENYL-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002333_YMR217W-MONOMER_GMP-SYN-GLUT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002333_YLR359W-MONOMER_AICARSYN-RXN_controller_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29888_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13131,7 +13104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13144,7 +13117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13152,15 +13125,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002333_MONOMER3O-102_GUANYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13171,14 +13155,14 @@
           <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_16708_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_29985_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13201,7 +13185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13228,27 +13212,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285BiochemicalReaction34053> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000004830>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -13259,7 +13229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13271,11 +13241,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13286,16 +13256,8 @@
           <http://model.geneontology.org/CHEBI_58017_PRPPAMIDOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000004830>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -13309,7 +13271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13317,14 +13279,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YML022W-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002233_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13332,11 +13294,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_BFO_0000066_reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13347,35 +13309,27 @@
           <http://model.geneontology.org/reaction_IMP-DEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29888_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_GUANINE-DEAMINASE-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GUANINE-DEAMINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008892> ;
@@ -13398,7 +13352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13406,43 +13360,62 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002333_YLR209C-MONOMER_INOPHOSPHOR-RXN_controller_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_28938_GUANINE-DEAMINASE-RXN>
+] .
 
 <http://identifiers.org/sgd/S000002816>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_28938_AMP-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002862>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002411_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13453,15 +13426,37 @@
           <http://model.geneontology.org/CHEBI_58359_GMP-SYN-GLUT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_16526_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13472,26 +13467,15 @@
           <http://model.geneontology.org/CHEBI_16526_AIRCARBOXY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-11_RXN-7607_controller_BFO_0000051_SGD_S000005681_CPLX3O-11_component_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-11_RXN-7607_controller_BFO_0000051_SGD_S000005681_CPLX3O-11_component_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13502,48 +13486,15 @@
           <http://model.geneontology.org/SGD_S000005681_CPLX3O-11_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_456215_AMPSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_17368_ADENINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13554,6 +13505,17 @@
           <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57464_XANPRIBOSYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57464> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -13563,7 +13525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13575,11 +13537,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13590,26 +13552,15 @@
           <http://model.geneontology.org/CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ATP + 2-(formamido)-N<sup>1</sup>-(5-phospho-&beta;-D-ribosyl)acetamidine &rarr; ADP + 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + phosphate + H<SUP>+</SUP>' 'null' '5-amino-1-(5-phospho-D-ribosyl)imidazole-4-carboxylate + 2 H<SUP>+</SUP> &harr; 5-amino-1-(5-phospho-&beta;-D-ribosyl)imidazole + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002413_AIRCARBOXY-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002413_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13624,11 +13575,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13639,15 +13590,26 @@
           <http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002413_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_16335_ADENOSINE-KINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_16335_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13665,7 +13627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13673,14 +13635,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13690,6 +13652,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_57720>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002413_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YML035C-MONOMER_AMP-DEAMINASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004498> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -13697,7 +13670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13705,15 +13678,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13743,13 +13727,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285BiochemicalReaction34186> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15740_RXN0-745_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YKL067W-MONOMER_DADPKIN-RXN_controller>
         a       <http://identifiers.org/sgd/S000001550> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -13758,7 +13753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13766,14 +13761,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_BFO_0000066_reaction_ADENINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13781,11 +13787,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002333_CPLX3O-11_RXN-7607_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002333_CPLX3O-11_RXN-7607_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13796,15 +13802,48 @@
           <http://model.geneontology.org/CPLX3O-11_RXN-7607_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_58053_AMP-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002333_YJR133W-MONOMER_XANPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13824,7 +13863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13839,11 +13878,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_BFO_0000066_reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13854,6 +13893,39 @@
           <http://model.geneontology.org/reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_BFO_0000066_reaction_DGDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58017_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YJR105W-MONOMER_ADENOSINE-KINASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000003866> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -13861,24 +13933,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein34162> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ADENINE-DEAMINASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0000034> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -13899,7 +13960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13907,15 +13968,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13926,17 +13998,6 @@
           <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_SAICARSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -13946,7 +14007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13959,7 +14020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13972,7 +14033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13980,32 +14041,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/b3ec212c-0a64-4c0d-a72b-50c8106ce8f8_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_456216_AIRS-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33922> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_15378_GMP-SYN-NH3-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_15378_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14020,11 +14086,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002333_YGL234W-MONOMER_AIRS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14035,28 +14101,6 @@
           <http://model.geneontology.org/YGL234W-MONOMER_AIRS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_30616_GMP-SYN-NH3-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_PRPPAMIDOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -14066,7 +14110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14085,18 +14129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14104,11 +14137,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14119,25 +14152,14 @@
           <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002233_CHEBI_30616_DADPKIN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14145,11 +14167,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14179,7 +14201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14199,7 +14221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14214,11 +14236,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14229,15 +14251,26 @@
           <http://model.geneontology.org/CHEBI_58359_FGAMSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14248,26 +14281,15 @@
           <http://model.geneontology.org/YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_BFO_0000066_reaction_GDPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14278,28 +14300,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000066_reaction_GART-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16708_ADENPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_17712>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -14307,11 +14307,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14326,11 +14326,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14350,7 +14350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-3.ttl
+++ b/models/YeastPathways_PWY3O-3.ttl
@@ -1,14 +1,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_16749>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_CHEBI_17268_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-3>
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_16749_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-3>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-3" ;
+                "SGD_PWY:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16,11 +16,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_15378_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-3> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_15378_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-3> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,6 +37,17 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_CHEBI_17268_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-3>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-3" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000006317>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -47,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -55,39 +66,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002333_YPR113W-MONOMER_2.7.8.11-RXN_controller_SGD_YeastPathways_PWY3O-3>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-3" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/6b422f8e-40eb-4486-847f-9f6b9959a1f7_2.7.8.11-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-3SmallMolecule43941> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17268> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -98,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -110,11 +93,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_6b422f8e-40eb-4486-847f-9f6b9959a1f7_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-3> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_60371310-85bc-4226-8cfd-214dd35d56c6_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-3> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -122,7 +105,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.8.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6b422f8e-40eb-4486-847f-9f6b9959a1f7_2.7.8.11-RXN>
+          <http://model.geneontology.org/60371310-85bc-4226-8cfd-214dd35d56c6_2.7.8.11-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16749_2.7.8.11-RXN>
@@ -134,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -144,6 +127,17 @@
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_15378_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-3>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-3" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -160,13 +154,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-3SmallMolecule44000> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000066_reaction_2.7.8.11-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-3>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-3" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17268>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -179,18 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_60377_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-3>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-3" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -201,11 +195,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_CHEBI_17268_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-3> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_CHEBI_17268_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-3> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -216,6 +210,17 @@
           <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000050_YeastPathways_PWY3O-3/YeastPathways_PWY3O-3_SGD_PWY_YeastPathways_PWY3O-3>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-3" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-3>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -225,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidylinositol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -236,6 +241,28 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002333_YPR113W-MONOMER_2.7.8.11-RXN_controller_SGD_PWY_YeastPathways_PWY3O-3>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-3" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_60377_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-3>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-3" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/2.7.8.11-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003881> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -245,7 +272,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.7.8.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/6b422f8e-40eb-4486-847f-9f6b9959a1f7_2.7.8.11-RXN> ;
+                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/60371310-85bc-4226-8cfd-214dd35d56c6_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_60377_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_16749_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -253,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -264,26 +291,15 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_6b422f8e-40eb-4486-847f-9f6b9959a1f7_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-3>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-3" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002333_YPR113W-MONOMER_2.7.8.11-RXN_controller_SGD_YeastPathways_PWY3O-3> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002333_YPR113W-MONOMER_2.7.8.11-RXN_controller_SGD_PWY_YeastPathways_PWY3O-3> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -294,28 +310,6 @@
           <http://model.geneontology.org/YPR113W-MONOMER_2.7.8.11-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000050_YeastPathways_PWY3O-3/YeastPathways_PWY3O-3_SGD_YeastPathways_PWY3O-3>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-3" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_16749_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-3>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-3" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_60377_2.7.8.11-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_60377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -325,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -337,11 +331,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000066_reaction_2.7.8.11-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-3> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000066_reaction_2.7.8.11-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-3> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -358,6 +352,23 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/60371310-85bc-4226-8cfd-214dd35d56c6_2.7.8.11-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-3SmallMolecule43941> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -368,11 +379,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_60377_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-3> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_60377_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-3> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -392,17 +403,6 @@
 <http://purl.obolibrary.org/obo/GO_0003881>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000066_reaction_2.7.8.11-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-3>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-3" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY3O-3/YeastPathways_PWY3O-3>
         a       <http://purl.obolibrary.org/obo/GO_0006661> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -412,7 +412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -424,11 +424,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000050_YeastPathways_PWY3O-3/YeastPathways_PWY3O-3_SGD_YeastPathways_PWY3O-3> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000050_YeastPathways_PWY3O-3/YeastPathways_PWY3O-3_SGD_PWY_YeastPathways_PWY3O-3> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -448,17 +448,6 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_15378_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-3>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-3" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -466,11 +455,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_16749_2.7.8.11-RXN_SGD_YeastPathways_PWY3O-3> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_16749_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-3> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -483,3 +472,14 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_60371310-85bc-4226-8cfd-214dd35d56c6_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-3>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-3" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-31704.ttl
+++ b/models/YeastPathways_PWY3O-31704.ttl
@@ -1,16 +1,16 @@
-<http://identifiers.org/sgd/S000003407>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002333_YGL001C-MONOMER_RXN66-313_controller_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-316_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003407>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-310>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -30,7 +30,7 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/RXN66-316>
-        a       <http://purl.obolibrary.org/obo/GO_0000254> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000254> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -38,9 +38,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-316_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/e23d74b1-5b77-44fb-a630-00c9a5940635_RXN66-315> , <http://model.geneontology.org/CHEBI_15378_RXN66-316> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-316> , <http://model.geneontology.org/CHEBI_15379_RXN66-316> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN66-316> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-316> , <http://model.geneontology.org/CHEBI_15379_RXN66-316> , <http://model.geneontology.org/635234a2-ce53-45b1-a716-7b83a0bce81e_RXN66-315> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_RXN66-316> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-316> , <http://model.geneontology.org/cb8aaddc-3452-4b8d-bf4e-061fbfec7ada_RXN66-316> ;
+                <http://model.geneontology.org/400b0e26-a014-4f59-8113-24f29e48fe4d_RXN66-316> , <http://model.geneontology.org/CHEBI_15377_RXN66-316> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-316> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN66-316_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -56,36 +56,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_58349_RXN66-319_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_18252_RXN66-319_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_15379_RXN66-311_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_FERRICYTOCHROME-B5_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_15440_RXN66-281_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-218_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -101,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -113,11 +113,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_SQUALENE-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -128,14 +128,14 @@
           <http://model.geneontology.org/CHEBI_15377_SQUALENE-MONOOXYGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002333_YNL280C-MONOMER_RXN66-306_controller_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_15378_RXN66-314_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -159,8 +159,16 @@
 <http://purl.obolibrary.org/obo/CHEBI_17038>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/035b873e-c050-43ed-a7ea-4b01e4948157_RXN66-317>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002333_YHR007C-MONOMER_RXN3O-130_controller_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -174,7 +182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -201,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -213,11 +221,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -228,15 +236,26 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-310_BFO_0000066_reaction_RXN66-310_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_CHEBI_17813_RXN3O-130_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_CHEBI_17813_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -252,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -260,11 +279,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_57783_RXN66-319_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_57783_RXN66-319_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -279,11 +298,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_15440_RXN66-281_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_15440_RXN66-281_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -315,11 +334,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_FERRICYTOCHROME-B5_RXN66-311_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_FERRICYTOCHROME-B5_RXN66-311_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -334,11 +353,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_15379_RXN66-316_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_15379_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,11 +372,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000066_reaction_RXN3O-203_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000066_reaction_RXN3O-203_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -381,11 +400,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -396,14 +415,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002233_CHEBI_15378_RXN3O-218_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -411,11 +430,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002234_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002234_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,7 +450,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_FERROCYTOCHROME-B5_RXN66-310_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -439,11 +469,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -454,14 +484,14 @@
           <http://model.geneontology.org/CHEBI_29888_FPPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_SQUALENE-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_16933_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -474,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -491,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -499,42 +529,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/cb8aaddc-3452-4b8d-bf4e-061fbfec7ada_RXN66-316>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44191> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000066_reaction_RXN66-313_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_57783_RXN66-314_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -547,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -564,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -591,7 +593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -599,14 +601,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_1949_RXN66-314_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_58349_RXN66-306_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_e85795fa-65b3-4b37-b58c-1f457b8e0ac9_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000066_reaction_RXN66-318_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -619,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -627,14 +651,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_18364_RXN66-306_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002413_RXN66-281_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_16526_RXN66-313_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -647,7 +693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -655,25 +701,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002413_RXN66-313_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-130_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -681,11 +716,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -703,11 +738,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Provides Input For Rule. The relation '4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + H<SUP>+</SUP> &rarr; 4&alpha;-carboxy-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' '4&alpha;-carboxy-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> &rarr; 3-dehydro-4-methylzymosterol + CO<SUB>2</SUB> + NAD(P)H' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002413_RXN66-313_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002413_RXN66-313_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -723,7 +758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -731,11 +766,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002233_CHEBI_15441_SQUALENE-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002233_CHEBI_15441_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -746,26 +781,15 @@
           <http://model.geneontology.org/CHEBI_15441_SQUALENE-MONOOXYGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_13392_RXN66-281_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_3b3a2611-6db9-4f3f-82df-be186a489ae8_RXN66-316_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_e85795fa-65b3-4b37-b58c-1f457b8e0ac9_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -773,29 +797,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3b3a2611-6db9-4f3f-82df-be186a489ae8_RXN66-316>
+          <http://model.geneontology.org/e85795fa-65b3-4b37-b58c-1f457b8e0ac9_RXN66-316>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002413_RXN3O-218_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002234_FERRICYTOCHROME-B5_RXN3O-218_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002234_FERRICYTOCHROME-B5_RXN3O-218_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -806,14 +819,14 @@
           <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN3O-218>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_57783_RXN66-319_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002333_YGR060W-MONOMER_RXN66-311_controller_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -821,11 +834,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_57783_RXN66-314_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_57783_RXN66-314_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -840,11 +853,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002233_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002233_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -855,17 +868,6 @@
           <http://model.geneontology.org/CHEBI_16521_LANOSTEROL-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_Red-NADPH-Hemoprotein-Reductases_SQUALENE-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_17813_RXN3O-130>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17813> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -875,7 +877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -887,11 +889,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_15379_RXN66-311_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_15379_RXN66-311_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -902,17 +904,6 @@
           <http://model.geneontology.org/CHEBI_15379_RXN66-311>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_59789_RXN3O-178_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15379_RXN66-317>
         a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -922,7 +913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -937,24 +928,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704Protein44523> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_FERRICYTOCHROME-B5_RXN66-311_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_136486_RXN66-313>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_136486> ;
@@ -965,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -977,11 +957,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -992,34 +972,23 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_CHEBI_52972_RXN3O-218_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002233_CHEBI_17038_RXN3O-178_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN66-316_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_57310_RXN-12263_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1032,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1040,15 +1009,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN66-310_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1064,7 +1055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1079,7 +1070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1094,7 +1085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1109,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1124,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1136,11 +1127,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_18249_RXN3O-227_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_18249_RXN3O-227_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1151,40 +1142,18 @@
           <http://model.geneontology.org/CHEBI_18249_RXN3O-227>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_Red-NADPH-Hemoprotein-Reductases_RXN3O-227_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0000246>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN66-317_BFO_0000066_reaction_RXN66-317_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002333_YGL001C-MONOMER_RXN66-318_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002333_YGL001C-MONOMER_RXN66-318_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1199,11 +1168,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1214,25 +1183,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_18249_RXN3O-227_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002413_LANOSTEROL-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002413_RXN3O-178_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1240,11 +1198,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_a7498b33-bae6-400c-804e-62adacba422b_RXN66-315_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_971baa4f-40eb-4520-99a8-4eaf82b107eb_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1252,18 +1210,40 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-315> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a7498b33-bae6-400c-804e-62adacba422b_RXN66-315>
+          <http://model.geneontology.org/971baa4f-40eb-4520-99a8-4eaf82b107eb_RXN66-315>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_52386_RXN66-318_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_13392_RXN66-281_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_15378_RXN3O-178_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_15378_RXN3O-178_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1277,15 +1257,26 @@
 <http://identifiers.org/sgd/S000004467>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002233_CHEBI_17038_RXN3O-178_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_57783_RXN66-306_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_57783_RXN66-306_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1305,7 +1296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1317,11 +1308,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_FERROCYTOCHROME-B5_RXN66-312_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_FERROCYTOCHROME-B5_RXN66-312_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1332,26 +1323,15 @@
           <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-312>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_FERROCYTOCHROME-B5_RXN66-310_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1371,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1383,11 +1363,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1402,11 +1382,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002233_CHEBI_15379_RXN3O-218_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002233_CHEBI_15379_RXN3O-218_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1417,25 +1397,36 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-218>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_57310_RXN-12263_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_cc905f95-a029-4f85-9c93-168fc7a92b70_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-227_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1448,7 +1439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1468,7 +1459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1476,8 +1467,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/3b3a2611-6db9-4f3f-82df-be186a489ae8_RXN66-316>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_15379_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN66-315>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1488,7 +1487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1496,14 +1495,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_FERRICYTOCHROME-B5_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1516,7 +1515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1524,51 +1523,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002333_YLR100W-MONOMER_RXN66-319_controller_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_15378_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002413_RXN66-311_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_FERROCYTOCHROME-B5_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/e23d74b1-5b77-44fb-a630-00c9a5940635_RXN66-315>
+<http://model.geneontology.org/e85795fa-65b3-4b37-b58c-1f457b8e0ac9_RXN66-316>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002413_RXN3O-203_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002411_RXN66-317_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002411_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1582,15 +1581,26 @@
 <http://purl.obolibrary.org/obo/GO_0004310>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002234_FERRICYTOCHROME-B5_RXN66-312_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002233_CHEBI_15378_RXN3O-218_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002233_CHEBI_15378_RXN3O-218_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1601,26 +1611,15 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-218>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_29888_RXN-12263_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002333_YGL001C-MONOMER_RXN66-313_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002333_YGL001C-MONOMER_RXN66-313_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1636,7 +1635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1644,11 +1643,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_57310_RXN-12263_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_57310_RXN-12263_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1659,15 +1658,37 @@
           <http://model.geneontology.org/CHEBI_57310_RXN-12263>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-311_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002333_YMR202W-MONOMER_RXN3O-203_controller_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_13390_RXN66-318_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_13390_RXN66-318_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1678,26 +1699,15 @@
           <http://model.geneontology.org/CHEBI_13390_RXN66-318>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_15378_RXN66-319_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_CHEBI_15377_RXN3O-227_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_CHEBI_15377_RXN3O-227_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1708,15 +1718,26 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-227>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_57310_RXN-12263_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_FERRICYTOCHROME-B5_RXN66-310_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_FERRICYTOCHROME-B5_RXN66-310_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1731,11 +1752,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_15379_RXN66-315_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_15379_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1746,14 +1767,14 @@
           <http://model.geneontology.org/CHEBI_15379_RXN66-315>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-312_BFO_0000066_reaction_RXN66-312_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000066_reaction_RXN66-319_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1761,11 +1782,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'lanosterol + 3 a reduced [NADPH-hemoprotein reductase] + 3 oxygen &rarr; 4,4-dimethyl-cholesta-8,14,24-trienol + formate + 3 an oxidized [NADPH-hemoprotein reductase] + 4 H<sub>2</sub>O + H<SUP>+</SUP>' 'null' '4,4-dimethylzymosterol + NADP<sup>+</sup> &larr; 4,4-dimethyl-cholesta-8,14,24-trienol + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002413_RXN66-306_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002413_RXN66-306_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1781,7 +1802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1794,13 +1815,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704Protein44134> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_15378_RXN3O-178_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN66-318>
         a       <http://purl.obolibrary.org/obo/GO_0103067> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1811,7 +1843,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13390_RXN66-318> , <http://model.geneontology.org/035b873e-c050-43ed-a7ea-4b01e4948157_RXN66-317> ;
+                <http://model.geneontology.org/CHEBI_13390_RXN66-318> , <http://model.geneontology.org/cc905f95-a029-4f85-9c93-168fc7a92b70_RXN66-317> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16526_RXN66-318> , <http://model.geneontology.org/CHEBI_13392_RXN66-318> , <http://model.geneontology.org/CHEBI_52386_RXN66-318> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1821,7 +1853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1829,19 +1861,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_15440_RXN66-281_SGD_YeastPathways_PWY3O-31704>
+<http://purl.obolibrary.org/obo/GO_0050046>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002413_RXN66-319_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_Red-NADPH-Hemoprotein-Reductases_RXN3O-227_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0050046>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_18364_RXN66-306>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_18364> ;
@@ -1852,7 +1906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1860,14 +1914,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_CHEBI_15379_RXN3O-227_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_15378_RXN66-311_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1876,18 +1930,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_15379_RXN66-315_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_Red-NADPH-Hemoprotein-Reductases_RXN3O-227_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_58349_RXN66-319_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1895,11 +1960,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_Red-NADPH-Hemoprotein-Reductases_SQUALENE-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_Red-NADPH-Hemoprotein-Reductases_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1910,17 +1975,6 @@
           <http://model.geneontology.org/Red-NADPH-Hemoprotein-Reductases_SQUALENE-MONOOXYGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_64925_RXN66-312_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN3O-218>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1930,13 +1984,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704Protein44134> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_18252_RXN66-319_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN66-310>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1947,7 +2023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1955,41 +2031,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_CHEBI_87289_RXN66-310_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_CHEBI_18364_RXN66-306_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_57856_RXN3O-178_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-315_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002333_YGR060W-MONOMER_RXN66-315_controller_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_15378_RXN66-281_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0000254>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1998,11 +2074,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_58349_RXN66-319_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_58349_RXN66-319_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2013,8 +2089,16 @@
           <http://model.geneontology.org/CHEBI_58349_RXN66-319>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0050613>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_15378_RXN66-306_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29888_RXN-12263>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
@@ -2025,7 +2109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2037,11 +2121,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002333_YHR190W-MONOMER_RXN66-281_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002333_YHR190W-MONOMER_RXN66-281_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2052,15 +2136,18 @@
           <http://model.geneontology.org/YHR190W-MONOMER_RXN66-281_controller>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0050613>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Provides Input For Rule. The relation '4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' 'null' '4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + H<SUP>+</SUP> &rarr; 4&alpha;-carboxy-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002413_RXN66-312_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002413_RXN66-312_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2071,25 +2158,36 @@
           <http://model.geneontology.org/RXN66-312>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002233_CHEBI_175763_FPPSYN-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_18252_RXN66-319_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_136486_RXN66-313_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2097,11 +2195,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_e23d74b1-5b77-44fb-a630-00c9a5940635_RXN66-315_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_635234a2-ce53-45b1-a716-7b83a0bce81e_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2109,32 +2207,21 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e23d74b1-5b77-44fb-a630-00c9a5940635_RXN66-315>
+          <http://model.geneontology.org/635234a2-ce53-45b1-a716-7b83a0bce81e_RXN66-315>
 ] .
 
 <http://identifiers.org/sgd/S000001114>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002413_RXN66-306_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002234_CHEBI_50586_RXN3O-203_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002234_CHEBI_50586_RXN3O-203_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2145,14 +2232,14 @@
           <http://model.geneontology.org/CHEBI_50586_RXN3O-203>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-227_BFO_0000066_reaction_RXN3O-227_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000066_reaction_RXN66-313_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2160,11 +2247,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_13390_RXN66-313_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_13390_RXN66-313_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2179,11 +2266,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Provides Input For Rule. The relation '(3<i>S</i>)-2,3-epoxy-2,3-dihydrosqualene &rarr; lanosterol' 'null' 'lanosterol + 3 a reduced [NADPH-hemoprotein reductase] + 3 oxygen &rarr; 4,4-dimethyl-cholesta-8,14,24-trienol + formate + 3 an oxidized [NADPH-hemoprotein reductase] + 4 H<sub>2</sub>O + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002413_RXN3O-130_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002413_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2198,11 +2285,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'geranyl diphosphate + isopentenyl diphosphate &rarr; (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate + diphosphate' 'null' '2 (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate &rarr; presqualene diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002413_RXN-12263_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002413_RXN-12263_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2213,15 +2300,26 @@
           <http://model.geneontology.org/RXN-12263>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_CHEBI_15379_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_CHEBI_15379_RXN66-310_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_CHEBI_15379_RXN66-310_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2232,34 +2330,34 @@
           <http://model.geneontology.org/CHEBI_15379_RXN66-310>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002333_YGL012W-MONOMER_1.3.1.71-RXN_controller_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_GPPSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002234_FERRICYTOCHROME-B5_RXN66-312_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002234_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_CHEBI_15377_RXN3O-227_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2282,7 +2380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2295,18 +2393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_17813_RXN3O-130_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2320,7 +2407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2328,28 +2415,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/GO_0004161>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN66-316_BFO_0000066_reaction_RXN66-316_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_57783_RXN66-306_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_3b3a2611-6db9-4f3f-82df-be186a489ae8_RXN66-316_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/GO_0004161>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_CHEBI_15377_RXN66-310_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2358,29 +2445,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002233_CHEBI_50586_RXN3O-203_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002233_CHEBI_15379_RXN3O-218_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2403,7 +2479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2420,7 +2496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2432,11 +2508,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_SQUALENE-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2450,6 +2526,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_18249>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_57783_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000004046>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2462,7 +2549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2470,15 +2557,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000066_reaction_RXN3O-203_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_CHEBI_15378_RXN66-310_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_CHEBI_15378_RXN66-310_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2498,7 +2596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2506,26 +2604,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002233_CHEBI_15379_RXN3O-130_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_FERRICYTOCHROME-B5_RXN66-317_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_FERRICYTOCHROME-B5_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2536,15 +2623,26 @@
           <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-317>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-218_BFO_0000066_reaction_RXN3O-218_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'episterol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; ergosta-5,7,24(28)-trien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' 'null' 'ergosta-5,7,24(28)-trien-3&beta;-ol + a reduced [NADPH-hemoprotein reductase] + oxygen &rarr; ergosta-5,7,22,24(28)-tetraen-3-&beta;-ol + an oxidized [NADPH-hemoprotein reductase] + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002413_RXN3O-227_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002413_RXN3O-227_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2554,17 +2652,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN3O-227>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_15378_RXN66-312_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2578,7 +2665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2590,11 +2677,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_58349_RXN66-314_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_58349_RXN66-314_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2612,11 +2699,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_CHEBI_15377_RXN3O-130_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_CHEBI_15377_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2627,26 +2714,15 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-130>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_e23d74b1-5b77-44fb-a630-00c9a5940635_RXN66-315_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000066_reaction_RXN66-319_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000066_reaction_RXN66-319_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2657,25 +2733,14 @@
           <http://model.geneontology.org/reaction_RXN66-319_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_FERROCYTOCHROME-B5_RXN66-311_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002413_LANOSTEROL-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_FERROCYTOCHROME-B5_RXN66-316_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2683,11 +2748,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_15378_RXN66-281_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_15378_RXN66-281_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2702,11 +2767,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_FERROCYTOCHROME-B5_RXN66-311_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_FERROCYTOCHROME-B5_RXN66-311_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2717,25 +2782,36 @@
           <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-311>
 ] .
 
-<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000066_reaction_LANOSTEROL-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_58349_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002333_YGL001C-MONOMER_RXN66-318_controller_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_CHEBI_18249_RXN3O-227_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2746,7 +2822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2761,7 +2837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2779,7 +2855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2791,11 +2867,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2805,17 +2881,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_128769_FPPSYN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002233_CHEBI_15441_SQUALENE-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_18364>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2829,7 +2894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2840,30 +2905,8 @@
 <http://purl.obolibrary.org/obo/CHEBI_13390>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002233_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57623>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_CHEBI_15377_RXN66-317_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58349_1.3.1.71-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
@@ -2874,7 +2917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2886,11 +2929,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_16933_1.3.1.71-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_16933_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2901,48 +2944,70 @@
           <http://model.geneontology.org/CHEBI_16933_1.3.1.71-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002413_RXN66-310_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_1.3.1.71-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002333_MONOMER3O-232_RXN3O-227_controller_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_CHEBI_15740_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004506>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_58349_RXN66-306_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002333_YGR060W-MONOMER_RXN66-310_controller_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002233_CHEBI_175763_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_FERRICYTOCHROME-B5_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2950,11 +3015,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002411_RXN66-316_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002411_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2969,11 +3034,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_57856_RXN3O-178_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_57856_RXN3O-178_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2984,26 +3049,15 @@
           <http://model.geneontology.org/CHEBI_57856_RXN3O-178>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-311_BFO_0000066_reaction_RXN66-311_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_58349_RXN66-306_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_58349_RXN66-306_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3019,7 +3073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3027,11 +3081,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002234_CHEBI_64925_RXN66-312_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002234_CHEBI_64925_RXN66-312_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3042,15 +3096,26 @@
           <http://model.geneontology.org/CHEBI_64925_RXN66-312>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_FERROCYTOCHROME-B5_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'dimethylallyl diphosphate + isopentenyl diphosphate &rarr; geranyl diphosphate + diphosphate' 'null' 'geranyl diphosphate + isopentenyl diphosphate &rarr; (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3068,11 +3133,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_CHEBI_15378_RXN66-317_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_CHEBI_15378_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3087,11 +3152,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002233_FERROCYTOCHROME-B5_RXN3O-218_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002233_FERROCYTOCHROME-B5_RXN3O-218_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3102,6 +3167,28 @@
           <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN3O-218>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_FERRICYTOCHROME-B5_RXN66-311_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_1949_RXN66-314_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16521>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3109,11 +3196,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000066_reaction_RXN66-314_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000066_reaction_RXN66-314_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3129,7 +3216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3137,11 +3224,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-130_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-130_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3152,14 +3239,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_15378_RXN3O-178_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_15379_RXN66-312_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3172,7 +3259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3189,13 +3276,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44091> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002234_CHEBI_15377_RXN66-312_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_CHEBI_15377_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_175763>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3212,7 +3321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3220,39 +3329,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002234_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002333_YLR100W-MONOMER_RXN66-319_controller_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_87287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-130_BFO_0000066_reaction_RXN3O-130_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000066_reaction_RXN66-314_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3265,7 +3374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3273,33 +3382,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000066_reaction_1.3.1.71-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58057>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15440>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002333_YGR060W-MONOMER_RXN66-312_controller_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YHR007C-MONOMER_RXN3O-130_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001049> ;
@@ -3308,7 +3395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3320,11 +3407,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3339,11 +3426,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Provides Input For Rule. The relation '2 (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate &rarr; presqualene diphosphate + diphosphate' 'null' 'presqualene diphosphate + NAD(P)H + H<SUP>+</SUP> &rarr; squalene + NAD(P)<sup>+</sup> + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002413_RXN66-281_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002413_RXN66-281_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3358,11 +3445,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_13392_RXN66-318_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_13392_RXN66-318_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3373,15 +3460,26 @@
           <http://model.geneontology.org/CHEBI_13392_RXN66-318>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_15378_RXN66-319_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_Red-NADPH-Hemoprotein-Reductases_RXN3O-227_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_Red-NADPH-Hemoprotein-Reductases_RXN3O-227_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3396,11 +3494,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '4,4-dimethylzymosterol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' '4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-formyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002413_RXN66-311_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002413_RXN66-311_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3415,11 +3513,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_FERROCYTOCHROME-B5_RXN66-315_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_FERROCYTOCHROME-B5_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3430,17 +3528,6 @@
           <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-315>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_1.3.1.71-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3450,7 +3537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3465,11 +3552,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000066_reaction_RXN3O-178_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000066_reaction_RXN3O-178_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3487,7 +3574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3504,7 +3591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3519,7 +3606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3531,11 +3618,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_15378_RXN66-312_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_15378_RXN66-312_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3546,26 +3633,15 @@
           <http://model.geneontology.org/CHEBI_15378_RXN66-312>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-311_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_GPPSYN-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3576,30 +3652,52 @@
           <http://model.geneontology.org/CHEBI_128769_GPPSYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_64925>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_57783_RXN66-306_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-315_BFO_0000066_reaction_RXN66-315_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_13392_RXN66-313_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002413_RXN66-306_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-130_BFO_0000066_reaction_RXN3O-130_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_64925>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57783_RXN66-314>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
@@ -3610,7 +3708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3618,26 +3716,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_CHEBI_15377_RXN66-310_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'squalene + a reduced [NADPH-hemoprotein reductase] + oxygen &rarr; (3<i>S</i>)-2,3-epoxy-2,3-dihydrosqualene + an oxidized [NADPH-hemoprotein reductase] + H<sub>2</sub>O' 'null' '(3<i>S</i>)-2,3-epoxy-2,3-dihydrosqualene &rarr; lanosterol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002413_LANOSTEROL-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002413_LANOSTEROL-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3648,47 +3735,25 @@
           <http://model.geneontology.org/LANOSTEROL-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_52967c99-dc66-4058-8345-fa6f053e837e_RXN66-317_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_57783_RXN66-319_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_FERRICYTOCHROME-B5_RXN66-310_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_CHEBI_15378_RXN66-310_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002411_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3701,7 +3766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3714,18 +3779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002413_RXN66-319_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3737,9 +3791,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/971baa4f-40eb-4520-99a8-4eaf82b107eb_RXN66-315>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44129> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN66-315>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3750,24 +3821,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44148> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002333_YGR060W-MONOMER_RXN66-315_controller_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_52972_RXN3O-218>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_52972> ;
@@ -3778,7 +3838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3786,26 +3846,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_cb8aaddc-3452-4b8d-bf4e-061fbfec7ada_RXN66-316_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'zymosterol + NADP<sup>+</sup> &larr; zymosterone + NADPH + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + zymosterol &rarr; <i>S</i>-adenosyl-L-homocysteine + fecosterol + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002413_RXN3O-178_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002413_RXN3O-178_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3816,15 +3865,26 @@
           <http://model.geneontology.org/RXN3O-178>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000066_reaction_RXN-12263_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3835,14 +3895,42 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_58349_RXN66-314_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/8e628c17-7080-4a0e-b881-644ec8e74be4_RXN66-317>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44198> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002413_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3850,11 +3938,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_FERRICYTOCHROME-B5_RXN66-316_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_FERRICYTOCHROME-B5_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3872,11 +3960,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'fecosterol &rarr; episterol' 'null' 'episterol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; ergosta-5,7,24(28)-trien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002413_RXN3O-218_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002413_RXN3O-218_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3890,15 +3978,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_18252>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_136486_RXN66-313_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_13392_RXN66-313_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_13392_RXN66-313_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3913,11 +4012,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000066_reaction_RXN-12263_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000066_reaction_RXN-12263_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3928,17 +4027,6 @@
           <http://model.geneontology.org/reaction_RXN-12263_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_FERROCYTOCHROME-B5_RXN66-317_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_RXN3O-218>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3948,7 +4036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3960,11 +4048,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002411_RXN66-318_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002411_RXN66-318_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3975,6 +4063,17 @@
           <http://model.geneontology.org/RXN66-318>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-316>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3984,7 +4083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3996,11 +4095,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_CHEBI_15379_RXN3O-227_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_CHEBI_15379_RXN3O-227_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4015,11 +4114,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_FERROCYTOCHROME-B5_RXN66-310_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_FERROCYTOCHROME-B5_RXN66-310_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4029,17 +4128,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-310>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_a7498b33-bae6-400c-804e-62adacba422b_RXN66-315_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/1.3.1.71-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000246> ;
@@ -4058,7 +4146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4066,36 +4154,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_52386_RXN66-318_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_Red-NADPH-Hemoprotein-Reductases_RXN3O-227_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_CHEBI_15740_RXN3O-130_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002413_RXN66-310_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_CHEBI_15377_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4110,7 +4198,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15379_RXN66-315> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-315> , <http://model.geneontology.org/CHEBI_1949_RXN66-314> , <http://model.geneontology.org/CHEBI_15378_RXN66-315> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/a7498b33-bae6-400c-804e-62adacba422b_RXN66-315> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-315> , <http://model.geneontology.org/CHEBI_15377_RXN66-315> ;
+                <http://model.geneontology.org/971baa4f-40eb-4520-99a8-4eaf82b107eb_RXN66-315> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-315> , <http://model.geneontology.org/CHEBI_15377_RXN66-315> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN66-315_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -4118,7 +4206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4126,25 +4214,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000066_reaction_RXN-12263_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_CHEBI_87287_RXN66-311_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002411_RXN66-316_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4155,7 +4232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4163,14 +4240,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000066_reaction_RXN3O-203_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002333_YLR100W-MONOMER_RXN66-314_controller_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4183,7 +4260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4196,7 +4273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4209,7 +4286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4221,11 +4298,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_Red-NADPH-Hemoprotein-Reductases_SQUALENE-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_Red-NADPH-Hemoprotein-Reductases_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4236,36 +4313,25 @@
           <http://model.geneontology.org/Red-NADPH-Hemoprotein-Reductases_SQUALENE-MONOOXYGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-310_BFO_0000066_reaction_RXN66-310_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002413_SQUALENE-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_15378_RXN66-316_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_13390_RXN66-313_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4273,11 +4339,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002333_YGR060W-MONOMER_RXN66-317_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002333_YGR060W-MONOMER_RXN66-317_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4292,11 +4358,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_BFO_0000066_reaction_RXN3O-227_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_BFO_0000066_reaction_RXN3O-227_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4306,6 +4372,9 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN3O-227_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/cc905f95-a029-4f85-9c93-168fc7a92b70_RXN66-317>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4319,7 +4388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4331,11 +4400,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Provides Input For Rule. The relation '4&alpha;-methyl-zymosterol + NADP<sup>+</sup> &larr; 3-dehydro-4-methylzymosterol + NADPH + H<SUP>+</SUP>' 'null' '4&alpha;-methyl-zymosterol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002413_RXN66-315_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002413_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4346,14 +4415,14 @@
           <http://model.geneontology.org/RXN66-315>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_CHEBI_15378_RXN66-310_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4361,11 +4430,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_CHEBI_15740_RXN3O-130_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_CHEBI_15740_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4379,15 +4448,26 @@
 <http://purl.obolibrary.org/obo/GO_0008398>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_52386_RXN66-318_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_52386_RXN66-318_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_52386_RXN66-318_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4402,11 +4482,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_13390_RXN66-281_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_13390_RXN66-281_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4421,11 +4501,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_CHEBI_87287_RXN66-311_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_CHEBI_87287_RXN66-311_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4455,7 +4535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4472,7 +4552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4484,11 +4564,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_15378_RXN66-316_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_15378_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4503,11 +4583,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4518,36 +4598,36 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_15378_RXN66-281_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_Red-NADPH-Hemoprotein-Reductases_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002333_YHR190W-MONOMER_RXN-12263_controller_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002411_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002333_YHR190W-MONOMER_RXN66-281_controller_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002234_CHEBI_52972_RXN3O-218_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4555,11 +4635,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4579,7 +4659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4587,61 +4667,50 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_15379_RXN66-312_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_FERRICYTOCHROME-B5_RXN66-310_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002234_CHEBI_15377_RXN3O-218_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_971baa4f-40eb-4520-99a8-4eaf82b107eb_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000066_reaction_LANOSTEROL-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_13392>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_87289_RXN66-310_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_CHEBI_52972_RXN3O-218_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_57783_RXN66-314_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_15378_RXN66-306_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4654,7 +4723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4664,6 +4733,17 @@
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_17813_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN66-310>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000254> ;
@@ -4684,7 +4764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4696,11 +4776,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002333_YGL012W-MONOMER_1.3.1.71-RXN_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002333_YGL012W-MONOMER_1.3.1.71-RXN_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4711,59 +4791,70 @@
           <http://model.geneontology.org/YGL012W-MONOMER_1.3.1.71-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002333_YLR100W-MONOMER_RXN66-314_controller_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002413_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_Red-NADPH-Hemoprotein-Reductases_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002411_RXN66-317_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000066_reaction_RXN3O-178_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_CHEBI_15377_RXN3O-130_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002233_Red-NADPH-Hemoprotein-Reductases_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_1949_RXN66-314_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-203_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4771,11 +4862,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '4,4-dimethylzymosterol + NADP<sup>+</sup> &larr; 4,4-dimethyl-cholesta-8,14,24-trienol + NADPH + H<SUP>+</SUP>' 'null' '4,4-dimethylzymosterol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002413_RXN66-310_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002413_RXN66-310_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4790,11 +4881,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002333_YGR060W-MONOMER_RXN66-312_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002333_YGR060W-MONOMER_RXN66-312_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4814,7 +4905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4826,11 +4917,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000066_reaction_LANOSTEROL-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000066_reaction_LANOSTEROL-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4841,15 +4932,26 @@
           <http://model.geneontology.org/reaction_LANOSTEROL-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-310_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_FERROCYTOCHROME-B5_RXN66-317_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_FERROCYTOCHROME-B5_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4864,11 +4966,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002234_CHEBI_52972_RXN3O-218_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002234_CHEBI_52972_RXN3O-218_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4879,26 +4981,15 @@
           <http://model.geneontology.org/CHEBI_52972_RXN3O-218>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_CHEBI_15379_RXN66-317_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_15378_RXN66-314_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_15378_RXN66-314_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4913,11 +5004,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002233_CHEBI_15379_RXN3O-130_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002233_CHEBI_15379_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4928,14 +5019,25 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-130>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_58349_1.3.1.71-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000066_reaction_1.3.1.71-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4946,11 +5048,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_15378_RXN66-311_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_15378_RXN66-311_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4961,17 +5063,6 @@
           <http://model.geneontology.org/CHEBI_15378_RXN66-311>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16526_RXN66-313>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4981,13 +5072,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44248> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15379_RXN66-316>
         a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4998,7 +5100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5006,39 +5108,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-178_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_CHEBI_18249_RXN3O-227_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16933>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_87287_RXN66-311_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN66-319>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5049,7 +5140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5057,97 +5148,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002413_RXN66-311_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002333_MONOMER3O-188_RXN3O-178_controller_SGD_YeastPathways_PWY3O-31704>
+<http://purl.obolibrary.org/obo/CHEBI_87289>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_15378_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_87289>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_FERRICYTOCHROME-B5_RXN66-316_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_57310_RXN-12263_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002411_RXN66-318_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002413_RXN-12263_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002333_YGR060W-MONOMER_RXN66-311_controller_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5155,11 +5180,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_15378_1.3.1.71-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_15378_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5170,14 +5195,25 @@
           <http://model.geneontology.org/CHEBI_15378_1.3.1.71-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_29888_RXN66-281_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-317_BFO_0000066_reaction_RXN66-317_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5200,7 +5236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5212,11 +5248,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_52386_RXN66-318_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_52386_RXN66-318_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5231,11 +5267,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ergosta-5,7,24(28)-trien-3&beta;-ol + a reduced [NADPH-hemoprotein reductase] + oxygen &rarr; ergosta-5,7,22,24(28)-tetraen-3-&beta;-ol + an oxidized [NADPH-hemoprotein reductase] + 2 H<sub>2</sub>O' 'null' 'ergosterol + NADP<sup>+</sup> &larr; ergosta-5,7,22,24(28)-tetraen-3-&beta;-ol + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002413_1.3.1.71-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002413_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5250,11 +5286,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_BFO_0000066_reaction_RXN66-311_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_BFO_0000066_reaction_RXN66-311_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5265,14 +5301,14 @@
           <http://model.geneontology.org/reaction_RXN66-311_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002333_YGL012W-MONOMER_1.3.1.71-RXN_controller_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5280,11 +5316,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_FERRICYTOCHROME-B5_RXN66-315_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_FERRICYTOCHROME-B5_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5302,11 +5338,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_59789_RXN3O-178_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_59789_RXN3O-178_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5321,11 +5357,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_17813_RXN3O-130_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_17813_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5345,7 +5381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5357,11 +5393,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_87287_RXN66-311_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_87287_RXN66-311_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5376,11 +5412,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5391,30 +5427,19 @@
           <http://model.geneontology.org/CHEBI_29888_GPPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_13390_RXN66-318_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_57856_RXN3O-178_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001049>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_FERROCYTOCHROME-B5_RXN66-315_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGL001C-MONOMER_RXN66-313_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002969> ;
@@ -5423,7 +5448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5434,28 +5459,28 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002413_RXN3O-203_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_13390_RXN66-281_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5468,7 +5493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5482,17 +5507,6 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_15378_RXN66-314_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_RXN66-314>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5502,13 +5516,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44065> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_18252_RXN66-319_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YMR202W-MONOMER_RXN3O-203_controller>
         a       <http://identifiers.org/sgd/S000004815> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5517,7 +5542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5525,25 +5550,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002413_1.3.1.71-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_15379_RXN66-311_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5556,7 +5570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5564,25 +5578,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15441_SQUALENE-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002413_RXN66-314_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_1949_RXN66-314_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-311_BFO_0000066_reaction_RXN66-311_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002234_CHEBI_50586_RXN3O-203_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5590,11 +5615,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002333_YGR060W-MONOMER_RXN66-316_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002333_YGR060W-MONOMER_RXN66-316_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5605,15 +5630,26 @@
           <http://model.geneontology.org/YGR060W-MONOMER_RXN66-316_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_CHEBI_15377_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-218_BFO_0000066_reaction_RXN3O-218_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-218_BFO_0000066_reaction_RXN3O-218_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5624,17 +5660,6 @@
           <http://model.geneontology.org/reaction_RXN3O-218_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-218_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_GPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5644,7 +5669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5652,26 +5677,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_CHEBI_15379_RXN66-310_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_16526_RXN66-313_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_16526_RXN66-313_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5686,11 +5700,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_29888_RXN-12263_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_29888_RXN-12263_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5701,15 +5715,48 @@
           <http://model.geneontology.org/CHEBI_29888_RXN-12263>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_CHEBI_17813_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_BFO_0000066_reaction_SQUALENE-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002413_RXN66-312_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000066_reaction_RXN66-318_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000066_reaction_RXN66-318_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5720,15 +5767,26 @@
           <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002333_MONOMER3O-188_RXN3O-178_controller_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_Red-NADPH-Hemoprotein-Reductases_RXN3O-227_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_Red-NADPH-Hemoprotein-Reductases_RXN3O-227_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5743,11 +5801,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_CHEBI_87289_RXN66-310_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_CHEBI_87289_RXN66-310_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5765,7 +5823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5773,22 +5831,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/a7498b33-bae6-400c-804e-62adacba422b_RXN66-315>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_17038_RXN3O-178_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44129> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0006696>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5797,11 +5849,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_15378_RXN66-315_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_15378_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5816,11 +5868,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002333_YHR007C-MONOMER_RXN3O-130_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002333_YHR007C-MONOMER_RXN3O-130_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5831,6 +5883,17 @@
           <http://model.geneontology.org/YHR007C-MONOMER_RXN3O-130_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002234_CHEBI_64925_RXN66-312_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16521_LANOSTEROL-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16521> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5840,7 +5903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5857,13 +5920,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704Protein44134> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_FERROCYTOCHROME-B5_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN66-317>
         a       <http://purl.obolibrary.org/obo/GO_0000254> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5874,9 +5948,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-317_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_RXN66-317> , <http://model.geneontology.org/CHEBI_15379_RXN66-317> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-317> , <http://model.geneontology.org/3b3a2611-6db9-4f3f-82df-be186a489ae8_RXN66-316> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN66-317> , <http://model.geneontology.org/CHEBI_15379_RXN66-317> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-317> , <http://model.geneontology.org/e85795fa-65b3-4b37-b58c-1f457b8e0ac9_RXN66-316> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_RXN66-317> , <http://model.geneontology.org/52967c99-dc66-4058-8345-fa6f053e837e_RXN66-317> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-317> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN66-317> , <http://model.geneontology.org/8e628c17-7080-4a0e-b881-644ec8e74be4_RXN66-317> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-317> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN66-317_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -5884,13 +5958,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704BiochemicalReaction44184> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002333_YHR072W-MONOMER_LANOSTEROL-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-178>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5901,7 +5986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5916,7 +6001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5931,11 +6016,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15441_SQUALENE-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15441_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5955,7 +6040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5963,14 +6048,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002333_YGR060W-MONOMER_RXN66-317_controller_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_29888_RXN66-281_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5983,7 +6068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5995,11 +6080,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_BFO_0000066_reaction_RXN66-315_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_BFO_0000066_reaction_RXN66-315_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6014,11 +6099,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_Red-NADPH-Hemoprotein-Reductases_RXN3O-130_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_Red-NADPH-Hemoprotein-Reductases_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6033,11 +6118,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_18252_RXN66-319_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_18252_RXN66-319_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6052,11 +6137,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_29888_RXN66-281_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_29888_RXN66-281_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6071,11 +6156,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002333_YGR060W-MONOMER_RXN66-311_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002333_YGR060W-MONOMER_RXN66-311_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6086,37 +6171,15 @@
           <http://model.geneontology.org/YGR060W-MONOMER_RXN66-311_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-227_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002333_YLR056W-MONOMER_RXN3O-218_controller_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_FERROCYTOCHROME-B5_RXN66-316_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_FERROCYTOCHROME-B5_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6131,11 +6194,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002233_CHEBI_17038_RXN3O-178_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002233_CHEBI_17038_RXN3O-178_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6146,26 +6209,15 @@
           <http://model.geneontology.org/CHEBI_17038_RXN3O-178>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002413_RXN66-312_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000066_reaction_RXN66-313_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000066_reaction_RXN66-313_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6179,26 +6231,15 @@
 <http://identifiers.org/sgd/S000003292>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_15379_RXN66-316_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002333_YHR072W-MONOMER_LANOSTEROL-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002333_YHR072W-MONOMER_LANOSTEROL-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6213,11 +6254,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6231,14 +6272,14 @@
 <http://identifiers.org/sgd/S000004617>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002413_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6251,7 +6292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6278,7 +6319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6295,7 +6336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6322,7 +6363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6333,17 +6374,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15740>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_FERRICYTOCHROME-B5_RXN66-317_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_52386_RXN66-318>
         a       <http://purl.obolibrary.org/obo/CHEBI_52386> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6353,7 +6383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6361,14 +6391,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_Red-NADPH-Hemoprotein-Reductases_SQUALENE-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002233_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_CHEBI_15377_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6376,11 +6417,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_BFO_0000066_reaction_SQUALENE-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_BFO_0000066_reaction_SQUALENE-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6391,26 +6432,15 @@
           <http://model.geneontology.org/reaction_SQUALENE-MONOOXYGENASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002233_CHEBI_15379_RXN3O-218_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_BFO_0000066_reaction_RXN66-310_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_BFO_0000066_reaction_RXN66-310_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6421,15 +6451,26 @@
           <http://model.geneontology.org/reaction_RXN66-310_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_8e628c17-7080-4a0e-b881-644ec8e74be4_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_CHEBI_15377_RXN66-317_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_CHEBI_15377_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6444,11 +6485,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002333_YLR056W-MONOMER_RXN3O-218_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002333_YLR056W-MONOMER_RXN3O-218_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6459,25 +6500,14 @@
           <http://model.geneontology.org/YLR056W-MONOMER_RXN3O-218_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_CHEBI_15378_RXN3O-130_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15441_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_52386_RXN66-318_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6485,11 +6515,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_1949_RXN66-314_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_1949_RXN66-314_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6504,11 +6534,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002233_Red-NADPH-Hemoprotein-Reductases_RXN3O-130_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002233_Red-NADPH-Hemoprotein-Reductases_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6519,14 +6549,14 @@
           <http://model.geneontology.org/Red-NADPH-Hemoprotein-Reductases_RXN3O-130>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002234_CHEBI_15377_RXN66-312_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002333_YHR190W-MONOMER_RXN66-281_controller_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6534,11 +6564,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6549,25 +6579,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002233_FERROCYTOCHROME-B5_RXN3O-218_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002234_CHEBI_15377_RXN3O-218_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002413_RXN66-313_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6575,11 +6594,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_13392_RXN66-281_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_13392_RXN66-281_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6594,11 +6613,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_87289_RXN66-310_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_87289_RXN66-310_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6609,15 +6628,48 @@
           <http://model.geneontology.org/CHEBI_87289_RXN66-310>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-317_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-312_BFO_0000066_reaction_RXN66-312_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15440_RXN66-281_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6628,25 +6680,14 @@
           <http://model.geneontology.org/reaction_FPPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_136486_RXN66-313_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_57783_1.3.1.71-RXN_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN3O-130_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6669,13 +6710,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704BiochemicalReaction44309> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_13392_RXN66-318_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGR060W-MONOMER_RXN66-315_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003292> ;
@@ -6684,35 +6736,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704Protein44155> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_16526_RXN66-313_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_136486_RXN66-313_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_1949>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6722,33 +6752,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002333_YGR060W-MONOMER_RXN66-310_controller_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_57783_1.3.1.71-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_57783_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6763,11 +6782,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Provides Input For Rule. The relation '4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> &rarr; zymosterone + CO<SUB>2</SUB> + NAD(P)H' 'null' 'zymosterol + NADP<sup>+</sup> &larr; zymosterone + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002413_RXN66-319_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002413_RXN66-319_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6782,11 +6801,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000066_reaction_RXN66-281_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000066_reaction_RXN66-281_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6806,7 +6825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6818,11 +6837,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002333_YGR060W-MONOMER_RXN66-315_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002333_YGR060W-MONOMER_RXN66-315_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6837,11 +6856,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_17038_RXN3O-178_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_17038_RXN3O-178_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6859,7 +6878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6876,7 +6895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6888,11 +6907,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_18364_RXN66-306_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_18364_RXN66-306_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6910,11 +6929,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002234_CHEBI_15377_RXN66-312_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002234_CHEBI_15377_RXN66-312_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6925,26 +6944,15 @@
           <http://model.geneontology.org/CHEBI_15377_RXN66-312>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6959,11 +6967,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_BFO_0000066_reaction_RXN66-317_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_BFO_0000066_reaction_RXN66-317_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6978,11 +6986,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002233_CHEBI_50586_RXN3O-203_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002233_CHEBI_50586_RXN3O-203_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6993,36 +7001,25 @@
           <http://model.geneontology.org/CHEBI_50586_RXN3O-203>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002413_RXN66-314_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-218_BFO_0000066_reaction_RXN3O-218_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002333_YHR190W-MONOMER_RXN-12263_controller_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_16526_RXN66-318_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002233_CHEBI_15441_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7045,7 +7042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7065,7 +7062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7082,13 +7079,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44479> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_87287_RXN66-311_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_87289_RXN66-310_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57856>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -7102,7 +7121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7110,15 +7129,70 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002234_FERRICYTOCHROME-B5_RXN3O-218_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_FERROCYTOCHROME-B5_RXN66-312_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002233_FERROCYTOCHROME-B5_RXN3O-218_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Provides Input For Rule. The relation '4&alpha;-carboxy-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> &rarr; 3-dehydro-4-methylzymosterol + CO<SUB>2</SUB> + NAD(P)H' 'null' '4&alpha;-methyl-zymosterol + NADP<sup>+</sup> &larr; 3-dehydro-4-methylzymosterol + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002413_RXN66-314_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002413_RXN66-314_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7133,11 +7207,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002333_YHR190W-MONOMER_RXN-12263_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002333_YHR190W-MONOMER_RXN-12263_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7152,11 +7226,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_035b873e-c050-43ed-a7ea-4b01e4948157_RXN66-317_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_cc905f95-a029-4f85-9c93-168fc7a92b70_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7164,37 +7238,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-318> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/035b873e-c050-43ed-a7ea-4b01e4948157_RXN66-317>
+          <http://model.geneontology.org/cc905f95-a029-4f85-9c93-168fc7a92b70_RXN66-317>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002333_YGR060W-MONOMER_RXN66-310_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_CHEBI_18249_RXN3O-227_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-310> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR060W-MONOMER_RXN66-310_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_CHEBI_18249_RXN3O-227_SGD_YeastPathways_PWY3O-31704> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7214,7 +7269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7222,14 +7277,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002413_RXN3O-227_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002333_YGR060W-MONOMER_RXN66-310_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN66-310> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGR060W-MONOMER_RXN66-310_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_13390_RXN66-318_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7237,11 +7311,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_1949_RXN66-314_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_1949_RXN66-314_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7256,11 +7330,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7280,7 +7354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7288,15 +7362,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_15378_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_BFO_0000066_reaction_RXN66-312_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-312_BFO_0000066_reaction_RXN66-312_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7307,43 +7392,37 @@
           <http://model.geneontology.org/reaction_RXN66-312_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002413_RXN66-315_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002413_RXN-12263_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/52967c99-dc66-4058-8345-fa6f053e837e_RXN66-317>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002333_YGR060W-MONOMER_RXN66-317_controller_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44198> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7353,17 +7432,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_GPPSYN-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN66-316_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN66-319>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0102176> ;
@@ -7384,7 +7452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7392,14 +7460,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7412,7 +7480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7429,7 +7497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7441,11 +7509,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002333_YGR175C-MONOMER_SQUALENE-MONOOXYGENASE-RXN_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002333_YGR175C-MONOMER_SQUALENE-MONOOXYGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7456,25 +7524,14 @@
           <http://model.geneontology.org/YGR175C-MONOMER_SQUALENE-MONOOXYGENASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002333_YGR060W-MONOMER_RXN66-316_controller_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_CHEBI_15378_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7497,7 +7554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7514,13 +7571,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44065> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002333_YGL001C-MONOMER_RXN66-318_controller_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_SQUALENE-MONOOXYGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -7531,24 +7599,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44148> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-310_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-130>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7559,7 +7616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7567,26 +7624,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_FERRICYTOCHROME-B5_RXN66-315_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002333_YLR100W-MONOMER_RXN66-319_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002333_YLR100W-MONOMER_RXN66-319_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7601,11 +7647,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'presqualene diphosphate + NAD(P)H + H<SUP>+</SUP> &rarr; squalene + NAD(P)<sup>+</sup> + diphosphate' 'null' 'squalene + a reduced [NADPH-hemoprotein reductase] + oxygen &rarr; (3<i>S</i>)-2,3-epoxy-2,3-dihydrosqualene + an oxidized [NADPH-hemoprotein reductase] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002413_SQUALENE-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002413_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7620,11 +7666,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-312_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7639,11 +7685,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_CHEBI_15377_RXN66-316_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_CHEBI_15377_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7654,15 +7700,37 @@
           <http://model.geneontology.org/CHEBI_15377_RXN66-316>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_CHEBI_15379_RXN3O-227_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002333_YMR202W-MONOMER_RXN3O-203_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002333_YMR202W-MONOMER_RXN3O-203_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7682,7 +7750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7694,11 +7762,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_64925_RXN66-312_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_64925_RXN66-312_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7713,11 +7781,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7737,7 +7805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7749,11 +7817,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7764,9 +7832,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_50586>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-315>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7776,7 +7841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7784,26 +7849,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_CHEBI_15377_RXN66-311_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_50586>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_128769>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_CHEBI_18364_RXN66-306_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_CHEBI_18364_RXN66-306_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7814,33 +7874,41 @@
           <http://model.geneontology.org/CHEBI_18364_RXN66-306>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_128769>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_SQUALENE-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_59789_RXN3O-178_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_15378_RXN66-311_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_CHEBI_15379_RXN66-310_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000066_reaction_RXN66-306_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN66-314>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0102176> ;
@@ -7861,7 +7929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7869,44 +7937,44 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_CHEBI_87287_RXN66-311_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_18249_RXN3O-227_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002333_YMR202W-MONOMER_RXN3O-203_controller_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002333_MONOMER3O-232_RXN3O-227_controller_SGD_YeastPathways_PWY3O-31704>
+<http://purl.obolibrary.org/obo/GO_0004337>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_18364_RXN66-306_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004337>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YLR100W-MONOMER_RXN66-314_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004090> ;
@@ -7915,7 +7983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7923,37 +7991,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002413_RXN66-281_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15440_RXN66-281_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15440_RXN66-281_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7964,48 +8010,29 @@
           <http://model.geneontology.org/CHEBI_15440_RXN66-281>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_CHEBI_17813_RXN3O-130_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002234_CHEBI_52972_RXN3O-218_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_CHEBI_87289_RXN66-310_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002233_Red-NADPH-Hemoprotein-Reductases_RXN3O-130_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/635234a2-ce53-45b1-a716-7b83a0bce81e_RXN66-315>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_52967c99-dc66-4058-8345-fa6f053e837e_RXN66-317_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_8e628c17-7080-4a0e-b881-644ec8e74be4_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8013,18 +8040,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/52967c99-dc66-4058-8345-fa6f053e837e_RXN66-317>
+          <http://model.geneontology.org/8e628c17-7080-4a0e-b881-644ec8e74be4_RXN66-317>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8038,14 +8065,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_CHEBI_15377_RXN66-316_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_29888_RXN-12263_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_CHEBI_15378_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8053,11 +8091,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002333_YLR100W-MONOMER_RXN66-314_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002333_YLR100W-MONOMER_RXN66-314_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8068,6 +8106,17 @@
           <http://model.geneontology.org/YLR100W-MONOMER_RXN66-314_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-312_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0000250>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -8075,11 +8124,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_CHEBI_15378_RXN3O-130_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_CHEBI_15378_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8090,15 +8139,32 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-130>
 ] .
 
+<http://model.geneontology.org/400b0e26-a014-4f59-8113-24f29e48fe4d_RXN66-316>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44191> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_15378_RXN66-319_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_15378_RXN66-319_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8113,11 +8179,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_57310_RXN-12263_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_57310_RXN-12263_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8132,11 +8198,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_CHEBI_15377_RXN66-311_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_CHEBI_15377_RXN66-311_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8151,11 +8217,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_BFO_0000066_reaction_RXN66-316_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_BFO_0000066_reaction_RXN66-316_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8171,7 +8237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8179,11 +8245,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + zymosterol &rarr; <i>S</i>-adenosyl-L-homocysteine + fecosterol + H<SUP>+</SUP>' 'null' 'fecosterol &rarr; episterol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002413_RXN3O-203_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002413_RXN3O-203_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8213,7 +8279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8230,7 +8296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8238,25 +8304,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000066_reaction_RXN66-319_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002333_YGR060W-MONOMER_RXN66-312_controller_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000066_reaction_RXN66-281_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8269,7 +8324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8281,11 +8336,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8296,6 +8351,17 @@
           <http://model.geneontology.org/CHEBI_58057_GPPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_58349_RXN66-314_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-310>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8305,7 +8371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8313,25 +8379,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_CHEBI_15378_RXN66-317_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-315_BFO_0000066_reaction_RXN66-315_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_13390_RXN66-281_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002233_CHEBI_15378_RXN3O-218_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8347,7 +8413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8377,7 +8443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8389,11 +8455,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_58349_1.3.1.71-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_58349_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8404,25 +8470,58 @@
           <http://model.geneontology.org/CHEBI_58349_1.3.1.71-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000066_reaction_RXN66-306_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_400b0e26-a014-4f59-8113-24f29e48fe4d_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_035b873e-c050-43ed-a7ea-4b01e4948157_RXN66-317_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_Red-NADPH-Hemoprotein-Reductases_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002333_YGL001C-MONOMER_RXN66-313_controller_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-227_BFO_0000066_reaction_RXN3O-227_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002233_CHEBI_50586_RXN3O-203_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8436,24 +8535,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704Protein44466> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002234_CHEBI_16933_1.3.1.71-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005224>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -8462,11 +8550,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8477,15 +8565,26 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704>
 ] .
 
+<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002413_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002333_MONOMER3O-188_RXN3O-178_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002333_MONOMER3O-188_RXN3O-178_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8503,11 +8602,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002333_YNL280C-MONOMER_RXN66-306_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002333_YNL280C-MONOMER_RXN66-306_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8518,15 +8617,37 @@
           <http://model.geneontology.org/YNL280C-MONOMER_RXN66-306_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_15379_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-315_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002234_FERRICYTOCHROME-B5_RXN66-312_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002234_FERRICYTOCHROME-B5_RXN66-312_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8537,15 +8658,37 @@
           <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-312>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002413_RXN3O-227_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_FERROCYTOCHROME-B5_RXN66-311_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8556,15 +8699,26 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002333_YNL280C-MONOMER_RXN66-306_controller_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_CHEBI_15379_RXN66-317_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_CHEBI_15379_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8579,11 +8733,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002234_CHEBI_15377_RXN3O-218_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002234_CHEBI_15377_RXN3O-218_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8598,11 +8752,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_136486_RXN66-313_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_136486_RXN66-313_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8617,11 +8771,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-130_BFO_0000066_reaction_RXN3O-130_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-130_BFO_0000066_reaction_RXN3O-130_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8632,19 +8786,19 @@
           <http://model.geneontology.org/reaction_RXN3O-130_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_52972>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002333_YHR072W-MONOMER_LANOSTEROL-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_64925_RXN66-312_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_52972>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15379_RXN66-315>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15379> ;
@@ -8655,35 +8809,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44120> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002413_RXN3O-130_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002234_CHEBI_50586_RXN3O-203_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGL012W-MONOMER_1.3.1.71-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002980> ;
@@ -8692,7 +8824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8700,88 +8832,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-317_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_15378_1.3.1.71-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000066_reaction_RXN66-314_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002234_FERRICYTOCHROME-B5_RXN3O-218_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002233_CHEBI_13390_RXN66-313_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_52386>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN66-312_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000066_reaction_RXN3O-178_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004161> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -8802,7 +8868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8819,7 +8885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8846,7 +8912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8857,26 +8923,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_15441>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_GPPSYN-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000066_reaction_1.3.1.71-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000066_reaction_1.3.1.71-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8887,40 +8942,29 @@
           <http://model.geneontology.org/reaction_1.3.1.71-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0102176>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_13392_RXN66-313_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002333_YLR056W-MONOMER_RXN3O-218_controller_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002234_CHEBI_64925_RXN66-312_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0102176>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_16526_RXN66-318_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_16526_RXN66-318_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8940,7 +8984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "ergosterol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -8948,18 +8992,15 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://purl.obolibrary.org/obo/CHEBI_57310>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002333_MONOMER3O-232_RXN3O-227_controller_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002333_MONOMER3O-232_RXN3O-227_controller_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8970,14 +9011,14 @@
           <http://model.geneontology.org/MONOMER3O-232_RXN3O-227_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002333_YGR175C-MONOMER_SQUALENE-MONOOXYGENASE-RXN_controller_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_15378_RXN66-312_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8985,11 +9026,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-311_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-311_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9000,48 +9041,18 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_17038_RXN3O-178_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_BFO_0000066_reaction_SQUALENE-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_GPPSYN-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57310>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_CHEBI_15377_RXN66-315_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_CHEBI_15377_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9052,15 +9063,26 @@
           <http://model.geneontology.org/CHEBI_15377_RXN66-315>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002411_RXN66-318_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_18252_RXN66-319_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002233_CHEBI_18252_RXN66-319_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9075,11 +9097,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_15378_RXN66-306_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002233_CHEBI_15378_RXN66-306_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9099,7 +9121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9111,11 +9133,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_15379_RXN66-312_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_15379_RXN66-312_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9133,11 +9155,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_GPPSYN-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9148,6 +9170,17 @@
           <http://model.geneontology.org/CHEBI_57623_GPPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000066_reaction_RXN66-281_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15441_SQUALENE-MONOOXYGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15441> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9157,7 +9190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9168,25 +9201,36 @@
 <http://purl.obolibrary.org/obo/CHEBI_136486>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002233_CHEBI_18364_RXN66-306_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-178_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_635234a2-ce53-45b1-a716-7b83a0bce81e_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9199,7 +9243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9211,11 +9255,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9229,28 +9273,6 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_13392_RXN66-318_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_Red-NADPH-Hemoprotein-Reductases_RXN3O-130_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_87287_RXN66-311>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_87287> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9260,7 +9282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9268,14 +9290,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-203_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_16526_RXN66-318_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9284,7 +9306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9297,7 +9319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9309,11 +9331,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9324,43 +9346,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15440_RXN66-281_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_16933_1.3.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16933> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ergosterol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44402> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000066_reaction_RXN66-306_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000066_reaction_RXN66-306_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9371,48 +9365,32 @@
           <http://model.geneontology.org/reaction_RXN66-306_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_FERROCYTOCHROME-B5_RXN66-312_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_16933_1.3.1.71-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16933> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ergosterol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002333_YHR007C-MONOMER_RXN3O-130_controller_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002413_RXN3O-178_SGD_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44402> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_cb8aaddc-3452-4b8d-bf4e-061fbfec7ada_RXN66-316_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_400b0e26-a014-4f59-8113-24f29e48fe4d_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9420,8 +9398,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/cb8aaddc-3452-4b8d-bf4e-061fbfec7ada_RXN66-316>
+          <http://model.geneontology.org/400b0e26-a014-4f59-8113-24f29e48fe4d_RXN66-316>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002233_CHEBI_15379_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58057_GPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58057> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -9432,7 +9421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9444,11 +9433,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-218_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-218_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9466,7 +9455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9477,14 +9466,14 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_CHEBI_15377_RXN3O-227_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN66-316_BFO_0000066_reaction_RXN66-316_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9492,11 +9481,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_136486_RXN66-313_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_136486_RXN66-313_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9507,25 +9496,14 @@
           <http://model.geneontology.org/CHEBI_136486_RXN66-313>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000066_reaction_RXN66-318_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002333_YGR060W-MONOMER_RXN66-316_controller_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_CHEBI_15377_RXN66-315_SGD_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9533,11 +9511,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002233_CHEBI_175763_FPPSYN-RXN_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002233_CHEBI_175763_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9557,7 +9535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9565,15 +9543,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002413_RXN3O-218_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000050_YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9593,7 +9582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9605,11 +9594,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_CHEBI_52972_RXN3O-218_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_CHEBI_52972_RXN3O-218_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9620,15 +9609,26 @@
           <http://model.geneontology.org/CHEBI_52972_RXN3O-218>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_CHEBI_15377_RXN66-311_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_CHEBI_15377_RXN66-310_SGD_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_CHEBI_15377_RXN66-310_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9639,13 +9639,13 @@
           <http://model.geneontology.org/CHEBI_15377_RXN66-310>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_15378_RXN66-315_SGD_YeastPathways_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002333_YGR175C-MONOMER_SQUALENE-MONOOXYGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-31723.ttl
+++ b/models/YeastPathways_PWY3O-31723.ttl
@@ -1,14 +1,3 @@
-<http://model.geneontology.org/ev_w_id_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_BFO_0000051_SGD_S000001665_CPLX-7627_component_SGD_YeastPathways_PWY3O-31723>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31723" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -17,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -30,7 +19,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,15 +27,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57288_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31723>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31723" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_15378_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_15378_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -66,7 +66,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -83,41 +83,8 @@
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57384_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31723>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31723" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_33184_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31723>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31723" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57783_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31723>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31723" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -132,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -140,32 +107,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57783_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31723>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31723" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000006152>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57288_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31723>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31723" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_FATTY-ACYL-COA-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_FATTY-ACYL-COA-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -176,6 +143,17 @@
           <http://model.geneontology.org/reaction_FATTY-ACYL-COA-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_BFO_0000051_SGD_S000006152_CPLX-7627_component_SGD_PWY_YeastPathways_PWY3O-31723>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31723" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -184,18 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002333_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY3O-31723>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31723" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -211,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -246,11 +213,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_16526_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_16526_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -261,17 +228,6 @@
           <http://model.geneontology.org/CHEBI_16526_FATTY-ACYL-COA-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_15378_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31723>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31723" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -279,11 +235,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002333_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002333_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -298,11 +254,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-31723/YeastPathways_PWY3O-31723_SGD_YeastPathways_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-31723/YeastPathways_PWY3O-31723_SGD_PWY_YeastPathways_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -330,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,6 +297,28 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_58349_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31723>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31723" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_15378_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31723>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31723" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -350,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -358,25 +336,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_FATTY-ACYL-COA-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-31723>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31723" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57288>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_33184_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31723>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31723" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_BFO_0000051_SGD_S000001665_CPLX-7627_component_SGD_PWY_YeastPathways_PWY3O-31723>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31723" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004321>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -388,11 +377,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57783_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57783_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,14 +392,14 @@
           <http://model.geneontology.org/CHEBI_57783_FATTY-ACYL-COA-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_58349_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31723>
+<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57384_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31723>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31723" ;
+                "SGD_PWY:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -419,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -427,11 +416,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_58349_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_58349_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -446,11 +435,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_BFO_0000051_SGD_S000006152_CPLX-7627_component_SGD_YeastPathways_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_BFO_0000051_SGD_S000006152_CPLX-7627_component_SGD_PWY_YeastPathways_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -470,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -487,24 +476,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31723SmallMolecule75673> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_16526_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31723>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31723" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001665>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -518,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fatty acids biosynthesis (yeast) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -538,15 +516,18 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57384_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57384_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -557,8 +538,16 @@
           <http://model.geneontology.org/CHEBI_57384_FATTY-ACYL-COA-SYNTHASE-RXN>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_FATTY-ACYL-COA-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31723>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31723" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -572,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -580,15 +569,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_16526_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31723>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31723" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002333_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-31723>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31723" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_57287_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_57287_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -603,11 +614,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_BFO_0000051_SGD_S000001665_CPLX-7627_component_SGD_YeastPathways_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_BFO_0000051_SGD_S000001665_CPLX-7627_component_SGD_PWY_YeastPathways_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -617,17 +628,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/SGD_S000001665_CPLX-7627_component>
 ] .
-
-<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-31723/YeastPathways_PWY3O-31723_SGD_YeastPathways_PWY3O-31723>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31723" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -647,13 +647,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31723SmallMolecule75703> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-31723/YeastPathways_PWY3O-31723_SGD_PWY_YeastPathways_PWY3O-31723>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31723" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -662,11 +673,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57288_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002233_CHEBI_57288_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -677,14 +688,14 @@
           <http://model.geneontology.org/CHEBI_57288_FATTY-ACYL-COA-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_57287_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31723>
+<http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_57287_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31723>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31723" ;
+                "SGD_PWY:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -692,11 +703,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_33184_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-31723> ;
+          <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_33184_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31723> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -709,14 +720,3 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_BFO_0000051_SGD_S000006152_CPLX-7627_component_SGD_YeastPathways_PWY3O-31723>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31723" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-335.ttl
+++ b/models/YeastPathways_PWY3O-335.ttl
@@ -1,59 +1,26 @@
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_16583_RXN-6081_SGD_YeastPathways_PWY3O-335>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002413_RXN-6081_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15378_RXN-6081_SGD_YeastPathways_PWY3O-335>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
+                "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000515>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15361_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-335>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000066_reaction_ACETOLACTSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-335>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -68,11 +35,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_57945_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_57945_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -87,11 +54,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>S</i>)-2-acetolactate + an oxidized electron acceptor + H<SUP>+</SUP> &rarr; diacetyl + CO<SUB>2</SUB> + a reduced electron acceptor' 'null' 'acetoin + NAD<sup>+</sup> &larr; diacetyl + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002413_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002413_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -108,6 +75,20 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15378_RXN-6081_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58476>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CPLX3O-79_ACETOINDEHYDROG-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -117,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -125,21 +106,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://purl.obolibrary.org/obo/CHEBI_58476>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000050_YeastPathways_PWY3O-335/YeastPathways_PWY3O-335_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15339_RXN-6081_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15339_RXN-6081_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -159,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "acetoin biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -179,6 +168,39 @@
 <http://purl.obolibrary.org/obo/GO_0045151>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-335/YeastPathways_PWY3O-335_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000066_reaction_RXN-6081_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_16583_RXN-6081_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000000056>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -186,11 +208,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_58476_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_58476_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -205,11 +227,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_16583_RXN-6081_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_16583_RXN-6081_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,17 +242,6 @@
           <http://model.geneontology.org/CHEBI_16583_RXN-6081>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_16e0be0a-08e5-4f18-bd0a-dd6177778ff7_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-335>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -240,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -252,11 +263,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_17499_RXN-6081_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_17499_RXN-6081_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,28 +278,6 @@
           <http://model.geneontology.org/CHEBI_17499_RXN-6081>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_57540_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-335>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_58476_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-335>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -298,29 +287,40 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002333_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-335>
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_BFO_0000066_reaction_ACETOINDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-335>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
+                "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15361_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000066_reaction_RXN-6081_location_lociGO_0005829_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000066_reaction_RXN-6081_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -330,6 +330,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN-6081_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_17499_RXN-6081_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16526_RXN-6081_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16583>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -343,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -354,15 +376,18 @@
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,18 +398,37 @@
           <http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component>
 ] .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_57945_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000050_YeastPathways_PWY3O-335/YeastPathways_PWY3O-335_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000050_YeastPathways_PWY3O-335/YeastPathways_PWY3O-335_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,17 +439,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-335/YeastPathways_PWY3O-335>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_BFO_0000066_reaction_ACETOINDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-335>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15361_ACETOLACTSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15361> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -415,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -428,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -439,11 +472,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_16526_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_16526_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -454,26 +487,15 @@
           <http://model.geneontology.org/CHEBI_16526_ACETOLACTSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_17499_RXN-6081_SGD_YeastPathways_PWY3O-335>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_15378_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_15378_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -484,14 +506,25 @@
           <http://model.geneontology.org/CHEBI_15378_ACETOINDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002413_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-335>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_58476_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
+                "SGD_PWY:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002333_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -499,11 +532,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16583_RXN-6081_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16583_RXN-6081_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -536,13 +569,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-335BiochemicalReaction22388> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-6081>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -553,7 +597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -561,51 +605,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_YeastPathways_PWY3O-335>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000066_reaction_ACETOLACTSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
+                "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_58476_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-335>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16583_RXN-6081_SGD_YeastPathways_PWY3O-335>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000050_YeastPathways_PWY3O-335/YeastPathways_PWY3O-335_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000050_YeastPathways_PWY3O-335/YeastPathways_PWY3O-335_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -616,12 +638,34 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-335/YeastPathways_PWY3O-335>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15339_RXN-6081_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
         a       <http://identifiers.org/sgd/S000004714> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -636,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -644,11 +688,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -659,26 +703,15 @@
           <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_57945_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-335>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002333_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002333_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -689,56 +722,6 @@
           <http://model.geneontology.org/CPLX3O-79_ACETOINDEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15339_RXN-6081_SGD_YeastPathways_PWY3O-335>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/16e0be0a-08e5-4f18-bd0a-dd6177778ff7_ACETOINDEHYDROG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-335SmallMolecule22271> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_YeastPathways_PWY3O-335>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000050_YeastPathways_PWY3O-335/YeastPathways_PWY3O-335_SGD_YeastPathways_PWY3O-335>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16583_RXN-6081>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16583> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -748,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -760,11 +743,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -779,11 +762,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_BFO_0000066_reaction_ACETOINDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_BFO_0000066_reaction_ACETOINDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,29 +777,29 @@
           <http://model.geneontology.org/reaction_ACETOINDEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57945>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_YeastPathways_PWY3O-335>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002413_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
+                "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57945>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16526_RXN-6081_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16526_RXN-6081_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -826,6 +809,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16526_RXN-6081>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16583_RXN-6081_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -839,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -852,18 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_YeastPathways_PWY3O-335>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -876,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -884,19 +867,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16526_RXN-6081_SGD_YeastPathways_PWY3O-335>
+<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_58476_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-335>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
+                "SGD_PWY:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_dc659465-4cf2-4d3f-adce-bc87d5acae32_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_15378_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004714>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -908,11 +913,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -930,11 +935,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_16e0be0a-08e5-4f18-bd0a-dd6177778ff7_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_dc659465-4cf2-4d3f-adce-bc87d5acae32_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -942,7 +947,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ACETOINDEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/16e0be0a-08e5-4f18-bd0a-dd6177778ff7_ACETOINDEHYDROG-RXN>
+          <http://model.geneontology.org/dc659465-4cf2-4d3f-adce-bc87d5acae32_ACETOINDEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_17499_RXN-6081>
@@ -954,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -979,7 +984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1002,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1015,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1028,7 +1033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1040,11 +1045,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15361_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15361_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1066,13 +1071,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57945_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_15378_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_16583_RXN-6081> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/16e0be0a-08e5-4f18-bd0a-dd6177778ff7_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN> ;
+                <http://model.geneontology.org/dc659465-4cf2-4d3f-adce-bc87d5acae32_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-79_ACETOINDEHYDROG-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1087,11 +1092,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-335/YeastPathways_PWY3O-335_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-335/YeastPathways_PWY3O-335_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1102,26 +1107,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-335/YeastPathways_PWY3O-335>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002413_RXN-6081_SGD_YeastPathways_PWY3O-335>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_58476_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_58476_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1141,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1152,19 +1146,19 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000050_YeastPathways_PWY3O-335/YeastPathways_PWY3O-335_SGD_YeastPathways_PWY3O-335>
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_16526_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-335>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
+                "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-335/YeastPathways_PWY3O-335>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0045151> ;
@@ -1175,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1195,7 +1189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1203,25 +1197,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-335>
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_57540_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-335>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
+                "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_15378_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-335>
+<http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000050_YeastPathways_PWY3O-335/YeastPathways_PWY3O-335_SGD_PWY_YeastPathways_PWY3O-335>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
+                "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1233,7 +1227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1241,11 +1235,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 pyruvate + H<SUP>+</SUP> &rarr; (<i>S</i>)-2-acetolactate + CO<SUB>2</SUB>' 'null' '(<i>S</i>)-2-acetolactate + an oxidized electron acceptor + H<SUP>+</SUP> &rarr; diacetyl + CO<SUB>2</SUB> + a reduced electron acceptor' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002413_RXN-6081_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002413_RXN-6081_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1260,11 +1254,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_57540_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_57540_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1275,21 +1269,46 @@
           <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/dc659465-4cf2-4d3f-adce-bc87d5acae32_ACETOINDEHYDROG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-335SmallMolecule22271> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000066_reaction_ACETOLACTSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000066_reaction_ACETOLACTSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1300,26 +1319,18 @@
           <http://model.geneontology.org/reaction_ACETOLACTSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_16526_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-335>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15378_RXN-6081_SGD_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15378_RXN-6081_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1339,7 +1350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1347,24 +1358,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-335/YeastPathways_PWY3O-335_SGD_YeastPathways_PWY3O-335>
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_PWY_YeastPathways_PWY3O-335>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000066_reaction_RXN-6081_location_lociGO_0005829_SGD_YeastPathways_PWY3O-335>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-335" ;
+                "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-351.ttl
+++ b/models/YeastPathways_PWY3O-351.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_58828_R145-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_58828_R145-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,14 +17,14 @@
           <http://model.geneontology.org/CHEBI_58828_R145-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000066_reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15378_R147-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -32,11 +32,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000066_reaction_SAMDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000066_reaction_SAMDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -52,18 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -71,11 +60,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_15379_R147-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_15379_R147-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -86,17 +75,6 @@
           <http://model.geneontology.org/CHEBI_15379_R147-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_SAMDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -106,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,37 +95,15 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002333_YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002333_MONOMER3O-186_R147-RXN_controller_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002333_MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002333_MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,25 +114,14 @@
           <http://model.geneontology.org/MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002413_R15-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -184,11 +129,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_15378_SPERMIDINESYN-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_15378_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -199,29 +144,29 @@
           <http://model.geneontology.org/CHEBI_15378_SPERMIDINESYN-RXN>
 ] .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY3O-351>
+<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_CPLX-9432_R15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_57844_R15-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_57844_R15-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -241,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -252,15 +197,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX-9432_R15-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_R15-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,25 +230,14 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000066_reaction_R15-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351>
+<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000066_reaction_3.1.3.77-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_57844_R15-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -300,11 +245,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_45725_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_45725_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -319,11 +264,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -351,36 +296,47 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002333_MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002413_5.3.1.23-RXN_SGD_YeastPathways_PWY3O-351>
+<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002413_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_43474_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_16723_R147-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -393,7 +349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -401,15 +357,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_16526_SAMDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -420,18 +387,40 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-351/YeastPathways_PWY3O-351>
 ] .
 
+<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002413_5.3.1.23-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58795>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002333_MONOMER3O-186_R147-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" , "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine' 'null' 'putrescine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermidine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMIDINESYN-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -442,14 +431,14 @@
           <http://model.geneontology.org/SPERMIDINESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351>
+<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_16723_R147-RXN_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -460,11 +449,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + oxygen &rarr; 4-(methylsulfanyl)-2-oxobutanoate + formate + H<SUP>+</SUP>' 'null' 'L-methionine + a 2-oxo carboxylate &larr; 4-(methylsulfanyl)-2-oxobutanoate + a proteinogenic amino acid' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002413_R15-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002413_R15-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -482,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -490,14 +479,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_326268_SPERMIDINESYN-RXN_SGD_YeastPathways_PWY3O-351>
+<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000066_reaction_5.3.1.23-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000066_reaction_SPERMINE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -510,7 +510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -518,14 +518,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351>
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -536,11 +536,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" , "Provides Input For Rule. The relation '<i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate &rarr; 5-(methylsulfanyl)-ribulose 1-phosphate' 'null' '5-(methylsulfanyl)-ribulose 1-phosphate &rarr; 5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002413_R145-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002413_R145-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,15 +554,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_45725>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002333_MONOMER3O-175_3.1.3.77-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000066_reaction_SPERMINE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000066_reaction_SPERMINE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -573,15 +584,26 @@
           <http://model.geneontology.org/reaction_SPERMINE-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_15378_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_58828_R145-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_58828_R145-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -592,48 +614,15 @@
           <http://model.geneontology.org/CHEBI_58828_R145-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002333_YOL052C-MONOMER_SAMDECARB-RXN_controller_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR208W-MONOMER_R15-RXN_controller_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -644,17 +633,6 @@
           <http://model.geneontology.org/reaction_S-ADENMETSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YLR180W-MONOMER_S-ADENMETSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000004170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -662,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -677,35 +655,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-351Protein34759> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_17509_SPERMIDINESYN-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58548>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -714,11 +670,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_15378_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_15378_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -729,17 +685,6 @@
           <http://model.geneontology.org/CHEBI_15378_3.1.3.77-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57834_SPERMIDINESYN-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16723_R147-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16723> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -749,7 +694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -766,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -778,11 +723,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -797,11 +742,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_58795_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_58795_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -819,11 +764,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>S</i>-methyl-5'-thioadenosine + phosphate &rarr; adenine + <i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate' 'null' '<i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate &rarr; 5-(methylsulfanyl)-ribulose 1-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002413_5.3.1.23-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002413_5.3.1.23-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -856,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -864,14 +809,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002233_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-351>
+<http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000066_reaction_R145-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -879,11 +824,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_17509_SPERMIDINESYN-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_17509_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -894,6 +839,17 @@
           <http://model.geneontology.org/CHEBI_17509_SPERMIDINESYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002413_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0010309>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -901,11 +857,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_CPLX-9432_R15-RXN_controller_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_CPLX-9432_R15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,7 +903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -967,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -975,26 +931,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002333_CPLX3O-113_5.3.1.23-RXN_controller_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1005,15 +950,26 @@
           <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002234_CHEBI_58548_5.3.1.23-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002333_YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002333_YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1023,6 +979,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YJR148W-MONOMER_R15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/R147-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0010309> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1043,7 +1010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1058,7 +1025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1070,11 +1037,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1085,6 +1052,28 @@
           <http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002333_YLR146C-MONOMER_SPERMINE-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER3O-1014_S-ADENMETSYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002910> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1092,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1103,6 +1092,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_16723>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_45725_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1110,11 +1110,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000066_reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000066_reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1128,40 +1128,18 @@
 <http://identifiers.org/sgd/S000006273>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_15378_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" , "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine' 'null' 'spermidine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1172,6 +1150,17 @@
           <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_16708_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000004007> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1179,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1191,11 +1180,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1210,11 +1199,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1235,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1247,11 +1236,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1262,6 +1251,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-351/YeastPathways_PWY3O-351>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000066_reaction_SAMDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-351>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1271,7 +1271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of methionine salvage pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1283,11 +1283,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000066_reaction_R15-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000066_reaction_R15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1307,7 +1307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1315,15 +1315,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002333_YPR069C-MONOMER_SPERMIDINESYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_15377_R145-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15740_R147-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1338,11 +1371,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002333_MONOMER3O-169_R145-RXN_controller_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002333_MONOMER3O-169_R145-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1353,14 +1386,14 @@
           <http://model.geneontology.org/MONOMER3O-169_R145-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_PWY3O-351>
+<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_83813_R15-RXN_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1368,11 +1401,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1383,51 +1416,29 @@
           <http://model.geneontology.org/CHEBI_15377_S-ADENMETSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_58828_R145-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002413_R145-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_15377_R145-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57844>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15378_R147-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_43474_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_43474_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1438,28 +1449,6 @@
           <http://model.geneontology.org/CHEBI_43474_3.1.3.77-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_CPLX-9432_R15-RXN_controller_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_43474_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004766>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1467,11 +1456,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1482,25 +1471,14 @@
           <http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000066_reaction_R147-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_15377_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1523,7 +1501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1535,11 +1513,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15378_R147-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15378_R147-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1549,6 +1527,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_R147-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002333_MONOMER3O-169_R145-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002413_R147-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1560,11 +1560,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1583,7 +1583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1591,11 +1591,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_57834_SPERMIDINESYN-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_57834_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1606,17 +1606,6 @@
           <http://model.geneontology.org/CHEBI_57834_SPERMIDINESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000066_reaction_SPERMINE-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/MONOMER3O-169_R145-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1624,7 +1613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1636,11 +1625,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR137W-MONOMER_R15-RXN_controller_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR137W-MONOMER_R15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1651,14 +1640,25 @@
           <http://model.geneontology.org/YHR137W-MONOMER_R15-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_15379_R147-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002413_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1671,7 +1671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1686,11 +1686,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1710,7 +1710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1718,26 +1718,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_58795_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'spermidine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' 'null' '<i>S</i>-methyl-5'-thioadenosine + phosphate &rarr; adenine + <i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002413_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002413_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1748,26 +1737,15 @@
           <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_83813_R15-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1781,19 +1759,19 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://identifiers.org/sgd/S000005412>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000066_reaction_SAMDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351>
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000005412>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15377_3.1.3.77-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -1804,7 +1782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1812,45 +1790,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_43474_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_SAMDECARB-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_15379_R147-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57834_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1858,11 +1825,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_43474_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_43474_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1873,6 +1840,17 @@
           <http://model.geneontology.org/CHEBI_43474_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15740_R147-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15740> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1882,7 +1860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1899,7 +1877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1907,37 +1885,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_16526_SAMDECARB-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000066_reaction_SPERMIDINESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000066_reaction_SPERMIDINESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1948,14 +1904,14 @@
           <http://model.geneontology.org/reaction_SPERMIDINESYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YJR148W-MONOMER_R15-RXN_controller_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX-9432_R15-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1963,11 +1919,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_16723_R147-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_16723_R147-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1978,44 +1934,11 @@
           <http://model.geneontology.org/CHEBI_16723_R147-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002413_R145-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000001251>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000002910>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002333_MONOMER3O-169_R145-RXN_controller_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_15378_SPERMIDINESYN-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_83813_R15-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_83813> ;
@@ -2026,24 +1949,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-351SmallMolecule34676> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002333_MONOMER3O-175_3.1.3.77-RXN_controller_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/S-ADENMETSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004478> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2064,7 +1976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2072,15 +1984,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_17509_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57834_SPERMIDINESYN-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57834_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2096,7 +2030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2104,11 +2038,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '5-(methylsulfanyl)-ribulose 1-phosphate &rarr; 5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O' 'null' '5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O &rarr; 1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002413_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002413_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2131,7 +2065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2139,26 +2073,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002333_YPR069C-MONOMER_SPERMIDINESYN-RXN_controller_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2178,17 +2101,6 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_43474_3.1.3.77-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2198,7 +2110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2206,25 +2118,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_R15-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2232,11 +2133,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_58795_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_58795_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2247,14 +2148,25 @@
           <http://model.geneontology.org/CHEBI_58795_3.1.3.77-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_16723_R147-RXN_SGD_YeastPathways_PWY3O-351>
+<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_15377_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR137W-MONOMER_R15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2262,11 +2174,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_16526_SAMDECARB-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_16526_SAMDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2277,14 +2189,36 @@
           <http://model.geneontology.org/CHEBI_16526_SAMDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002413_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_58795_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2292,11 +2226,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15740_R147-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15740_R147-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2307,14 +2241,25 @@
           <http://model.geneontology.org/CHEBI_15740_R147-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351>
+<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_58828_R145-RXN_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002333_YOL052C-MONOMER_SAMDECARB-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2325,11 +2270,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000066_reaction_5.3.1.23-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000066_reaction_5.3.1.23-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2346,26 +2291,15 @@
 <http://identifiers.org/sgd/S000004007>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000066_reaction_SPERMIDINESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002333_YPR069C-MONOMER_SPERMIDINESYN-RXN_controller_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002333_YPR069C-MONOMER_SPERMIDINESYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2385,7 +2319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2393,15 +2327,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR208W-MONOMER_R15-RXN_controller_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR208W-MONOMER_R15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2415,19 +2360,19 @@
 <http://identifiers.org/sgd/S000004611>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002413_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://purl.obolibrary.org/obo/CHEBI_58533>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58533>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0046570>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2437,21 +2382,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0043874>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002413_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2459,11 +2404,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000066_reaction_R145-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000066_reaction_R145-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2474,15 +2419,37 @@
           <http://model.geneontology.org/reaction_R145-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002413_R15-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2497,11 +2464,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2512,36 +2479,25 @@
           <http://model.geneontology.org/YLR180W-MONOMER_S-ADENMETSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15740_R147-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-351>
+<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR208W-MONOMER_R15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000066_reaction_R145-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351>
+<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002233_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2549,11 +2505,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000066_reaction_3.1.3.77-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000066_reaction_3.1.3.77-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2564,14 +2520,14 @@
           <http://model.geneontology.org/reaction_3.1.3.77-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR137W-MONOMER_R15-RXN_controller_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002413_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2579,11 +2535,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" , "Provides Input For Rule. The relation 'ATP + L-methionine + H<sub>2</sub>O &rarr; <i>S</i>-adenosyl-L-methionine + phosphate + diphosphate' 'null' '<i>S</i>-adenosyl-L-methionine + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002413_SAMDECARB-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002413_SAMDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2606,7 +2562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2623,7 +2579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2640,7 +2596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2648,14 +2604,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY3O-351>
+<http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2668,7 +2624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2680,11 +2636,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2714,7 +2670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2731,24 +2687,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-351SmallMolecule34790> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002413_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-113_5.3.1.23-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -2759,7 +2704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2771,11 +2716,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_16708_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_16708_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2795,7 +2740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2818,7 +2763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2834,7 +2779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2842,11 +2787,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_326268_SPERMIDINESYN-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_326268_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2856,6 +2801,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_326268_SPERMIDINESYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_43474_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2868,18 +2824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_58828_R145-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2887,11 +2832,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_83813_R15-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_83813_R15-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2911,7 +2856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2928,7 +2873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2936,25 +2881,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_16708_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-351>
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_58795_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2965,11 +2899,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2989,7 +2923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3000,15 +2934,26 @@
 <http://identifiers.org/sgd/S000003170>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_R15-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_R15-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3025,29 +2970,40 @@
 <http://purl.obolibrary.org/obo/CHEBI_17509>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002233_CHEBI_58548_5.3.1.23-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0071267>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_R147-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3055,11 +3011,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002333_MONOMER3O-175_3.1.3.77-RXN_controller_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002333_MONOMER3O-175_3.1.3.77-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3075,40 +3031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002413_SAMDECARB-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000066_reaction_3.1.3.77-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_45725_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3116,11 +3039,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3140,7 +3063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3148,40 +3071,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX-9432_R15-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0017061>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_16723_R147-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_16723_R147-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3201,7 +3102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3218,7 +3119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3226,12 +3127,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_R15-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3254,7 +3166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3269,7 +3181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3281,11 +3193,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002233_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002233_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3296,14 +3208,14 @@
           <http://model.geneontology.org/CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3314,11 +3226,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" , "Provides Input For Rule. The relation 'putrescine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermidine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' 'null' 'spermidine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3329,14 +3241,25 @@
           <http://model.geneontology.org/SPERMINE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY3O-351>
+<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_35910_R15-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3344,11 +3267,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YJR148W-MONOMER_R15-RXN_controller_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YJR148W-MONOMER_R15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3364,7 +3287,40 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_57844_R15-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3372,11 +3328,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002233_CHEBI_58548_5.3.1.23-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002233_CHEBI_58548_5.3.1.23-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3406,7 +3362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3414,19 +3370,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMIDINESYN-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0017061> ;
@@ -3447,7 +3403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3464,35 +3420,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-351SmallMolecule34737> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000066_reaction_5.3.1.23-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_16723_R147-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -3501,11 +3435,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_15377_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_15377_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3516,14 +3450,14 @@
           <http://model.geneontology.org/CHEBI_15377_3.1.3.77-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3531,11 +3465,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3546,6 +3480,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-351/YeastPathways_PWY3O-351>
 ] .
 
+<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002333_CPLX3O-113_5.3.1.23-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -3554,13 +3499,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000066_reaction_R147-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000066_reaction_R147-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3578,7 +3523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3586,26 +3531,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3623,13 +3557,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-351Protein34692> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3638,11 +3583,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3672,7 +3617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3680,14 +3625,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_YeastPathways_PWY3O-351>
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000066_reaction_R15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3698,11 +3654,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_35910_R15-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_35910_R15-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3713,40 +3669,18 @@
           <http://model.geneontology.org/CHEBI_35910_R15-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_57834_SPERMIDINESYN-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57443>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002413_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3757,32 +3691,26 @@
           <http://model.geneontology.org/CHEBI_17509_SPERMINE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_15377_R145-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
+<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002333_MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-351SmallMolecule34552> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3802,7 +3730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3810,14 +3738,42 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_PWY3O-351>
+<http://model.geneontology.org/CHEBI_15377_R145-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-351SmallMolecule34552> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002413_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_58795_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3828,11 +3784,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O &rarr; 1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + phosphate + H<SUP>+</SUP>' 'null' '1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + oxygen &rarr; 4-(methylsulfanyl)-2-oxobutanoate + formate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002413_R147-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002413_R147-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3843,14 +3799,14 @@
           <http://model.geneontology.org/R147-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_15378_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3861,11 +3817,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002333_YOL052C-MONOMER_SAMDECARB-RXN_controller_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002333_YOL052C-MONOMER_SAMDECARB-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3876,15 +3832,26 @@
           <http://model.geneontology.org/YOL052C-MONOMER_SAMDECARB-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002233_CHEBI_58548_5.3.1.23-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002333_MONOMER3O-186_R147-RXN_controller_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002333_MONOMER3O-186_R147-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3895,15 +3862,48 @@
           <http://model.geneontology.org/MONOMER3O-186_R147-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000066_reaction_SPERMIDINESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002413_SAMDECARB-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002234_CHEBI_58548_5.3.1.23-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002234_CHEBI_58548_5.3.1.23-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3914,26 +3914,15 @@
           <http://model.geneontology.org/CHEBI_58548_5.3.1.23-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002234_CHEBI_58548_5.3.1.23-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" , "Provides Input For Rule. The relation 'putrescine + <i>S</i>-adenosyl 3-(methylsulfanyl)propylamine &rarr; spermidine + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' 'null' '<i>S</i>-methyl-5'-thioadenosine + phosphate &rarr; adenine + <i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002413_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002413_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3944,25 +3933,14 @@
           <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002413_R147-RXN_SGD_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_35910_R15-RXN_SGD_YeastPathways_PWY3O-351>
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_326268_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3970,11 +3948,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" , "Provides Input For Rule. The relation 'L-methionine + a 2-oxo carboxylate &larr; 4-(methylsulfanyl)-2-oxobutanoate + a proteinogenic amino acid' 'null' 'ATP + L-methionine + H<sub>2</sub>O &rarr; <i>S</i>-adenosyl-L-methionine + phosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002413_S-ADENMETSYN-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002413_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3985,15 +3963,26 @@
           <http://model.geneontology.org/S-ADENMETSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002234_CHEBI_57834_SPERMIDINESYN-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002333_CPLX3O-113_5.3.1.23-RXN_controller_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002333_CPLX3O-113_5.3.1.23-RXN_controller_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4011,11 +4000,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4031,7 +4020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4042,11 +4031,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_15377_R145-RXN_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_15377_R145-RXN_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4061,11 +4050,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4076,19 +4065,19 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-351/YeastPathways_PWY3O-351>
 ] .
 
-<http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000066_reaction_R147-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-351>
+<http://purl.obolibrary.org/obo/CHEBI_59789>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000066_reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-351" ;
+                "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_59789>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YHR137W-MONOMER_R15-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001179> ;
@@ -4097,10 +4086,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-351Protein34707> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_58828_R145-RXN_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-355.ttl
+++ b/models/YeastPathways_PWY3O-355.ttl
@@ -1,29 +1,23 @@
-<http://model.geneontology.org/CHEBI_15378_RXN-9633>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
+<http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000066_reaction_RXN-9634_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-355SmallMolecule18742> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_CHEBI_57394_RXN3O-5304_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_CHEBI_57394_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,11 +32,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_Palmitoyl-ACPs_RXN3O-1803_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_Palmitoyl-ACPs_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,7 +56,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -70,29 +64,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_CHEBI_57394_RXN3O-5304_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_25629>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_57287_RXN-9624_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_57287_RXN-9624_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -103,14 +83,28 @@
           <http://model.geneontology.org/CHEBI_57287_RXN-9624>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002413_RXN-9633_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://purl.obolibrary.org/obo/CHEBI_25629>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_15377_RXN-9624_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -123,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -131,44 +125,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_Palmitoyl-ACPs_RXN3O-1803_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002333_YKL182W-MONOMER_RXN3O-5293_controller_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YPL231W-MONOMER_RXN3O-1803_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006152> ;
@@ -177,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -189,11 +150,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000066_reaction_RXN3O-5293_location_lociGO_0005829_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000066_reaction_RXN3O-5293_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -208,11 +169,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -223,23 +184,12 @@
           <http://model.geneontology.org/R-3-hydroxystearoyl-ACPs_RXN-9633>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_57287_RXN-9624_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-5293_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -252,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -269,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -286,39 +236,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_25629_RXN-9624_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_Octadec-2-enoyl-ACPs_RXN-9634_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58349_RXN-9633>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -328,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -340,11 +257,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -355,15 +272,37 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-355/YeastPathways_PWY3O-355>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_CHEBI_15378_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" , "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxyoctadecanoyl-[acp] &rarr; a (2<i>E</i>)-octadec-2-enoyl-[acp] + H<sub>2</sub>O' 'null' 'a stearoyl-[acp] + NADP<sup>+</sup> &larr; a (2<i>E</i>)-octadec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002413_RXN3O-5293_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002413_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -374,6 +313,17 @@
           <http://model.geneontology.org/RXN3O-5293>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -381,11 +331,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000066_reaction_RXN-9624_location_lociGO_0005829_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000066_reaction_RXN-9624_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -396,51 +346,40 @@
           <http://model.geneontology.org/reaction_RXN-9624_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_Stearoyl-ACPs_RXN3O-5293_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000066_reaction_RXN-9624_location_lociGO_0005829_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002413_RXN-9634_SGD_YeastPathways_PWY3O-355>
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002413_RXN-9633_SGD_PWY_YeastPathways_PWY3O-355>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
+                "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002413_RXN-9634_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -451,40 +390,62 @@
           <http://model.geneontology.org/3-oxo-stearoyl-ACPs_RXN3O-1803>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_RXN-9624_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_15378_RXN-9633_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_15378_RXN-9624_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_Octadec-2-enoyl-ACPs_RXN-9634_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_CHEBI_57287_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000863>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_15378_RXN3O-5293_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_Octadec-2-enoyl-ACPs_RXN-9634_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_Octadec-2-enoyl-ACPs_RXN-9634_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -519,11 +480,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000066_reaction_RXN-9634_location_lociGO_0005829_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000066_reaction_RXN-9634_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -536,28 +497,6 @@
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_57783_RXN3O-5293_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_CHEBI_15378_RXN3O-1803_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9634>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -578,7 +517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -595,24 +534,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-355SmallMolecule18700> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_ACP_RXN3O-1803_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/Palmitoyl-ACPs_RXN3O-1803>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -623,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -631,26 +559,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_Stearoyl-ACPs_RXN3O-5293_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_Stearoyl-ACPs_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,26 +578,15 @@
           <http://model.geneontology.org/Stearoyl-ACPs_RXN3O-5293>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_ACP_RXN3O-1803_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_ACP_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -698,11 +604,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_15378_RXN-9624_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_15378_RXN-9624_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,73 +619,18 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-9624>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YER061C-MONOMER_RXN3O-1803_controller_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YPL231W-MONOMER_RXN3O-1803_controller_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" , "Provides Input For Rule. The relation 'a palmitoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxooctadecanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein' 'null' 'a (3<i>R</i>)-3-hydroxyoctadecanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxooctadecanoyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002413_RXN-9633_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002413_RXN-9633_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -790,15 +641,37 @@
           <http://model.geneontology.org/RXN-9633>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_ACP_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_ACP_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -814,7 +687,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_25629_RXN-9624_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -828,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -836,18 +720,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_15378_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_Octadec-2-enoyl-ACPs_RXN-9634_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002333_YKL182W-MONOMER_RXN3O-5293_controller_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002333_YKL182W-MONOMER_RXN3O-5293_controller_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -862,11 +779,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_Octadec-2-enoyl-ACPs_RXN-9634_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_Octadec-2-enoyl-ACPs_RXN-9634_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -877,25 +794,14 @@
           <http://model.geneontology.org/Octadec-2-enoyl-ACPs_RXN-9634>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_ACP_RXN3O-1803_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_YeastPathways_PWY3O-355>
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-355>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
+                "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -904,17 +810,6 @@
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000066_reaction_RXN3O-1803_location_lociGO_0005829_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-1803>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -925,7 +820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -942,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -954,11 +849,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002333_YKL182W-MONOMER_RXN3O-5304_controller_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002333_YKL182W-MONOMER_RXN3O-5304_controller_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,26 +864,15 @@
           <http://model.geneontology.org/YKL182W-MONOMER_RXN3O-5304_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_Stearoyl-ACPs_RXN3O-5293_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_ACP_RXN3O-1803_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_ACP_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1003,11 +887,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1018,14 +902,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-355/YeastPathways_PWY3O-355>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_57394_RXN3O-5304_SGD_YeastPathways_PWY3O-355>
+<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002333_YKL182W-MONOMER_RXN-9634_controller_SGD_PWY_YeastPathways_PWY3O-355>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
+                "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1044,7 +928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1052,40 +936,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_CHEBI_15377_RXN-9634_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_Octadec-2-enoyl-ACPs_RXN-9634_SGD_YeastPathways_PWY3O-355>
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002333_YKL182W-MONOMER_RXN3O-5304_controller_SGD_PWY_YeastPathways_PWY3O-355>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
+                "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_15378_RXN3O-5293_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_15378_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1100,11 +973,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" , "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxyoctadecanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxooctadecanoyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (3<i>R</i>)-3-hydroxyoctadecanoyl-[acp] &rarr; a (2<i>E</i>)-octadec-2-enoyl-[acp] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002413_RXN-9634_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002413_RXN-9634_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1115,14 +988,14 @@
           <http://model.geneontology.org/RXN-9634>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000066_reaction_RXN-9633_location_lociGO_0005829_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000066_reaction_RXN-9633_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
+                "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1138,6 +1011,17 @@
 <http://purl.obolibrary.org/obo/GO_0006633>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002333_YKL182W-MONOMER_RXN3O-5293_controller_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1145,11 +1029,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000066_reaction_RXN3O-5304_location_lociGO_0005829_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000066_reaction_RXN3O-5304_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1164,11 +1048,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1186,7 +1070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1198,11 +1082,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_15377_RXN-9624_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_15377_RXN-9624_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1222,7 +1106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1230,32 +1114,65 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_15378_RXN-9624_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000066_reaction_RXN3O-5293_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
+                "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YER061C-MONOMER_RXN3O-1803_controller_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YER061C-MONOMER_RXN3O-1803_controller_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1269,15 +1186,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_CHEBI_15377_RXN-9634_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_15378_RXN-9633_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_15378_RXN-9633_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1288,17 +1216,39 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-9633>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002413_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000001665>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_58349_RXN3O-5293_SGD_YeastPathways_PWY3O-355>
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_Stearoyl-ACPs_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_Palmitoyl-ACPs_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-355>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
+                "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1311,7 +1261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1328,7 +1278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1340,11 +1290,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_58349_RXN3O-5293_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_58349_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1355,15 +1305,26 @@
           <http://model.geneontology.org/CHEBI_58349_RXN3O-5293>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_57783_RXN-9633_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1373,6 +1334,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/R-3-hydroxystearoyl-ACPs_RXN-9633>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_CHEBI_57394_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-5293>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -1393,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1406,7 +1389,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_58349_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1414,11 +1408,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_ACP_RXN3O-5304_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_ACP_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1433,11 +1427,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_CHEBI_15378_RXN3O-1803_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_CHEBI_15378_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1457,13 +1451,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-355SmallMolecule18849> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_57783_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_25629_RXN-9624>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_25629> ;
@@ -1474,7 +1479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1486,11 +1491,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_25629_RXN-9624_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_25629_RXN-9624_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1501,43 +1506,43 @@
           <http://model.geneontology.org/CHEBI_25629_RXN-9624>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YER061C-MONOMER_RXN3O-1803_controller_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_58349_RXN-9633_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_15378_RXN-9633_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1553,7 +1558,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_RXN-9624_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1561,11 +1577,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_58349_RXN-9633_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_58349_RXN-9633_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1585,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1600,7 +1616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1611,17 +1627,6 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002333_YKL182W-MONOMER_RXN3O-5304_controller_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY3O-355>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1631,7 +1636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "stearate biosynthesis III (fungi) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1643,11 +1648,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" , "Provides Input For Rule. The relation 'a stearoyl-[acp] + NADP<sup>+</sup> &larr; a (2<i>E</i>)-octadec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a stearoyl-[acp] + coenzyme A &rarr; stearoyl-CoA + acyl-carrier protein' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002413_RXN3O-5304_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002413_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1662,11 +1667,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002333_YKL182W-MONOMER_RXN-9634_controller_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002333_YKL182W-MONOMER_RXN-9634_controller_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1681,11 +1686,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1715,7 +1720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1723,14 +1728,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_CHEBI_16526_RXN3O-1803_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_57287_RXN-9624_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
+                "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1738,11 +1743,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a stearoyl-[acp] + coenzyme A &rarr; stearoyl-CoA + acyl-carrier protein' 'null' 'stearoyl-CoA + H<sub>2</sub>O &rarr; stearate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_RXN-9624_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_RXN-9624_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1762,13 +1767,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-355SmallMolecule18811> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YPL231W-MONOMER_RXN3O-1803_controller_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000006152>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1777,11 +1793,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_CHEBI_16526_RXN3O-1803_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_CHEBI_16526_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1792,37 +1808,15 @@
           <http://model.geneontology.org/CHEBI_16526_RXN3O-1803>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_ACP_RXN3O-5304_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002413_RXN3O-5304_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000066_reaction_RXN-9633_location_lociGO_0005829_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000066_reaction_RXN-9633_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1836,23 +1830,23 @@
 <http://purl.obolibrary.org/obo/GO_0004315>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_15377_RXN-9624_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN-9624_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000066_reaction_RXN3O-1803_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1860,11 +1854,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_57783_RXN3O-5293_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_57783_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1879,11 +1873,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1897,17 +1891,39 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_Stearoyl-ACPs_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-5304_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_CHEBI_16526_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACP_RXN3O-5304>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1918,7 +1934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1943,24 +1959,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-355BiochemicalReaction18817> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002413_RXN3O-5293_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YER061C-MONOMER_RXN3O-1803_controller>
         a       <http://identifiers.org/sgd/S000000863> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1969,7 +1974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1999,7 +2004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2007,26 +2012,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_CHEBI_57287_RXN3O-5304_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_CHEBI_57287_RXN3O-5304_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_CHEBI_57287_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2037,14 +2031,14 @@
           <http://model.geneontology.org/CHEBI_57287_RXN3O-5304>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000066_reaction_RXN-9634_location_lociGO_0005829_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002413_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
+                "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2052,11 +2046,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000066_reaction_RXN3O-1803_location_lociGO_0005829_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000066_reaction_RXN3O-1803_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2067,15 +2061,26 @@
           <http://model.geneontology.org/reaction_RXN3O-1803_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_58349_RXN-9633_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_57394_RXN3O-5304_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_57394_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2086,6 +2091,17 @@
           <http://model.geneontology.org/CHEBI_57394_RXN3O-5304>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000066_reaction_RXN-9624_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/R-3-hydroxystearoyl-ACPs_RXN-9633>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2095,7 +2111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2106,36 +2122,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_YeastPathways_PWY3O-355>
+<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_57394_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-355>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000050_YeastPathways_PWY3O-355/YeastPathways_PWY3O-355_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000066_reaction_RXN3O-5304_location_lociGO_0005829_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
+                "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2143,11 +2137,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YPL231W-MONOMER_RXN3O-1803_controller_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YPL231W-MONOMER_RXN3O-1803_controller_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2158,17 +2152,6 @@
           <http://model.geneontology.org/YPL231W-MONOMER_RXN3O-1803_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002333_YKL182W-MONOMER_RXN-9634_controller_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57394_RXN3O-5304>
         a       <http://purl.obolibrary.org/obo/CHEBI_57394> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2178,7 +2161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2190,11 +2173,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_57783_RXN-9633_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_57783_RXN-9633_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2205,17 +2188,6 @@
           <http://model.geneontology.org/CHEBI_57783_RXN-9633>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000066_reaction_RXN3O-5293_location_lociGO_0005829_SGD_YeastPathways_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ACP_RXN3O-1803>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2225,7 +2197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2233,15 +2205,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_ACP_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_Stearoyl-ACPs_RXN3O-5293_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_Stearoyl-ACPs_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2256,11 +2239,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_CHEBI_15377_RXN-9634_SGD_YeastPathways_PWY3O-355> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_CHEBI_15377_RXN-9634_SGD_PWY_YeastPathways_PWY3O-355> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2280,7 +2263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2288,16 +2271,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_57783_RXN-9633_SGD_YeastPathways_PWY3O-355>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_57394>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000066_reaction_RXN3O-5304_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
+                "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57394>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/CHEBI_15378_RXN-9633>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-355SmallMolecule18742> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .

--- a/models/YeastPathways_PWY3O-3827.ttl
+++ b/models/YeastPathways_PWY3O-3827.ttl
@@ -1,9 +1,20 @@
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YGL253W-MONOMER_GLUCOKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-3827>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-3827" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_GLUCOKIN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16,24 +27,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-3827SmallMolecule28398> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_4167_GLUCOKIN-RXN_SGD_YeastPathways_PWY3O-3827>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-3827" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_4170_GLUCOKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_4170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -56,11 +56,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_15378_GLUCOKIN-RXN_SGD_YeastPathways_PWY3O-3827> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_15378_GLUCOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-3827> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,17 +77,6 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000050_YeastPathways_PWY3O-3827/YeastPathways_PWY3O-3827_SGD_YeastPathways_PWY3O-3827>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-3827" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_GLUCOKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -97,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -118,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -130,11 +119,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_4167_GLUCOKIN-RXN_SGD_YeastPathways_PWY3O-3827> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_4167_GLUCOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-3827> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,19 +134,19 @@
           <http://model.geneontology.org/CHEBI_4167_GLUCOKIN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000066_reaction_GLUCOKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-3827>
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000066_reaction_GLUCOKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-3827>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-3827" ;
+                "SGD_PWY:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -171,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glucose-6-phosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -196,13 +185,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-3827BiochemicalReaction28390> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000050_YeastPathways_PWY3O-3827/YeastPathways_PWY3O-3827_SGD_PWY_YeastPathways_PWY3O-3827>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-3827" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -211,11 +211,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YFR053C-MONOMER_GLUCOKIN-RXN_controller_SGD_YeastPathways_PWY3O-3827> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YFR053C-MONOMER_GLUCOKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-3827> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -226,17 +226,6 @@
           <http://model.geneontology.org/YFR053C-MONOMER_GLUCOKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YGL253W-MONOMER_GLUCOKIN-RXN_controller_SGD_YeastPathways_PWY3O-3827>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-3827" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -244,11 +233,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_30616_GLUCOKIN-RXN_SGD_YeastPathways_PWY3O-3827> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_30616_GLUCOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-3827> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -259,14 +248,14 @@
           <http://model.geneontology.org/CHEBI_30616_GLUCOKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_4170_GLUCOKIN-RXN_SGD_YeastPathways_PWY3O-3827>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_4167_GLUCOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-3827>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-3827" ;
+                "SGD_PWY:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -277,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,20 +277,42 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_30616_GLUCOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-3827>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-3827" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_456216_GLUCOKIN-RXN_SGD_YeastPathways_PWY3O-3827>
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YCL040W-MONOMER_GLUCOKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-3827>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-3827" ;
+                "SGD_PWY:PWY3O-3827" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YFR053C-MONOMER_GLUCOKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-3827>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -309,11 +320,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YCL040W-MONOMER_GLUCOKIN-RXN_controller_SGD_YeastPathways_PWY3O-3827> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YCL040W-MONOMER_GLUCOKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-3827> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,7 +344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -345,11 +356,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000066_reaction_GLUCOKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-3827> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000066_reaction_GLUCOKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-3827> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,6 +373,39 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_4170>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_15378_GLUCOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-3827>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-3827" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_4170_GLUCOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-3827>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-3827" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_456216_GLUCOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-3827>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-3827" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -379,11 +423,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_456216_GLUCOKIN-RXN_SGD_YeastPathways_PWY3O-3827> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_456216_GLUCOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-3827> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -417,26 +461,15 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YFR053C-MONOMER_GLUCOKIN-RXN_controller_SGD_YeastPathways_PWY3O-3827>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-3827" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000050_YeastPathways_PWY3O-3827/YeastPathways_PWY3O-3827_SGD_YeastPathways_PWY3O-3827> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000050_YeastPathways_PWY3O-3827/YeastPathways_PWY3O-3827_SGD_PWY_YeastPathways_PWY3O-3827> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -454,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -471,17 +504,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YCL040W-MONOMER_GLUCOKIN-RXN_controller_SGD_YeastPathways_PWY3O-3827>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-3827" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -497,17 +519,6 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_15378_GLUCOKIN-RXN_SGD_YeastPathways_PWY3O-3827>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-3827" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000003222>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -515,11 +526,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_4170_GLUCOKIN-RXN_SGD_YeastPathways_PWY3O-3827> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002234_CHEBI_4170_GLUCOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-3827> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -551,11 +562,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YGL253W-MONOMER_GLUCOKIN-RXN_controller_SGD_YeastPathways_PWY3O-3827> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002333_YGL253W-MONOMER_GLUCOKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-3827> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -568,14 +579,3 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_RO_0002233_CHEBI_30616_GLUCOKIN-RXN_SGD_YeastPathways_PWY3O-3827>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-3827" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-4.ttl
+++ b/models/YeastPathways_PWY3O-4.ttl
@@ -1,11 +1,22 @@
-<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-4/YeastPathways_PWY3O-4_SGD_YeastPathways_PWY3O-4>
+<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002411_RXN3O-37_SGD_PWY_YeastPathways_PWY3O-4>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4" ;
+                "SGD_PWY:PWY3O-4" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002233_CHEBI_57589_RXN3O-37_SGD_PWY_YeastPathways_PWY3O-4>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13,11 +24,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002234_CHEBI_57288_RXN3O-37_SGD_YeastPathways_PWY3O-4> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002234_CHEBI_57288_RXN3O-37_SGD_PWY_YeastPathways_PWY3O-4> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -32,11 +43,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_CARNITINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4> ;
+          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_CARNITINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -54,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,14 +73,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YML042W-MONOMER_CARNITINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-4>
+<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_16347_CARNITINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4" ;
+                "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -85,13 +96,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4SmallMolecule51223> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-37_BFO_0000050_YeastPathways_PWY3O-4/YeastPathways_PWY3O-4_SGD_PWY_YeastPathways_PWY3O-4>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YML042W-MONOMER_RXN3O-37_controller>
         a       <http://identifiers.org/sgd/S000004506> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -100,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -127,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -135,44 +157,55 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-37_BFO_0000050_YeastPathways_PWY3O-4/YeastPathways_PWY3O-4_SGD_YeastPathways_PWY3O-4>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002234_CHEBI_57288_RXN3O-37_SGD_PWY_YeastPathways_PWY3O-4>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4" ;
+                "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_CARNITINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_CARNITINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_CARNITINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002333_YML042W-MONOMER_RXN3O-37_controller_SGD_PWY_YeastPathways_PWY3O-4>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_CARNITINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57589>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -181,11 +214,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002234_CHEBI_16347_RXN3O-37_SGD_YeastPathways_PWY3O-4> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002234_CHEBI_16347_RXN3O-37_SGD_PWY_YeastPathways_PWY3O-4> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -200,11 +233,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_CARNITINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4> ;
+          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_CARNITINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -224,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "carnitine shuttle - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -238,31 +271,42 @@
 <http://purl.obolibrary.org/obo/GO_0004092>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000000826>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002233_CHEBI_57589_RXN3O-37_SGD_YeastPathways_PWY3O-4>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YER024W-MONOMER_CARNITINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4" ;
+                "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000826>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002234_CHEBI_16347_RXN3O-37_SGD_YeastPathways_PWY3O-4>
+<http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002234_CHEBI_16347_RXN3O-37_SGD_PWY_YeastPathways_PWY3O-4>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4" ;
+                "SGD_PWY:PWY3O-4" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YML042W-MONOMER_CARNITINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -273,11 +317,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YML042W-MONOMER_CARNITINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-4> ;
+          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YML042W-MONOMER_CARNITINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -295,11 +339,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002233_CHEBI_57589_RXN3O-37_SGD_YeastPathways_PWY3O-4> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002233_CHEBI_57589_RXN3O-37_SGD_PWY_YeastPathways_PWY3O-4> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,11 +358,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_16347_CARNITINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4> ;
+          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_16347_CARNITINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,19 +373,30 @@
           <http://model.geneontology.org/CHEBI_16347_CARNITINE-O-ACETYLTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_CARNITINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4>
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_CARNITINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4" ;
+                "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57589_CARNITINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57589_CARNITINE-O-ACETYLTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57589> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -352,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -378,7 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -396,11 +451,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YER024W-MONOMER_CARNITINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-4> ;
+          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YER024W-MONOMER_CARNITINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -418,7 +473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -430,11 +485,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002233_CHEBI_57287_RXN3O-37_SGD_YeastPathways_PWY3O-4> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002233_CHEBI_57287_RXN3O-37_SGD_PWY_YeastPathways_PWY3O-4> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -454,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -466,11 +521,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_CARNITINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4> ;
+          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_CARNITINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -498,39 +553,6 @@
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002234_CHEBI_57288_RXN3O-37_SGD_YeastPathways_PWY3O-4>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002233_CHEBI_57287_RXN3O-37_SGD_YeastPathways_PWY3O-4>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YAR035W-MONOMER_CARNITINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-4>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0006853>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -545,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -556,17 +578,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002333_YML042W-MONOMER_RXN3O-37_controller_SGD_YeastPathways_PWY3O-4>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -574,11 +585,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YAR035W-MONOMER_CARNITINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-4> ;
+          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YAR035W-MONOMER_CARNITINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -602,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -610,15 +621,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-4/YeastPathways_PWY3O-4_SGD_PWY_YeastPathways_PWY3O-4>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-37_BFO_0000050_YeastPathways_PWY3O-4/YeastPathways_PWY3O-4_SGD_YeastPathways_PWY3O-4> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-37_BFO_0000050_YeastPathways_PWY3O-4/YeastPathways_PWY3O-4_SGD_PWY_YeastPathways_PWY3O-4> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -633,11 +655,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-4/YeastPathways_PWY3O-4_SGD_YeastPathways_PWY3O-4> ;
+          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-4/YeastPathways_PWY3O-4_SGD_PWY_YeastPathways_PWY3O-4> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,17 +669,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-4/YeastPathways_PWY3O-4>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YER024W-MONOMER_CARNITINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-4>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -670,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -683,7 +694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -694,6 +705,17 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YAR035W-MONOMER_CARNITINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YML042W-MONOMER_CARNITINE-O-ACETYLTRANSFERASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004506> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -701,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -722,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -734,11 +756,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002333_YML042W-MONOMER_RXN3O-37_controller_SGD_YeastPathways_PWY3O-4> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002333_YML042W-MONOMER_RXN3O-37_controller_SGD_PWY_YeastPathways_PWY3O-4> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,11 +775,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57589_CARNITINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4> ;
+          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57589_CARNITINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,28 +790,6 @@
           <http://model.geneontology.org/CHEBI_57589_CARNITINE-O-ACETYLTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_16347_CARNITINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57589_CARNITINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000000080>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -797,11 +797,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002411_RXN3O-37_SGD_YeastPathways_PWY3O-4> ;
+          <http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002411_RXN3O-37_SGD_PWY_YeastPathways_PWY3O-4> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -832,13 +832,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_RO_0002411_RXN3O-37_SGD_YeastPathways_PWY3O-4>
+<http://model.geneontology.org/ev_w_id_RXN3O-37_RO_0002233_CHEBI_57287_RXN3O-37_SGD_PWY_YeastPathways_PWY3O-4>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4" ;
+                "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-402.ttl
+++ b/models/YeastPathways_PWY3O-402.ttl
@@ -1,12 +1,23 @@
+<http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002233_CHEBI_30616_RXN-7163_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9819_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9819_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -26,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,11 +49,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002233_CHEBI_58628_2.7.1.152-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002233_CHEBI_58628_2.7.1.152-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,15 +64,26 @@
           <http://model.geneontology.org/CHEBI_58628_2.7.1.152-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_d77dbe09-0e3a-4195-ad92-9eeb5663f146_RXN3O-9819_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002233_CHEBI_57627_2.7.1.151-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002233_CHEBI_57627_2.7.1.151-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -84,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,17 +117,6 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002233_CHEBI_203600_3.1.4.11-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_RXN-7162>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -115,35 +126,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46966> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002234_CHEBI_58130_RXN-7163_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002411_RXN3O-786_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57895_2.7.1.127-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57895> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -154,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -162,34 +151,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002234_CHEBI_456216_2.7.1.127-RXN_SGD_YeastPathways_PWY3O-402> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.7.1.127-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_2.7.1.127-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002413_2.7.1.152-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002233_CHEBI_16322_RXN-7184_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -200,27 +192,24 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-402/YeastPathways_PWY3O-402>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002233_CHEBI_16322_RXN-7184_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002233_CHEBI_203600_3.1.4.11-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002234_CHEBI_456216_2.7.1.127-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.7.1.127-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456216_2.7.1.127-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_456216_RXN-4941>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -231,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -243,11 +232,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002411_RXN3O-9819_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002411_RXN3O-9819_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,17 +247,6 @@
           <http://model.geneontology.org/RXN3O-9819>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002234_CHEBI_58628_2.7.1.152-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -276,11 +254,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002234_CHEBI_456216_RXN-7163_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002234_CHEBI_456216_RXN-7163_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -291,17 +269,6 @@
           <http://model.geneontology.org/CHEBI_456216_RXN-7163>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002333_MONOMER3O-205_2.7.1.152-RXN_controller_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58130_RXN3O-785>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58130> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -311,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -319,14 +286,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002333_YPL268W-MONOMER_3.1.4.11-RXN_controller_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002234_CHEBI_58130_RXN3O-785_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -334,11 +301,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" , "Provides Input For Rule. The relation 'D-<i>myo</i>-inositol (1,4,5)-trisphosphate + ATP &rarr; D-<i>myo</i>-inositol (1,4,5,6)-tetrakisphosphate + ADP + H<SUP>+</SUP>' 'null' 'D-<i>myo</i>-inositol (1,4,5,6)-tetrakisphosphate + ATP &rarr; D-<i>myo</i>-inositol 1,3,4,5,6-pentakisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002413_RXN-7162_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002413_RXN-7162_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,11 +320,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-4941_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-4941_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -371,15 +338,26 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002234_CHEBI_43474_RXN3O-785_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_CHEBI_15377_RXN3O-786_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_CHEBI_15377_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,24 +387,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402BiochemicalReaction47230> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002233_CHEBI_58130_RXN-7163_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -435,11 +402,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002333_MONOMER3O-64_RXN-7184_controller_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002333_MONOMER3O-64_RXN-7184_controller_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,25 +417,42 @@
           <http://model.geneontology.org/MONOMER3O-64_RXN-7184_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9819_BFO_0000066_reaction_RXN3O-9819_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002333_YOR163W-MONOMER_RXN3O-785_controller_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/47b12746-a63f-42ab-9dca-630abdc6ab7c_3.1.4.11-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47183> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-143_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -481,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -489,26 +473,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002234_CHEBI_456216_RXN-7162_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002411_RXN3O-786_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002411_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -519,26 +492,15 @@
           <http://model.geneontology.org/RXN3O-786>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002411_RXN3O-786_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-258_BFO_0000066_reaction_RXN3O-258_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-258_BFO_0000066_reaction_RXN3O-258_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -553,11 +515,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" , "Provides Input For Rule. The relation 'D-<i>myo</i>-inositol (1,4,5,6)-tetrakisphosphate + ATP &rarr; D-<i>myo</i>-inositol 1,3,4,5,6-pentakisphosphate + ADP + H<SUP>+</SUP>' 'null' 'D-<i>myo</i>-inositol 1,3,4,5,6-pentakisphosphate + ATP &rarr; phytate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002413_RXN-7163_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002413_RXN-7163_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,11 +534,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002234_CHEBI_15378_2.7.1.152-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002234_CHEBI_15378_2.7.1.152-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -587,23 +549,56 @@
           <http://model.geneontology.org/CHEBI_15378_2.7.1.152-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002233_CHEBI_30616_RXN-7162_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002234_CHEBI_15378_2.7.1.152-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-785_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7162_BFO_0000066_reaction_RXN-7162_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002233_CHEBI_16322_RXN-7184_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_47b12746-a63f-42ab-9dca-630abdc6ab7c_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -616,35 +611,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47008> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002233_CHEBI_58130_RXN-7163_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-4941_BFO_0000066_reaction_RXN-4941_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -660,13 +633,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16322_RXN-7184> , <http://model.geneontology.org/CHEBI_30616_RXN-4941> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_RXN-4941> , <http://model.geneontology.org/38e46e6f-5298-4b37-8598-f641beb9fa4f_RXN-4941> ;
+                <http://model.geneontology.org/CHEBI_456216_RXN-4941> , <http://model.geneontology.org/6ec1e05b-74d8-4177-89e0-d9b09501b9ae_RXN-4941> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-64_RXN-4941_controller> , <http://model.geneontology.org/MONOMER3O-205_RXN-4941_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -678,11 +651,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002333_YPL268W-MONOMER_3.1.4.11-RXN_controller_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002333_YPL268W-MONOMER_3.1.4.11-RXN_controller_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -697,11 +670,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002233_CHEBI_30616_2.7.1.151-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002233_CHEBI_30616_2.7.1.151-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,25 +685,25 @@
           <http://model.geneontology.org/CHEBI_30616_2.7.1.151-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002413_RXN-7184_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002411_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002233_CHEBI_30616_2.7.1.151-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002233_CHEBI_30616_2.7.1.151-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -738,11 +711,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002333_YOR163W-MONOMER_RXN3O-785_controller_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002333_YOR163W-MONOMER_RXN3O-785_controller_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,23 +726,6 @@
           <http://model.geneontology.org/YOR163W-MONOMER_RXN3O-785_controller>
 ] .
 
-<http://model.geneontology.org/4e7c9d40-6532-488d-8e70-8749f8a5fce0_RXN3O-258>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4- or 6-diphosphoinositol pentakisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46949> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/MONOMER3O-205_RXN-4941_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -777,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -789,11 +745,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002333_MONOMER3O-205_RXN-4941_controller_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002333_MONOMER3O-205_RXN-4941_controller_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -821,14 +777,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7163_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_RXN3O-785_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -836,11 +792,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002233_CHEBI_30616_RXN-7184_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002233_CHEBI_30616_RXN-7184_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -851,47 +807,25 @@
           <http://model.geneontology.org/CHEBI_30616_RXN-7184>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002333_MONOMER3O-224_RXN3O-143_controller_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002234_CHEBI_15378_2.7.1.127-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002233_CHEBI_30616_2.7.1.127-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002234_CHEBI_456216_2.7.1.152-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002233_CHEBI_30616_RXN-4941_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002333_MONOMER3O-205_RXN-4941_controller_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -900,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -913,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -921,14 +855,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7184_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002333_YOR163W-MONOMER_RXN3O-786_controller_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -936,11 +870,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9819_BFO_0000066_reaction_RXN3O-9819_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9819_BFO_0000066_reaction_RXN3O-9819_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -951,12 +885,23 @@
           <http://model.geneontology.org/reaction_RXN3O-9819_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-258_BFO_0000066_reaction_RXN3O-258_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-143_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -969,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -986,7 +931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -998,11 +943,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_CHEBI_456216_RXN3O-143_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_CHEBI_456216_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1013,37 +958,15 @@
           <http://model.geneontology.org/CHEBI_456216_RXN3O-143>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_4e7c9d40-6532-488d-8e70-8749f8a5fce0_RXN3O-258_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_38043969-2b90-4815-a08e-830484be8348_RXN3O-143_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002234_CHEBI_15378_RXN-7162_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002234_CHEBI_15378_RXN-7162_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1073,7 +996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1081,14 +1004,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002333_MONOMER3O-64_2.7.1.151-RXN_controller_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002233_CHEBI_30616_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1101,7 +1024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1112,18 +1035,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/e95a5c91-8515-4db8-98b0-ab5dc2c6f58d_RXN3O-786>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_RXN3O-9819_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_BFO_0000066_reaction_3.1.4.11-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_BFO_0000066_reaction_3.1.4.11-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1138,11 +1069,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002234_CHEBI_57895_2.7.1.127-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002234_CHEBI_57895_2.7.1.127-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1156,40 +1087,26 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-7162_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002234_CHEBI_456216_RXN-7163_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002413_2.7.1.152-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/38043969-2b90-4815-a08e-830484be8348_RXN3O-143>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-785_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-785_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1200,14 +1117,36 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-402/YeastPathways_PWY3O-402>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002234_CHEBI_16322_RXN-7184_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002333_MONOMER3O-64_2.7.1.151-RXN_controller_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002234_CHEBI_15378_RXN-7163_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_582be5db-88b3-43f0-b55c-056f4e0e0f94_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1220,7 +1159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1228,26 +1167,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002233_CHEBI_30616_RXN-7163_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002234_CHEBI_58130_RXN-7163_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002234_CHEBI_58130_RXN-7163_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1257,28 +1185,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58130_RXN-7163>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002234_CHEBI_15378_RXN-7163_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_CHEBI_15377_RXN3O-786_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1297,7 +1203,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_58628_2.7.1.152-RXN> , <http://model.geneontology.org/CHEBI_30616_RXN3O-143> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_RXN3O-143> , <http://model.geneontology.org/b0f32f9d-00b5-4181-a5d1-7f1ecfc11761_RXN3O-143> ;
+                <http://model.geneontology.org/bee427d1-2ed5-4e43-b946-6ecfe35a1408_RXN3O-143> , <http://model.geneontology.org/CHEBI_456216_RXN3O-143> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-224_RXN3O-143_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1305,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1317,11 +1223,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1336,11 +1242,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-4941_BFO_0000066_reaction_RXN-4941_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-4941_BFO_0000066_reaction_RXN-4941_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1351,18 +1257,26 @@
           <http://model.geneontology.org/reaction_RXN-4941_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/3968b60b-0f1d-406b-b2dc-7c13262b4350_RXN3O-258>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002233_CHEBI_58130_RXN-7163_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_38043969-2b90-4815-a08e-830484be8348_RXN3O-143_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_3eb7d37f-ba2e-4cad-8430-6877652317ed_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1370,29 +1284,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-786> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/38043969-2b90-4815-a08e-830484be8348_RXN3O-143>
+          <http://model.geneontology.org/3eb7d37f-ba2e-4cad-8430-6877652317ed_RXN3O-143>
 ] .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002234_CHEBI_456216_2.7.1.152-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-<i>myo</i>-inositol (1,3,4,5)-tetrakisphosphate + ATP &rarr; D-<i>myo</i>-inositol 1,3,4,5,6-pentakisphosphate + ADP + H<SUP>+</SUP>' 'null' 'ATP + D-<i>myo</i>-inositol 1,3,4,5,6-pentakisphosphate &rarr; a diphospho-1D-myo-inositol tetrakisphosphate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002413_RXN-4941_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002413_RXN-4941_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1403,14 +1306,42 @@
           <http://model.geneontology.org/RXN-4941>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002413_RXN3O-258_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/28dd3f27-e588-4eba-b67a-f72aff1f9408_RXN3O-258>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4- or 6-diphosphoinositol pentakisphosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46949> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002234_CHEBI_58628_2.7.1.152-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1433,13 +1364,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402BiochemicalReaction47224> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/4831da01-1177-4e4a-9013-da92e8e81534_RXN3O-258>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/CHEBI_456216_RXN3O-143>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -1450,7 +1384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1458,47 +1392,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002234_CHEBI_15378_RXN-7184_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/7eb3767d-f15d-4674-ac34-220588968aad_RXN3O-786>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9819_BFO_0000066_reaction_RXN3O-9819_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002234_CHEBI_57895_2.7.1.127-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002233_CHEBI_30616_RXN3O-258_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002413_RXN-7163_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1506,11 +1410,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1527,6 +1431,28 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-4941_BFO_0000066_reaction_RXN-4941_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002233_CHEBI_203600_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YPL268W-MONOMER_3.1.4.11-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006189> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1534,7 +1460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1549,24 +1475,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402Protein47094> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_17815_3.1.4.11-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1575,11 +1490,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002233_CHEBI_30616_RXN3O-258_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002233_CHEBI_30616_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1590,14 +1505,14 @@
           <http://model.geneontology.org/CHEBI_30616_RXN3O-258>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-143_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002413_RXN-7163_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1606,18 +1521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002234_CHEBI_58130_RXN3O-785_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1625,11 +1529,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7163_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7163_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1644,11 +1548,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002234_CHEBI_456216_2.7.1.152-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002234_CHEBI_456216_2.7.1.152-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1663,11 +1567,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_BFO_0000066_reaction_2.7.1.127-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_BFO_0000066_reaction_2.7.1.127-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1678,37 +1582,15 @@
           <http://model.geneontology.org/reaction_2.7.1.127-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002234_CHEBI_456216_RXN-7163_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002233_CHEBI_15378_2.7.1.152-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002233_CHEBI_58130_RXN-7163_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002233_CHEBI_58130_RXN-7163_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1728,7 +1610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1736,25 +1618,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002411_RXN3O-785_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002234_CHEBI_15378_2.7.1.151-RXN_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002411_RXN3O-9819_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1762,11 +1633,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7163_BFO_0000066_reaction_RXN-7163_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7163_BFO_0000066_reaction_RXN-7163_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1777,14 +1648,14 @@
           <http://model.geneontology.org/reaction_RXN-7163_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-786_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-143_BFO_0000066_reaction_RXN3O-143_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1792,11 +1663,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + H<sub>2</sub>O &rarr; a 1,2-diacyl-<i>sn</i>-glycerol + D-<i>myo</i>-inositol (1,4,5)-trisphosphate + H<SUP>+</SUP>' 'null' 'D-<i>myo</i>-inositol (1,4,5)-trisphosphate + ATP &rarr; D-<i>myo</i>-inositol (1,3,4,5)-tetrakisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002413_2.7.1.127-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002413_2.7.1.127-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1811,11 +1682,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002234_CHEBI_15378_2.7.1.151-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002234_CHEBI_15378_2.7.1.151-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1833,7 +1704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1841,37 +1712,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_e8b5723a-8000-48f2-8093-65faf33cdd2b_RXN3O-786_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002413_RXN-4941_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'diphosphoinositol pentakisphosphate + H<sub>2</sub>O &rarr; phytate + phosphate' 'null' 'ATP + phytate &rarr; ADP + 4- or 6-diphosphoinositol pentakisphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002413_RXN3O-258_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002413_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1882,14 +1731,25 @@
           <http://model.geneontology.org/RXN3O-258>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_BFO_0000066_reaction_2.7.1.151-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_RXN3O-258_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002233_CHEBI_58130_RXN-7163_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1897,11 +1757,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002333_MONOMER3O-64_RXN-4941_controller_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002333_MONOMER3O-64_RXN-4941_controller_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1912,40 +1772,29 @@
           <http://model.geneontology.org/MONOMER3O-64_RXN-4941_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002233_CHEBI_58628_2.7.1.152-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002234_CHEBI_456216_2.7.1.151-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002233_CHEBI_57895_2.7.1.127-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002233_CHEBI_57895_2.7.1.127-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1956,14 +1805,69 @@
           <http://model.geneontology.org/CHEBI_57895_2.7.1.127-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002333_YDR315C-MONOMER_RXN-7163_controller_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002234_CHEBI_15378_RXN-7162_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002234_CHEBI_57895_2.7.1.127-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_CHEBI_15377_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002233_CHEBI_30616_RXN-7184_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_7eb3767d-f15d-4674-ac34-220588968aad_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002234_CHEBI_16322_RXN-7162_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1971,11 +1875,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_CHEBI_30616_RXN3O-9819_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_CHEBI_30616_RXN3O-9819_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1986,30 +1890,19 @@
           <http://model.geneontology.org/CHEBI_30616_RXN3O-9819>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002413_2.7.1.152-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-785_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_17815>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002411_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_RXN3O-786>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -2020,7 +1913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2028,15 +1921,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_CHEBI_15377_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_b0f32f9d-00b5-4181-a5d1-7f1ecfc11761_RXN3O-143_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_bee427d1-2ed5-4e43-b946-6ecfe35a1408_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2044,18 +1948,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-143> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b0f32f9d-00b5-4181-a5d1-7f1ecfc11761_RXN3O-143>
+          <http://model.geneontology.org/bee427d1-2ed5-4e43-b946-6ecfe35a1408_RXN3O-143>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002234_CHEBI_16322_RXN-7162_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002234_CHEBI_16322_RXN-7162_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2066,14 +1970,25 @@
           <http://model.geneontology.org/CHEBI_16322_RXN-7162>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002234_CHEBI_15378_2.7.1.151-RXN_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002333_MONOMER3O-205_RXN-4941_controller_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002333_YPL268W-MONOMER_3.1.4.11-RXN_controller_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2091,7 +2006,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_58130_RXN-7163> , <http://model.geneontology.org/CHEBI_30616_RXN3O-258> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/4e7c9d40-6532-488d-8e70-8749f8a5fce0_RXN3O-258> , <http://model.geneontology.org/CHEBI_456216_RXN3O-258> ;
+                <http://model.geneontology.org/CHEBI_456216_RXN3O-258> , <http://model.geneontology.org/28dd3f27-e588-4eba-b67a-f72aff1f9408_RXN3O-258> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-224_RXN3O-258_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2099,7 +2014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2116,7 +2031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2128,11 +2043,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_CHEBI_15377_3.1.4.11-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_CHEBI_15377_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2147,11 +2062,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002333_MONOMER3O-64_2.7.1.127-RXN_controller_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002333_MONOMER3O-64_2.7.1.127-RXN_controller_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2171,7 +2086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2183,11 +2098,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-785_BFO_0000066_reaction_RXN3O-785_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-785_BFO_0000066_reaction_RXN3O-785_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2198,32 +2113,48 @@
           <http://model.geneontology.org/reaction_RXN3O-785_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/afc2c8b0-2caa-4f40-91b6-61c2dd92926d_RXN3O-9819>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "[PP]<sub>2</sub>-IP<sub>4</sub>" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_3eb7d37f-ba2e-4cad-8430-6877652317ed_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46971> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_17815_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002413_RXN-7163_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002333_YDR315C-MONOMER_RXN-7163_controller_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002333_YDR315C-MONOMER_RXN-7163_controller_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2238,11 +2169,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_d9bf06fb-331a-49dd-bd21-3e81adbd0651_3.1.4.11-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_47b12746-a63f-42ab-9dca-630abdc6ab7c_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2250,8 +2181,30 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.1.4.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d9bf06fb-331a-49dd-bd21-3e81adbd0651_3.1.4.11-RXN>
+          <http://model.geneontology.org/47b12746-a63f-42ab-9dca-630abdc6ab7c_3.1.4.11-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_4831da01-1177-4e4a-9013-da92e8e81534_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002333_MONOMER3O-64_RXN-4941_controller_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_RXN3O-258>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -2262,7 +2215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2277,11 +2230,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_BFO_0000066_reaction_2.7.1.152-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_BFO_0000066_reaction_2.7.1.152-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2299,11 +2252,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002233_CHEBI_16322_RXN-7184_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002233_CHEBI_16322_RXN-7184_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2317,29 +2270,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_57627>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002333_YOR163W-MONOMER_RXN3O-786_controller_SGD_YeastPathways_PWY3O-402>
+<http://purl.obolibrary.org/obo/CHEBI_58628>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-7184_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58628>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_CHEBI_43474_RXN3O-786_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_CHEBI_43474_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2350,6 +2303,17 @@
           <http://model.geneontology.org/CHEBI_43474_RXN3O-786>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002233_CHEBI_30616_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_17815_3.1.4.11-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17815> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2359,7 +2323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2367,37 +2331,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_BFO_0000066_reaction_3.1.4.11-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002333_MONOMER3O-224_RXN3O-258_controller_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" , "Provides Input For Rule. The relation 'D-<i>myo</i>-inositol (1,3,4,5)-tetrakisphosphate + ATP &rarr; D-<i>myo</i>-inositol 1,3,4,5,6-pentakisphosphate + ADP + H<SUP>+</SUP>' 'null' 'D-<i>myo</i>-inositol 1,3,4,5,6-pentakisphosphate + ATP &rarr; phytate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002413_RXN-7163_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002413_RXN-7163_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2411,25 +2353,14 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9819_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_CHEBI_456216_RXN-4941_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-258_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2438,18 +2369,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_203600_3.1.4.11-RXN_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_CHEBI_456216_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2459,29 +2401,29 @@
 <http://purl.obolibrary.org/obo/GO_0000823>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004435>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002333_YOR163W-MONOMER_RXN3O-785_controller_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002333_MONOMER3O-64_RXN-7184_controller_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004435>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002234_CHEBI_58628_2.7.1.152-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002234_CHEBI_58628_2.7.1.152-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2496,11 +2438,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002233_CHEBI_203600_3.1.4.11-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002233_CHEBI_203600_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2511,26 +2453,15 @@
           <http://model.geneontology.org/CHEBI_203600_3.1.4.11-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002233_CHEBI_57895_2.7.1.127-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_CHEBI_456216_RXN3O-258_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_CHEBI_456216_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2541,6 +2472,17 @@
           <http://model.geneontology.org/CHEBI_456216_RXN3O-258>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_BFO_0000066_reaction_2.7.1.151-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_RXN-7163>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2550,7 +2492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2561,14 +2503,14 @@
 <http://purl.obolibrary.org/obo/GO_0008486>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_CHEBI_30616_RXN3O-9819_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_BFO_0000066_reaction_2.7.1.127-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2576,11 +2518,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002233_CHEBI_16322_RXN-7184_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002233_CHEBI_16322_RXN-7184_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2591,25 +2533,14 @@
           <http://model.geneontology.org/CHEBI_16322_RXN-7184>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002413_RXN-4941_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002233_CHEBI_30616_RXN-7184_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002333_YDR315C-MONOMER_RXN-7163_controller_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2632,7 +2563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2644,11 +2575,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" , "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + H<sub>2</sub>O &rarr; a 1,2-diacyl-<i>sn</i>-glycerol + D-<i>myo</i>-inositol (1,4,5)-trisphosphate + H<SUP>+</SUP>' 'null' 'D-<i>myo</i>-inositol (1,4,5)-trisphosphate + ATP &rarr; D-<i>myo</i>-inositol (1,4,5,6)-tetrakisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002413_2.7.1.151-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002413_2.7.1.151-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2663,11 +2594,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002234_CHEBI_456216_2.7.1.151-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002234_CHEBI_456216_2.7.1.151-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2687,7 +2618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2695,26 +2626,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" , "Provides Input For Rule. The relation 'diphosphoinositol pentakisphosphate + H<sub>2</sub>O &rarr; phytate + phosphate' 'null' 'phytate + ATP + H<SUP>+</SUP> &rarr; 1D-<i>myo</i>inositol 5-diphosphate 1,2,3,4,6-pentakisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002413_2.7.1.152-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002413_2.7.1.152-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2729,11 +2649,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7162_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7162_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2747,15 +2667,26 @@
 <http://identifiers.org/sgd/S000005689>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002413_RXN-7184_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002234_CHEBI_15378_RXN-7184_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002234_CHEBI_15378_RXN-7184_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2775,7 +2706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2792,7 +2723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2800,21 +2731,54 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_203600_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002233_CHEBI_30616_RXN-4941_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-786_BFO_0000066_reaction_RXN3O-786_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_3968b60b-0f1d-406b-b2dc-7c13262b4350_RXN3O-258_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_4831da01-1177-4e4a-9013-da92e8e81534_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2822,7 +2786,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9819> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3968b60b-0f1d-406b-b2dc-7c13262b4350_RXN3O-258>
+          <http://model.geneontology.org/4831da01-1177-4e4a-9013-da92e8e81534_RXN3O-258>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-7184_location_lociGO_0005829>
@@ -2830,18 +2794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_CHEBI_456216_RXN3O-9819_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2849,11 +2802,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002333_MONOMER3O-224_RXN3O-143_controller_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002333_MONOMER3O-224_RXN3O-143_controller_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2864,41 +2817,19 @@
           <http://model.geneontology.org/MONOMER3O-224_RXN3O-143_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_b0f32f9d-00b5-4181-a5d1-7f1ecfc11761_RXN3O-143_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002233_CHEBI_16322_RXN-7184_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002333_MONOMER3O-64_RXN-7184_controller_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000002723>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002233_CHEBI_203600_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_2.7.1.152-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -2909,7 +2840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2921,11 +2852,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002234_CHEBI_456216_RXN-7162_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002234_CHEBI_456216_RXN-7162_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2945,15 +2876,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9819_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/3968b60b-0f1d-406b-b2dc-7c13262b4350_RXN3O-258> , <http://model.geneontology.org/CHEBI_30616_RXN3O-9819> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-9819> , <http://model.geneontology.org/4831da01-1177-4e4a-9013-da92e8e81534_RXN3O-258> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/afc2c8b0-2caa-4f40-91b6-61c2dd92926d_RXN3O-9819> , <http://model.geneontology.org/CHEBI_456216_RXN3O-9819> ;
+                <http://model.geneontology.org/d77dbe09-0e3a-4195-ad92-9eeb5663f146_RXN3O-9819> , <http://model.geneontology.org/CHEBI_456216_RXN3O-9819> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
                 <http://model.geneontology.org/RXN3O-786> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2961,26 +2892,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_CHEBI_456216_RXN3O-258_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" , "Provides Input For Rule. The relation 'D-<i>myo</i>-inositol (1,4,5)-trisphosphate + ATP &rarr; D-<i>myo</i>-inositol (1,3,4,5)-tetrakisphosphate + ADP + H<SUP>+</SUP>' 'null' 'D-<i>myo</i>-inositol (1,3,4,5)-tetrakisphosphate + ATP &rarr; D-<i>myo</i>-inositol 1,3,4,5,6-pentakisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002413_RXN-7184_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002413_RXN-7184_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2991,17 +2911,6 @@
           <http://model.geneontology.org/RXN-7184>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-258_BFO_0000066_reaction_RXN3O-258_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_RXN-7163>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3011,7 +2920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3019,15 +2928,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002234_CHEBI_15378_RXN-7184_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_CHEBI_15377_RXN3O-785_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_CHEBI_15377_RXN3O-785_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3038,15 +2958,26 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-785>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002233_CHEBI_15378_2.7.1.152-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" , "Provides Input For Rule. The relation 'D-<i>myo</i>-inositol 1,3,4,5,6-pentakisphosphate + ATP &rarr; phytate + ADP + H<SUP>+</SUP>' 'null' 'ATP + phytate &rarr; ADP + 4- or 6-diphosphoinositol pentakisphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002413_RXN3O-258_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002413_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3061,11 +2992,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_15378_3.1.4.11-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_15378_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3076,14 +3007,14 @@
           <http://model.geneontology.org/CHEBI_15378_3.1.4.11-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_3968b60b-0f1d-406b-b2dc-7c13262b4350_RXN3O-258_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002333_MONOMER3O-224_RXN3O-143_controller_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3091,11 +3022,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002233_CHEBI_15378_2.7.1.152-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002233_CHEBI_15378_2.7.1.152-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3110,11 +3041,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002233_CHEBI_30616_RXN-4941_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002233_CHEBI_30616_RXN-4941_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3125,24 +3056,38 @@
           <http://model.geneontology.org/CHEBI_30616_RXN-4941>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_e8b5723a-8000-48f2-8093-65faf33cdd2b_RXN3O-786_SGD_YeastPathways_PWY3O-402> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-786> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e8b5723a-8000-48f2-8093-65faf33cdd2b_RXN3O-786>
-] .
+<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002234_CHEBI_456216_2.7.1.127-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002233_CHEBI_57895_2.7.1.127-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002234_CHEBI_456216_RXN-7184_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YDR315C-MONOMER_RXN-7163_controller>
         a       <http://identifiers.org/sgd/S000002723> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3151,7 +3096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3163,11 +3108,52 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-143_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_582be5db-88b3-43f0-b55c-056f4e0e0f94_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-786> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/582be5db-88b3-43f0-b55c-056f4e0e0f94_RXN3O-786>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_CHEBI_456216_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7163_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-143_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3183,52 +3169,36 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-785_BFO_0000066_reaction_RXN3O-785_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/6ec1e05b-74d8-4177-89e0-d9b09501b9ae_RXN-4941>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a diphospho-1D-myo-inositol tetrakisphosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002333_MONOMER3O-64_RXN-4941_controller_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002234_CHEBI_57627_2.7.1.151-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47070> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002333_YOR163W-MONOMER_RXN3O-786_controller_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002333_YOR163W-MONOMER_RXN3O-786_controller_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3239,25 +3209,14 @@
           <http://model.geneontology.org/YOR163W-MONOMER_RXN3O-786_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002333_MONOMER3O-224_RXN3O-258_controller_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002234_CHEBI_456216_RXN-7184_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3270,7 +3229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3278,14 +3237,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002234_CHEBI_16322_RXN-7162_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002411_RXN3O-9819_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3296,11 +3255,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-143_BFO_0000066_reaction_RXN3O-143_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-143_BFO_0000066_reaction_RXN3O-143_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3311,15 +3270,37 @@
           <http://model.geneontology.org/reaction_RXN3O-143_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002234_CHEBI_456216_2.7.1.151-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002413_2.7.1.151-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7162_BFO_0000066_reaction_RXN-7162_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7162_BFO_0000066_reaction_RXN-7162_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3330,17 +3311,6 @@
           <http://model.geneontology.org/reaction_RXN-7162_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002234_CHEBI_15378_2.7.1.127-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_RXN3O-143>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3350,7 +3320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3367,28 +3337,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46966> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/b0f32f9d-00b5-4181-a5d1-7f1ecfc11761_RXN3O-143>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "[PP]<sub>2</sub>-IP<sub>4</sub>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46971> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3397,7 +3350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3405,11 +3358,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002333_MONOMER3O-205_2.7.1.152-RXN_controller_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002333_MONOMER3O-205_2.7.1.152-RXN_controller_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3424,11 +3377,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002233_CHEBI_30616_2.7.1.127-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002233_CHEBI_30616_2.7.1.127-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3449,11 +3402,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_4e7c9d40-6532-488d-8e70-8749f8a5fce0_RXN3O-258_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_28dd3f27-e588-4eba-b67a-f72aff1f9408_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3461,28 +3414,28 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-258> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4e7c9d40-6532-488d-8e70-8749f8a5fce0_RXN3O-258>
+          <http://model.geneontology.org/28dd3f27-e588-4eba-b67a-f72aff1f9408_RXN3O-258>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002233_CHEBI_30616_RXN-7162_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_RXN-7184_BFO_0000066_reaction_RXN-7184_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002233_CHEBI_57627_2.7.1.151-RXN_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002234_CHEBI_57627_2.7.1.151-RXN_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3495,24 +3448,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46986> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7184_BFO_0000066_reaction_RXN-7184_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58130_RXN-7163>
         a       <http://purl.obolibrary.org/obo/CHEBI_58130> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3523,7 +3465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3531,26 +3473,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002234_CHEBI_15378_RXN-7162_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002233_CHEBI_30616_RXN-7163_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002233_CHEBI_30616_RXN-7163_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3561,31 +3492,20 @@
           <http://model.geneontology.org/CHEBI_30616_RXN-7163>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002233_CHEBI_30616_RXN3O-143_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/e8b5723a-8000-48f2-8093-65faf33cdd2b_RXN3O-786>
+<http://model.geneontology.org/d77dbe09-0e3a-4195-ad92-9eeb5663f146_RXN3O-9819>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphoinositol pentakisphosphate" ;
+                "[PP]<sub>2</sub>-IP<sub>4</sub>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46994> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46971> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3608,7 +3528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3620,11 +3540,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002234_CHEBI_57627_2.7.1.151-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002234_CHEBI_57627_2.7.1.151-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3638,6 +3558,9 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/3eb7d37f-ba2e-4cad-8430-6877652317ed_RXN3O-143>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 <http://model.geneontology.org/CHEBI_16322_RXN-7162>
         a       <http://purl.obolibrary.org/obo/CHEBI_16322> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3647,7 +3570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3659,11 +3582,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-786_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-786_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3674,6 +3597,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-402/YeastPathways_PWY3O-402>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002413_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/RXN3O-785>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008486> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3683,7 +3617,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-785_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/e95a5c91-8515-4db8-98b0-ab5dc2c6f58d_RXN3O-786> , <http://model.geneontology.org/CHEBI_15377_RXN3O-785> ;
+                <http://model.geneontology.org/7eb3767d-f15d-4674-ac34-220588968aad_RXN3O-786> , <http://model.geneontology.org/CHEBI_15377_RXN3O-785> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_58130_RXN3O-785> , <http://model.geneontology.org/CHEBI_43474_RXN3O-785> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -3693,24 +3627,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402BiochemicalReaction46990> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002333_MONOMER3O-64_2.7.1.127-RXN_controller_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_2.7.1.151-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -3721,7 +3644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3733,11 +3656,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002234_CHEBI_16322_RXN-7184_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002234_CHEBI_16322_RXN-7184_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3757,7 +3680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3765,29 +3688,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002234_CHEBI_43474_RXN3O-785_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_15378_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002234_CHEBI_456216_RXN-7162_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_CHEBI_456216_RXN3O-9819_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_CHEBI_456216_RXN3O-9819_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3798,14 +3732,36 @@
           <http://model.geneontology.org/CHEBI_456216_RXN3O-9819>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002233_CHEBI_30616_2.7.1.152-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_28dd3f27-e588-4eba-b67a-f72aff1f9408_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002413_RXN-4941_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002413_RXN-7162_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3813,11 +3769,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002411_RXN3O-786_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002411_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3828,18 +3784,51 @@
           <http://model.geneontology.org/RXN3O-786>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_BFO_0000066_reaction_3.1.4.11-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_bee427d1-2ed5-4e43-b946-6ecfe35a1408_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0008440>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002333_MONOMER3O-205_2.7.1.152-RXN_controller_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002333_MONOMER3O-64_RXN-7162_controller_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002333_MONOMER3O-64_RXN-7162_controller_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3854,11 +3843,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002233_CHEBI_30616_2.7.1.152-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002233_CHEBI_30616_2.7.1.152-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3869,14 +3858,14 @@
           <http://model.geneontology.org/CHEBI_30616_2.7.1.152-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7163_BFO_0000066_reaction_RXN-7163_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002333_MONOMER3O-64_RXN-7162_controller_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3887,7 +3876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3904,24 +3893,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "inositol phosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002413_2.7.1.127-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58130>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3930,11 +3908,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3949,11 +3927,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_e95a5c91-8515-4db8-98b0-ab5dc2c6f58d_RXN3O-786_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_7eb3767d-f15d-4674-ac34-220588968aad_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3961,18 +3939,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-785> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e95a5c91-8515-4db8-98b0-ab5dc2c6f58d_RXN3O-786>
+          <http://model.geneontology.org/7eb3767d-f15d-4674-ac34-220588968aad_RXN3O-786>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-<i>myo</i>-inositol 1,3,4,5,6-pentakisphosphate + ATP &rarr; phytate + ADP + H<SUP>+</SUP>' 'null' 'phytate + ATP + H<SUP>+</SUP> &rarr; 1D-<i>myo</i>inositol 5-diphosphate 1,2,3,4,6-pentakisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002413_2.7.1.152-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002413_2.7.1.152-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3987,11 +3965,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_17815_3.1.4.11-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_17815_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4009,7 +3987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4017,14 +3995,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_CHEBI_15377_RXN3O-785_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002413_2.7.1.127-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002234_CHEBI_58130_RXN-7163_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4032,11 +4021,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_CHEBI_456216_RXN-4941_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_CHEBI_456216_RXN-4941_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4053,6 +4042,45 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_CHEBI_43474_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/bee427d1-2ed5-4e43-b946-6ecfe35a1408_RXN3O-143>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "[PP]<sub>2</sub>-IP<sub>4</sub>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46971> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-4941_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_RXN3O-258>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4062,7 +4090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4070,14 +4098,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002234_CHEBI_456216_2.7.1.127-RXN_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002413_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_6ec1e05b-74d8-4177-89e0-d9b09501b9ae_RXN-4941_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4088,11 +4127,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002411_RXN3O-785_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002411_RXN3O-785_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4108,7 +4147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4121,7 +4160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4138,7 +4177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4146,14 +4185,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-143_BFO_0000066_reaction_RXN3O-143_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_RXN-7162_BFO_0000066_reaction_RXN-7162_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4161,11 +4200,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002233_CHEBI_30616_RXN3O-143_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002233_CHEBI_30616_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4176,17 +4215,6 @@
           <http://model.geneontology.org/CHEBI_30616_RXN3O-143>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_afc2c8b0-2caa-4f40-91b6-61c2dd92926d_RXN3O-9819_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -4194,11 +4222,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002233_CHEBI_30616_RXN-7162_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002233_CHEBI_30616_RXN-7162_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4209,15 +4237,37 @@
           <http://model.geneontology.org/CHEBI_30616_RXN-7162>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-786_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_BFO_0000066_reaction_2.7.1.152-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" , "Provides Input For Rule. The relation 'phytate + ATP + H<SUP>+</SUP> &rarr; 1D-<i>myo</i>inositol 5-diphosphate 1,2,3,4,6-pentakisphosphate + ADP + H<SUP>+</SUP>' 'null' 'ATP + 1D-<i>myo</i>inositol 5-diphosphate 1,2,3,4,6-pentakisphosphate &rarr; ADP + [PP]<sub>2</sub>-IP<sub>4</sub>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002413_RXN3O-143_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002413_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4232,11 +4282,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002234_CHEBI_15378_2.7.1.127-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002234_CHEBI_15378_2.7.1.127-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4250,14 +4300,36 @@
 <http://identifiers.org/sgd/S000002580>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002333_MONOMER3O-64_RXN-7162_controller_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002234_CHEBI_16322_RXN-7184_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002413_RXN-4941_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4268,11 +4340,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002333_MONOMER3O-224_RXN3O-258_controller_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002333_MONOMER3O-224_RXN3O-258_controller_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4282,34 +4354,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/MONOMER3O-224_RXN3O-258_controller>
 ] .
-
-<http://model.geneontology.org/d9bf06fb-331a-49dd-bd21-3e81adbd0651_3.1.4.11-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47183> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002413_RXN-7163_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57895>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4321,7 +4365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4333,11 +4377,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002234_CHEBI_15378_RXN-7163_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002234_CHEBI_15378_RXN-7163_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4348,6 +4392,17 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-7163>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002233_CHEBI_57627_2.7.1.151-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_2.7.1.127-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4357,7 +4412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4370,7 +4425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4381,7 +4436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4393,11 +4448,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002333_MONOMER3O-64_2.7.1.151-RXN_controller_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002333_MONOMER3O-64_2.7.1.151-RXN_controller_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4408,25 +4463,14 @@
           <http://model.geneontology.org/MONOMER3O-64_2.7.1.151-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_15378_3.1.4.11-RXN_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_RXN-7163_BFO_0000066_reaction_RXN-7163_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_e95a5c91-8515-4db8-98b0-ab5dc2c6f58d_RXN3O-786_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4434,11 +4478,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-786_BFO_0000066_reaction_RXN3O-786_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-786_BFO_0000066_reaction_RXN3O-786_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4449,6 +4493,17 @@
           <http://model.geneontology.org/reaction_RXN3O-786_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_CHEBI_15377_RXN3O-785_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/3.1.4.11-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004435> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4458,7 +4513,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_3.1.4.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_3.1.4.11-RXN> , <http://model.geneontology.org/d9bf06fb-331a-49dd-bd21-3e81adbd0651_3.1.4.11-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_3.1.4.11-RXN> , <http://model.geneontology.org/47b12746-a63f-42ab-9dca-630abdc6ab7c_3.1.4.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_203600_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_17815_3.1.4.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -4468,13 +4523,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402BiochemicalReaction47176> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002411_RXN3O-785_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-786>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4485,9 +4551,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-786_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/38043969-2b90-4815-a08e-830484be8348_RXN3O-143> , <http://model.geneontology.org/CHEBI_15377_RXN3O-786> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN3O-786> , <http://model.geneontology.org/3eb7d37f-ba2e-4cad-8430-6877652317ed_RXN3O-143> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN3O-786> , <http://model.geneontology.org/e8b5723a-8000-48f2-8093-65faf33cdd2b_RXN3O-786> ;
+                <http://model.geneontology.org/582be5db-88b3-43f0-b55c-056f4e0e0f94_RXN3O-786> , <http://model.geneontology.org/CHEBI_43474_RXN3O-786> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR163W-MONOMER_RXN3O-786_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -4495,7 +4561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4503,32 +4569,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/38e46e6f-5298-4b37-8598-f641beb9fa4f_RXN-4941>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a diphospho-1D-myo-inositol tetrakisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47070> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002234_CHEBI_456216_RXN-7184_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002234_CHEBI_456216_RXN-7184_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4546,24 +4595,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402Protein47078> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_d9bf06fb-331a-49dd-bd21-3e81adbd0651_3.1.4.11-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YOR163W-MONOMER_RXN3O-786_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005689> ;
@@ -4572,7 +4610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4583,6 +4621,23 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/582be5db-88b3-43f0-b55c-056f4e0e0f94_RXN3O-786>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphoinositol pentakisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46994> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_15378_2.7.1.127-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4592,7 +4647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4612,7 +4667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4624,11 +4679,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_afc2c8b0-2caa-4f40-91b6-61c2dd92926d_RXN3O-9819_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_d77dbe09-0e3a-4195-ad92-9eeb5663f146_RXN3O-9819_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4636,17 +4691,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9819> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/afc2c8b0-2caa-4f40-91b6-61c2dd92926d_RXN3O-9819>
+          <http://model.geneontology.org/d77dbe09-0e3a-4195-ad92-9eeb5663f146_RXN3O-9819>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002413_RXN3O-143_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002233_CHEBI_58628_2.7.1.152-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4662,7 +4717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4675,7 +4730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4683,11 +4738,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-258_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-258_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4717,7 +4772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4725,37 +4780,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_BFO_0000066_reaction_2.7.1.127-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_CHEBI_43474_RXN3O-786_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-<i>myo</i>-inositol (1,4,5,6)-tetrakisphosphate + ATP &rarr; D-<i>myo</i>-inositol 1,3,4,5,6-pentakisphosphate + ADP + H<SUP>+</SUP>' 'null' 'ATP + D-<i>myo</i>-inositol 1,3,4,5,6-pentakisphosphate &rarr; a diphospho-1D-myo-inositol tetrakisphosphate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002413_RXN-4941_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002413_RXN-4941_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4770,11 +4803,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002233_CHEBI_58130_RXN-7163_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002233_CHEBI_58130_RXN-7163_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4785,15 +4818,37 @@
           <http://model.geneontology.org/CHEBI_58130_RXN-7163>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002333_MONOMER3O-64_2.7.1.127-RXN_controller_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7162_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_BFO_0000066_reaction_2.7.1.151-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_BFO_0000066_reaction_2.7.1.151-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4804,28 +4859,6 @@
           <http://model.geneontology.org/reaction_2.7.1.151-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_CHEBI_456216_RXN3O-143_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002413_RXN3O-258_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/MONOMER3O-64_RXN-7162_controller>
         a       <http://identifiers.org/sgd/S000002580> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4833,7 +4866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4841,15 +4874,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-785_BFO_0000066_reaction_RXN3O-785_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002234_CHEBI_43474_RXN3O-785_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002234_CHEBI_43474_RXN3O-785_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4860,14 +4904,14 @@
           <http://model.geneontology.org/CHEBI_43474_RXN3O-785>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002413_2.7.1.152-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4875,49 +4919,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002233_CHEBI_203600_3.1.4.11-RXN_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_203600_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.7.1.151-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_203600_3.1.4.11-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7184_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7184> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY3O-402/YeastPathways_PWY3O-402>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_203600_3.1.4.11-RXN_SGD_YeastPathways_PWY3O-402> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4928,14 +4934,63 @@
           <http://model.geneontology.org/CHEBI_203600_3.1.4.11-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-4941_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_YeastPathways_PWY3O-402>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-7184_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-7184> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY3O-402/YeastPathways_PWY3O-402>
+] .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002233_CHEBI_30616_2.7.1.152-RXN_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002233_CHEBI_203600_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.7.1.151-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_203600_3.1.4.11-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002413_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4946,11 +5001,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002234_CHEBI_58130_RXN3O-785_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002234_CHEBI_58130_RXN3O-785_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4961,51 +5016,18 @@
           <http://model.geneontology.org/CHEBI_58130_RXN3O-785>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_CHEBI_456216_RXN-4941_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-786_BFO_0000066_reaction_RXN3O-786_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002234_CHEBI_15378_2.7.1.152-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_38e46e6f-5298-4b37-8598-f641beb9fa4f_RXN-4941_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_6ec1e05b-74d8-4177-89e0-d9b09501b9ae_RXN-4941_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5013,17 +5035,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-4941> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/38e46e6f-5298-4b37-8598-f641beb9fa4f_RXN-4941>
+          <http://model.geneontology.org/6ec1e05b-74d8-4177-89e0-d9b09501b9ae_RXN-4941>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_CHEBI_15377_3.1.4.11-RXN_SGD_YeastPathways_PWY3O-402>
+<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_CHEBI_30616_RXN3O-9819_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5031,11 +5053,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7184_BFO_0000066_reaction_RXN-7184_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7184_BFO_0000066_reaction_RXN-7184_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5046,28 +5068,6 @@
           <http://model.geneontology.org/reaction_RXN-7184_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_BFO_0000066_reaction_2.7.1.152-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_38e46e6f-5298-4b37-8598-f641beb9fa4f_RXN-4941_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/MONOMER3O-64_RXN-7184_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002580> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -5075,7 +5075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5083,34 +5083,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002413_RXN-7162_SGD_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN-7163_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002413_2.7.1.151-RXN_SGD_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_CHEBI_456216_RXN3O-9819_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5119,6 +5108,17 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002233_CHEBI_30616_2.7.1.127-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-4031.ttl
+++ b/models/YeastPathways_PWY3O-4031.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7669_BFO_0000066_reaction_RXN-7669_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7669_BFO_0000066_reaction_RXN-7669_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,11 +24,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" , "Provides Input For Rule. The relation '&alpha;-D-glucopyranose 1-phosphate &harr; D-glucopyranose 6-phosphate' 'null' '&alpha;-D-glucopyranose 1-phosphate + UTP + H<SUP>+</SUP> &rarr; UDP-&alpha;-D-glucose + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002413_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002413_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -43,11 +43,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002234_CHEBI_58885_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002234_CHEBI_58885_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,27 +58,36 @@
           <http://model.geneontology.org/CHEBI_58885_GLUC1PURIDYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002333_YLR258W-MONOMER_RXN-7668_controller_SGD_YeastPathways_PWY3O-4031>
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002234_CHEBI_29888_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4031>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002234_CHEBI_24384_RXN-7669_SGD_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/6fa2057f-1500-4df2-9ae3-7a61e76f2d92_RXN-7668>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a glucosylated glycogenin" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51367> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/GLUC1PURIDYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003983> ;
@@ -99,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,32 +116,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002233_455ae88b-cc21-417d-ad4c-47456046b443_RXN-7668_SGD_YeastPathways_PWY3O-4031>
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002234_CHEBI_24384_RXN-7669_SGD_PWY_YeastPathways_PWY3O-4031>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://purl.obolibrary.org/obo/CHEBI_4170>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002333_MONOMER3O-4031_RXN-7667_controller_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002333_MONOMER3O-4031_RXN-7667_controller_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -143,17 +152,25 @@
           <http://model.geneontology.org/MONOMER3O-4031_RXN-7667_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_4170>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002233_GLUCOSYL-GLYCOGENIN_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002233_CHEBI_58885_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -161,11 +178,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002233_GLYCOGENIN_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002233_GLYCOGENIN_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -179,41 +196,8 @@
 <http://identifiers.org/sgd/S000001911>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002413_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002333_YKL035W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller_SGD_YeastPathways_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002333_MONOMER3O-4054_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -227,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -257,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -265,26 +249,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_BFO_0000066_reaction_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_01685489-1bcf-452f-b70d-ad187a9ab97d_RXN-7668_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_38dbd168-e1df-4819-9a2d-5db47f23fb71_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -292,29 +265,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7668> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/01685489-1bcf-452f-b70d-ad187a9ab97d_RXN-7668>
+          <http://model.geneontology.org/38dbd168-e1df-4819-9a2d-5db47f23fb71_RXN-7668>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_CHEBI_58223_RXN-7668_SGD_YeastPathways_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,26 +290,15 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002333_YHL012W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller_SGD_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_BFO_0000066_reaction_GLUC1PURIDYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_BFO_0000066_reaction_GLUC1PURIDYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,6 +308,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_GLUC1PURIDYLTRANS-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002233_CHEBI_58885_RXN-7667_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -371,11 +333,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002333_YEL011W-MONOMER_RXN-7669_controller_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002333_YEL011W-MONOMER_RXN-7669_controller_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -390,11 +352,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002233_CHEBI_58885_RXN-7667_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002233_CHEBI_58885_RXN-7667_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -408,25 +370,25 @@
 <http://purl.obolibrary.org/obo/GO_0003983>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002413_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_BFO_0000066_reaction_GLUC1PURIDYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_46398_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002234_CPD-7010_RXN-7667_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -434,11 +396,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7668_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7668_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,26 +414,15 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002333_YEL011W-MONOMER_RXN-7669_controller_SGD_YeastPathways_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002234_GLUCOSYL-GLYCOGENIN_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002234_GLUCOSYL-GLYCOGENIN_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,14 +439,14 @@
 <http://identifiers.org/sgd/S000001004>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_01685489-1bcf-452f-b70d-ad187a9ab97d_RXN-7668_SGD_YeastPathways_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -508,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -521,29 +472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002411_RXN-7668_SGD_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_15378_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -559,24 +488,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51306> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002333_MONOMER3O-4054_RXN-7667_controller_SGD_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -597,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -614,7 +532,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-7669_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/455ae88b-cc21-417d-ad4c-47456046b443_RXN-7668> ;
+                <http://model.geneontology.org/3428e415-2a26-4483-9729-9f175934f517_RXN-7668> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_24384_RXN-7669> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -622,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -634,11 +552,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002411_RXN-7669_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002411_RXN-7669_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -656,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -673,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -685,11 +603,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,11 +625,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,32 +640,65 @@
           <http://model.geneontology.org/CHEBI_58601_PHOSPHOGLUCMUT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000000737>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_CHEBI_58885_RXN-7668_SGD_YeastPathways_PWY3O-4031>
+<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002333_YKL035W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4031>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002333_YHL012W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002234_CHEBI_58223_RXN-7667_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002234_CHEBI_58223_RXN-7667_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -762,11 +713,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_BFO_0000066_reaction_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_BFO_0000066_reaction_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,6 +728,17 @@
           <http://model.geneontology.org/reaction_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-7669_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YLR258W-MONOMER_RXN-7668_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004248> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -784,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -801,7 +763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -811,28 +773,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_58601>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002233_CHEBI_58885_RXN-7667_SGD_YeastPathways_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7668_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_YeastPathways_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58885>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -844,11 +784,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_a3ea305e-6c4d-48d0-b585-26a976b930d7_RXN-7668_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_6fa2057f-1500-4df2-9ae3-7a61e76f2d92_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -856,18 +796,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7668> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a3ea305e-6c4d-48d0-b585-26a976b930d7_RXN-7668>
+          <http://model.geneontology.org/6fa2057f-1500-4df2-9ae3-7a61e76f2d92_RXN-7668>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" , "Provides Input For Rule. The relation 'UDP-&alpha;-D-glucose + a [glycogenin] &rarr; an &alpha;-D-glucosyl-[glycogenin] + UDP + H<SUP>+</SUP>' 'null' 'UDP-&alpha;-D-glucose + an &alpha;-D-glucosyl-[glycogenin] &rarr; (1,4-&alpha;-D-glucosyl)<sub>n</sub>-glucosyl glucogenin + UDP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002413_RXN-7667_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002413_RXN-7667_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -878,17 +818,6 @@
           <http://model.geneontology.org/RXN-7667>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_GLUC1PURIDYLTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -898,7 +827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -906,23 +835,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002234_CPD-7010_RXN-7667_SGD_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_15378_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -935,13 +864,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY3O-4031" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002411_RXN-7669_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -953,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,15 +901,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_CHEBI_58885_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002233_455ae88b-cc21-417d-ad4c-47456046b443_RXN-7668_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002233_3428e415-2a26-4483-9729-9f175934f517_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -977,18 +928,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7669> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/455ae88b-cc21-417d-ad4c-47456046b443_RXN-7668>
+          <http://model.geneontology.org/3428e415-2a26-4483-9729-9f175934f517_RXN-7668>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7667_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7667_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -999,15 +950,37 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-7668_BFO_0000066_reaction_RXN-7668_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002234_CHEBI_15378_RXN-7667_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002333_YHL012W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002333_YHL012W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1018,14 +991,14 @@
           <http://model.geneontology.org/YHL012W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002333_YFR015C-MONOMER_RXN-7668_controller_SGD_YeastPathways_PWY3O-4031>
+<http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002233_3428e415-2a26-4483-9729-9f175934f517_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1036,11 +1009,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002333_MONOMER3O-4054_RXN-7667_controller_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002333_MONOMER3O-4054_RXN-7667_controller_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1055,11 +1028,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002234_CHEBI_15378_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002234_CHEBI_15378_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,17 +1043,6 @@
           <http://model.geneontology.org/CHEBI_15378_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002234_CHEBI_58223_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_GLUC1PURIDYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1090,7 +1052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1098,23 +1060,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002411_RXN-7669_SGD_YeastPathways_PWY3O-4031>
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002234_CHEBI_58223_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4031>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1143,7 +1105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1155,11 +1117,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002333_YFR015C-MONOMER_RXN-7668_controller_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002333_YFR015C-MONOMER_RXN-7668_controller_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1170,37 +1132,15 @@
           <http://model.geneontology.org/YFR015C-MONOMER_RXN-7668_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002234_GLUCOSYL-GLYCOGENIN_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002233_GLYCOGENIN_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1214,15 +1154,26 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002234_GLUCOSYL-GLYCOGENIN_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_15378_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_15378_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1233,6 +1184,28 @@
           <http://model.geneontology.org/CHEBI_15378_GLUC1PURIDYLTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-7669_BFO_0000066_reaction_RXN-7669_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002233_GLYCOGENIN_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
         a       <http://identifiers.org/sgd/S000004711> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1240,7 +1213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1251,18 +1224,15 @@
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002233_GLUCOSYL-GLYCOGENIN_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002233_GLUCOSYL-GLYCOGENIN_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1273,26 +1243,18 @@
           <http://model.geneontology.org/GLUCOSYL-GLYCOGENIN_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7667_BFO_0000066_reaction_RXN-7667_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_33695>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '&alpha;-D-glucopyranose 1-phosphate + UTP + H<SUP>+</SUP> &rarr; UDP-&alpha;-D-glucose + diphosphate' 'null' 'UDP-&alpha;-D-glucose + a [glycogenin] &rarr; an &alpha;-D-glucosyl-[glycogenin] + UDP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002413_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002413_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1312,7 +1274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1320,36 +1282,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002333_MONOMER3O-4031_RXN-7667_controller_SGD_YeastPathways_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7669_BFO_0000066_reaction_RXN-7669_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_YeastPathways_PWY3O-4031>
+<http://model.geneontology.org/ev_w_id_RXN-7667_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_PWY_YeastPathways_PWY3O-4031>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1362,7 +1302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1370,25 +1310,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002234_CHEBI_15378_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4031>
+<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_CHEBI_58223_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_6fa2057f-1500-4df2-9ae3-7a61e76f2d92_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1396,11 +1336,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7668_BFO_0000066_reaction_RXN-7668_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7668_BFO_0000066_reaction_RXN-7668_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1420,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycogen biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1432,11 +1372,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002333_MONOMER3O-4031_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002333_MONOMER3O-4031_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1447,28 +1387,20 @@
           <http://model.geneontology.org/MONOMER3O-4031_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002234_CHEBI_58223_RXN-7667_SGD_YeastPathways_PWY3O-4031>
+<http://purl.obolibrary.org/obo/CHEBI_58223>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/3428e415-2a26-4483-9729-9f175934f517_RXN-7668>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002333_MONOMER3O-4031_RXN-7667_controller_SGD_PWY_YeastPathways_PWY3O-4031>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58223>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002234_CHEBI_58885_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1479,7 +1411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1496,7 +1428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1511,11 +1443,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7669_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7669_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1526,15 +1458,26 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002333_YLR258W-MONOMER_RXN-7668_controller_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1545,15 +1488,18 @@
           <http://model.geneontology.org/YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
 ] .
 
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002234_CHEBI_29888_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002234_CHEBI_29888_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1564,56 +1510,6 @@
           <http://model.geneontology.org/CHEBI_29888_GLUC1PURIDYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_BFO_0000066_reaction_GLUC1PURIDYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/01685489-1bcf-452f-b70d-ad187a9ab97d_RXN-7668>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a glucosylated glycogenin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51367> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002413_RXN-7667_SGD_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_46398_GLUC1PURIDYLTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_46398> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1623,7 +1519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1631,14 +1527,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002333_MONOMER3O-4031_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-4031>
+<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002333_MONOMER3O-4031_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4031>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1651,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1659,8 +1555,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/38dbd168-e1df-4819-9a2d-5db47f23fb71_RXN-7668>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a glucosylated glycogenin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51367> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000001518>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1672,13 +1582,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031Protein51443> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7668_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002234_CHEBI_15378_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1687,11 +1619,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002234_CPD-7010_RXN-7667_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002234_CPD-7010_RXN-7667_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1706,11 +1638,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002233_CHEBI_58885_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002233_CHEBI_58885_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1721,22 +1653,16 @@
           <http://model.geneontology.org/CHEBI_58885_GLUC1PURIDYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/a3ea305e-6c4d-48d0-b585-26a976b930d7_RXN-7668>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a glucosylated glycogenin" ;
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_46398_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51367> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1746,7 +1672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1757,11 +1683,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_CHEBI_58223_RXN-7668_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_CHEBI_58223_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1772,6 +1698,17 @@
           <http://model.geneontology.org/CHEBI_58223_RXN-7668>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-7667_BFO_0000066_reaction_RXN-7667_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/GLUCOSYL-GLYCOGENIN_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1779,7 +1716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1791,11 +1728,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1806,14 +1743,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1821,11 +1758,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1845,7 +1782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1853,15 +1790,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002234_CHEBI_58223_RXN-7667_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_BFO_0000066_reaction_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002234_CHEBI_24384_RXN-7669_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002234_CHEBI_24384_RXN-7669_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1872,14 +1831,14 @@
           <http://model.geneontology.org/CHEBI_24384_RXN-7669>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_YeastPathways_PWY3O-4031>
+<http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002333_YEL011W-MONOMER_RXN-7669_controller_SGD_PWY_YeastPathways_PWY3O-4031>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1887,11 +1846,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7667_BFO_0000066_reaction_RXN-7667_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7667_BFO_0000066_reaction_RXN-7667_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1902,14 +1861,14 @@
           <http://model.geneontology.org/reaction_RXN-7667_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7669_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_YeastPathways_PWY3O-4031>
+<http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002411_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1918,7 +1877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1926,11 +1885,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002333_YKL035W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002333_YKL035W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1950,7 +1909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1958,17 +1917,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/455ae88b-cc21-417d-ad4c-47456046b443_RXN-7668>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_RXN-7668_BFO_0000066_reaction_RXN-7668_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002413_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1976,11 +1932,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002411_RXN-7668_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002411_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1995,11 +1951,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002234_CHEBI_58223_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002234_CHEBI_58223_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2020,7 +1976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2028,41 +1984,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002234_CHEBI_29888_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002233_CHEBI_58885_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002233_GLUCOSYL-GLYCOGENIN_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -2072,29 +1995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7667_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2102,11 +2003,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002333_YLR258W-MONOMER_RXN-7668_controller_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002333_YLR258W-MONOMER_RXN-7668_controller_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2126,9 +2027,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-7668_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58885_RXN-7668> , <http://model.geneontology.org/a3ea305e-6c4d-48d0-b585-26a976b930d7_RXN-7668> ;
+                <http://model.geneontology.org/6fa2057f-1500-4df2-9ae3-7a61e76f2d92_RXN-7668> , <http://model.geneontology.org/CHEBI_58885_RXN-7668> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/01685489-1bcf-452f-b70d-ad187a9ab97d_RXN-7668> , <http://model.geneontology.org/CHEBI_58223_RXN-7668> ;
+                <http://model.geneontology.org/38dbd168-e1df-4819-9a2d-5db47f23fb71_RXN-7668> , <http://model.geneontology.org/CHEBI_58223_RXN-7668> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR258W-MONOMER_RXN-7668_controller> , <http://model.geneontology.org/YFR015C-MONOMER_RXN-7668_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2136,7 +2037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2151,7 +2052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2168,7 +2069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2180,11 +2081,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2195,14 +2096,14 @@
           <http://model.geneontology.org/CHEBI_58601_PHOSPHOGLUCMUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_YeastPathways_PWY3O-4031>
+<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002333_YFR015C-MONOMER_RXN-7668_controller_SGD_PWY_YeastPathways_PWY3O-4031>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2213,11 +2114,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_46398_GLUC1PURIDYLTRANS-RXN_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_46398_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2228,6 +2129,39 @@
           <http://model.geneontology.org/CHEBI_46398_GLUC1PURIDYLTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002413_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002413_RXN-7667_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000003673>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2235,11 +2169,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002234_CHEBI_15378_RXN-7667_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002234_CHEBI_15378_RXN-7667_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2250,6 +2184,17 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-7667>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002333_MONOMER3O-4054_RXN-7667_controller_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YFR015C-MONOMER_RXN-7668_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001911> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2257,7 +2202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2269,11 +2214,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2289,7 +2234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2312,7 +2257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2320,14 +2265,47 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002234_CHEBI_15378_RXN-7667_SGD_YeastPathways_PWY3O-4031>
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_PWY_YeastPathways_PWY3O-4031>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_38dbd168-e1df-4819-9a2d-5db47f23fb71_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2335,11 +2313,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_CHEBI_58885_RXN-7668_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_CHEBI_58885_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2349,17 +2327,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58885_RXN-7668>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_a3ea305e-6c4d-48d0-b585-26a976b930d7_RXN-7668_SGD_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001766>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2371,11 +2338,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002333_MONOMER3O-4054_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002333_MONOMER3O-4054_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2386,6 +2353,28 @@
           <http://model.geneontology.org/MONOMER3O-4054_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-4031/YeastPathways_PWY3O-4031_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002333_MONOMER3O-4054_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER3O-4031_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000003673> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2393,7 +2382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2403,3 +2392,14 @@
 
 <http://identifiers.org/sgd/S000004711>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002234_CHEBI_58885_GLUC1PURIDYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-4105.ttl
+++ b/models/YeastPathways_PWY3O-4105.ttl
@@ -1,22 +1,22 @@
-<http://model.geneontology.org/ev_w_id_RXN3O-4141_BFO_0000050_YeastPathways_PWY3O-4105/YeastPathways_PWY3O-4105_SGD_YeastPathways_PWY3O-4105>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
+                "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002234_CHEBI_46645_RXN3O-4141_SGD_YeastPathways_PWY3O-4105>
+<http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002233_CHEBI_11851_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_PWY3O-4105>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
+                "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -24,11 +24,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YGL256W-MONOMER_RXN3O-4141_controller_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YGL256W-MONOMER_RXN3O-4141_controller_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,17 +38,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YGL256W-MONOMER_RXN3O-4141_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-4133_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-4105>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004034>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -60,11 +49,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002233_CHEBI_11851_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002233_CHEBI_11851_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,18 +64,26 @@
           <http://model.geneontology.org/CHEBI_11851_BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000002327>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YBR145W-MONOMER_RXN3O-4141_controller_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_11851_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_11851_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -97,17 +94,6 @@
           <http://model.geneontology.org/CHEBI_11851_BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002233_CHEBI_48943_RXN3O-4133_SGD_YeastPathways_PWY3O-4105>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000003319>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -115,11 +101,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YBR145W-MONOMER_RXN3O-4141_controller_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YBR145W-MONOMER_RXN3O-4141_controller_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,39 +116,20 @@
           <http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4141_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YOL086C-MONOMER_RXN3O-4141_controller_SGD_YeastPathways_PWY3O-4105>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000050_YeastPathways_PWY3O-4105/YeastPathways_PWY3O-4105_SGD_YeastPathways_PWY3O-4105>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000002327>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4105>
+<http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002234_CHEBI_16526_RXN3O-4133_SGD_PWY_YeastPathways_PWY3O-4105>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
+                "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -173,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -188,11 +155,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_BFO_0000050_YeastPathways_PWY3O-4105/YeastPathways_PWY3O-4105_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_BFO_0000050_YeastPathways_PWY3O-4105/YeastPathways_PWY3O-4105_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -222,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -233,17 +200,39 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YMR083W-MONOMER_RXN3O-4141_controller_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
         a       <http://identifiers.org/sgd/S000004034> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-4133_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-4105/YeastPathways_PWY3O-4105>
         a       <http://purl.obolibrary.org/obo/GO_0006574> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -254,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -269,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -284,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -297,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -310,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -318,26 +307,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_PWY3O-4105>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4133_BFO_0000066_reaction_RXN3O-4133_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4133_BFO_0000066_reaction_RXN3O-4133_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -348,26 +326,15 @@
           <http://model.geneontology.org/reaction_RXN3O-4133_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002234_CHEBI_48943_RXN3O-4133_SGD_YeastPathways_PWY3O-4105>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -383,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -391,11 +358,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002234_CHEBI_57540_RXN3O-4141_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002234_CHEBI_57540_RXN3O-4141_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -411,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -426,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -443,11 +410,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '3-methyl-2-oxobutanoate &rarr; isobutanal + CO<SUB>2</SUB>' 'null' 'isobutanal + NADH &rarr; isobutanol + NAD<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002413_RXN3O-4141_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002413_RXN3O-4141_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,36 +425,25 @@
           <http://model.geneontology.org/RXN3O-4141>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_PWY3O-4105>
+<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YMR303C-MONOMER_RXN3O-4141_controller_SGD_PWY_YeastPathways_PWY3O-4105>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
+                "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002233_CHEBI_11851_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_PWY3O-4105>
+<http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002333_CPLX3O-58_RXN3O-4133_controller_SGD_PWY_YeastPathways_PWY3O-4105>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4133_BFO_0000050_YeastPathways_PWY3O-4105/YeastPathways_PWY3O-4105_SGD_YeastPathways_PWY3O-4105>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
+                "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -496,12 +452,34 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002413_RXN3O-4133_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003225>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -515,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -527,11 +505,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002333_CPLX3O-58_RXN3O-4133_controller_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002333_CPLX3O-58_RXN3O-4133_controller_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,11 +527,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" , "Provides Input For Rule. The relation 'L-valine + 2-oxoglutarate &harr; L-glutamate + 3-methyl-2-oxobutanoate' 'null' '3-methyl-2-oxobutanoate &rarr; isobutanal + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002413_RXN3O-4133_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002413_RXN3O-4133_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -564,14 +542,47 @@
           <http://model.geneontology.org/RXN3O-4133>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002233_CHEBI_57945_RXN3O-4141_SGD_YeastPathways_PWY3O-4105>
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_11851_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4133_BFO_0000066_reaction_RXN3O-4133_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4105>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002333_CPLX3O-118_RXN3O-4133_controller_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002233_CHEBI_48943_RXN3O-4133_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -582,11 +593,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4133_BFO_0000050_YeastPathways_PWY3O-4105/YeastPathways_PWY3O-4105_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4133_BFO_0000050_YeastPathways_PWY3O-4105/YeastPathways_PWY3O-4105_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -601,11 +612,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -625,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -637,11 +648,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002234_CHEBI_46645_RXN3O-4141_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002234_CHEBI_46645_RXN3O-4141_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -664,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -692,7 +703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -713,11 +724,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002333_CPLX3O-67_RXN3O-4133_controller_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002333_CPLX3O-67_RXN3O-4133_controller_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -732,11 +743,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YOL086C-MONOMER_RXN3O-4141_controller_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YOL086C-MONOMER_RXN3O-4141_controller_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -754,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -768,14 +779,25 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002333_CPLX3O-58_RXN3O-4133_controller_SGD_YeastPathways_PWY3O-4105>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002234_CHEBI_48943_RXN3O-4133_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000050_YeastPathways_PWY3O-4105/YeastPathways_PWY3O-4105_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -783,11 +805,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002333_CPLX3O-118_RXN3O-4133_controller_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002333_CPLX3O-118_RXN3O-4133_controller_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -798,15 +820,37 @@
           <http://model.geneontology.org/CPLX3O-118_RXN3O-4133_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4141_BFO_0000050_YeastPathways_PWY3O-4105/YeastPathways_PWY3O-4105_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -816,17 +860,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-4133_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-4105>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0052656>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -850,35 +883,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4105BiochemicalReaction47739> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002413_RXN3O-4133_SGD_YeastPathways_PWY3O-4105>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002333_CPLX3O-67_RXN3O-4133_controller_SGD_YeastPathways_PWY3O-4105>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YDL168W-MONOMER_RXN3O-4141_controller>
         a       <http://identifiers.org/sgd/S000002327> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -887,7 +898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -902,11 +913,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-4133_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-4133_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -917,26 +928,15 @@
           <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4141_BFO_0000066_reaction_RXN3O-4141_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4105>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -954,11 +954,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002233_CHEBI_57945_RXN3O-4141_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002233_CHEBI_57945_RXN3O-4141_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,17 +969,6 @@
           <http://model.geneontology.org/CHEBI_57945_RXN3O-4141>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_PWY3O-4105>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57762> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -989,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1000,17 +989,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002333_CPLX3O-118_RXN3O-4133_controller_SGD_YeastPathways_PWY3O-4105>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YMR083W-MONOMER_RXN3O-4141_controller>
         a       <http://identifiers.org/sgd/S000004688> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1018,7 +996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1026,36 +1004,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_11851_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_PWY3O-4105>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_YeastPathways_PWY3O-4105>
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-4133_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-4105>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YDL168W-MONOMER_RXN3O-4141_controller_SGD_YeastPathways_PWY3O-4105>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
+                "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1066,11 +1022,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YMR303C-MONOMER_RXN3O-4141_controller_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YMR303C-MONOMER_RXN3O-4141_controller_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1084,17 +1040,6 @@
 <http://purl.obolibrary.org/obo/GO_0006574>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4133_BFO_0000066_reaction_RXN3O-4133_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4105>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1102,11 +1047,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002234_CHEBI_48943_RXN3O-4133_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002234_CHEBI_48943_RXN3O-4133_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1126,7 +1071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "valine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1138,11 +1083,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1159,14 +1104,14 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YGL256W-MONOMER_RXN3O-4141_controller_SGD_YeastPathways_PWY3O-4105>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
+                "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1179,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1187,17 +1132,50 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_46645>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YBR145W-MONOMER_RXN3O-4141_controller_SGD_YeastPathways_PWY3O-4105>
+<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002234_CHEBI_46645_RXN3O-4141_SGD_PWY_YeastPathways_PWY3O-4105>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_46645>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-4133_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YDL168W-MONOMER_RXN3O-4141_controller_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YOL086C-MONOMER_RXN3O-4141_controller_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1205,11 +1183,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-4133_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-4133_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1223,15 +1201,37 @@
 <http://purl.obolibrary.org/obo/CHEBI_48943>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002413_RXN3O-4141_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002233_CHEBI_57945_RXN3O-4141_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000050_YeastPathways_PWY3O-4105/YeastPathways_PWY3O-4105_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000050_YeastPathways_PWY3O-4105/YeastPathways_PWY3O-4105_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1249,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1257,15 +1257,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YGL256W-MONOMER_RXN3O-4141_controller_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002233_CHEBI_48943_RXN3O-4133_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002233_CHEBI_48943_RXN3O-4133_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1286,7 +1297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1303,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1314,30 +1325,8 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-4133_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-4105>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002234_CHEBI_57540_RXN3O-4141_SGD_YeastPathways_PWY3O-4105>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004688>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1346,11 +1335,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YMR083W-MONOMER_RXN3O-4141_controller_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YMR083W-MONOMER_RXN3O-4141_controller_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1370,24 +1359,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4105SmallMolecule47753> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002234_CHEBI_16526_RXN3O-4133_SGD_YeastPathways_PWY3O-4105>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-118_RXN3O-4133_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -1398,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1416,11 +1394,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002234_CHEBI_16526_RXN3O-4133_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002234_CHEBI_16526_RXN3O-4133_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1440,7 +1418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1448,15 +1426,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4133_BFO_0000050_YeastPathways_PWY3O-4105/YeastPathways_PWY3O-4105_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1471,11 +1460,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YDL168W-MONOMER_RXN3O-4141_controller_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YDL168W-MONOMER_RXN3O-4141_controller_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1486,28 +1475,28 @@
           <http://model.geneontology.org/YDL168W-MONOMER_RXN3O-4141_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YMR303C-MONOMER_RXN3O-4141_controller_SGD_YeastPathways_PWY3O-4105>
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4105>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
+                "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_YeastPathways_PWY3O-4105>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-4141_BFO_0000066_reaction_RXN3O-4141_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
+                "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1516,6 +1505,9 @@
 
 <http://identifiers.org/sgd/S000001251>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_57945_RXN3O-4141>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
@@ -1526,7 +1518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1538,11 +1530,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-4133_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-4133_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1553,18 +1545,26 @@
           <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
 ] .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4141_BFO_0000066_reaction_RXN3O-4141_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4105> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4141_BFO_0000066_reaction_RXN3O-4141_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1575,17 +1575,6 @@
           <http://model.geneontology.org/reaction_RXN3O-4141_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002413_RXN3O-4141_SGD_YeastPathways_PWY3O-4105>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16526_RXN3O-4133>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1595,7 +1584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1603,14 +1592,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YMR083W-MONOMER_RXN3O-4141_controller_SGD_YeastPathways_PWY3O-4105>
+<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002234_CHEBI_57540_RXN3O-4141_SGD_PWY_YeastPathways_PWY3O-4105>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4105" ;
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002333_CPLX3O-67_RXN3O-4133_controller_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 

--- a/models/YeastPathways_PWY3O-4106.ttl
+++ b/models/YeastPathways_PWY3O-4106.ttl
@@ -1,45 +1,12 @@
-<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4106>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4106" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002234_CHEBI_57540_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4106>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4106" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-4106/YeastPathways_PWY3O-4106_SGD_YeastPathways_PWY3O-4106>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4106" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002234_CHEBI_29888_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4106> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002234_CHEBI_29888_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4106> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,15 +17,26 @@
           <http://model.geneontology.org/CHEBI_29888_2.7.7.1-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4106>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4106" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4106> ;
+          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4106> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -68,6 +46,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002234_CHEBI_57540_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4106>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4106" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -81,34 +70,12 @@
 <http://identifiers.org/sgd/S000004320>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_456216_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4106>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4106" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_BFO_0000050_YeastPathways_PWY3O-4106/YeastPathways_PWY3O-4106_SGD_YeastPathways_PWY3O-4106>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4106" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_2.7.7.1-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -121,17 +88,6 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002333_YLR328W-MONOMER_2.7.7.1-RXN_controller_SGD_YeastPathways_PWY3O-4106>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4106" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_2.7.7.1-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -141,13 +97,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4106SmallMolecule69479> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002413_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4106>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4106" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29888_2.7.7.1-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
@@ -158,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -166,26 +133,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002233_CHEBI_30616_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4106>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4106" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_30616_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4106> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_30616_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4106> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -196,15 +152,26 @@
           <http://model.geneontology.org/CHEBI_30616_2.7.7.1-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_BFO_0000066_reaction_RIBOSYLNICOTINAMIDE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4106>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4106" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002233_CHEBI_30616_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4106> ;
+          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002233_CHEBI_30616_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4106> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -215,17 +182,6 @@
           <http://model.geneontology.org/CHEBI_30616_RIBOSYLNICOTINAMIDE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002413_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4106>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4106" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_14649>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -235,41 +191,19 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_BFO_0000066_reaction_2.7.7.1-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4106>
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_15378_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4106>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4106" ;
+                "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005073>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_30616_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4106>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4106" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4106>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4106" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -293,7 +227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -304,14 +238,36 @@
 <http://purl.obolibrary.org/obo/CHEBI_15927>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002234_CHEBI_29888_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4106>
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_BFO_0000066_reaction_2.7.7.1-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4106>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4106" ;
+                "SGD_PWY:PWY3O-4106" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_BFO_0000050_YeastPathways_PWY3O-4106/YeastPathways_PWY3O-4106_SGD_PWY_YeastPathways_PWY3O-4106>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4106" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_456216_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4106>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -322,11 +278,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" , "Provides Input For Rule. The relation '1-(&beta;-D ribofuranosyl)nicotinamide + ATP &rarr; &beta;-nicotinamide D-ribonucleotide + ADP + H<SUP>+</SUP>' 'null' '&beta;-nicotinamide D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; NAD<sup>+</sup> + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002413_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4106> ;
+          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002413_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4106> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -344,11 +300,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_15378_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4106> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_15378_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4106> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,11 +319,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002233_CHEBI_15927_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4106> ;
+          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002233_CHEBI_15927_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4106> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,6 +334,17 @@
           <http://model.geneontology.org/CHEBI_15927_RIBOSYLNICOTINAMIDE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002234_CHEBI_29888_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4106>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4106" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_RIBOSYLNICOTINAMIDE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -387,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -405,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -426,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -437,17 +404,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_15378_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4106>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4106" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -455,11 +411,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002333_YLR328W-MONOMER_2.7.7.1-RXN_controller_SGD_YeastPathways_PWY3O-4106> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002333_YLR328W-MONOMER_2.7.7.1-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4106> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -479,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "NAD salvage pathway IV (from nicotinamide riboside) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -491,11 +447,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002333_MONOMER3O-4139_RIBOSYLNICOTINAMIDE-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-4106> ;
+          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002333_MONOMER3O-4139_RIBOSYLNICOTINAMIDE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4106> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -510,11 +466,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4106> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4106> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -525,26 +481,15 @@
           <http://model.geneontology.org/CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002333_YGR010W-MONOMER_2.7.7.1-RXN_controller_SGD_YeastPathways_PWY3O-4106>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4106" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_BFO_0000066_reaction_RIBOSYLNICOTINAMIDE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4106> ;
+          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_BFO_0000066_reaction_RIBOSYLNICOTINAMIDE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4106> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -555,14 +500,36 @@
           <http://model.geneontology.org/reaction_RIBOSYLNICOTINAMIDE-KINASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002233_CHEBI_15927_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4106>
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_30616_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4106>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4106" ;
+                "SGD_PWY:PWY3O-4106" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-4106/YeastPathways_PWY3O-4106_SGD_PWY_YeastPathways_PWY3O-4106>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4106" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_15378_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4106>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -575,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -586,8 +553,30 @@
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002333_MONOMER3O-4139_RIBOSYLNICOTINAMIDE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4106>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4106" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002333_YLR328W-MONOMER_2.7.7.1-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4106>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4106" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0034355>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -599,11 +588,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002333_YGR010W-MONOMER_2.7.7.1-RXN_controller_SGD_YeastPathways_PWY3O-4106> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002333_YGR010W-MONOMER_2.7.7.1-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4106> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -621,11 +610,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_456216_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4106> ;
+          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_456216_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4106> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -645,7 +634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -662,7 +651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -673,15 +662,26 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4106>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4106" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_BFO_0000066_reaction_2.7.7.1-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4106> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_BFO_0000066_reaction_2.7.7.1-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4106> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -692,6 +692,17 @@
           <http://model.geneontology.org/reaction_2.7.7.1-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002233_CHEBI_15927_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4106>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4106" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YGR010W-MONOMER_2.7.7.1-RXN_controller>
         a       <http://identifiers.org/sgd/S000003242> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -699,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -711,11 +722,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-4106/YeastPathways_PWY3O-4106_SGD_YeastPathways_PWY3O-4106> ;
+          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-4106/YeastPathways_PWY3O-4106_SGD_PWY_YeastPathways_PWY3O-4106> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -737,37 +748,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002333_MONOMER3O-4139_RIBOSYLNICOTINAMIDE-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-4106>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4106" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_BFO_0000066_reaction_RIBOSYLNICOTINAMIDE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4106>
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002333_YGR010W-MONOMER_2.7.7.1-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4106>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4106" ;
+                "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_57540_2.7.7.1-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
@@ -778,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -793,11 +793,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002234_CHEBI_57540_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4106> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002234_CHEBI_57540_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4106> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -808,26 +808,15 @@
           <http://model.geneontology.org/CHEBI_57540_2.7.7.1-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_15378_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4106>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4106" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_15378_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4106> ;
+          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_15378_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4106> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -842,11 +831,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_BFO_0000050_YeastPathways_PWY3O-4106/YeastPathways_PWY3O-4106_SGD_YeastPathways_PWY3O-4106> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_BFO_0000050_YeastPathways_PWY3O-4106/YeastPathways_PWY3O-4106_SGD_PWY_YeastPathways_PWY3O-4106> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -869,13 +858,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4106SmallMolecule69494> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002233_CHEBI_30616_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4106>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4106" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/2.7.7.1-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0000309> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -894,30 +894,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4106BiochemicalReaction69520> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/CHEBI_456216_RIBOSYLNICOTINAMIDE-KINASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ADP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4106SmallMolecule69509> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_30616_2.7.7.1-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -928,11 +911,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4106SmallMolecule69466> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_456216_RIBOSYLNICOTINAMIDE-KINASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ADP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4106SmallMolecule69509> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 

--- a/models/YeastPathways_PWY3O-4107.ttl
+++ b/models/YeastPathways_PWY3O-4107.ttl
@@ -1,12 +1,23 @@
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002413_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_de2a85c3-8910-4b01-9a5a-cb0598fd2d53_RXN-15025_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_212517d5-c9a5-471d-89ac-8da42b30ea64_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14,19 +25,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/de2a85c3-8910-4b01-9a5a-cb0598fd2d53_RXN-15025>
+          <http://model.geneontology.org/212517d5-c9a5-471d-89ac-8da42b30ea64_RXN-15025>
 ] .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -35,11 +35,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002233_CHEBI_17154_RXN-15025_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002233_CHEBI_17154_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -91,11 +91,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -118,24 +118,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule70027> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58437_NICONUCADENYLYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58437> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -146,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -154,20 +143,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107>
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -188,25 +188,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_32544_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_212517d5-c9a5-471d-89ac-8da42b30ea64_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_456216_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -214,11 +203,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_30616_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_30616_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -229,26 +218,15 @@
           <http://model.geneontology.org/CHEBI_30616_NICOTINATEPRIBOSYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -285,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -306,11 +284,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" , "Provides Input For Rule. The relation 'nicotinate + 5-phospho-&alpha;-D-ribose 1-diphosphate + ATP + H<sub>2</sub>O &rarr; &beta;-nicotinate D-ribonucleotide + ADP + diphosphate + phosphate' 'null' '&beta;-nicotinate D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; nicotinate adenine dinucleotide + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,15 +299,26 @@
           <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -340,17 +329,6 @@
           <http://model.geneontology.org/YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_NICONUCADENYLYLTRAN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -360,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -375,11 +353,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -396,33 +374,47 @@
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_1a7b2aac-fa20-4dc4-a6ef-fb9abb012f55_RXN-15025_SGD_YeastPathways_PWY3O-4107> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-15025> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1a7b2aac-fa20-4dc4-a6ef-fb9abb012f55_RXN-15025>
-] .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4107>
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_CHEBI_15377_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_83767_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000066_reaction_RXN-15025_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -430,11 +422,52 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002333_YGL037C-MONOMER_NICOTINAMID-RXN_controller_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_3f096c82-36cb-4700-9699-1356b7da2269_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-15025> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/3f096c82-36cb-4700-9699-1356b7da2269_RXN-15025>
+] .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002333_YGL037C-MONOMER_NICOTINAMID-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4107> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -454,9 +487,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-15025_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_RXN-15025> , <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/de2a85c3-8910-4b01-9a5a-cb0598fd2d53_RXN-15025> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN-15025> , <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/212517d5-c9a5-471d-89ac-8da42b30ea64_RXN-15025> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/1a7b2aac-fa20-4dc4-a6ef-fb9abb012f55_RXN-15025> , <http://model.geneontology.org/CHEBI_17154_RXN-15025> , <http://model.geneontology.org/CHEBI_83767_RXN-15025> ;
+                <http://model.geneontology.org/3f096c82-36cb-4700-9699-1356b7da2269_RXN-15025> , <http://model.geneontology.org/CHEBI_17154_RXN-15025> , <http://model.geneontology.org/CHEBI_83767_RXN-15025> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-4152_RXN-15025_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -464,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -472,14 +505,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002233_CHEBI_15377_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -492,7 +525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -505,47 +538,47 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_83767>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_YeastPathways_PWY3O-4107>
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_17154_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -559,15 +592,26 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -581,40 +625,57 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4107>
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_3f096c82-36cb-4700-9699-1356b7da2269_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004516>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_de2a85c3-8910-4b01-9a5a-cb0598fd2d53_RXN-15025_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/3f096c82-36cb-4700-9699-1356b7da2269_RXN-15025>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [histone]-L-lysine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule69962> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_CHEBI_15377_RXN-15025_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_CHEBI_15377_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -625,37 +686,15 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-15025>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_CHEBI_15377_RXN-15025_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_30616_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000066_reaction_NICOTINAMID-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000066_reaction_NICOTINAMID-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,6 +704,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_NICOTINAMID-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -688,7 +738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -700,11 +750,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -715,43 +765,43 @@
           <http://model.geneontology.org/CHEBI_58359_NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4107>
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4107>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_BFO_0000066_reaction_NICOTINATEPRIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_BFO_0000066_reaction_NICOTINATEPRIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -762,26 +812,15 @@
           <http://model.geneontology.org/reaction_NICOTINATEPRIBOSYLTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002234_CHEBI_32544_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -797,7 +836,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002234_CHEBI_28938_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -810,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -824,17 +874,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_NICOTINAMID-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15377_NICOTINATEPRIBOSYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -845,7 +906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -853,37 +914,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_57502_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_57502_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -898,11 +937,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -916,14 +955,25 @@
 <http://purl.obolibrary.org/obo/GO_0003952>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_BFO_0000066_reaction_NICOTINATEPRIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4107>
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002233_CHEBI_15377_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -936,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -947,29 +997,40 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002333_YGL037C-MONOMER_NICOTINAMID-RXN_controller_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_15377_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002200>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_17154_RXN-15025_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_17154_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -987,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -999,11 +1060,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002234_CHEBI_28938_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002234_CHEBI_28938_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1014,15 +1075,26 @@
           <http://model.geneontology.org/CHEBI_28938_NICOTINAMID-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1036,15 +1108,26 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_32544_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_32544_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1055,15 +1138,26 @@
           <http://model.geneontology.org/CHEBI_32544_NICOTINAMID-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1077,6 +1171,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_32544>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002333_YOR209C-MONOMER_NICOTINATEPRIBOSYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1085,6 +1190,17 @@
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_32544_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1101,7 +1217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "NAD salvage pathway V (PNC V cycle) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1118,7 +1234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1132,15 +1248,26 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002333_YGL037C-MONOMER_NICOTINAMID-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1151,37 +1278,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" , "Provides Input For Rule. The relation '&beta;-nicotinate D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; nicotinate adenine dinucleotide + diphosphate' 'null' 'ATP + nicotinate adenine dinucleotide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + AMP + NAD<sup>+</sup> + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1192,26 +1297,15 @@
           <http://model.geneontology.org/NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_57502_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1225,31 +1319,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/de2a85c3-8910-4b01-9a5a-cb0598fd2d53_RXN-15025>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [histone]-N<sup>6</sup>-acetyl-L-lysine" ;
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule69955> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_15377_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000066_reaction_NICOTINAMID-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1260,7 +1348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1268,26 +1356,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_1a7b2aac-fa20-4dc4-a6ef-fb9abb012f55_RXN-15025_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002333_MONOMER3O-4152_RXN-15025_controller_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002333_MONOMER3O-4152_RXN-15025_controller_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1302,11 +1379,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'nicotinamide + H<sub>2</sub>O &rarr; ammonium + nicotinate' 'null' 'nicotinate + 5-phospho-&alpha;-D-ribose 1-diphosphate + ATP + H<sub>2</sub>O &rarr; &beta;-nicotinate D-ribonucleotide + ADP + diphosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002413_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002413_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1321,11 +1398,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1336,51 +1413,62 @@
           <http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002233_CHEBI_17154_RXN-15025_SGD_YeastPathways_PWY3O-4107>
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_BFO_0000066_reaction_NICOTINATEPRIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002413_RXN-15025_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002234_CHEBI_32544_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_43474_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_43474_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1391,26 +1479,15 @@
           <http://model.geneontology.org/CHEBI_43474_NICOTINATEPRIBOSYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1420,6 +1497,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57502_NICOTINATEPRIBOSYLTRANS-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002333_MONOMER3O-4152_RXN-15025_controller_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17154>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1433,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1441,48 +1540,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1493,15 +1559,26 @@
           <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002233_CHEBI_15377_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002233_CHEBI_15377_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1512,6 +1589,17 @@
           <http://model.geneontology.org/CHEBI_15377_NICOTINAMID-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002233_CHEBI_17154_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001116> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1519,7 +1607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1531,11 +1619,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1558,7 +1646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1569,14 +1657,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002413_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1592,7 +1680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1609,7 +1697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1621,11 +1709,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_15377_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_15377_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1645,7 +1733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1653,15 +1741,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/212517d5-c9a5-471d-89ac-8da42b30ea64_RXN-15025>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [histone]-N<sup>6</sup>-acetyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule69955> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" , "Provides Input For Rule. The relation 'ATP + nicotinate adenine dinucleotide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + AMP + NAD<sup>+</sup> + diphosphate + H<SUP>+</SUP>' 'null' 'a [histone]-N<sup>6</sup>-acetyl-L-lysine + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; a [histone]-L-lysine + 2''-<i>O</i>-acetyl-ADP-ribose + nicotinamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002413_RXN-15025_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002413_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1672,6 +1777,17 @@
           <http://model.geneontology.org/RXN-15025>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_43474_NICOTINATEPRIBOSYLTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1681,7 +1797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1689,14 +1805,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002333_MONOMER3O-4152_RXN-15025_controller_SGD_YeastPathways_PWY3O-4107>
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_43474_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1707,11 +1823,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002333_YOR209C-MONOMER_NICOTINATEPRIBOSYLTRANS-RXN_controller_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002333_YOR209C-MONOMER_NICOTINATEPRIBOSYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1726,11 +1842,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1750,7 +1866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1758,26 +1874,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1788,36 +1893,25 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002413_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4107>
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002413_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000066_reaction_RXN-15025_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1830,24 +1924,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule69821> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003242> ;
@@ -1856,7 +1939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1864,26 +1947,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_83767_RXN-15025_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_83767_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1894,17 +1966,6 @@
           <http://model.geneontology.org/CHEBI_83767_RXN-15025>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000005735>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1912,11 +1973,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002234_CHEBI_32544_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002234_CHEBI_32544_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1926,17 +1987,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_32544_NICOTINAMID-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/NAD-SYNTH-GLN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003952> ;
@@ -1957,7 +2007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1969,11 +2019,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2006,7 +2056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2014,25 +2064,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002234_CHEBI_28938_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4107>
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_30616_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_17154_RXN-15025_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2040,11 +2079,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2064,7 +2103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2076,11 +2115,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2093,34 +2132,6 @@
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002413_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/1a7b2aac-fa20-4dc4-a6ef-fb9abb012f55_RXN-15025>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [histone]-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule69962> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -2137,7 +2148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2157,7 +2168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2170,18 +2181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_83767_RXN-15025_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2189,11 +2189,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000066_reaction_RXN-15025_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000066_reaction_RXN-15025_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2208,11 +2208,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2223,14 +2223,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_YeastPathways_PWY3O-4107>
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2243,7 +2243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2251,26 +2251,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2290,7 +2279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2298,23 +2287,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000066_reaction_NICOTINAMID-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2337,7 +2315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2348,15 +2326,26 @@
 <http://identifiers.org/sgd/S000003005>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a [histone]-N<sup>6</sup>-acetyl-L-lysine + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; a [histone]-L-lysine + 2''-<i>O</i>-acetyl-ADP-ribose + nicotinamide' 'null' 'nicotinamide + H<sub>2</sub>O &rarr; ammonium + nicotinate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002413_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002413_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2371,11 +2360,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2390,11 +2379,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2412,24 +2401,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107Protein70034> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_43474_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YOR209C-MONOMER_NICOTINATEPRIBOSYLTRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005735> ;
@@ -2438,7 +2416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2450,11 +2428,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_456216_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_456216_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2469,11 +2447,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2490,13 +2468,35 @@
 <http://purl.obolibrary.org/obo/GO_0008936>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002333_YOR209C-MONOMER_NICOTINATEPRIBOSYLTRANS-RXN_controller_SGD_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_456216_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_57502_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-4108.ttl
+++ b/models/YeastPathways_PWY3O-4108.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13,39 +13,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002233_CHEBI_36242_RXN3O-4157_SGD_YeastPathways_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000003170>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_YeastPathways_PWY3O-4108/YeastPathways_PWY3O-4108_SGD_YeastPathways_PWY3O-4108>
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_YeastPathways_PWY3O-4108/YeastPathways_PWY3O-4108_SGD_PWY_YeastPathways_PWY3O-4108>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000003170>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_15378_RXN3O-4113_SGD_YeastPathways_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
+                "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -53,11 +31,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_BFO_0000050_YeastPathways_PWY3O-4108/YeastPathways_PWY3O-4108_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_BFO_0000050_YeastPathways_PWY3O-4108/YeastPathways_PWY3O-4108_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -91,14 +69,14 @@
 <http://identifiers.org/sgd/S000000349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YMR303C-MONOMER_RXN3O-4113_controller_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
+                "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -111,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -124,18 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_BFO_0000066_reaction_RXN3O-4113_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -143,11 +110,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,6 +125,17 @@
           <http://model.geneontology.org/reaction_RXN3O-4157_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002233_CHEBI_15378_4.1.1.80-RXN_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58315>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -165,11 +143,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_15621_4.1.1.80-RXN_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_15621_4.1.1.80-RXN_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,15 +158,26 @@
           <http://model.geneontology.org/CHEBI_15621_4.1.1.80-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -222,26 +211,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_1879>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_57540_RXN3O-4113_SGD_YeastPathways_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
+                "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_1879>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_RXN3O-4157_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -257,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -284,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -296,11 +285,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-4108/YeastPathways_PWY3O-4108_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-4108/YeastPathways_PWY3O-4108_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,11 +304,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002234_CHEBI_16526_4.1.1.80-RXN_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002234_CHEBI_16526_4.1.1.80-RXN_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,19 +322,30 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002413_RXN3O-4113_SGD_YeastPathways_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002234_CHEBI_15621_4.1.1.80-RXN_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
+                "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-4108>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -356,13 +356,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-tyrosine degradation III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_4.1.1.80-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -373,35 +384,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48552> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YGL256W-MONOMER_RXN3O-4113_controller_SGD_YeastPathways_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -412,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -420,26 +409,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YBR145W-MONOMER_RXN3O-4113_controller_SGD_YeastPathways_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_YeastPathways_PWY3O-4108/YeastPathways_PWY3O-4108_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_YeastPathways_PWY3O-4108/YeastPathways_PWY3O-4108_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -454,11 +432,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_15378_RXN3O-4113_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_15378_RXN3O-4113_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -469,15 +447,26 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-4113>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_15621_4.1.1.80-RXN_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -491,35 +480,46 @@
 <http://purl.obolibrary.org/obo/GO_0050546>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_BFO_0000066_reaction_4.1.1.80-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_1879_RXN3O-4113_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
+                "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-tyrosine + pyruvate &harr; 3-(4-hydroxyphenyl)pyruvate + L-alanine' 'null' '3-(4-hydroxyphenyl)pyruvate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + (4-hydroxyphenyl)acetaldehyde' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_4.1.1.80-RXN_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_4.1.1.80-RXN_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -547,26 +547,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_1879_RXN3O-4113_SGD_YeastPathways_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002234_CHEBI_15621_4.1.1.80-RXN_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002234_CHEBI_15621_4.1.1.80-RXN_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -576,6 +565,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15621_4.1.1.80-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002233_CHEBI_36242_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -587,11 +587,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_57972_RXN3O-4157_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_57972_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -605,26 +605,15 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YBR145W-MONOMER_RXN3O-4113_controller_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YBR145W-MONOMER_RXN3O-4113_controller_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -635,50 +624,6 @@
           <http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4113_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_4.1.1.80-RXN_SGD_YeastPathways_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YMR303C-MONOMER_RXN3O-4113_controller>
         a       <http://identifiers.org/sgd/S000004918> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -686,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -694,23 +639,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YMR303C-MONOMER_RXN3O-4113_controller_SGD_YeastPathways_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-4113_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -721,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -736,11 +670,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YOL086C-MONOMER_RXN3O-4113_controller_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YOL086C-MONOMER_RXN3O-4113_controller_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -755,11 +689,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_BFO_0000066_reaction_RXN3O-4113_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_BFO_0000066_reaction_RXN3O-4113_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -779,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -791,11 +725,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -806,6 +740,17 @@
           <http://model.geneontology.org/CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_15378_RXN3O-4113_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57540_RXN3O-4113>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -815,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -828,17 +773,6 @@
 
 <http://purl.obolibrary.org/obo/GO_0004022>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YMR083W-MONOMER_RXN3O-4113_controller_SGD_YeastPathways_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-4113>
         a       <http://purl.obolibrary.org/obo/GO_0004022> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -857,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -875,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -886,15 +820,37 @@
 <http://purl.obolibrary.org/obo/CHEBI_15621>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YOL086C-MONOMER_RXN3O-4113_controller_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_BFO_0000066_reaction_RXN3O-4113_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -905,26 +861,15 @@
           <http://model.geneontology.org/YHR137W-MONOMER_RXN3O-4157_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_36242_RXN3O-4157_SGD_YeastPathways_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002233_CHEBI_36242_RXN3O-4157_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002233_CHEBI_36242_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -935,6 +880,17 @@
           <http://model.geneontology.org/CHEBI_36242_RXN3O-4157>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YGL256W-MONOMER_RXN3O-4113_controller_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58315> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -944,13 +900,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48377> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_57945_RXN3O-4113_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -967,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -979,11 +946,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_36242_RXN3O-4157_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_36242_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -994,14 +961,14 @@
           <http://model.geneontology.org/CHEBI_36242_RXN3O-4157>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002234_CHEBI_16526_4.1.1.80-RXN_SGD_YeastPathways_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002413_RXN3O-4113_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
+                "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1014,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1026,11 +993,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_57540_RXN3O-4113_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_57540_RXN3O-4113_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1041,43 +1008,54 @@
           <http://model.geneontology.org/CHEBI_57540_RXN3O-4113>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_BFO_0000050_YeastPathways_PWY3O-4108/YeastPathways_PWY3O-4108_SGD_YeastPathways_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_4.1.1.80-RXN_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YOL086C-MONOMER_RXN3O-4113_controller_SGD_YeastPathways_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
+                "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_BFO_0000050_YeastPathways_PWY3O-4108/YeastPathways_PWY3O-4108_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_36242>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_4.1.1.80-RXN_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YMR303C-MONOMER_RXN3O-4113_controller_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YMR303C-MONOMER_RXN3O-4113_controller_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1092,11 +1070,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_BFO_0000050_YeastPathways_PWY3O-4108/YeastPathways_PWY3O-4108_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_BFO_0000050_YeastPathways_PWY3O-4108/YeastPathways_PWY3O-4108_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1114,11 +1092,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,101 +1107,24 @@
           <http://model.geneontology.org/CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_BFO_0000066_reaction_4.1.1.80-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-4108/YeastPathways_PWY3O-4108_SGD_YeastPathways_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_YeastPathways_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001179>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_57945_RXN3O-4113_SGD_YeastPathways_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_15361_RXN3O-4157_SGD_YeastPathways_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_BFO_0000050_YeastPathways_PWY3O-4108/YeastPathways_PWY3O-4108_SGD_YeastPathways_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002233_CHEBI_15378_4.1.1.80-RXN_SGD_YeastPathways_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002233_CHEBI_15378_4.1.1.80-RXN_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002233_CHEBI_15378_4.1.1.80-RXN_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1234,12 +1135,14 @@
           <http://model.geneontology.org/CHEBI_15378_4.1.1.80-RXN>
 ] .
 
-<http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
-        a       <http://identifiers.org/sgd/S000003170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_57540_RXN3O-4113_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1260,13 +1163,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108BiochemicalReaction48538> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
+        a       <http://identifiers.org/sgd/S000003170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4113_controller>
         a       <http://identifiers.org/sgd/S000000349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1275,7 +1198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1290,11 +1213,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1305,15 +1228,29 @@
           <http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
 ] .
 
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_36242_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_1879_RXN3O-4113_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_1879_RXN3O-4113_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1324,38 +1261,65 @@
           <http://model.geneontology.org/CHEBI_1879_RXN3O-4113>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_57972_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002234_CHEBI_16526_4.1.1.80-RXN_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_57972_RXN3O-4157_SGD_YeastPathways_PWY3O-4108>
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-4108/YeastPathways_PWY3O-4108_SGD_PWY_YeastPathways_PWY3O-4108>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
+                "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57972>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YMR083W-MONOMER_RXN3O-4113_controller_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YMR083W-MONOMER_RXN3O-4113_controller_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1366,15 +1330,21 @@
           <http://model.geneontology.org/YMR083W-MONOMER_RXN3O-4113_controller>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_57972>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_15361>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1385,40 +1355,15 @@
           <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15361>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_4.1.1.80-RXN_SGD_YeastPathways_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1438,7 +1383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1446,14 +1391,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_YeastPathways_PWY3O-4108>
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YBR145W-MONOMER_RXN3O-4113_controller_SGD_PWY_YeastPathways_PWY3O-4108>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1465,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1478,7 +1434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1486,8 +1442,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_BFO_0000050_YeastPathways_PWY3O-4108/YeastPathways_PWY3O-4108_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YMR083W-MONOMER_RXN3O-4113_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004688> ;
@@ -1496,13 +1460,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108Protein48523> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1511,11 +1478,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_BFO_0000066_reaction_4.1.1.80-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_BFO_0000066_reaction_4.1.1.80-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1529,29 +1496,29 @@
 <http://identifiers.org/sgd/S000004688>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002234_CHEBI_15621_4.1.1.80-RXN_SGD_YeastPathways_PWY3O-4108>
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4108>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
+                "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_15361_RXN3O-4157_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_15361_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1571,7 +1538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1583,11 +1550,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_57945_RXN3O-4113_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_57945_RXN3O-4113_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1598,15 +1565,26 @@
           <http://model.geneontology.org/CHEBI_57945_RXN3O-4113>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YMR083W-MONOMER_RXN3O-4113_controller_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-tyrosine + 2-oxoglutarate &harr; 3-(4-hydroxyphenyl)pyruvate + L-glutamate' 'null' '3-(4-hydroxyphenyl)pyruvate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + (4-hydroxyphenyl)acetaldehyde' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_4.1.1.80-RXN_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_4.1.1.80-RXN_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1632,7 +1610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1640,29 +1618,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_15621_4.1.1.80-RXN_SGD_YeastPathways_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_15361_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4108" ;
+                "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YGL256W-MONOMER_RXN3O-4113_controller_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YGL256W-MONOMER_RXN3O-4113_controller_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1673,6 +1651,17 @@
           <http://model.geneontology.org/YGL256W-MONOMER_RXN3O-4113_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57945_RXN3O-4113>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1682,13 +1671,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4108SmallMolecule48504> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-4157>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -1709,7 +1709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1721,11 +1721,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1740,11 +1740,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" , "Provides Input For Rule. The relation '3-(4-hydroxyphenyl)pyruvate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + (4-hydroxyphenyl)acetaldehyde' 'null' '4-tyrosol + NAD<sup>+</sup> &larr; (4-hydroxyphenyl)acetaldehyde + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002413_RXN3O-4113_SGD_YeastPathways_PWY3O-4108> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002413_RXN3O-4113_SGD_PWY_YeastPathways_PWY3O-4108> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-4109.ttl
+++ b/models/YeastPathways_PWY3O-4109.ttl
@@ -1,11 +1,22 @@
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002413_RXN3O-4117_SGD_YeastPathways_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_BFO_0000050_YeastPathways_PWY3O-4109/YeastPathways_PWY3O-4109_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002234_CHEBI_48945_RXN3O-4117_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13,11 +24,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_BFO_0000050_YeastPathways_PWY3O-4109/YeastPathways_PWY3O-4109_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_BFO_0000050_YeastPathways_PWY3O-4109/YeastPathways_PWY3O-4109_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,11 +46,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,32 +61,43 @@
           <http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002233_CHEBI_57945_RXN3O-4117_SGD_YeastPathways_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-58_4.1.1.72-RXN_controller_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-58_4.1.1.72-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -90,11 +112,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-71_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-71_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -105,25 +127,14 @@
           <http://model.geneontology.org/SGD_S000002788_CPLX3O-71_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YOL086C-MONOMER_RXN3O-4117_controller_SGD_YeastPathways_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_BFO_0000066_reaction_RXN3O-4117_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
+                "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -139,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -152,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -163,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -176,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -189,7 +200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -197,26 +208,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-110_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000002238_CPLX3O-110_component_SGD_YeastPathways_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YDL168W-MONOMER_RXN3O-4117_controller_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YDL168W-MONOMER_RXN3O-4117_controller_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -227,17 +227,6 @@
           <http://model.geneontology.org/YDL168W-MONOMER_RXN3O-4117_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002234_CHEBI_16526_4.1.1.72-RXN_SGD_YeastPathways_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -245,11 +234,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -277,19 +266,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001251>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/SGD_S000002238_CPLX3O-110_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002238> ;
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002234_CHEBI_16182_4.1.1.72-RXN_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -297,11 +288,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002233_CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002233_CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,14 +303,12 @@
           <http://model.geneontology.org/CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000050_YeastPathways_PWY3O-4109/YeastPathways_PWY3O-4109_SGD_YeastPathways_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/SGD_S000002238_CPLX3O-110_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002238> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -332,7 +321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -340,14 +329,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002233_CHEBI_16182_4.1.1.72-RXN_SGD_YeastPathways_PWY3O-4109>
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YMR303C-MONOMER_RXN3O-4117_controller_SGD_PWY_YeastPathways_PWY3O-4109>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002233_CHEBI_16182_4.1.1.72-RXN_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -355,11 +355,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" , "Provides Input For Rule. The relation '(<i>S</i>)-3-methyl-2-oxopentanoate + H<SUP>+</SUP> &rarr; 2-methylbutanal + CO<SUB>2</SUB>' 'null' '2-methylbutanal + NADH &rarr; 2-methylbutanol + NAD<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002413_RXN3O-4117_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002413_RXN3O-4117_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -377,11 +377,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002233_CHEBI_16182_4.1.1.72-RXN_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002233_CHEBI_16182_4.1.1.72-RXN_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,23 +395,12 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-110_4.1.1.72-RXN_controller_SGD_YeastPathways_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-4117_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -424,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "isoleucine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -432,14 +421,14 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-71_4.1.1.72-RXN_controller_SGD_YeastPathways_PWY3O-4109>
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000050_YeastPathways_PWY3O-4109/YeastPathways_PWY3O-4109_SGD_PWY_YeastPathways_PWY3O-4109>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
+                "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -447,11 +436,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YMR303C-MONOMER_RXN3O-4117_controller_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YMR303C-MONOMER_RXN3O-4117_controller_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -469,11 +458,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -487,6 +476,28 @@
 <http://identifiers.org/sgd/S000004688>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-58_4.1.1.72-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -496,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -516,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -531,11 +542,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-110_4.1.1.72-RXN_controller_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-110_4.1.1.72-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,11 +561,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-58_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -564,28 +575,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
 ] .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002233_CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002234_CHEBI_48945_RXN3O-4117_SGD_YeastPathways_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -600,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -612,11 +601,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002234_CHEBI_57540_RXN3O-4117_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002234_CHEBI_57540_RXN3O-4117_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -637,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -657,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -665,15 +654,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YMR083W-MONOMER_RXN3O-4117_controller_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_BFO_0000066_reaction_4.1.1.72-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_BFO_0000066_reaction_4.1.1.72-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -687,26 +687,15 @@
 <http://purl.obolibrary.org/obo/GO_0004022>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YDL168W-MONOMER_RXN3O-4117_controller_SGD_YeastPathways_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -726,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -734,14 +723,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002234_CHEBI_57540_RXN3O-4117_SGD_YeastPathways_PWY3O-4109>
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_PWY3O-4109>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
+                "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -752,11 +741,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-67_4.1.1.72-RXN_controller_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-67_4.1.1.72-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,17 +756,6 @@
           <http://model.geneontology.org/CPLX3O-67_4.1.1.72-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YMR083W-MONOMER_RXN3O-4117_controller_SGD_YeastPathways_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0052656>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -785,11 +763,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_BFO_0000050_YeastPathways_PWY3O-4109/YeastPathways_PWY3O-4109_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_BFO_0000050_YeastPathways_PWY3O-4109/YeastPathways_PWY3O-4109_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -800,47 +778,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4109/YeastPathways_PWY3O-4109>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002413_4.1.1.72-RXN_SGD_YeastPathways_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002234_CHEBI_16182_4.1.1.72-RXN_SGD_YeastPathways_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-58_4.1.1.72-RXN_controller_SGD_YeastPathways_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -852,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -870,11 +815,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YGL256W-MONOMER_RXN3O-4117_controller_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YGL256W-MONOMER_RXN3O-4117_controller_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -885,14 +830,14 @@
           <http://model.geneontology.org/YGL256W-MONOMER_RXN3O-4117_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YMR303C-MONOMER_RXN3O-4117_controller_SGD_YeastPathways_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YGL256W-MONOMER_RXN3O-4117_controller_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
+                "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -900,11 +845,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -915,6 +860,28 @@
           <http://model.geneontology.org/CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002234_CHEBI_57540_RXN3O-4117_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002413_RXN3O-4117_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_35146>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -922,11 +889,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002234_CHEBI_16182_4.1.1.72-RXN_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002234_CHEBI_16182_4.1.1.72-RXN_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -944,11 +911,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-110_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000002238_CPLX3O-110_component_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-110_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000002238_CPLX3O-110_component_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -959,28 +926,6 @@
           <http://model.geneontology.org/SGD_S000002238_CPLX3O-110_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YGL256W-MONOMER_RXN3O-4117_controller_SGD_YeastPathways_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY3O-4109/YeastPathways_PWY3O-4109>
         a       <http://purl.obolibrary.org/obo/GO_0006550> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -990,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1001,17 +946,6 @@
 <http://identifiers.org/sgd/S000003225>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002233_CHEBI_15378_4.1.1.72-RXN_SGD_YeastPathways_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57540_RXN3O-4117>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1021,7 +955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1029,25 +963,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_BFO_0000050_YeastPathways_PWY3O-4109/YeastPathways_PWY3O-4109_SGD_YeastPathways_PWY3O-4109>
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-58_4.1.1.72-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4109>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-67_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
+                "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1055,11 +978,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002233_CHEBI_57945_RXN3O-4117_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002233_CHEBI_57945_RXN3O-4117_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,17 +993,28 @@
           <http://model.geneontology.org/CHEBI_57945_RXN3O-4117>
 ] .
 
-<http://identifiers.org/sgd/S000004034>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_BFO_0000066_reaction_4.1.1.72-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4109>
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YBR145W-MONOMER_RXN3O-4117_controller_SGD_PWY_YeastPathways_PWY3O-4109>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004034>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_BFO_0000066_reaction_RXN3O-4117_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1099,7 +1033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1107,15 +1041,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YOL086C-MONOMER_RXN3O-4117_controller_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YOL086C-MONOMER_RXN3O-4117_controller_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1126,26 +1071,15 @@
           <http://model.geneontology.org/YOL086C-MONOMER_RXN3O-4117_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1159,25 +1093,14 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_BFO_0000050_YeastPathways_PWY3O-4109/YeastPathways_PWY3O-4109_SGD_YeastPathways_PWY3O-4109>
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-67_4.1.1.72-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4109>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-118_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
+                "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1190,13 +1113,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Complex48675> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16810> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1207,7 +1141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1219,11 +1153,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-118_4.1.1.72-RXN_controller_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-118_4.1.1.72-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1239,7 +1173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1247,11 +1181,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-67_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1267,6 +1201,17 @@
 
 <http://identifiers.org/sgd/S000004918>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002413_4.1.1.72-RXN_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1290,7 +1235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1302,11 +1247,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YBR145W-MONOMER_RXN3O-4117_controller_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YBR145W-MONOMER_RXN3O-4117_controller_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1317,14 +1262,14 @@
           <http://model.geneontology.org/YBR145W-MONOMER_RXN3O-4117_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_YeastPathways_PWY3O-4109>
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_BFO_0000050_YeastPathways_PWY3O-4109/YeastPathways_PWY3O-4109_SGD_PWY_YeastPathways_PWY3O-4109>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
+                "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1332,11 +1277,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000050_YeastPathways_PWY3O-4109/YeastPathways_PWY3O-4109_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000050_YeastPathways_PWY3O-4109/YeastPathways_PWY3O-4109_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1354,13 +1299,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4109Protein48770> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002233_CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1377,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1392,11 +1348,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002233_CHEBI_15378_4.1.1.72-RXN_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002233_CHEBI_15378_4.1.1.72-RXN_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1407,15 +1363,26 @@
           <http://model.geneontology.org/CHEBI_15378_4.1.1.72-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-110_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000002238_CPLX3O-110_component_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-isoleucine + 2-oxoglutarate &harr; L-glutamate + (<i>S</i>)-3-methyl-2-oxopentanoate' 'null' '(<i>S</i>)-3-methyl-2-oxopentanoate + H<SUP>+</SUP> &rarr; 2-methylbutanal + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002413_4.1.1.72-RXN_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002413_4.1.1.72-RXN_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1426,17 +1393,6 @@
           <http://model.geneontology.org/4.1.1.72-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003909> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1444,7 +1400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1452,30 +1408,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_PWY3O-4109>
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002233_CHEBI_15378_4.1.1.72-RXN_SGD_PWY_YeastPathways_PWY3O-4109>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-118_4.1.1.72-RXN_controller_SGD_YeastPathways_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
+                "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004124>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-110_4.1.1.72-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller>
         a       <http://identifiers.org/sgd/S000001251> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1484,7 +1440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1492,15 +1448,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002234_CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-71_4.1.1.72-RXN_controller_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-71_4.1.1.72-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1511,14 +1478,14 @@
           <http://model.geneontology.org/CPLX3O-71_4.1.1.72-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-67_4.1.1.72-RXN_controller_SGD_YeastPathways_PWY3O-4109>
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_BFO_0000066_reaction_4.1.1.72-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4109>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
+                "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1526,11 +1493,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_BFO_0000066_reaction_RXN3O-4117_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_BFO_0000066_reaction_RXN3O-4117_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1546,6 +1513,17 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1572,7 +1550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1584,11 +1562,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YMR083W-MONOMER_RXN3O-4117_controller_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YMR083W-MONOMER_RXN3O-4117_controller_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1599,17 +1577,6 @@
           <http://model.geneontology.org/YMR083W-MONOMER_RXN3O-4117_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YBR145W-MONOMER_RXN3O-4117_controller_SGD_YeastPathways_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1619,7 +1586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1632,7 +1599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1640,11 +1607,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002233_CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1655,17 +1622,6 @@
           <http://model.geneontology.org/CHEBI_58045_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-71_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_YeastPathways_PWY3O-4109>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_4.1.1.72-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1675,7 +1631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1683,17 +1639,50 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000005446>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-58_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-4109>
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YDL168W-MONOMER_RXN3O-4117_controller_SGD_PWY_YeastPathways_PWY3O-4109>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002333_YOL086C-MONOMER_RXN3O-4117_controller_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-71_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000005446>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-118_4.1.1.72-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1704,7 +1693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1716,11 +1705,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002234_CHEBI_16526_4.1.1.72-RXN_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002234_CHEBI_16526_4.1.1.72-RXN_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1738,11 +1727,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-118_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_4.1.1.72-RXN_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1756,14 +1745,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_58045>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4109>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002333_CPLX3O-71_4.1.1.72-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
+                "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1771,11 +1760,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002234_CHEBI_48945_RXN3O-4117_SGD_YeastPathways_PWY3O-4109> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002234_CHEBI_48945_RXN3O-4117_SGD_PWY_YeastPathways_PWY3O-4109> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1789,14 +1778,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_48945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERILEU-RXN_controller_SGD_YeastPathways_PWY3O-4109>
+<http://model.geneontology.org/ev_w_id_4.1.1.72-RXN_RO_0002234_CHEBI_16526_4.1.1.72-RXN_SGD_PWY_YeastPathways_PWY3O-4109>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4109" ;
+                "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1817,7 +1806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1834,7 +1823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1844,3 +1833,14 @@
 
 <http://identifiers.org/sgd/S000002788>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4117_RO_0002233_CHEBI_57945_RXN3O-4117_SGD_PWY_YeastPathways_PWY3O-4109>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4109" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-4112.ttl
+++ b/models/YeastPathways_PWY3O-4112.ttl
@@ -1,23 +1,12 @@
-<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YMR083W-MONOMER_RXN3O-4109_controller_SGD_YeastPathways_PWY3O-4112>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YMR303C-MONOMER_RXN3O-4109_controller_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YMR303C-MONOMER_RXN3O-4109_controller_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -80,11 +69,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002234_CHEBI_16526_RXN3O-4108_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002234_CHEBI_16526_RXN3O-4108_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -95,14 +84,14 @@
           <http://model.geneontology.org/CHEBI_16526_RXN3O-4108>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002333_CPLX3O-71_RXN3O-4108_controller_SGD_YeastPathways_PWY3O-4112>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YOL086C-MONOMER_RXN3O-4109_controller_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
+                "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -110,11 +99,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_17865_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_17865_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -125,18 +114,26 @@
           <http://model.geneontology.org/CHEBI_17865_BRANCHED-CHAINAMINOTRANSFERLEU-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000002327>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YDL168W-MONOMER_RXN3O-4109_controller_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YGL256W-MONOMER_RXN3O-4109_controller_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YGL256W-MONOMER_RXN3O-4109_controller_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -147,19 +144,11 @@
           <http://model.geneontology.org/YGL256W-MONOMER_RXN3O-4109_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
+<http://identifiers.org/sgd/S000002327>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4108_BFO_0000066_reaction_RXN3O-4108_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4112>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YDL168W-MONOMER_RXN3O-4109_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002327> ;
@@ -168,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -185,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -193,25 +182,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YOL086C-MONOMER_RXN3O-4109_controller_SGD_YeastPathways_PWY3O-4112>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-4109_BFO_0000066_reaction_RXN3O-4109_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
+                "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002333_CPLX3O-110_RXN3O-4108_controller_SGD_YeastPathways_PWY3O-4112>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002333_CPLX3O-71_RXN3O-4108_controller_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
+                "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -222,11 +211,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002233_CHEBI_16638_RXN3O-4108_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002233_CHEBI_16638_RXN3O-4108_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -237,25 +226,14 @@
           <http://model.geneontology.org/CHEBI_16638_RXN3O-4108>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_YeastPathways_PWY3O-4112>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_57427_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_PWY3O-4112>
+<http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002333_CPLX3O-110_RXN3O-4108_controller_SGD_PWY_YeastPathways_PWY3O-4112>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
+                "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -266,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -289,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -297,26 +275,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002234_CHEBI_57540_RXN3O-4109_SGD_YeastPathways_PWY3O-4112>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002233_CHEBI_17865_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002233_CHEBI_17865_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -327,14 +294,14 @@
           <http://model.geneontology.org/CHEBI_17865_BRANCHED-CHAINAMINOTRANSFERLEU-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4108_BFO_0000050_YeastPathways_PWY3O-4112/YeastPathways_PWY3O-4112_SGD_YeastPathways_PWY3O-4112>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-4109_BFO_0000050_YeastPathways_PWY3O-4112/YeastPathways_PWY3O-4112_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
+                "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -342,11 +309,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_57427_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_57427_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -361,11 +328,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YDL168W-MONOMER_RXN3O-4109_controller_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YDL168W-MONOMER_RXN3O-4109_controller_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -388,13 +355,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4112SmallMolecule49075> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -409,11 +387,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_BFO_0000066_reaction_RXN3O-4109_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_BFO_0000066_reaction_RXN3O-4109_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -440,13 +418,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4112Protein48975> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-71_RXN3O-4108_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57427>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -460,7 +449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -474,15 +463,26 @@
 <http://identifiers.org/sgd/S000003225>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YGL256W-MONOMER_RXN3O-4109_controller_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" , "Provides Input For Rule. The relation '4-methyl-2-oxopentanoate &rarr; 3-methylbutanal + CO<SUB>2</SUB>' 'null' '3-methylbutanal + NADH &rarr; 3-methylbutanol + NAD<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002413_RXN3O-4109_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002413_RXN3O-4109_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -500,11 +500,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" , "Provides Input For Rule. The relation 'L-leucine + 2-oxoglutarate &harr; L-glutamate + 4-methyl-2-oxopentanoate' 'null' '4-methyl-2-oxopentanoate &rarr; 3-methylbutanal + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002413_RXN3O-4108_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002413_RXN3O-4108_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,14 +515,14 @@
           <http://model.geneontology.org/RXN3O-4108>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-110_RXN3O-4108_controller_BFO_0000051_SGD_S000002238_CPLX3O-110_component_SGD_YeastPathways_PWY3O-4112>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002413_RXN3O-4108_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
+                "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -533,11 +533,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4108_BFO_0000066_reaction_RXN3O-4108_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4108_BFO_0000066_reaction_RXN3O-4108_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -557,7 +557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -569,11 +569,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -584,15 +584,26 @@
           <http://model.geneontology.org/CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002233_CHEBI_16638_RXN3O-4108_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YBR145W-MONOMER_RXN3O-4109_controller_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YBR145W-MONOMER_RXN3O-4109_controller_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -615,13 +626,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4112SmallMolecule49007> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002234_CHEBI_15837_RXN3O-4109_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-110_RXN3O-4108_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -632,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -643,17 +665,6 @@
 <http://purl.obolibrary.org/obo/GO_0004022>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4109_BFO_0000050_YeastPathways_PWY3O-4112/YeastPathways_PWY3O-4112_SGD_YeastPathways_PWY3O-4112>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16810> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -663,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -674,15 +685,18 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000002238>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_BFO_0000050_YeastPathways_PWY3O-4112/YeastPathways_PWY3O-4112_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_BFO_0000050_YeastPathways_PWY3O-4112/YeastPathways_PWY3O-4112_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -693,8 +707,38 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4112/YeastPathways_PWY3O-4112>
 ] .
 
-<http://identifiers.org/sgd/S000002238>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_57427_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002233_CHEBI_57945_RXN3O-4109_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4108_BFO_0000050_YeastPathways_PWY3O-4112/YeastPathways_PWY3O-4112_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -702,26 +746,15 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002413_RXN3O-4109_SGD_YeastPathways_PWY3O-4112>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002333_CPLX3O-71_RXN3O-4108_controller_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002333_CPLX3O-71_RXN3O-4108_controller_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -732,26 +765,15 @@
           <http://model.geneontology.org/CPLX3O-71_RXN3O-4108_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002234_CHEBI_16526_RXN3O-4108_SGD_YeastPathways_PWY3O-4112>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -774,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -785,15 +807,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_17865_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4108_BFO_0000050_YeastPathways_PWY3O-4112/YeastPathways_PWY3O-4112_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4108_BFO_0000050_YeastPathways_PWY3O-4112/YeastPathways_PWY3O-4112_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -804,17 +837,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4112/YeastPathways_PWY3O-4112>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4112>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001251> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -822,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -834,11 +856,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -849,17 +871,6 @@
           <http://model.geneontology.org/reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_PWY3O-4112>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -867,11 +878,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002234_CHEBI_57540_RXN3O-4109_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002234_CHEBI_57540_RXN3O-4109_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -882,26 +893,37 @@
           <http://model.geneontology.org/CHEBI_57540_RXN3O-4109>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4109_BFO_0000066_reaction_RXN3O-4109_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4112>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YBR145W-MONOMER_RXN3O-4109_controller_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
+                "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YMR303C-MONOMER_RXN3O-4109_controller_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SGD_S000002788_CPLX3O-71_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002788> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -914,17 +936,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_16638>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002234_CHEBI_16638_RXN3O-4108_SGD_YeastPathways_PWY3O-4112>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16638_RXN3O-4108>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16638> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -934,13 +945,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4112SmallMolecule48892> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002234_CHEBI_57540_RXN3O-4109_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002234_CHEBI_16638_RXN3O-4108_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002413_RXN3O-4109_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -949,11 +993,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002333_CPLX3O-110_RXN3O-4108_controller_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002333_CPLX3O-110_RXN3O-4108_controller_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -964,18 +1008,15 @@
           <http://model.geneontology.org/CPLX3O-110_RXN3O-4108_controller>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -986,14 +1027,17 @@
           <http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002233_CHEBI_16638_RXN3O-4108_SGD_YeastPathways_PWY3O-4112>
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4108_BFO_0000066_reaction_RXN3O-4108_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4112>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
+                "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1004,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1022,7 +1066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1030,25 +1074,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_17865_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_PWY3O-4112>
+<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YMR083W-MONOMER_RXN3O-4109_controller_SGD_PWY_YeastPathways_PWY3O-4112>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002233_CHEBI_57945_RXN3O-4109_SGD_YeastPathways_PWY3O-4112>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
+                "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1056,11 +1089,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-71_RXN3O-4108_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-71_RXN3O-4108_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1071,14 +1104,14 @@
           <http://model.geneontology.org/SGD_S000002788_CPLX3O-71_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YGL256W-MONOMER_RXN3O-4109_controller_SGD_YeastPathways_PWY3O-4112>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
+                "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1086,11 +1119,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000050_YeastPathways_PWY3O-4112/YeastPathways_PWY3O-4112_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000050_YeastPathways_PWY3O-4112/YeastPathways_PWY3O-4112_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1101,14 +1134,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4112/YeastPathways_PWY3O-4112>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YBR145W-MONOMER_RXN3O-4109_controller_SGD_YeastPathways_PWY3O-4112>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
+                "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1116,11 +1149,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002234_CHEBI_15837_RXN3O-4109_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002234_CHEBI_15837_RXN3O-4109_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1140,7 +1173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "leucine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1153,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1166,7 +1199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1177,46 +1210,35 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000050_YeastPathways_PWY3O-4112/YeastPathways_PWY3O-4112_SGD_YeastPathways_PWY3O-4112>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000002238_CPLX3O-110_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002238> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002413_RXN3O-4108_SGD_YeastPathways_PWY3O-4112>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002234_CHEBI_16526_RXN3O-4108_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1229,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1237,43 +1259,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-71_RXN3O-4108_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_YeastPathways_PWY3O-4112>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://identifiers.org/sgd/S000004688>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_YeastPathways_PWY3O-4112>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YOL086C-MONOMER_RXN3O-4109_controller_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YOL086C-MONOMER_RXN3O-4109_controller_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1301,13 +1301,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4112BiochemicalReaction48880> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002233_CHEBI_17865_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004737>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1319,11 +1330,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002234_CHEBI_16638_RXN3O-4108_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002234_CHEBI_16638_RXN3O-4108_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1341,11 +1352,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1356,26 +1367,15 @@
           <http://model.geneontology.org/CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_PWY3O-4112>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YMR083W-MONOMER_RXN3O-4109_controller_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YMR083W-MONOMER_RXN3O-4109_controller_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1386,25 +1386,36 @@
           <http://model.geneontology.org/YMR083W-MONOMER_RXN3O-4109_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002234_CHEBI_15837_RXN3O-4109_SGD_YeastPathways_PWY3O-4112>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16810>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000004918>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000001251>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000004918>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000050_YeastPathways_PWY3O-4112/YeastPathways_PWY3O-4112_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003909> ;
@@ -1413,7 +1424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1421,48 +1432,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YDL168W-MONOMER_RXN3O-4109_controller_SGD_YeastPathways_PWY3O-4112>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002233_CHEBI_17865_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_YeastPathways_PWY3O-4112>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002333_YMR303C-MONOMER_RXN3O-4109_controller_SGD_YeastPathways_PWY3O-4112>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-110_RXN3O-4108_controller_BFO_0000051_SGD_S000002238_CPLX3O-110_component_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-110_RXN3O-4108_controller_BFO_0000051_SGD_S000002238_CPLX3O-110_component_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,6 +1454,17 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0006552>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1483,11 +1472,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002233_CHEBI_57945_RXN3O-4109_SGD_YeastPathways_PWY3O-4112> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002233_CHEBI_57945_RXN3O-4109_SGD_PWY_YeastPathways_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1497,6 +1486,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57945_RXN3O-4109>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-110_RXN3O-4108_controller_BFO_0000051_SGD_S000002238_CPLX3O-110_component_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERLEU-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0052656> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1517,7 +1517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-4115.ttl
+++ b/models/YeastPathways_PWY3O-4115.ttl
@@ -1,22 +1,11 @@
-<http://model.geneontology.org/ev_w_id_RXN3O-163_BFO_0000066_reaction_RXN3O-163_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4115>
+<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YOL086C-MONOMER_RXN3O-163_controller_SGD_PWY_YeastPathways_PWY3O-4115>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002234_CHEBI_49000_RXN3O-163_SGD_YeastPathways_PWY3O-4115>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -24,11 +13,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_BFO_0000066_reaction_RXN3O-163_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_BFO_0000066_reaction_RXN3O-163_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -46,11 +35,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_BFO_0000066_reaction_PHENYLPYRUVATE-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_BFO_0000066_reaction_PHENYLPYRUVATE-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,19 +50,19 @@
           <http://model.geneontology.org/reaction_PHENYLPYRUVATE-DECARBOXYLASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/GO_0050177>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-71_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0050177>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_18005_2.6.1.58-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_18005> ;
@@ -84,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -98,15 +87,26 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002234_CHEBI_49000_RXN3O-163_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YMR083W-MONOMER_RXN3O-163_controller_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YMR083W-MONOMER_RXN3O-163_controller_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -121,11 +121,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-67_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-67_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -153,26 +153,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YGL256W-MONOMER_RXN3O-163_controller_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
         a       <http://identifiers.org/sgd/S000004124> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-4115/YeastPathways_PWY3O-4115_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -181,7 +192,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002413_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -190,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -198,11 +220,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,11 +242,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_29985_RXN-10814_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_29985_RXN-10814_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -235,28 +257,6 @@
           <http://model.geneontology.org/CHEBI_29985_RXN-10814>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_58095_2.6.1.58-RXN_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-58_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY3O-4115>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -264,11 +264,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-118_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -288,24 +288,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4115SmallMolecule49135> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YMR303C-MONOMER_RXN3O-163_controller_SGD_YeastPathways_PWY3O-4115>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -319,7 +308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -336,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -348,11 +337,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002234_CHEBI_49000_RXN3O-163_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002234_CHEBI_49000_RXN3O-163_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,17 +351,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_49000_RXN3O-163>
 ] .
-
-<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002413_RXN3O-163_SGD_YeastPathways_PWY3O-4115>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PHENYLPYRUVATE-DECARBOXYLASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0050177> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -393,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -401,51 +379,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002413_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-4115>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_YeastPathways_PWY3O-4115>
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_18005_2.6.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-4115>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_18005_RXN-10814_SGD_YeastPathways_PWY3O-4115>
+<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-67_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4115>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-4115/YeastPathways_PWY3O-4115_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-4115/YeastPathways_PWY3O-4115_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -456,37 +420,18 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4115/YeastPathways_PWY3O-4115>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_YeastPathways_PWY3O-4115/YeastPathways_PWY3O-4115_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_YeastPathways_PWY3O-4115/YeastPathways_PWY3O-4115_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -500,6 +445,17 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YMR303C-MONOMER_RXN3O-163_controller>
         a       <http://identifiers.org/sgd/S000004918> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -507,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -519,11 +475,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" , "Provides Input For Rule. The relation 'L-phenylalanine + 2-oxoglutarate &harr; 3-phenyl-2-oxopropanoate + L-glutamate' 'null' '3-phenyl-2-oxopropanoate + H<SUP>+</SUP> &rarr; phenylacetaldehyde + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002413_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002413_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,11 +497,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-71_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-71_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -568,24 +524,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4115SmallMolecule49344> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16424_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003319>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -597,11 +542,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YDL168W-MONOMER_RXN3O-163_controller_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YDL168W-MONOMER_RXN3O-163_controller_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -616,11 +561,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-118_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-118_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -633,17 +578,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_49000>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_18005_2.6.1.58-RXN_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/2.6.1.58-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -664,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -681,7 +615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -692,6 +626,21 @@
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/YMR083W-MONOMER_RXN3O-163_controller>
+        a       <http://identifiers.org/sgd/S000004688> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "alcohol dehydrogenase / alcohol dehydrogenase III" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4115Protein49385> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -700,34 +649,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/YMR083W-MONOMER_RXN3O-163_controller>
-        a       <http://identifiers.org/sgd/S000004688> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "alcohol dehydrogenase / alcohol dehydrogenase III" ;
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4115Protein49385> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_58095_2.6.1.58-RXN_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_58095_2.6.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -741,26 +686,15 @@
 <http://purl.obolibrary.org/obo/GO_0006559>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002413_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_58095_RXN-10814_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_58095_RXN-10814_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -778,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -786,22 +720,55 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_16810_RXN-10814_SGD_YeastPathways_PWY3O-4115>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_16810_RXN-10814_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-163_BFO_0000050_YeastPathways_PWY3O-4115/YeastPathways_PWY3O-4115_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_18005_RXN-10814_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002413_RXN3O-163_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX-9432_RXN-10814_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -812,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -824,11 +791,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002233_CHEBI_16424_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002233_CHEBI_16424_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -839,40 +806,29 @@
           <http://model.geneontology.org/CHEBI_16424_PHENYLPYRUVATE-DECARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002233_CHEBI_16424_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004022>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_15361_2.6.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_15378_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_15378_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -883,29 +839,40 @@
           <http://model.geneontology.org/CHEBI_15378_PHENYLPYRUVATE-DECARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-58_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-4115>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_15378_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002233_CHEBI_16424_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YMR303C-MONOMER_RXN3O-163_controller_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YMR303C-MONOMER_RXN3O-163_controller_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -916,15 +883,26 @@
           <http://model.geneontology.org/YMR303C-MONOMER_RXN3O-163_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002413_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-71_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-71_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -935,30 +913,19 @@
           <http://model.geneontology.org/CPLX3O-71_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_YeastPathways_PWY3O-4115/YeastPathways_PWY3O-4115_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002233_CHEBI_57945_RXN3O-163_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001378>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002234_CHEBI_57540_RXN3O-163_SGD_YeastPathways_PWY3O-4115>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57540_RXN3O-163>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -969,13 +936,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4115SmallMolecule49359> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -989,14 +967,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_BFO_0000066_reaction_PHENYLPYRUVATE-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_58095_2.6.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1010,11 +988,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1034,7 +1012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1046,11 +1024,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1061,14 +1039,25 @@
           <http://model.geneontology.org/CPLX-9432_RXN-10814_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_29985_RXN-10814_SGD_YeastPathways_PWY3O-4115>
+<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-118_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-71_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_PWY_YeastPathways_PWY3O-4115>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1076,11 +1065,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-58_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1091,14 +1080,14 @@
           <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_15361_2.6.1.58-RXN_SGD_YeastPathways_PWY3O-4115>
+<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002234_CHEBI_57540_RXN3O-163_SGD_PWY_YeastPathways_PWY3O-4115>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1111,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1128,7 +1117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phenylalanine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1145,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1160,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1168,15 +1157,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YGL256W-MONOMER_RXN3O-163_controller_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002234_CHEBI_57540_RXN3O-163_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002234_CHEBI_57540_RXN3O-163_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1194,11 +1194,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16424_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16424_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1212,14 +1212,14 @@
 <http://identifiers.org/sgd/S000003225>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-118_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-4115>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YMR303C-MONOMER_RXN3O-163_controller_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1233,11 +1233,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1252,11 +1252,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1266,6 +1266,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN-10814_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004034>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1279,7 +1290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1287,36 +1298,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-118_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY3O-4115>
+<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_BFO_0000066_reaction_PHENYLPYRUVATE-DECARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4115>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_YeastPathways_PWY3O-4115>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-4115/YeastPathways_PWY3O-4115_SGD_YeastPathways_PWY3O-4115>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1324,11 +1313,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_BFO_0000050_YeastPathways_PWY3O-4115/YeastPathways_PWY3O-4115_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_BFO_0000050_YeastPathways_PWY3O-4115/YeastPathways_PWY3O-4115_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1339,15 +1328,26 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4115/YeastPathways_PWY3O-4115>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-4115/YeastPathways_PWY3O-4115_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-4115/YeastPathways_PWY3O-4115_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1361,17 +1361,6 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YIL116W-MONOMER_RXN-10814_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001378> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1379,7 +1368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1387,14 +1376,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-67_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_18005_RXN-10814_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1408,11 +1397,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YGL256W-MONOMER_RXN3O-163_controller_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YGL256W-MONOMER_RXN3O-163_controller_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1423,12 +1412,34 @@
           <http://model.geneontology.org/YGL256W-MONOMER_RXN3O-163_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_58095_RXN-10814_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003319> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-58_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1439,7 +1450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1451,11 +1462,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-58_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-58_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1469,41 +1480,8 @@
 <http://identifiers.org/sgd/S000002327>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-4115/YeastPathways_PWY3O-4115_SGD_YeastPathways_PWY3O-4115>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000004918>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002233_CHEBI_57945_RXN3O-163_SGD_YeastPathways_PWY3O-4115>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4115>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1512,11 +1490,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_18005_2.6.1.58-RXN_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_18005_2.6.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1531,11 +1509,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_18005_RXN-10814_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_18005_RXN-10814_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1551,7 +1529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1564,7 +1542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1576,11 +1554,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1590,28 +1568,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YMR083W-MONOMER_RXN3O-163_controller_SGD_YeastPathways_PWY3O-4115>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-67_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57972>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1631,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1639,15 +1595,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-163_BFO_0000066_reaction_RXN3O-163_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002233_CHEBI_57945_RXN3O-163_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002233_CHEBI_57945_RXN3O-163_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1662,11 +1629,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_18005_RXN-10814_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_18005_RXN-10814_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1676,6 +1643,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_18005_RXN-10814>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001179>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1689,7 +1667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1709,7 +1687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1717,37 +1695,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-163_BFO_0000050_YeastPathways_PWY3O-4115/YeastPathways_PWY3O-4115_SGD_YeastPathways_PWY3O-4115>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YDL168W-MONOMER_RXN3O-163_controller_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YOL086C-MONOMER_RXN3O-163_controller_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YOL086C-MONOMER_RXN3O-163_controller_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1765,11 +1721,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" , "Provides Input For Rule. The relation '3-phenyl-2-oxopropanoate + H<SUP>+</SUP> &rarr; phenylacetaldehyde + CO<SUB>2</SUB>' 'null' 'phenylacetaldehyde + NADH &rarr; 2-phenylethanol + NAD<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002413_RXN3O-163_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002413_RXN3O-163_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1787,7 +1743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1807,7 +1763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1827,7 +1783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1852,7 +1808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1864,11 +1820,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-phenylalanine + pyruvate &harr; 3-phenyl-2-oxopropanoate + L-alanine' 'null' '3-phenyl-2-oxopropanoate + H<SUP>+</SUP> &rarr; phenylacetaldehyde + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002413_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002413_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1883,11 +1839,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1898,23 +1854,12 @@
           <http://model.geneontology.org/YIL116W-MONOMER_RXN-10814_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YOL086C-MONOMER_RXN3O-163_controller_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000002788_CPLX3O-71_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002788> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1937,7 +1882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1949,11 +1894,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-67_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1969,32 +1914,43 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YBR145W-MONOMER_RXN3O-163_controller_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YMR083W-MONOMER_RXN3O-163_controller_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_YeastPathways_PWY3O-4115/YeastPathways_PWY3O-4115_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005446>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_58095_RXN-10814_SGD_YeastPathways_PWY3O-4115>
+<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YDL168W-MONOMER_RXN3O-163_controller_SGD_PWY_YeastPathways_PWY3O-4115>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2002,11 +1958,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YBR145W-MONOMER_RXN3O-163_controller_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YBR145W-MONOMER_RXN3O-163_controller_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2021,11 +1977,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2036,28 +1992,6 @@
           <http://model.geneontology.org/CHEBI_16526_PHENYLPYRUVATE-DECARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002333_CPLX3O-71_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_18005_RXN-10814_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_18005_RXN-10814>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_18005> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2067,7 +2001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2075,14 +2009,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_15378_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-4115>
+<http://model.geneontology.org/ev_w_id_RXN3O-163_RO_0002333_YBR145W-MONOMER_RXN3O-163_controller_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_29985_RXN-10814_SGD_PWY_YeastPathways_PWY3O-4115>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16424_PHENYLPYRUVATE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2091,7 +2047,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHENYLPYRUVATE-DECARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-4115/YeastPathways_PWY3O-4115_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2099,11 +2077,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_15361_2.6.1.58-RXN_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_15361_2.6.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2118,11 +2096,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_16810_RXN-10814_SGD_YeastPathways_PWY3O-4115> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_16810_RXN-10814_SGD_PWY_YeastPathways_PWY3O-4115> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2136,6 +2114,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_58095>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YBR145W-MONOMER_RXN3O-163_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000349> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2143,7 +2132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2151,14 +2140,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-71_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000002788_CPLX3O-71_component_SGD_YeastPathways_PWY3O-4115>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4115" ;
+                "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2167,3 +2156,14 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_PHENYLPYRUVATE-DECARBOXYLASE-RXN_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-4115>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4115" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-4120.ttl
+++ b/models/YeastPathways_PWY3O-4120.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17,28 +17,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120_SGD_YeastPathways_PWY3O-4120>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002234_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_PWY3O-4120>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003170>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -50,11 +28,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -84,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -101,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -109,23 +87,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_YeastPathways_PWY3O-4120>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -133,11 +100,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" , "Provides Input For Rule. The relation 'L-tyrosine + pyruvate &harr; 3-(4-hydroxyphenyl)pyruvate + L-alanine' 'null' 'L-tyrosine + 2-oxoglutarate &harr; 3-(4-hydroxyphenyl)pyruvate + L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -155,11 +122,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002333_YPR060C-MONOMER_CHORISMATEMUT-RXN_controller_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002333_YPR060C-MONOMER_CHORISMATEMUT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -174,11 +141,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -201,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -209,14 +176,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002413_RXN3O-4157_SGD_YeastPathways_PWY3O-4120>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002233_CHEBI_29748_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -225,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -241,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -268,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -280,11 +258,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -295,31 +273,42 @@
           <http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_PWY3O-4120>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_58315_RXN3O-4157_SGD_YeastPathways_PWY3O-4120>
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_57972_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4120>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -338,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -346,26 +335,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_RXN3O-4157_SGD_YeastPathways_PWY3O-4120>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -380,11 +358,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002234_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002234_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,15 +373,26 @@
           <http://model.geneontology.org/CHEBI_29934_CHORISMATEMUT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -423,7 +412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -437,54 +426,54 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_PWY3O-4120>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002233_CHEBI_29748_CHORISMATEMUT-RXN_SGD_YeastPathways_PWY3O-4120>
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4120>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
+                "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_YeastPathways_PWY3O-4120>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
+                "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -495,29 +484,40 @@
           <http://model.geneontology.org/CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120_SGD_YeastPathways_PWY3O-4120>
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_PWY3O-4120>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
+                "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -535,11 +535,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -559,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -577,11 +577,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_58315_RXN3O-4157_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_58315_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -592,15 +592,26 @@
           <http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_58315_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002233_CHEBI_29748_CHORISMATEMUT-RXN_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002233_CHEBI_29748_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -615,11 +626,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -635,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -648,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -656,22 +667,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_PWY3O-4120>
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_PWY_YeastPathways_PWY3O-4120>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
+                "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_15361_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YHR137W-MONOMER_RXN3O-4157_controller>
         a       <http://identifiers.org/sgd/S000001179> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -680,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -688,26 +710,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_15361_RXN3O-4157_SGD_YeastPathways_PWY3O-4120>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -718,14 +729,14 @@
           <http://model.geneontology.org/CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_PWY3O-4120>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
+                "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -736,24 +747,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4120Protein49549> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000066_reaction_CHORISMATEMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4120>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -787,7 +787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -799,11 +799,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -818,11 +818,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000050_YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,17 +833,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4120>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YPR060C-MONOMER_CHORISMATEMUT-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006264> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -851,7 +840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -859,15 +848,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_CHORISMATEMUT-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -878,11 +900,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_15361_RXN3O-4157_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_15361_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -897,11 +919,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000066_reaction_CHORISMATEMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000066_reaction_CHORISMATEMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -912,15 +934,26 @@
           <http://model.geneontology.org/reaction_CHORISMATEMUT-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -950,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -971,11 +1004,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" , "Provides Input For Rule. The relation 'prephenate + NADP<sup>+</sup> &rarr; CO<SUB>2</SUB> + 3-(4-hydroxyphenyl)pyruvate + NADPH' 'null' 'L-tyrosine + pyruvate &harr; 3-(4-hydroxyphenyl)pyruvate + L-alanine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002413_RXN3O-4157_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002413_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -995,7 +1028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "tyrosine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1003,12 +1036,34 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
         a       <http://identifiers.org/sgd/S000003170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1022,11 +1077,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1037,25 +1092,25 @@
           <http://model.geneontology.org/reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002333_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-4120>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
+                "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_PWY3O-4120>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
+                "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1063,11 +1118,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1078,17 +1133,6 @@
           <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_PWY3O-4120>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1098,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1106,46 +1150,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002234_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_YeastPathways_PWY3O-4120>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4120>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57972>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_57972_RXN3O-4157_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_57972_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1156,16 +1186,8 @@
           <http://model.geneontology.org/CHEBI_57972_RXN3O-4157>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4120>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57972>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1174,11 +1196,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1189,26 +1211,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_PWY3O-4120>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1219,6 +1230,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000050_YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1228,7 +1250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1236,19 +1258,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4120>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
+                "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16810> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1259,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1277,11 +1299,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1292,40 +1314,18 @@
           <http://model.geneontology.org/YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4120>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_BFO_0000066_reaction_RXN3O-4157_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4120>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1336,15 +1336,26 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002333_YBR166C-MONOMER_PREPHENATE-DEHYDROGENASE-NADP+-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'chorismate &harr; prephenate' 'null' 'prephenate + NADP<sup>+</sup> &rarr; CO<SUB>2</SUB> + 3-(4-hydroxyphenyl)pyruvate + NADPH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1355,37 +1366,18 @@
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120_SGD_YeastPathways_PWY3O-4120>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4120>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004665>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1396,17 +1388,25 @@
           <http://model.geneontology.org/CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004665>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4120>
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_PWY3O-4120>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002413_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1422,24 +1422,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4120SmallMolecule49473> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_57972_RXN3O-4157_SGD_YeastPathways_PWY3O-4120>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29748>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1448,11 +1437,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_36242_TYROSINE-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1465,17 +1454,6 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002333_YPR060C-MONOMER_CHORISMATEMUT-RXN_controller_SGD_YeastPathways_PWY3O-4120>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-4157>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -1496,7 +1474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1504,26 +1482,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-4120/YeastPathways_PWY3O-4120_SGD_YeastPathways_PWY3O-4120>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4120" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-tyrosine + 2-oxoglutarate &harr; 3-(4-hydroxyphenyl)pyruvate + L-glutamate' 'null' 'L-tyrosine + pyruvate &harr; 3-(4-hydroxyphenyl)pyruvate + L-alanine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_RXN3O-4157_SGD_YeastPathways_PWY3O-4120> ;
+          <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002413_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4120> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1533,3 +1500,36 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN3O-4157>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000066_reaction_CHORISMATEMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002333_YPR060C-MONOMER_CHORISMATEMUT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4120>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-4153.ttl
+++ b/models/YeastPathways_PWY3O-4153.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13,14 +13,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_PWY3O-4153>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_58095_2.6.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
+                "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -34,11 +34,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_15361_2.6.1.58-RXN_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_15361_2.6.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -68,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -76,14 +76,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002333_YPR060C-MONOMER_CHORISMATEMUT-RXN_controller_SGD_YeastPathways_PWY3O-4153>
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_15361_2.6.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-4153>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
+                "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -91,11 +102,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -106,15 +117,29 @@
           <http://model.geneontology.org/MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0004664>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002333_YPR060C-MONOMER_CHORISMATEMUT-RXN_controller_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002333_YPR060C-MONOMER_CHORISMATEMUT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,22 +155,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0004664>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000066_reaction_CHORISMATEMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -162,14 +195,14 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002234_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_PWY3O-4153>
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002333_YPR060C-MONOMER_CHORISMATEMUT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4153>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
+                "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -180,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -197,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -212,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -227,11 +260,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_16810_RXN-10814_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_16810_RXN-10814_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -261,7 +294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -275,30 +308,41 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_PWY3O-4153>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_58095_RXN-10814_SGD_YeastPathways_PWY3O-4153>
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_PWY3O-4153>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
+                "SGD_PWY:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_2.6.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005260>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_RXN-10814>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
@@ -309,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -317,14 +361,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_RXN-10814_SGD_YeastPathways_PWY3O-4153>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002233_CHEBI_29748_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
+                "SGD_PWY:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_58095_RXN-10814_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -332,11 +387,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -345,25 +400,6 @@
           <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_18005_PREPHENATEDEHYDRAT-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002234_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_PWY3O-4153> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CHORISMATEMUT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29934_CHORISMATEMUT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_PREPHENATEDEHYDRAT-RXN>
@@ -375,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -383,37 +419,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_PWY3O-4153>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000066_reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4153>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002234_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_PWY3O-4153> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CHORISMATEMUT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29934_CHORISMATEMUT-RXN>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -436,7 +469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -450,28 +483,39 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_PWY3O-4153>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_YeastPathways_PWY3O-4153>
+<http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_YeastPathways_PWY3O-4153/YeastPathways_PWY3O-4153_SGD_PWY_YeastPathways_PWY3O-4153>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
+                "SGD_PWY:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -479,11 +523,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_29985_RXN-10814_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_29985_RXN-10814_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -511,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -519,14 +563,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_YeastPathways_PWY3O-4153>
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_16810_RXN-10814_SGD_PWY_YeastPathways_PWY3O-4153>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
+                "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -537,11 +592,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -559,11 +614,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000066_reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000066_reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,17 +629,6 @@
           <http://model.geneontology.org/reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_YeastPathways_PWY3O-4153/YeastPathways_PWY3O-4153_SGD_YeastPathways_PWY3O-4153>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29748_CHORISMATEMUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29748> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -594,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -602,65 +646,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000006264>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000066_reaction_2.6.1.58-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4153>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002233_CHEBI_29748_CHORISMATEMUT-RXN_SGD_YeastPathways_PWY3O-4153>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_2.6.1.58-RXN_SGD_YeastPathways_PWY3O-4153>
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_RXN-10814_SGD_PWY_YeastPathways_PWY3O-4153>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
+                "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_15361_2.6.1.58-RXN_SGD_YeastPathways_PWY3O-4153>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000006264>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -675,11 +686,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002233_CHEBI_29748_CHORISMATEMUT-RXN_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002233_CHEBI_29748_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -694,11 +705,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-4153/YeastPathways_PWY3O-4153_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-4153/YeastPathways_PWY3O-4153_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -709,17 +720,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4153/YeastPathways_PWY3O-4153>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_PWY3O-4153>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -728,33 +728,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_29985_RXN-10814_SGD_YeastPathways_PWY3O-4153>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -764,6 +764,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_18005_PREPHENATEDEHYDRAT-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_YeastPathways_PWY3O-4153/YeastPathways_PWY3O-4153_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -775,11 +786,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_YeastPathways_PWY3O-4153/YeastPathways_PWY3O-4153_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000050_YeastPathways_PWY3O-4153/YeastPathways_PWY3O-4153_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -807,26 +818,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_YeastPathways_PWY3O-4153/YeastPathways_PWY3O-4153_SGD_YeastPathways_PWY3O-4153>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_YeastPathways_PWY3O-4153/YeastPathways_PWY3O-4153_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_YeastPathways_PWY3O-4153/YeastPathways_PWY3O-4153_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -858,21 +858,18 @@
 <http://purl.obolibrary.org/obo/CHEBI_18005>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004400>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_16810_RXN-10814_SGD_YeastPathways_PWY3O-4153>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_15378_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
+                "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_29985>
+<http://purl.obolibrary.org/obo/GO_0004400>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_CHORISMATEMUT-RXN_location_lociGO_0005829>
@@ -880,30 +877,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_YeastPathways_PWY3O-4153>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_29985>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -918,11 +907,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000066_reaction_CHORISMATEMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000066_reaction_CHORISMATEMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -942,7 +931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -954,11 +943,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,30 +958,19 @@
           <http://model.geneontology.org/YIL116W-MONOMER_RXN-10814_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004106>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000066_reaction_CHORISMATEMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4153>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_58095_2.6.1.58-RXN_SGD_YeastPathways_PWY3O-4153>
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_PWY3O-4153>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
+                "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004106>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0009094>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1000,14 +978,14 @@
 <http://identifiers.org/sgd/S000001179>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_PWY3O-4153>
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_PWY3O-4153>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
+                "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1020,7 +998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1028,40 +1006,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_15378_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_PWY3O-4153>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_57972_2.6.1.58-RXN_SGD_YeastPathways_PWY3O-4153>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_57972_2.6.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002333_YHR137W-MONOMER_2.6.1.58-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1072,12 +1039,23 @@
           <http://model.geneontology.org/YHR137W-MONOMER_2.6.1.58-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002333_MONOMER3O-279_PREPHENATEDEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
         a       <http://identifiers.org/sgd/S000003170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1093,7 +1071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1105,11 +1083,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" , "Provides Input For Rule. The relation 'prephenate + H<SUP>+</SUP> &harr; 3-phenyl-2-oxopropanoate + CO<SUB>2</SUB> + H<sub>2</sub>O' 'null' 'L-phenylalanine + pyruvate &harr; 3-phenyl-2-oxopropanoate + L-alanine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_2.6.1.58-RXN_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_2.6.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,11 +1102,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1151,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1162,46 +1140,24 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_YeastPathways_PWY3O-4153/YeastPathways_PWY3O-4153_SGD_YeastPathways_PWY3O-4153>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000001378>
+<http://purl.obolibrary.org/obo/CHEBI_57972>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_PWY3O-4153>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57972>
+<http://identifiers.org/sgd/S000001378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_YeastPathways_PWY3O-4153/YeastPathways_PWY3O-4153_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_YeastPathways_PWY3O-4153/YeastPathways_PWY3O-4153_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1212,15 +1168,26 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4153/YeastPathways_PWY3O-4153>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1243,7 +1210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1268,13 +1235,43 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4153BiochemicalReaction49895> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_PWY_YeastPathways_PWY3O-4153> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-10814> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX-9432_RXN-10814_controller>
+] .
 
 <http://model.geneontology.org/CHEBI_15377_PREPHENATEDEHYDRAT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -1285,32 +1282,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4153SmallMolecule50085> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_YeastPathways_PWY3O-4153> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10814> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX-9432_RXN-10814_controller>
-] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1324,7 +1302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phenylalanine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1332,17 +1310,50 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-10814_BFO_0000066_reaction_RXN-10814_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4153>
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000066_reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4153>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
+                "SGD_PWY:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_YeastPathways_PWY3O-4153/YeastPathways_PWY3O-4153_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-4153/YeastPathways_PWY3O-4153_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002234_CHEBI_29934_CHORISMATEMUT-RXN_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1353,11 +1364,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_58095_2.6.1.58-RXN_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_58095_2.6.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1368,17 +1379,6 @@
           <http://model.geneontology.org/CHEBI_58095_2.6.1.58-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_PWY3O-4153>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1386,11 +1386,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'prephenate + H<SUP>+</SUP> &harr; 3-phenyl-2-oxopropanoate + CO<SUB>2</SUB> + H<sub>2</sub>O' 'null' 'L-phenylalanine + 2-oxoglutarate &harr; 3-phenyl-2-oxopropanoate + L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_RXN-10814_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002413_RXN-10814_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1401,26 +1401,15 @@
           <http://model.geneontology.org/RXN-10814>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_CPLX-9432_RXN-10814_controller_SGD_YeastPathways_PWY3O-4153>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'chorismate &harr; prephenate' 'null' 'prephenate + H<SUP>+</SUP> &harr; 3-phenyl-2-oxopropanoate + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1435,11 +1424,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_57972_2.6.1.58-RXN_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_57972_2.6.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1450,6 +1439,29 @@
           <http://model.geneontology.org/CHEBI_57972_2.6.1.58-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002233_CHEBI_29985_RXN-10814_SGD_PWY_YeastPathways_PWY3O-4153>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4153" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16810>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_16810_RXN-10814>
         a       <http://purl.obolibrary.org/obo/CHEBI_16810> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1459,7 +1471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1467,26 +1479,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_16810>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-4153/YeastPathways_PWY3O-4153_SGD_YeastPathways_PWY3O-4153>
+<http://model.geneontology.org/ev_w_id_CPLX-9432_RXN-10814_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_PWY3O-4153>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4153" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_PREPHENATEDEHYDRAT-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1497,11 +1497,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_15378_PREPHENATEDEHYDRAT-RXN_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002233_CHEBI_15378_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1524,7 +1524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1536,11 +1536,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_58095_RXN-10814_SGD_YeastPathways_PWY3O-4153> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002234_CHEBI_58095_RXN-10814_SGD_PWY_YeastPathways_PWY3O-4153> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-4158.ttl
+++ b/models/YeastPathways_PWY3O-4158.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -26,7 +26,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -39,12 +39,34 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58125>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_17154_RXN-8441_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-214>
         a       <http://purl.obolibrary.org/obo/GO_0045437> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -65,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -73,25 +95,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_456216_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -99,11 +110,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -118,11 +129,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_30616_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_30616_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,25 +144,14 @@
           <http://model.geneontology.org/CHEBI_30616_2.7.7.1-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -159,11 +159,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -174,26 +174,15 @@
           <http://model.geneontology.org/reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '1-(&beta;-D ribofuranosyl)nicotinamide + phosphate &rarr; nicotinamide + &alpha;-D-ribose-1-phosphate + H<SUP>+</SUP>' 'null' 'nicotinamide + H<sub>2</sub>O &rarr; ammonium + nicotinate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002413_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002413_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -204,6 +193,17 @@
           <http://model.geneontology.org/NICOTINAMID-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -233,14 +233,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002411_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -248,11 +248,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_17154_RXN-8441_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_17154_RXN-8441_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,11 +267,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002333_MONOMER3O-4139_RIBOSYLNICOTINAMIDE-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002333_MONOMER3O-4139_RIBOSYLNICOTINAMIDE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,32 +282,48 @@
           <http://model.geneontology.org/MONOMER3O-4139_RIBOSYLNICOTINAMIDE-KINASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/96cb3d13-b4dd-4b76-ac64-cea88d9bd89c_RXN-15025>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [histone]-L-lysine" ;
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002333_YLR328W-MONOMER_2.7.7.1-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35464> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Provides Input For Rule. The relation 'nicotinamide + H<sub>2</sub>O &rarr; ammonium + nicotinate' 'null' 'nicotinate + 5-phospho-&alpha;-D-ribose 1-diphosphate + ATP + H<sub>2</sub>O &rarr; &beta;-nicotinate D-ribonucleotide + ADP + diphosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002413_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002413_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,11 +341,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -340,37 +356,15 @@
           <http://model.geneontology.org/CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -381,17 +375,6 @@
           <http://model.geneontology.org/CHEBI_15377_NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_CHEBI_15377_RXN-15025_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000005735>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -399,11 +382,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002233_CHEBI_15377_RXN3O-214_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002233_CHEBI_15377_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -412,25 +395,6 @@
           <http://model.geneontology.org/RXN3O-214> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_RXN3O-214>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158>
 ] .
 
 <http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN>
@@ -442,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -453,27 +417,24 @@
 <http://purl.obolibrary.org/obo/GO_0008936>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002233_CHEBI_15927_RXN-8441_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002233_CHEBI_30616_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158>
+] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -485,11 +446,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_57502_RXN-8443_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_57502_RXN-8443_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -500,6 +461,17 @@
           <http://model.geneontology.org/CHEBI_57502_RXN-8443>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58437_NICONUCADENYLYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58437> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -509,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -517,26 +489,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,11 +512,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -575,7 +536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -592,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -600,25 +561,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002234_CHEBI_32544_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002333_MONOMER3O-4139_RXN-8443_controller_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_16675_RXN-5721_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -626,11 +576,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Provides Input For Rule. The relation 'nicotinate + 5-phospho-&alpha;-D-ribose 1-diphosphate + ATP + H<sub>2</sub>O &rarr; &beta;-nicotinate D-ribonucleotide + ADP + diphosphate + phosphate' 'null' '&beta;-nicotinate D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; nicotinate adenine dinucleotide + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -645,11 +595,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002233_CHEBI_58527_RXN3O-214_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002233_CHEBI_58527_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,25 +613,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_17154_RXN0-7092_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -689,11 +628,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Provides Input For Rule. The relation 'ATP + nicotinate adenine dinucleotide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + AMP + NAD<sup>+</sup> + diphosphate + H<SUP>+</SUP>' 'null' '&beta;-nicotinamide D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; NAD<sup>+</sup> + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002413_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002413_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -708,11 +647,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002333_MONOMER3O-4139_RXN-8443_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002333_MONOMER3O-4139_RXN-8443_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -723,61 +662,17 @@
           <http://model.geneontology.org/MONOMER3O-4139_RXN-8443_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002233_CHEBI_43474_RXN3O-205_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002413_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002333_YGR010W-MONOMER_2.7.7.1-RXN_controller_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_96cb3d13-b4dd-4b76-ac64-cea88d9bd89c_RXN-15025_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -790,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -798,29 +693,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002234_CHEBI_29888_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RXN0-7092_BFO_0000066_reaction_RXN0-7092_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_15377_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0033754>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_BFO_0000066_reaction_RIBOSYLNICOTINAMIDE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_BFO_0000066_reaction_RIBOSYLNICOTINAMIDE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,11 +752,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>' 'null' '2-amino-3-carboxymuconate-6-semialdehyde &rarr; quinolinate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -850,48 +767,32 @@
           <http://model.geneontology.org/RXN-5721>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002333_MONOMER3O-4152_RXN-15025_controller_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/b7b3766d-8da8-449f-a3d0-49671dbec633_RXN-15025>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [histone]-N<sup>6</sup>-acetyl-L-lysine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8441_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35457> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000066_reaction_NICOTINAMID-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000066_reaction_NICOTINAMID-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -906,11 +807,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002233_CHEBI_43474_RXN0-7092_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002233_CHEBI_43474_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -921,6 +822,28 @@
           <http://model.geneontology.org/CHEBI_43474_RXN0-7092>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_17154_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_43474_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -930,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of NAD biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -942,11 +865,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -961,11 +884,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8441_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -976,25 +899,25 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002411_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_57720_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1002,11 +925,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '&beta;-nicotinamide D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; NAD<sup>+</sup> + diphosphate' 'null' 'a [histone]-N<sup>6</sup>-acetyl-L-lysine + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; a [histone]-L-lysine + 2''-<i>O</i>-acetyl-ADP-ribose + nicotinamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002413_RXN-15025_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002413_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1036,24 +959,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158BiochemicalReaction35484> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002411_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1062,11 +974,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002333_YLR209C-MONOMER_RXN3O-205_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002333_YLR209C-MONOMER_RXN3O-205_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1077,6 +989,17 @@
           <http://model.geneontology.org/YLR209C-MONOMER_RXN3O-205_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29888_NICOTINATEPRIBOSYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1086,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1101,13 +1024,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158Protein35769> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1116,11 +1050,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8443_BFO_0000066_reaction_RXN-8443_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8443_BFO_0000066_reaction_RXN-8443_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1135,11 +1069,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_17154_RXN-15025_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_17154_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1169,7 +1103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1186,7 +1120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1198,11 +1132,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1213,15 +1147,37 @@
           <http://model.geneontology.org/CHEBI_29888_NICOTINATEPRIBOSYLTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_fe18d5c9-11d2-4f2f-95df-f96e0d6aa8b0_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002411_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1237,29 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-7092_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1267,11 +1201,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1289,11 +1223,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1304,17 +1238,6 @@
           <http://model.geneontology.org/reaction_1.13.11.6-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_RIBOSYLNICOTINAMIDE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1324,7 +1247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1336,11 +1259,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1351,51 +1274,18 @@
           <http://model.geneontology.org/CHEBI_58629_RXN-8665>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000001116>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1415,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1432,7 +1322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1444,11 +1334,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1459,14 +1349,14 @@
           <http://model.geneontology.org/CHEBI_58437_NICONUCADENYLYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1474,11 +1364,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002234_CHEBI_29888_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002234_CHEBI_29888_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1489,6 +1379,17 @@
           <http://model.geneontology.org/CHEBI_29888_2.7.7.1-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57972> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1498,7 +1399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1506,14 +1407,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1521,11 +1422,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1536,15 +1437,26 @@
           <http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-205_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-205_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1555,6 +1467,28 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001116> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1562,7 +1496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1573,18 +1507,37 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_58349>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002233_CHEBI_15377_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_47013_RXN-8441_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_47013_RXN-8441_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1599,11 +1552,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '1-(&beta;-D ribofuranosyl)nicotinamide + ATP &rarr; &beta;-nicotinamide D-ribonucleotide + ADP + H<SUP>+</SUP>' 'null' '&beta;-nicotinamide D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; NAD<sup>+</sup> + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002413_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002413_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1617,47 +1570,17 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002413_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_58349>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_BFO_0000066_reaction_RIBOSYLNICOTINAMIDE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1665,11 +1588,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1680,19 +1603,19 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002233_CHEBI_15927_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4158>
+<http://identifiers.org/sgd/S000001943>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000001943>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YJR078W-MONOMER_RXN-8665_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003839> ;
@@ -1701,7 +1624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1709,15 +1632,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_57502_RXN-8443_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1734,33 +1668,29 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/YOR209C-MONOMER_NICOTINATEPRIBOSYLTRANS-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005735> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "nicotinate phosphoribosyl transferase" ;
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158Protein35528> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1771,15 +1701,30 @@
           <http://model.geneontology.org/reaction_RXN-5721_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/YOR209C-MONOMER_NICOTINATEPRIBOSYLTRANS-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005735> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "nicotinate phosphoribosyl transferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158Protein35528> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1790,15 +1735,26 @@
           <http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-8443_BFO_0000066_reaction_RXN-8443_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1818,7 +1774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1826,15 +1782,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002413_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1849,11 +1827,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_16988_RXN3O-214_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_16988_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1864,39 +1842,50 @@
           <http://model.geneontology.org/CHEBI_16988_RXN3O-214>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002413_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002333_YGR010W-MONOMER_2.7.7.1-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002234_CHEBI_57720_RXN3O-205_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_57502_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_83767_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1904,11 +1893,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1923,11 +1912,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Provides Input For Rule. The relation '&beta;-D-ribosylnicotinate + ATP &rarr; &beta;-nicotinate D-ribonucleotide + ADP + H<SUP>+</SUP>' 'null' '&beta;-nicotinate D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; nicotinate adenine dinucleotide + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1938,14 +1927,14 @@
           <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16675_RXN-5721_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_BFO_0000066_reaction_NICOTINATEPRIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1956,7 +1945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1964,14 +1953,69 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002333_MONOMER3O-4139_RIBOSYLNICOTINAMIDE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002233_CHEBI_43474_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_30616_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-7092_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1984,24 +2028,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35327> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000066_reaction_NICOTINAMID-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2013,11 +2046,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002233_CHEBI_15927_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002233_CHEBI_15927_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2032,11 +2065,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2047,14 +2080,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002411_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2065,7 +2098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2080,11 +2113,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_15378_RXN0-7092_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_15378_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2099,11 +2132,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002233_CHEBI_15377_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002233_CHEBI_15377_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2123,7 +2156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2131,37 +2164,67 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_15378_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8441_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_BFO_0000066_reaction_RXN-8441_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-8441_BFO_0000066_reaction_RXN-8441_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2176,41 +2239,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002233_CHEBI_30616_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002413_RXN-15025_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002233_CHEBI_30616_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2228,7 +2261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2236,16 +2269,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_15378_RXN0-7092_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_30616_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000194>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_14649> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2256,7 +2292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2264,26 +2300,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002234_CHEBI_32544_RXN3O-205_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002233_CHEBI_17154_RXN0-7092_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002233_CHEBI_17154_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2294,18 +2319,26 @@
           <http://model.geneontology.org/CHEBI_17154_RXN0-7092>
 ] .
 
-<http://identifiers.org/sgd/S000000194>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2328,7 +2361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2336,29 +2369,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://identifiers.org/sgd/S000005073>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002413_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000005073>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2378,7 +2411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2390,11 +2423,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002411_RXN3O-214_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002411_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2414,7 +2447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2422,17 +2455,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_15378_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16988>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2440,41 +2484,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_83767_RXN-15025_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002233_CHEBI_30616_RXN-8443_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-15025> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_83767_RXN-15025>
-] .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002233_CHEBI_30616_RXN-8443_SGD_YeastPathways_PWY3O-4158> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2485,25 +2499,33 @@
           <http://model.geneontology.org/CHEBI_30616_RXN-8443>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_83767_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-15025> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_83767_RXN-15025>
+] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2526,7 +2548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2543,7 +2565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2551,15 +2573,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_43474_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_43474_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2577,11 +2610,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2601,7 +2634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2612,6 +2645,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002413_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_2.7.7.1-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2621,7 +2665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2629,14 +2673,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_BFO_0000066_reaction_2.7.7.1-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002413_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2644,11 +2688,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2663,11 +2707,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2678,16 +2722,19 @@
           <http://model.geneontology.org/CHEBI_15379_1.13.11.6-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_15378_RXN-8443_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000002836>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15927_RXN0-7092>
         a       <http://purl.obolibrary.org/obo/CHEBI_15927> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2698,7 +2745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2706,21 +2753,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000002836>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004320>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2731,71 +2808,45 @@
           <http://model.geneontology.org/YJR078W-MONOMER_RXN-8665_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002333_YLR209C-MONOMER_RXN0-7092_controller_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002411_RXN0-7092_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/dee60c6c-78d6-49da-b516-cd7147ee3e53_RXN-15025>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [histone]-N<sup>6</sup>-acetyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35457> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002411_RXN3O-214_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002233_CHEBI_15927_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_RIBOSYLNICOTINAMIDE-KINASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2803,11 +2854,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2818,6 +2869,26 @@
           <http://model.geneontology.org/CHEBI_57502_QUINOPRIBOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/reaction_RIBOSYLNICOTINAMIDE-KINASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29888_NAD-SYNTH-GLN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2827,7 +2898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2843,7 +2914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2851,11 +2922,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2870,11 +2941,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002234_CHEBI_57540_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002234_CHEBI_57540_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2885,70 +2956,15 @@
           <http://model.geneontology.org/CHEBI_57540_2.7.7.1-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002413_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_47013_RXN-8441_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002333_YOR209C-MONOMER_NICOTINATEPRIBOSYLTRANS-RXN_controller_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2963,11 +2979,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-205_BFO_0000066_reaction_RXN3O-205_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-205_BFO_0000066_reaction_RXN3O-205_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2990,7 +3006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3001,17 +3017,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_15377_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YGR010W-MONOMER_2.7.7.1-RXN_controller>
         a       <http://identifiers.org/sgd/S000003242> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3019,7 +3024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3031,11 +3036,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002333_YDR400W-MONOMER_RXN-8441_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002333_YDR400W-MONOMER_RXN-8441_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3050,11 +3055,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3069,11 +3074,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002333_YGR010W-MONOMER_2.7.7.1-RXN_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002333_YGR010W-MONOMER_2.7.7.1-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3087,14 +3092,14 @@
 <http://identifiers.org/sgd/S000003005>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002233_CHEBI_58527_RXN-8443_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002411_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3102,11 +3107,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_BFO_0000066_reaction_NICOTINATEPRIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_BFO_0000066_reaction_NICOTINATEPRIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3121,11 +3126,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002233_CHEBI_43474_RXN3O-205_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002233_CHEBI_43474_RXN3O-205_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3157,7 +3162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3169,11 +3174,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3188,11 +3193,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002411_RXN0-7092_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002411_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3203,14 +3208,25 @@
           <http://model.geneontology.org/RXN0-7092>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_57502_RXN-8443_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_RXN-8665_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3226,7 +3242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3238,11 +3254,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_1.13.11.6-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_1.13.11.6-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3253,15 +3269,26 @@
           <http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002234_CHEBI_28938_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3272,18 +3299,15 @@
           <http://model.geneontology.org/YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller>
 ] .
 
-<http://identifiers.org/sgd/S000003596>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3294,37 +3318,29 @@
           <http://model.geneontology.org/CHEBI_15377_ARYLFORMAMIDASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8441_BFO_0000066_reaction_RXN-8441_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_17154_RXN-8441_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000003596>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3344,7 +3360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3352,15 +3368,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000066_reaction_NICOTINAMID-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_32544_RXN3O-214_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_32544_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3380,7 +3407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3388,14 +3415,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002413_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3411,7 +3438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3428,13 +3455,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35224> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000066_reaction_RXN-15025_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58017_QUINOPRIBOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58017> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3445,7 +3483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3453,15 +3491,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_456216_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3476,11 +3525,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3491,30 +3540,8 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002233_CHEBI_58527_RXN3O-205_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0000334>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_NAD-SYNTH-GLN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3525,7 +3552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3536,17 +3563,6 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YDR400W-MONOMER_RXN3O-214_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002808> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3554,7 +3570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3562,25 +3578,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002333_YLR209C-MONOMER_RXN0-7092_controller_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002413_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-205_BFO_0000066_reaction_RXN3O-205_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_15378_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3593,13 +3620,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35279> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002333_MONOMER3O-4152_RXN-15025_controller_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YLR209C-MONOMER_RXN0-7092_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004199> ;
@@ -3608,7 +3657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3616,12 +3665,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_CHEBI_15377_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-8441_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3629,11 +3689,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_BFO_0000066_reaction_2.7.7.1-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_BFO_0000066_reaction_2.7.7.1-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3644,28 +3704,39 @@
           <http://model.geneontology.org/reaction_2.7.7.1-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_17154_RXN-15025_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002333_YGL037C-MONOMER_NICOTINAMID-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004731>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002333_YDR400W-MONOMER_RXN3O-214_controller_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_16988_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3673,11 +3744,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_17154_RXN0-7092_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_17154_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3688,14 +3759,14 @@
           <http://model.geneontology.org/CHEBI_17154_RXN0-7092>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_15378_RXN-8443_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16675_RXN-5721_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3706,24 +3777,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158Protein35586> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_32544_RXN3O-214_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_NAD-SYNTH-GLN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3734,7 +3794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3742,34 +3802,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002233_CHEBI_15377_RXN-8441_SGD_YeastPathways_PWY3O-4158> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-8441> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN-8441>
-] .
+<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_32544_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3780,6 +3832,36 @@
           <http://model.geneontology.org/CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002233_CHEBI_15377_RXN-8441_SGD_PWY_YeastPathways_PWY3O-4158> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-8441> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_RXN-8441>
+] .
+
+<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002233_CHEBI_30616_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16675_RXN-5721>
         a       <http://purl.obolibrary.org/obo/CHEBI_16675> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3789,7 +3871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3806,7 +3888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3831,13 +3913,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158BiochemicalReaction35531> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002233_CHEBI_15927_RXN-8441_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_14649>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3846,11 +3939,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002234_CHEBI_28938_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002234_CHEBI_28938_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3861,15 +3954,18 @@
           <http://model.geneontology.org/CHEBI_28938_NICOTINAMID-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_28938>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3880,32 +3976,62 @@
           <http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002413_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004199>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_28938>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002333_YOR209C-MONOMER_NICOTINATEPRIBOSYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-kynurenine + NADPH + oxygen + H<SUP>+</SUP> &rarr; 3-hydroxy-L-kynurenine + NADP<sup>+</sup> + H<sub>2</sub>O' 'null' '3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3920,11 +4046,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '&beta;-D-ribosylnicotinate + phosphate &rarr; nicotinate + &alpha;-D-ribose-1-phosphate' 'null' 'nicotinate + 5-phospho-&alpha;-D-ribose 1-diphosphate + ATP + H<sub>2</sub>O &rarr; &beta;-nicotinate D-ribonucleotide + ADP + diphosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002413_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002413_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3944,7 +4070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3952,29 +4078,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57959>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57959>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002233_CHEBI_58527_RXN-8443_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002233_CHEBI_58527_RXN-8443_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3989,11 +4115,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_96cb3d13-b4dd-4b76-ac64-cea88d9bd89c_RXN-15025_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_fe18d5c9-11d2-4f2f-95df-f96e0d6aa8b0_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4001,21 +4127,43 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/96cb3d13-b4dd-4b76-ac64-cea88d9bd89c_RXN-15025>
+          <http://model.geneontology.org/fe18d5c9-11d2-4f2f-95df-f96e0d6aa8b0_RXN-15025>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004502>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002234_CHEBI_57540_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_456216_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_456216_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4030,11 +4178,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4045,25 +4193,19 @@
           <http://model.geneontology.org/YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_BFO_0000066_reaction_NICOTINATEPRIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_994>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0050262>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_994>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/RXN3O-205>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004731> ;
@@ -4086,7 +4228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4094,37 +4236,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_456216_RXN-8443_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-205_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0050262>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4135,14 +4258,14 @@
           <http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002233_CHEBI_17154_RXN0-7092_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4150,11 +4273,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4165,38 +4288,11 @@
           <http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-214_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004514>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_BFO_0000066_reaction_RIBOSYLNICOTINAMIDE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002413_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58629_RXN-8665>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58629> ;
@@ -4207,7 +4303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4225,7 +4321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4233,14 +4329,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4253,7 +4349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4270,7 +4366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4278,15 +4374,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Provides Input For Rule. The relation 'L-tryptophan + oxygen &rarr; <i>N</i>-Formyl-L-kynurenine' 'null' '<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4306,7 +4413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4314,17 +4421,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0004514>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-7092_BFO_0000066_reaction_RXN0-7092_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4349,7 +4453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4366,7 +4470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4378,11 +4482,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4393,40 +4497,18 @@
           <http://model.geneontology.org/YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002413_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57972>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4446,7 +4528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4454,43 +4536,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002234_CHEBI_32544_RXN3O-205_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_57959_ARYLFORMAMIDASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57959> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "L-kynurenine" ;
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35784> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4501,31 +4577,81 @@
           <http://model.geneontology.org/CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_57959_ARYLFORMAMIDASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57959> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "L-kynurenine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35784> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002333_MONOMER3O-4139_RXN-8443_controller_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002233_CHEBI_15927_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002333_YLR209C-MONOMER_RXN3O-205_controller_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57912>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002233_CHEBI_43474_RXN0-7092_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RXN3O-205_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4533,11 +4659,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000066_reaction_RXN-15025_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000066_reaction_RXN-15025_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4552,11 +4678,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002333_YLR328W-MONOMER_2.7.7.1-RXN_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002333_YLR328W-MONOMER_2.7.7.1-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4567,48 +4693,15 @@
           <http://model.geneontology.org/YLR328W-MONOMER_2.7.7.1-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002233_CHEBI_15377_RXN3O-214_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002413_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_15377_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_15377_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4623,11 +4716,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002233_CHEBI_58527_RXN3O-205_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002233_CHEBI_58527_RXN3O-205_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4647,7 +4740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4655,57 +4748,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002413_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0030429>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002234_CHEBI_57540_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_47013_RXN-8441_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15927_RXN-8441>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15927> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(&beta;-D ribofuranosyl)nicotinamide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35350> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4720,11 +4807,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '1-(&beta;-D ribofuranosyl)nicotinamide + H<sub>2</sub>O &rarr; D-ribofuranose + nicotinamide + H<SUP>+</SUP>' 'null' 'nicotinamide + H<sub>2</sub>O &rarr; ammonium + nicotinate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002413_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002413_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4735,16 +4822,22 @@
           <http://model.geneontology.org/NICOTINAMID-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002411_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_15927_RXN-8441>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15927> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(&beta;-D ribofuranosyl)nicotinamide" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35350> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -4755,7 +4848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4763,27 +4856,101 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002413_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_456216_RXN-8443_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_456216_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_PWY_YeastPathways_PWY3O-4158> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-5721> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_RXN-5721>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>' 'null' '3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/1.13.11.6-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_RXN-8665_SGD_PWY_YeastPathways_PWY3O-4158> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58629_RXN-8665>
+] .
+
+<http://model.geneontology.org/CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58125> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-hydroxy-L-kynurenine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35748> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/NICOTINATEPRIBOSYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004516> ;
@@ -4804,7 +4971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4812,137 +4979,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_YeastPathways_PWY3O-4158> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5721> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN-5721>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>' 'null' '3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_SGD_YeastPathways_PWY3O-4158> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1.13.11.6-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_15378_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_RXN-8665_SGD_YeastPathways_PWY3O-4158> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58629_RXN-8665>
-] .
-
-<http://model.geneontology.org/CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58125> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-hydroxy-L-kynurenine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35748> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58629>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_57502>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002233_CHEBI_58527_RXN3O-214_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002233_CHEBI_58527_RXN-8443_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY3O-4158> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_QUINOPRIBOTRANS-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_29888_NICONUCADENYLYLTRAN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
@@ -4953,7 +5005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4965,11 +5017,41 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002333_YDR400W-MONOMER_RXN3O-214_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_QUINOPRIBOTRANS-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002333_YDR400W-MONOMER_RXN3O-214_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4989,7 +5071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4997,23 +5079,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002333_YDR400W-MONOMER_RXN-8441_controller_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002413_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5021,11 +5114,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5040,11 +5133,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5064,7 +5157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5072,14 +5165,58 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_30616_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_1.13.11.6-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002333_YDR400W-MONOMER_RXN-8441_controller_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5087,11 +5224,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16675_RXN-5721_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16675_RXN-5721_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5102,6 +5239,28 @@
           <http://model.geneontology.org/CHEBI_16675_RXN-5721>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002413_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_NAD-SYNTH-GLN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5111,7 +5270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5122,43 +5281,26 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002233_CHEBI_15377_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15377_RXN-8441>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35318> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5169,15 +5311,26 @@
           <http://model.geneontology.org/CHEBI_30616_NICONUCADENYLYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002234_CHEBI_57720_RXN3O-205_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5188,92 +5341,32 @@
           <http://model.geneontology.org/CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_15377_RXN-8441>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_43474_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-214_BFO_0000066_reaction_RXN3O-214_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35318> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Provides Input For Rule. The relation '<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>' 'null' 'L-kynurenine + NADPH + oxygen + H<SUP>+</SUP> &rarr; 3-hydroxy-L-kynurenine + NADP<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5291,11 +5384,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_57720_RXN0-7092_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_57720_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5306,61 +5399,47 @@
           <http://model.geneontology.org/CHEBI_57720_RXN0-7092>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_30616_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5368,11 +5447,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002233_CHEBI_15927_RXN-8441_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002233_CHEBI_15927_RXN-8441_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5383,15 +5462,26 @@
           <http://model.geneontology.org/CHEBI_15927_RXN-8441>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_17154_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_15378_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_15378_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5402,25 +5492,28 @@
           <http://model.geneontology.org/CHEBI_15378_RIBOSYLNICOTINAMIDE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000066_reaction_RXN-15025_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5434,11 +5527,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002234_CHEBI_32544_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002234_CHEBI_32544_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5453,11 +5546,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5468,19 +5561,19 @@
           <http://model.geneontology.org/CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_BFO_0000066_reaction_2.7.7.1-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YLR328W-MONOMER_2.7.7.1-RXN_controller>
         a       <http://identifiers.org/sgd/S000004320> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5489,7 +5582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5504,7 +5597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5512,26 +5605,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5546,11 +5628,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-214_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-214_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5561,25 +5643,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RXN3O-214_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5588,18 +5659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5607,11 +5667,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_15378_RXN-8443_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_15378_RXN-8443_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5626,11 +5686,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002333_MONOMER3O-4152_RXN-15025_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002333_MONOMER3O-4152_RXN-15025_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5651,7 +5711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5668,7 +5728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5695,7 +5755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5722,7 +5782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5734,11 +5794,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_57502_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_57502_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5761,7 +5821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5773,11 +5833,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002411_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002411_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5793,7 +5853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5801,11 +5861,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5816,12 +5876,23 @@
           <http://model.geneontology.org/CHEBI_15378_1.13.11.6-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-214_BFO_0000066_reaction_RXN3O-214_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-5721_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5830,7 +5901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5843,7 +5914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5857,43 +5928,18 @@
 <http://purl.obolibrary.org/obo/GO_0004515>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_58527_RXN-8443>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58527> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "&beta;-D-ribosylnicotinate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35181> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.obolibrary.org/obo/CHEBI_57720>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-7092_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-7092_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5904,16 +5950,22 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002233_CHEBI_30616_RXN-8443_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_58527_RXN-8443>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58527> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "&beta;-D-ribosylnicotinate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35181> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RIBOSYLNICOTINAMIDE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0050262> ;
@@ -5934,7 +5986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5942,8 +5994,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57720>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002233_CHEBI_17154_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57502_RXN-8443>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57502> ;
@@ -5954,7 +6014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5962,43 +6022,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002413_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000002808>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_57502_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_47013>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_83767_RXN-15025_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'CO<SUB>2</SUB> + &beta;-nicotinate D-ribonucleotide + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + quinolinate + 2 H<SUP>+</SUP>' 'null' '&beta;-nicotinate D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; nicotinate adenine dinucleotide + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6009,26 +6058,15 @@
           <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6048,7 +6086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6065,7 +6103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6073,36 +6111,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_15378_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6110,11 +6126,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-7092_BFO_0000066_reaction_RXN0-7092_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-7092_BFO_0000066_reaction_RXN0-7092_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6134,7 +6150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6146,11 +6162,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '&beta;-nicotinate D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; nicotinate adenine dinucleotide + diphosphate' 'null' 'ATP + nicotinate adenine dinucleotide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + AMP + NAD<sup>+</sup> + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6170,7 +6186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6178,25 +6194,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002234_CHEBI_29888_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_dee60c6c-78d6-49da-b516-cd7147ee3e53_RXN-15025_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8441_BFO_0000066_reaction_RXN-8441_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6204,11 +6231,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_16675_RXN-5721_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_16675_RXN-5721_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6223,11 +6250,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6257,27 +6284,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158BiochemicalReaction35664> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58437>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_57720_RXN0-7092_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_47013_RXN-8441>
         a       <http://purl.obolibrary.org/obo/CHEBI_47013> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6288,7 +6301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6296,45 +6309,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_16675_RXN-5721_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6345,7 +6325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6353,26 +6333,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002333_YGL037C-MONOMER_NICOTINAMID-RXN_controller_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002233_CHEBI_15377_RXN-8441_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58437>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002411_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002411_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6387,11 +6370,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_CHEBI_15377_RXN-15025_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_CHEBI_15377_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6411,24 +6394,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35264> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_1.13.11.6-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_83767_RXN-15025>
         a       <http://purl.obolibrary.org/obo/CHEBI_83767> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6439,7 +6411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6456,7 +6428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6464,26 +6436,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002233_CHEBI_15377_RXN-8441_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_30616_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_30616_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6498,11 +6459,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002234_CHEBI_32544_RXN3O-205_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002234_CHEBI_32544_RXN3O-205_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6522,7 +6483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6530,27 +6491,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/fe18d5c9-11d2-4f2f-95df-f96e0d6aa8b0_RXN-15025>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [histone]-L-lysine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35464> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_NICONUCADENYLYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6561,7 +6517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6573,11 +6529,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6592,11 +6548,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Provides Input For Rule. The relation '1-(&beta;-D ribofuranosyl)nicotinamide + H<sub>2</sub>O &rarr; D-ribofuranose + nicotinamide + H<SUP>+</SUP>' 'null' '&beta;-nicotinamide D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; NAD<sup>+</sup> + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002413_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002413_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6616,7 +6572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6624,47 +6580,47 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002413_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_16988_RXN3O-214_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002233_CHEBI_43474_RXN3O-205_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002333_MONOMER3O-4139_RIBOSYLNICOTINAMIDE-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6673,18 +6629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_456216_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6692,11 +6637,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6707,17 +6652,6 @@
           <http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_RXN-8665_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_RXN-8443>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6727,7 +6661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6742,11 +6676,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Provides Input For Rule. The relation '&beta;-D-ribosylnicotinate + H<sub>2</sub>O &rarr; D-ribose + nicotinate' 'null' 'nicotinate + 5-phospho-&alpha;-D-ribose 1-diphosphate + ATP + H<sub>2</sub>O &rarr; &beta;-nicotinate D-ribonucleotide + ADP + diphosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002413_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002413_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6766,7 +6700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6783,7 +6717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6798,7 +6732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6815,7 +6749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6827,11 +6761,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6842,6 +6776,17 @@
           <http://model.geneontology.org/CHEBI_15379_RXN-8665>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002234_CHEBI_32544_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0009435>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -6851,15 +6796,26 @@
 <http://identifiers.org/sgd/S000002200>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002333_YDR400W-MONOMER_RXN3O-214_controller_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6870,28 +6826,50 @@
           <http://model.geneontology.org/CHEBI_58017_QUINOPRIBOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17154>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002233_CHEBI_15927_RXN0-7092_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6899,11 +6877,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6918,11 +6896,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_15378_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_15378_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6939,6 +6917,17 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_RXN-15025>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6948,7 +6937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6960,11 +6949,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6982,11 +6971,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002333_YLR209C-MONOMER_RXN0-7092_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002333_YLR209C-MONOMER_RXN0-7092_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7006,7 +6995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7014,26 +7003,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002413_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_15378_RXN-8441_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_15378_RXN-8441_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7048,11 +7026,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_456216_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_456216_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7063,36 +7041,14 @@
           <http://model.geneontology.org/CHEBI_456216_RIBOSYLNICOTINAMIDE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002413_RXN-15025_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7103,11 +7059,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002333_YGL037C-MONOMER_NICOTINAMID-RXN_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002333_YGL037C-MONOMER_NICOTINAMID-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7118,15 +7074,26 @@
           <http://model.geneontology.org/YGL037C-MONOMER_NICOTINAMID-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-8443_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7137,14 +7104,47 @@
           <http://model.geneontology.org/CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002233_CHEBI_30616_RXN-8443_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002233_CHEBI_58527_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_32544_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7152,11 +7152,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7167,15 +7167,26 @@
           <http://model.geneontology.org/reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002413_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-214_BFO_0000066_reaction_RXN3O-214_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-214_BFO_0000066_reaction_RXN3O-214_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7186,25 +7197,14 @@
           <http://model.geneontology.org/reaction_RXN3O-214_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002234_CHEBI_28938_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_15378_RXN-8441_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7213,7 +7213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7221,11 +7221,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_456216_RXN-8443_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_456216_RXN-8443_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7240,11 +7240,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Provides Input For Rule. The relation 'a [histone]-N<sup>6</sup>-acetyl-L-lysine + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; a [histone]-L-lysine + 2''-<i>O</i>-acetyl-ADP-ribose + nicotinamide' 'null' 'nicotinamide + H<sub>2</sub>O &rarr; ammonium + nicotinate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002413_NICOTINAMID-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002413_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7258,17 +7258,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58017_NICOTINATEPRIBOSYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58017> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7278,7 +7267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7293,7 +7282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7301,14 +7290,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-205_BFO_0000066_reaction_RXN3O-205_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7316,11 +7305,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002333_YOR209C-MONOMER_NICOTINATEPRIBOSYLTRANS-RXN_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002333_YOR209C-MONOMER_NICOTINATEPRIBOSYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7336,7 +7325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7359,7 +7348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7367,14 +7356,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_32544_RXN3O-214_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7382,11 +7371,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ATP + nicotinate adenine dinucleotide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + AMP + NAD<sup>+</sup> + diphosphate + H<SUP>+</SUP>' 'null' 'a [histone]-N<sup>6</sup>-acetyl-L-lysine + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; a [histone]-L-lysine + 2''-<i>O</i>-acetyl-ADP-ribose + nicotinamide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002413_RXN-15025_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002413_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7397,8 +7386,41 @@
           <http://model.geneontology.org/RXN-15025>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002233_CHEBI_15377_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-15025>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -7409,9 +7431,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-15025_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_RXN-15025> , <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/dee60c6c-78d6-49da-b516-cd7147ee3e53_RXN-15025> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN-15025> , <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/b7b3766d-8da8-449f-a3d0-49671dbec633_RXN-15025> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_17154_RXN-15025> , <http://model.geneontology.org/96cb3d13-b4dd-4b76-ac64-cea88d9bd89c_RXN-15025> , <http://model.geneontology.org/CHEBI_83767_RXN-15025> ;
+                <http://model.geneontology.org/fe18d5c9-11d2-4f2f-95df-f96e0d6aa8b0_RXN-15025> , <http://model.geneontology.org/CHEBI_17154_RXN-15025> , <http://model.geneontology.org/CHEBI_83767_RXN-15025> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-4152_RXN-15025_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -7419,13 +7441,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158BiochemicalReaction35452> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004516>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -7452,24 +7485,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158BiochemicalReaction35166> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003786>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -7479,7 +7501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7492,7 +7514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7504,11 +7526,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7523,11 +7545,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7538,6 +7560,17 @@
           <http://model.geneontology.org/YJR025C-MONOMER_1.13.11.6-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -7546,7 +7579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7554,11 +7587,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7573,11 +7606,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002233_CHEBI_15927_RXN0-7092_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002233_CHEBI_15927_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7600,7 +7633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7608,26 +7641,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7638,15 +7660,26 @@
           <http://model.geneontology.org/CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_b7b3766d-8da8-449f-a3d0-49671dbec633_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2-amino-3-carboxymuconate-6-semialdehyde &rarr; quinolinate + H<sub>2</sub>O' 'null' 'CO<SUB>2</SUB> + &beta;-nicotinate D-ribonucleotide + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + quinolinate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002413_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002413_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7666,7 +7699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7683,7 +7716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7691,14 +7724,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002233_CHEBI_58527_RXN3O-205_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7706,11 +7739,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7742,7 +7775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7754,11 +7787,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002411_2.7.7.1-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002411_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7769,39 +7802,6 @@
           <http://model.geneontology.org/2.7.7.1-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002333_YLR328W-MONOMER_2.7.7.1-RXN_controller_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8443_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YJR025C-MONOMER_1.13.11.6-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003786> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -7809,7 +7809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7821,11 +7821,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_32544_RXN3O-214_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_32544_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7840,11 +7840,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002234_CHEBI_57720_RXN3O-205_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002234_CHEBI_57720_RXN3O-205_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7855,14 +7855,14 @@
           <http://model.geneontology.org/CHEBI_57720_RXN3O-205>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RXN3O-205_RO_0002333_YLR209C-MONOMER_RXN3O-205_controller_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7871,26 +7871,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15379> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "O<SUB>2</SUB>" ;
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35677> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_RIBOSYLNICOTINAMIDE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -7901,7 +7895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7916,11 +7910,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7935,11 +7929,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8443_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8443_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7954,11 +7948,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_dee60c6c-78d6-49da-b516-cd7147ee3e53_RXN-15025_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_b7b3766d-8da8-449f-a3d0-49671dbec633_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7966,19 +7960,25 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/dee60c6c-78d6-49da-b516-cd7147ee3e53_RXN-15025>
+          <http://model.geneontology.org/b7b3766d-8da8-449f-a3d0-49671dbec633_RXN-15025>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15379> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "O<SUB>2</SUB>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35677> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/QUINOPRIBOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004514> ;
@@ -7999,13 +7999,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158BiochemicalReaction35564> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57912_RXN-8665>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57912> ;
@@ -8016,7 +8027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8024,14 +8035,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8039,11 +8061,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_NICOTINATEPRIBOSYLTRANS-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8061,7 +8083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8076,11 +8098,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8110,7 +8132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8118,26 +8140,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8443_BFO_0000066_reaction_RXN-8443_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8148,26 +8159,15 @@
           <http://model.geneontology.org/CHEBI_29985_NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8178,25 +8178,25 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002411_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8204,11 +8204,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8219,6 +8219,17 @@
           <http://model.geneontology.org/CHEBI_57912_RXN-8665>
 ] .
 
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_2.7.7.1-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8228,7 +8239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8243,21 +8254,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158Protein35504> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_15378_RXN-8441_SGD_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-4300.ttl
+++ b/models/YeastPathways_PWY3O-4300.ttl
@@ -1,14 +1,3 @@
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_57540_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-4300>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YGL256W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller>
         a       <http://identifiers.org/sgd/S000003225> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -16,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -31,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -46,11 +35,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002234_CHEBI_30089_RXN66-3_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002234_CHEBI_30089_RXN66-3_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -60,6 +49,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30089_RXN66-3>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002233_CHEBI_15377_RXN66-3_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000349>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -83,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,11 +95,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_15343_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_15343_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -110,26 +110,15 @@
           <http://model.geneontology.org/CHEBI_15343_ALCOHOL-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002233_CHEBI_15343_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-4300>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_57287_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_57287_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -143,26 +132,18 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_57287_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-4300>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002233_CHEBI_57540_RXN66-3_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002233_CHEBI_57540_RXN66-3_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -173,8 +154,16 @@
           <http://model.geneontology.org/CHEBI_57540_RXN66-3>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN66-3_BFO_0000066_reaction_RXN66-3_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -188,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -203,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -220,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -237,13 +226,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4300SmallMolecule25688> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002233_CHEBI_57540_RXN66-3_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACETATE--COA-LIGASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003987> ;
@@ -262,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -274,11 +274,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YOL086C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YOL086C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -298,7 +298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -308,6 +308,17 @@
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30616_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16236>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -320,29 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_BFO_0000066_reaction_ACETATE--COA-LIGASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4300>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-3_BFO_0000066_reaction_RXN66-3_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4300>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -350,11 +339,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_57540_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_57540_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -365,26 +354,15 @@
           <http://model.geneontology.org/CHEBI_57540_ALCOHOL-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002233_CHEBI_15377_RXN66-3_SGD_YeastPathways_PWY3O-4300>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30616_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30616_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,15 +373,26 @@
           <http://model.geneontology.org/CHEBI_30616_ACETATE--COA-LIGASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002234_CHEBI_30089_RXN66-3_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002233_CHEBI_15377_RXN66-3_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002233_CHEBI_15377_RXN66-3_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -420,35 +409,46 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 <http://identifiers.org/sgd/S000000050>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/BFO_0000050>
+<http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30089_RXN66-3_SGD_YeastPathways_PWY3O-4300>
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_57945_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-4300>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
+                "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002413_RXN66-3_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR303C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR303C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -471,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -487,7 +487,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR303C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -495,11 +506,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YGL256W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YGL256W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -534,11 +545,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002333_YAL054C-MONOMER_ACETATE--COA-LIGASE-RXN_controller_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002333_YAL054C-MONOMER_ACETATE--COA-LIGASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,17 +560,6 @@
           <http://model.geneontology.org/YAL054C-MONOMER_ACETATE--COA-LIGASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YGL256W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-4300>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YMR083W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller>
         a       <http://identifiers.org/sgd/S000004688> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -575,14 +575,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_57945_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-4300>
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YBR145W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4300>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
+                "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -593,11 +593,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_16236_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_16236_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -608,15 +608,26 @@
           <http://model.geneontology.org/CHEBI_16236_ALCOHOL-DEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_BFO_0000066_reaction_ACETATE--COA-LIGASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30089_RXN66-3_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30089_RXN66-3_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -627,26 +638,15 @@
           <http://model.geneontology.org/CHEBI_30089_RXN66-3>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002234_CHEBI_30089_RXN66-3_SGD_YeastPathways_PWY3O-4300>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002233_CHEBI_15343_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002233_CHEBI_15343_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -657,34 +657,34 @@
           <http://model.geneontology.org/CHEBI_15343_ALCOHOL-DEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_456215_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/GO_0004022>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-4300/YeastPathways_PWY3O-4300_SGD_YeastPathways_PWY3O-4300>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_15343_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-4300>
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_57288_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-4300>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
+                "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -692,11 +692,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR083W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR083W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,14 +707,14 @@
           <http://model.geneontology.org/YMR083W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002234_CHEBI_57945_RXN66-3_SGD_YeastPathways_PWY3O-4300>
+<http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002233_CHEBI_15343_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-4300>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
+                "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -727,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -735,26 +735,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_15378_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-4300>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002413_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
+                "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002234_CHEBI_15378_RXN66-3_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN66-3_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -770,7 +781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "ethanol degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -790,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -802,11 +813,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YBR145W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YBR145W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -817,26 +828,15 @@
           <http://model.geneontology.org/YBR145W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002333_YAL054C-MONOMER_ACETATE--COA-LIGASE-RXN_controller_SGD_YeastPathways_PWY3O-4300>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_57288_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_57288_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -854,7 +854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -862,36 +862,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YOL086C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-4300>
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-4300/YeastPathways_PWY3O-4300_SGD_PWY_YeastPathways_PWY3O-4300>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
+                "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_57288_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-4300>
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_29888_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-4300>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
+                "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YBR145W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-4300>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_57540_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
+                "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -904,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -916,11 +916,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000066_reaction_ALCOHOL-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000066_reaction_ALCOHOL-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -935,11 +935,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_BFO_0000066_reaction_ACETATE--COA-LIGASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_BFO_0000066_reaction_ACETATE--COA-LIGASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -950,29 +950,29 @@
           <http://model.geneontology.org/reaction_ACETATE--COA-LIGASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57945>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002233_CHEBI_57540_RXN66-3_SGD_YeastPathways_PWY3O-4300>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_15378_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
+                "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57945>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-3_BFO_0000066_reaction_RXN66-3_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-3_BFO_0000066_reaction_RXN66-3_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -983,11 +983,44 @@
           <http://model.geneontology.org/reaction_RXN66-3_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002234_CHEBI_57945_RXN66-3_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0006068>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002333_YAL054C-MONOMER_ACETATE--COA-LIGASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR083W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003987>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -999,11 +1032,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" , "Provides Input For Rule. The relation 'acetaldehyde + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; acetate + NADH + 2 H<SUP>+</SUP>' 'null' 'acetate + ATP + coenzyme A &rarr; acetyl-CoA + AMP + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002413_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002413_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1023,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1031,20 +1064,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57287>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30616_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-4300>
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YOL086C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4300>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
+                "SGD_PWY:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57287>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_15343_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1052,11 +1099,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_57945_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_57945_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1067,8 +1114,16 @@
           <http://model.geneontology.org/CHEBI_57945_ALCOHOL-DEHYDROG-RXN>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_57287_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN66-3>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1087,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1099,11 +1154,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_456215_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_456215_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1121,7 +1176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1144,7 +1199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1152,26 +1207,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR303C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-4300>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-4300/YeastPathways_PWY3O-4300_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-4300/YeastPathways_PWY3O-4300_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1189,7 +1233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1201,11 +1245,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_BFO_0000050_YeastPathways_PWY3O-4300/YeastPathways_PWY3O-4300_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_BFO_0000050_YeastPathways_PWY3O-4300/YeastPathways_PWY3O-4300_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1220,11 +1264,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-3_BFO_0000050_YeastPathways_PWY3O-4300/YeastPathways_PWY3O-4300_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-3_BFO_0000050_YeastPathways_PWY3O-4300/YeastPathways_PWY3O-4300_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1234,17 +1278,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-4300/YeastPathways_PWY3O-4300>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002234_CHEBI_15378_RXN66-3_SGD_YeastPathways_PWY3O-4300>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN66-3>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1255,7 +1288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1266,55 +1299,36 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_29888_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-4300>
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000066_reaction_ALCOHOL-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4300>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002333_YLR153C-MONOMER_ACETATE--COA-LIGASE-RXN_controller_SGD_YeastPathways_PWY3O-4300>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
+                "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR083W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-4300>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002333_YLR153C-MONOMER_ACETATE--COA-LIGASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
+                "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_16236_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-4300>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000004688>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57945_RXN66-3>
         a       <http://purl.obolibrary.org/obo/CHEBI_57945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1325,7 +1339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1333,15 +1347,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN66-3_BFO_0000050_YeastPathways_PWY3O-4300/YeastPathways_PWY3O-4300_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002234_CHEBI_57945_RXN66-3_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002234_CHEBI_57945_RXN66-3_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1352,8 +1377,27 @@
           <http://model.geneontology.org/CHEBI_57945_RXN66-3>
 ] .
 
-<http://identifiers.org/sgd/S000004688>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_BFO_0000050_YeastPathways_PWY3O-4300/YeastPathways_PWY3O-4300_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YGL256W-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57288_ACETATE--COA-LIGASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1364,7 +1408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1375,37 +1419,15 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000066_reaction_ALCOHOL-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-4300>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_456215_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-4300>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_15378_ALCOHOL-DEHYDROG-RXN_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_15378_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1416,14 +1438,14 @@
           <http://model.geneontology.org/CHEBI_15378_ALCOHOL-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002413_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-4300>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30089_RXN66-3_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
+                "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1431,11 +1453,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_29888_ACETATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002234_CHEBI_29888_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1446,26 +1468,15 @@
           <http://model.geneontology.org/CHEBI_29888_ACETATE--COA-LIGASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-3_BFO_0000050_YeastPathways_PWY3O-4300/YeastPathways_PWY3O-4300_SGD_YeastPathways_PWY3O-4300>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002234_CHEBI_15378_RXN66-3_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002234_CHEBI_15378_RXN66-3_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,14 +1487,14 @@
           <http://model.geneontology.org/CHEBI_15378_RXN66-3>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002413_RXN66-3_SGD_YeastPathways_PWY3O-4300>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002233_CHEBI_16236_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
+                "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1496,7 +1507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1507,17 +1518,6 @@
 <http://identifiers.org/sgd/S000004918>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_BFO_0000050_YeastPathways_PWY3O-4300/YeastPathways_PWY3O-4300_SGD_YeastPathways_PWY3O-4300>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1525,11 +1525,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002333_YLR153C-MONOMER_ACETATE--COA-LIGASE-RXN_controller_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002333_YLR153C-MONOMER_ACETATE--COA-LIGASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1552,7 +1552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1564,11 +1564,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" , "Provides Input For Rule. The relation 'ethanol + NAD<sup>+</sup> &harr; acetaldehyde + NADH + H<SUP>+</SUP>' 'null' 'acetaldehyde + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; acetate + NADH + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002413_RXN66-3_SGD_YeastPathways_PWY3O-4300> ;
+          <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002413_RXN66-3_SGD_PWY_YeastPathways_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-440.ttl
+++ b/models/YeastPathways_PWY3O-440.ttl
@@ -1,22 +1,22 @@
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-67_RXN3O-470_controller_SGD_YeastPathways_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000050_YeastPathways_PWY3O-440/YeastPathways_PWY3O-440_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
+                "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-118_RXN3O-470_controller_SGD_YeastPathways_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_YeastPathways_PWY3O-440/YeastPathways_PWY3O-440_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
+                "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -24,11 +24,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000050_YeastPathways_PWY3O-440/YeastPathways_PWY3O-440_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000050_YeastPathways_PWY3O-440/YeastPathways_PWY3O-440_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,13 +50,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15361_RXN0-2022> , <http://model.geneontology.org/CHEBI_15343_RXN0-2022> , <http://model.geneontology.org/CHEBI_15378_RXN0-2022> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/a7f889db-7b5a-43d7-8669-bc5408f29fde_RXN0-2022> , <http://model.geneontology.org/CHEBI_16526_RXN0-2022> ;
+                <http://model.geneontology.org/cbed3a44-b8f4-4f48-9a77-f45d5e760c1a_RXN0-2022> , <http://model.geneontology.org/CHEBI_16526_RXN0-2022> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-58_RXN0-2022_controller> , <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller> , <http://model.geneontology.org/CPLX3O-67_RXN0-2022_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -64,19 +64,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://identifiers.org/sgd/S000004034>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_16526_RXN-6161_SGD_YeastPathways_PWY3O-440>
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN0-2022_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-440>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
+                "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004034>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15361_RXN0-2022>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
@@ -87,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -99,11 +99,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_16526_RXN-6161_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_16526_RXN-6161_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -114,15 +114,18 @@
           <http://model.geneontology.org/CHEBI_16526_RXN-6161>
 ] .
 
+<http://identifiers.org/sgd/S000003319>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN0-2022_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN0-2022_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,40 +136,29 @@
           <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000066_reaction_RXN0-2022_location_lociGO_0005829_SGD_YeastPathways_PWY3O-440>
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002233_CHEBI_15343_RXN-6161_SGD_PWY_YeastPathways_PWY3O-440>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
+                "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_YeastPathways_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000003319>
+<http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-58_RXN0-2022_controller_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-58_RXN0-2022_controller_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -177,20 +169,28 @@
           <http://model.geneontology.org/CPLX3O-58_RXN0-2022_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN0-2022_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN0-2022_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_5704112b-f068-497d-a863-309bb9563ce9_RXN3O-470_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -201,11 +201,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15343_RXN0-2022_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15343_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -216,17 +216,6 @@
           <http://model.geneontology.org/CHEBI_15343_RXN0-2022>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-67_RXN0-2022_controller_SGD_YeastPathways_PWY3O-440>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -236,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -244,15 +233,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000050_YeastPathways_PWY3O-440/YeastPathways_PWY3O-440_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-58_RXN3O-470_controller_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-58_RXN3O-470_controller_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -266,28 +266,39 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-58_RXN0-2022_controller_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
         a       <http://identifiers.org/sgd/S000004034> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15378_RXN-6161_SGD_YeastPathways_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-470_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0045151>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -301,24 +312,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440Complex37583> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_648a5a98-5711-4422-be32-40b68abf0e68_RXN3O-470_SGD_YeastPathways_PWY3O-440>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_RXN-6161>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -329,13 +329,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37558> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_16526_RXN-6161_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-58_RXN-6161_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -346,7 +357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -359,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -368,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -376,11 +387,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,7 +402,18 @@
           <http://model.geneontology.org/CHEBI_15343_RXN-6161>
 ] .
 
-<http://model.geneontology.org/648a5a98-5711-4422-be32-40b68abf0e68_RXN3O-470>
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-118_RXN3O-470_controller_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/cbed3a44-b8f4-4f48-9a77-f45d5e760c1a_RXN0-2022>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -400,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -412,11 +434,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN-6161_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN-6161_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -427,14 +449,14 @@
           <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_YeastPathways_PWY3O-440/YeastPathways_PWY3O-440_SGD_YeastPathways_PWY3O-440>
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-470_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-440>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
+                "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -447,7 +469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -459,11 +481,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-118_RXN0-2022_controller_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-118_RXN0-2022_controller_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -474,65 +496,54 @@
           <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_YeastPathways_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15378_RXN0-2022_SGD_YeastPathways_PWY3O-440>
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_PWY_YeastPathways_PWY3O-440>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
+                "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000066_reaction_RXN-6161_location_lociGO_0005829_SGD_YeastPathways_PWY3O-440>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_24431>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003319> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_YeastPathways_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-470_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN-6161_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -543,11 +554,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000066_reaction_RXN0-2022_location_lociGO_0005829_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000066_reaction_RXN0-2022_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -582,11 +593,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-118_RXN3O-470_controller_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-118_RXN3O-470_controller_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -597,18 +608,32 @@
           <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000066_reaction_RXN0-2022_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" , "Provides Input For Rule. The relation 'pyruvate + H<SUP>+</SUP> &rarr; acetaldehyde + CO<SUB>2</SUB>' 'null' '2 acetaldehyde &rarr; acetoin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-470_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-470_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -619,18 +644,26 @@
           <http://model.geneontology.org/RXN3O-470>
 ] .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN0-2022_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-470_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-470_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -641,6 +674,17 @@
           <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002411_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -648,11 +692,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15378_RXN-6161_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15378_RXN-6161_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,11 +711,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-470_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-470_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -691,7 +735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -699,26 +743,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-470_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-440>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_a7f889db-7b5a-43d7-8669-bc5408f29fde_RXN0-2022_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_cbed3a44-b8f4-4f48-9a77-f45d5e760c1a_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -726,49 +759,38 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a7f889db-7b5a-43d7-8669-bc5408f29fde_RXN0-2022>
+          <http://model.geneontology.org/cbed3a44-b8f4-4f48-9a77-f45d5e760c1a_RXN0-2022>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://identifiers.org/sgd/S000004124>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002233_CHEBI_15343_RXN-6161_SGD_YeastPathways_PWY3O-440>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002411_RXN0-2022_SGD_YeastPathways_PWY3O-440>
+<http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000066_reaction_RXN3O-470_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-440>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
+                "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004124>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000050_YeastPathways_PWY3O-440/YeastPathways_PWY3O-440_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000050_YeastPathways_PWY3O-440/YeastPathways_PWY3O-440_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -783,11 +805,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_648a5a98-5711-4422-be32-40b68abf0e68_RXN3O-470_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_5704112b-f068-497d-a863-309bb9563ce9_RXN3O-470_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -795,11 +817,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-470> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/648a5a98-5711-4422-be32-40b68abf0e68_RXN3O-470>
+          <http://model.geneontology.org/5704112b-f068-497d-a863-309bb9563ce9_RXN3O-470>
 ] .
-
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CPLX3O-58_RXN3O-470_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -810,7 +829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -821,6 +840,9 @@
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/CHEBI_16526_RXN0-2022>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -830,24 +852,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37558> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN-6161_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-440>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-440>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -858,7 +869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pyruvate fermentation to acetoin III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -870,11 +881,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -889,11 +900,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN0-2022_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN0-2022_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -904,17 +915,6 @@
           <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-470_SGD_YeastPathways_PWY3O-440>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CPLX3O-58_RXN0-2022_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -924,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -932,39 +932,20 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_YeastPathways_PWY3O-440> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_RXN-6161>
-] .
-
-<http://model.geneontology.org/a7f889db-7b5a-43d7-8669-bc5408f29fde_RXN0-2022>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://model.geneontology.org/CHEBI_15343_RXN-6161>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15343> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
+                "acetaldehyde" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37543> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37534> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -979,7 +960,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15343_RXN-6161> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/648a5a98-5711-4422-be32-40b68abf0e68_RXN3O-470> ;
+                <http://model.geneontology.org/5704112b-f068-497d-a863-309bb9563ce9_RXN3O-470> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller> , <http://model.geneontology.org/CPLX3O-67_RXN3O-470_controller> , <http://model.geneontology.org/CPLX3O-58_RXN3O-470_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -987,7 +968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -995,22 +976,65 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/CHEBI_15343_RXN-6161>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15343> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetaldehyde" ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_PWY_YeastPathways_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6161> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15361_RXN-6161>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37534> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-67_RXN3O-470_controller_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN0-2022_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
+] .
 
 <http://model.geneontology.org/RXN-6161>
         a       <http://purl.obolibrary.org/obo/GO_0004737> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1031,7 +1055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1043,41 +1067,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN0-2022_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_16526_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000051> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_16526_RXN0-2022_SGD_YeastPathways_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_16526_RXN0-2022_SGD_YeastPathways_PWY3O-440> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1088,28 +1082,8 @@
           <http://model.geneontology.org/CHEBI_16526_RXN0-2022>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_YeastPathways_PWY3O-440>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/reaction_RXN3O-470_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-67_RXN-6161_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -1120,7 +1094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1128,69 +1102,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000050_YeastPathways_PWY3O-440/YeastPathways_PWY3O-440_SGD_YeastPathways_PWY3O-440>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/reaction_RXN3O-470_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN0-2022_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-440>
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_16526_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-440>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-470_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-118_RXN0-2022_controller_SGD_YeastPathways_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN0-2022_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15343_RXN0-2022_SGD_YeastPathways_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
+                "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1201,11 +1129,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002233_CHEBI_15343_RXN-6161_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002233_CHEBI_15343_RXN-6161_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1216,17 +1144,6 @@
           <http://model.geneontology.org/CHEBI_15343_RXN-6161>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-58_RXN3O-470_controller_SGD_YeastPathways_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1234,11 +1151,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1249,15 +1166,26 @@
           <http://model.geneontology.org/CPLX3O-58_RXN-6161_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_cbed3a44-b8f4-4f48-9a77-f45d5e760c1a_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1271,22 +1199,36 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-470_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
+                "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15361>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15343_RXN0-2022>
         a       <http://purl.obolibrary.org/obo/CHEBI_15343> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1297,32 +1239,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37534> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000066_reaction_RXN-6161_location_lociGO_0005829_SGD_YeastPathways_PWY3O-440> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-6161_location_lociGO_0005829>
-] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN0-2022>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1333,7 +1256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1341,18 +1264,56 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15361>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000066_reaction_RXN-6161_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6161> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN-6161_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-118_RXN0-2022_controller_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN-6161_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN-6161_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1363,14 +1324,36 @@
           <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_YeastPathways_PWY3O-440>
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_PWY_YeastPathways_PWY3O-440>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15343_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1378,11 +1361,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15378_RXN0-2022_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15378_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1393,6 +1376,17 @@
           <http://model.geneontology.org/CHEBI_15378_RXN0-2022>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-67_RXN0-2022_controller_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -1400,11 +1394,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002411_RXN0-2022_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002411_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1415,76 +1409,54 @@
           <http://model.geneontology.org/RXN0-2022>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000050_YeastPathways_PWY3O-440/YeastPathways_PWY3O-440_SGD_YeastPathways_PWY3O-440>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15378_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15361_RXN0-2022_SGD_YeastPathways_PWY3O-440>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
+                "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-58_RXN0-2022_controller_SGD_YeastPathways_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN-6161_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000066_reaction_RXN3O-470_location_lociGO_0005829_SGD_YeastPathways_PWY3O-440>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN-6161_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000066_reaction_RXN-6161_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000066_reaction_RXN3O-470_location_lociGO_0005829_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000066_reaction_RXN3O-470_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1494,6 +1466,9 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN3O-470_location_lociGO_0005829>
 ] .
+
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/GO_0004737>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1507,7 +1482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1515,29 +1490,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-470_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/5704112b-f068-497d-a863-309bb9563ce9_RXN3O-470>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37543> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1553,7 +1531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1566,7 +1544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1578,11 +1556,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-470_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-470_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1593,26 +1571,15 @@
           <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_a7f889db-7b5a-43d7-8669-bc5408f29fde_RXN0-2022_SGD_YeastPathways_PWY3O-440>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-67_RXN0-2022_controller_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-67_RXN0-2022_controller_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1632,7 +1599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1644,11 +1611,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_YeastPathways_PWY3O-440/YeastPathways_PWY3O-440_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_YeastPathways_PWY3O-440/YeastPathways_PWY3O-440_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1662,15 +1629,26 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15361_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15361_RXN0-2022_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15361_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1681,15 +1659,37 @@
           <http://model.geneontology.org/CHEBI_15361_RXN0-2022>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-58_RXN3O-470_controller_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15378_RXN-6161_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-67_RXN3O-470_controller_SGD_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-67_RXN3O-470_controller_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-45.ttl
+++ b/models/YeastPathways_PWY3O-45.ttl
@@ -1,12 +1,23 @@
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_abebf4d2-e1d9-46a1-87cc-64d6088de975_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,11 +32,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" , "Provides Input For Rule. The relation 'L-glutamate + 7,8-dihydropteroate + ATP &rarr; ADP + 7,8-dihydrofolate monoglutamate + phosphate + H<SUP>+</SUP>' 'null' 'a tetrahydrofolate + NADP<sup>+</sup> &larr; a 7,8-dihydrofolate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,14 +50,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -54,11 +65,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,36 +83,19 @@
 <http://identifiers.org/sgd/S000004719>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_17839>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65389> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.obolibrary.org/obo/CHEBI_17839>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_GTP-CYCLOHYDRO-I-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -112,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,27 +114,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65389> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -151,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -159,35 +151,57 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_17071>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_17071>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://identifiers.org/sgd/S000005762>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,18 +212,37 @@
           <http://model.geneontology.org/reaction_PABASYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://identifiers.org/sgd/S000005762>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,15 +253,26 @@
           <http://model.geneontology.org/CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,26 +283,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-45/YeastPathways_PWY3O-45>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -269,25 +302,25 @@
           <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -305,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -319,11 +352,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,17 +366,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/H2NEOPTERINALDOL-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004150> ;
@@ -364,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -372,15 +394,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'GTP + H<sub>2</sub>O &rarr; formate + 7,8-dihydroneopterin 3'-triphosphate + H<SUP>+</SUP>' 'null' '7,8-dihydroneopterin 3'-triphosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin 3'-phosphate + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,11 +428,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,14 +443,14 @@
           <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -430,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -445,11 +478,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -459,17 +492,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_ADCLY-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_c060e5fb-a7ca-4b09-b73d-4f6bcf320d91_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ADCLY-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0008696> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -490,7 +512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -498,34 +520,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -535,43 +535,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NADP<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65606> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -582,25 +565,31 @@
           <http://model.geneontology.org/CHEBI_17839_H2PTEROATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NADP<sup>+</sup>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65606> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -608,11 +597,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -623,6 +612,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-45/YeastPathways_PWY3O-45>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-45>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -632,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "folate biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -640,26 +640,15 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -682,13 +671,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65402> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58406>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -698,18 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -722,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -730,25 +730,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -756,11 +745,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -778,11 +767,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -793,6 +782,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-45/YeastPathways_PWY3O-45>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -800,11 +800,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,14 +815,14 @@
           <http://model.geneontology.org/CHEBI_37565_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -835,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -847,11 +847,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -865,14 +865,36 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -885,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -902,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -910,66 +932,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '6-(hydroxymethyl)-7,8-dihydropterin + ATP &rarr; (7,8-dihydropterin-6-yl)methyl diphosphate + AMP + H<SUP>+</SUP>' 'null' '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY3O-45> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -982,13 +952,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65402> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '6-(hydroxymethyl)-7,8-dihydropterin + ATP &rarr; (7,8-dihydropterin-6-yl)methyl diphosphate + AMP + H<SUP>+</SUP>' 'null' '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/GO_0046820>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -997,11 +986,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1012,26 +1001,15 @@
           <http://model.geneontology.org/CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1049,11 +1027,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1073,7 +1051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1098,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1115,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1132,13 +1110,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY3O-45" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_73083> ;
@@ -1149,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1157,15 +1157,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' 'null' 'L-glutamate + 7,8-dihydropteroate + ATP &rarr; ADP + 7,8-dihydrofolate monoglutamate + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1176,15 +1187,26 @@
           <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1198,15 +1220,26 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1217,26 +1250,15 @@
           <http://model.geneontology.org/CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1247,38 +1269,19 @@
           <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_58359>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58462_GTP-CYCLOHYDRO-I-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58462> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1289,7 +1292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1297,8 +1300,20 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_58359>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/MONOMER3O-131_ADCLY-RXN_controller>
+        a       <http://identifiers.org/sgd/S000004902> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "aminodeoxychorismate lyase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45Protein65794> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003848> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1319,7 +1334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1327,29 +1342,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/MONOMER3O-131_ADCLY-RXN_controller>
-        a       <http://identifiers.org/sgd/S000004902> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "aminodeoxychorismate lyase" ;
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45Protein65794> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1357,11 +1357,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" , "Provides Input For Rule. The relation 'L-glutamine + chorismate &harr; 4-amino-4-deoxychorismate + L-glutamate' 'null' '4-amino-4-deoxychorismate &rarr; 4-aminobenzoate + pyruvate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1379,11 +1379,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1398,11 +1398,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1422,7 +1422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1433,26 +1433,15 @@
 <http://identifiers.org/sgd/S000005200>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1463,19 +1452,41 @@
           <http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004156>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1484,11 +1495,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_ADCLY-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_ADCLY-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1499,15 +1510,37 @@
           <http://model.geneontology.org/CHEBI_17836_ADCLY-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1525,11 +1558,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1544,11 +1577,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" , "Provides Input For Rule. The relation '4-amino-4-deoxychorismate &rarr; 4-aminobenzoate + pyruvate + H<SUP>+</SUP>' 'null' '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1559,14 +1592,36 @@
           <http://model.geneontology.org/H2PTEROATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1579,13 +1634,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65693> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58359_PABASYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58359> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1596,7 +1662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1604,14 +1670,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1624,13 +1690,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65466> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1639,11 +1727,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_29748_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1658,11 +1746,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1673,15 +1761,26 @@
           <http://model.geneontology.org/CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1692,32 +1791,26 @@
           <http://model.geneontology.org/reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/c060e5fb-a7ca-4b09-b73d-4f6bcf320d91_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65591> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_c060e5fb-a7ca-4b09-b73d-4f6bcf320d91_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_abebf4d2-e1d9-46a1-87cc-64d6088de975_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1725,7 +1818,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c060e5fb-a7ca-4b09-b73d-4f6bcf320d91_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/abebf4d2-e1d9-46a1-87cc-64d6088de975_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
@@ -1735,7 +1828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1760,7 +1853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1771,23 +1864,31 @@
 <http://identifiers.org/sgd/S000005316>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+<http://model.geneontology.org/abebf4d2-e1d9-46a1-87cc-64d6088de975_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65591> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1800,7 +1901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1808,14 +1909,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1825,28 +1924,28 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_98c92a78-a50f-4c8f-9b60-ba4349854015_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1854,11 +1953,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1876,11 +1975,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1891,6 +1990,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-45/YeastPathways_PWY3O-45>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58462>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1898,11 +2008,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1913,14 +2023,14 @@
           <http://model.geneontology.org/CHEBI_43474_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1936,7 +2046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1948,11 +2058,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1962,17 +2072,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58406_PABASYN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1984,13 +2083,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45Protein65701> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_DIHYDROFOLATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -2001,39 +2122,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65552> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller>
-        a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase [multifunctional]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45Protein65535> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2044,7 +2139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2052,28 +2147,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller>
+        a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase [multifunctional]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45Protein65535> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 <http://model.geneontology.org/reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2082,11 +2181,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2097,26 +2196,15 @@
           <http://model.geneontology.org/CHEBI_29888_H2PTEROATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2127,15 +2215,26 @@
           <http://model.geneontology.org/reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2150,11 +2249,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2165,28 +2264,6 @@
           <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_ADCLY-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2196,7 +2273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2207,8 +2284,47 @@
 <http://purl.obolibrary.org/obo/CHEBI_58762>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/3f2c7883-1401-46bb-8ee4-7d71fb0cb389_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65612> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/GO_0004146>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/H2PTEROATESYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004156> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2229,7 +2345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2256,7 +2372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2268,11 +2384,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2290,11 +2406,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2305,14 +2421,14 @@
           <http://model.geneontology.org/reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_58462_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_3f2c7883-1401-46bb-8ee4-7d71fb0cb389_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2321,7 +2437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2329,11 +2445,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2344,15 +2460,26 @@
           <http://model.geneontology.org/CHEBI_15378_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000066_reaction_PABASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2368,7 +2495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2382,7 +2509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2390,14 +2517,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_57451_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002333_MONOMER3O-131_ADCLY-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2405,11 +2543,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2420,32 +2558,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-45/YeastPathways_PWY3O-45>
 ] .
 
-<http://model.geneontology.org/98c92a78-a50f-4c8f-9b60-ba4349854015_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65612> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2456,15 +2577,26 @@
           <http://model.geneontology.org/CHEBI_17071_H2NEOPTERINALDOL-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2475,18 +2607,15 @@
           <http://model.geneontology.org/YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller>
 ] .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2497,33 +2626,14 @@
           <http://model.geneontology.org/CHEBI_17836_ADCLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_ADCLY-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57451>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57451>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17001> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2534,7 +2644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2551,7 +2661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2563,11 +2673,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2578,41 +2688,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-45/YeastPathways_PWY3O-45>
 ] .
 
-<http://model.geneontology.org/YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003499> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "GTP-cyclohydrolase I" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45Protein65437> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2623,16 +2707,20 @@
           <http://model.geneontology.org/CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003499> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "GTP-cyclohydrolase I" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45Protein65437> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
@@ -2643,7 +2731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2655,11 +2743,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" , "Provides Input For Rule. The relation '7,8-dihydroneopterin 3'-phosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin + phosphate' 'null' '7,8-dihydroneopterin &rarr; glycolaldehyde + 6-(hydroxymethyl)-7,8-dihydropterin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2679,7 +2767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2691,11 +2779,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_98c92a78-a50f-4c8f-9b60-ba4349854015_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_3f2c7883-1401-46bb-8ee4-7d71fb0cb389_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2703,7 +2791,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/98c92a78-a50f-4c8f-9b60-ba4349854015_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/3f2c7883-1401-46bb-8ee4-7d71fb0cb389_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_DIHYDROFOLATESYNTH-RXN>
@@ -2715,24 +2803,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65498> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -2742,40 +2819,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2788,7 +2843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2800,11 +2855,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2815,15 +2870,26 @@
           <http://model.geneontology.org/CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002333_YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2838,11 +2904,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2853,29 +2919,14 @@
           <http://model.geneontology.org/CHEBI_30616_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller>
-        a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase [multifunctional]" ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45Protein65535> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2888,7 +2939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2896,15 +2947,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller>
+        a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase [multifunctional]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45Protein65535> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2915,30 +2981,30 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-45/YeastPathways_PWY3O-45>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_ADCLY-RXN_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008696>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17071_H2NEOPTERINALDOL-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17071> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2949,7 +3015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2961,11 +3027,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2979,18 +3045,26 @@
 <http://identifiers.org/sgd/S000003499>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0019177>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '7,8-dihydroneopterin &rarr; glycolaldehyde + 6-(hydroxymethyl)-7,8-dihydropterin' 'null' '6-(hydroxymethyl)-7,8-dihydropterin + ATP &rarr; (7,8-dihydropterin-6-yl)methyl diphosphate + AMP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3001,16 +3075,8 @@
           <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0019177>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0008841> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3031,7 +3097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3043,11 +3109,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3062,11 +3128,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3077,25 +3143,36 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-45/YeastPathways_PWY3O-45>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3103,11 +3180,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3121,26 +3198,15 @@
 <http://purl.obolibrary.org/obo/GO_0003848>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000066_reaction_ADCLY-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" , "Provides Input For Rule. The relation '7,8-dihydroneopterin 3'-triphosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin 3'-phosphate + diphosphate + H<SUP>+</SUP>' 'null' '7,8-dihydroneopterin 3'-phosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3151,6 +3217,17 @@
           <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_44841>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3158,11 +3235,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3173,29 +3250,26 @@
           <http://model.geneontology.org/CHEBI_15377_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3206,39 +3280,20 @@
           <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3261,7 +3316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3272,17 +3327,6 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29985_PABASYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3292,7 +3336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3300,14 +3344,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3315,11 +3359,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3337,11 +3381,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3356,11 +3400,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3371,37 +3415,15 @@
           <http://model.geneontology.org/CHEBI_456216_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3422,7 +3444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3436,14 +3458,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3452,29 +3474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3482,11 +3482,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3501,11 +3501,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3519,26 +3519,15 @@
 <http://purl.obolibrary.org/obo/GO_0046656>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3553,11 +3542,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3568,17 +3557,6 @@
           <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15361_ADCLY-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3588,7 +3566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3596,14 +3574,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3616,13 +3594,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65678> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004146> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3633,15 +3622,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/98c92a78-a50f-4c8f-9b60-ba4349854015_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/3f2c7883-1401-46bb-8ee4-7d71fb0cb389_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/c060e5fb-a7ca-4b09-b73d-4f6bcf320d91_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/abebf4d2-e1d9-46a1-87cc-64d6088de975_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3649,25 +3638,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3675,11 +3653,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002333_YNR033W-MONOMER_PABASYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3694,11 +3672,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3713,11 +3691,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3728,14 +3706,14 @@
           <http://model.geneontology.org/CHEBI_15740_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3743,11 +3721,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3770,7 +3748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3783,32 +3761,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
+                "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3816,11 +3794,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3830,3 +3808,25 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-45/YeastPathways_PWY3O-45_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-450.ttl
+++ b/models/YeastPathways_PWY3O-450.ttl
@@ -1,32 +1,7 @@
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000066_reaction_2.7.7.15-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-450>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000003434>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_15378_RXN-5781_SGD_YeastPathways_PWY3O-450>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_295975>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0006657>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_16110_RXN-5781>
@@ -38,7 +13,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -55,7 +30,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -63,25 +38,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_15378_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-450>
+<http://purl.obolibrary.org/obo/GO_0006657>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-450>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002333_YNL130C-MONOMER_RXN-5781_controller_SGD_YeastPathways_PWY3O-450>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
+                "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -94,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -106,11 +73,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_16110_RXN-5781_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_16110_RXN-5781_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -125,11 +92,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_15378_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_15378_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -159,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -176,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidylcholine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -192,17 +159,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-450>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHOLINE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004103> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -223,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -238,11 +194,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_37563_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_37563_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -253,8 +209,30 @@
           <http://model.geneontology.org/CHEBI_37563_2.7.7.15-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_58779_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004103>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_30616_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -268,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -291,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -299,25 +277,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000050_YeastPathways_PWY3O-450/YeastPathways_PWY3O-450_SGD_YeastPathways_PWY3O-450>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_456216_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-450>
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_17815_RXN-5781_SGD_PWY_YeastPathways_PWY3O-450>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
+                "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -325,11 +292,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_15378_RXN-5781_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_15378_RXN-5781_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -344,11 +311,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_30616_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_30616_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -359,19 +326,19 @@
           <http://model.geneontology.org/CHEBI_30616_CHOLINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002333_YGR202C-MONOMER_2.7.7.15-RXN_controller_SGD_YeastPathways_PWY3O-450>
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000066_reaction_RXN-5781_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-450>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
+                "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -382,14 +349,14 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_60377_RXN-5781_SGD_YeastPathways_PWY3O-450>
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000050_YeastPathways_PWY3O-450/YeastPathways_PWY3O-450_SGD_PWY_YeastPathways_PWY3O-450>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
+                "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -402,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -414,11 +381,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,26 +396,15 @@
           <http://model.geneontology.org/CHEBI_295975_CHOLINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000066_reaction_CHOLINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-450>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000066_reaction_2.7.7.15-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000066_reaction_2.7.7.15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,11 +422,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" , "Provides Input For Rule. The relation 'choline + ATP &rarr; phosphocholine + ADP + H<SUP>+</SUP>' 'null' 'CTP + phosphocholine + H<SUP>+</SUP> &rarr; CDP-choline + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002413_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002413_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,6 +436,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/2.7.7.15-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002333_YGR202C-MONOMER_2.7.7.15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_15378_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -491,7 +469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -499,23 +477,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_58779_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-450>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_CHOLINE-KINASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -523,11 +490,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_58779_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_58779_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,11 +509,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_15354_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_15354_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -557,26 +524,15 @@
           <http://model.geneontology.org/CHEBI_15354_CHOLINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002333_YLR133W-MONOMER_CHOLINE-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-450>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" , "Provides Input For Rule. The relation 'CTP + phosphocholine + H<SUP>+</SUP> &rarr; CDP-choline + diphosphate' 'null' 'a 1,2-diacyl-<i>sn</i>-glycerol + CDP-choline &harr; a phosphatidylcholine + CMP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002413_RXN-5781_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002413_RXN-5781_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -587,17 +543,6 @@
           <http://model.geneontology.org/RXN-5781>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_15378_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-450>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_CHOLINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -607,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -615,21 +560,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_456216_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_37563_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_15378_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_15378_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -640,16 +607,11 @@
           <http://model.geneontology.org/CHEBI_15378_2.7.7.15-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000050_YeastPathways_PWY3O-450/YeastPathways_PWY3O-450_SGD_YeastPathways_PWY3O-450>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_30616>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_58779>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58779_2.7.7.15-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58779> ;
@@ -660,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -668,10 +630,7 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_58779>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_30616>
+<http://purl.obolibrary.org/obo/GO_0004142>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_30616_CHOLINE-KINASE-RXN>
@@ -683,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -691,11 +650,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0004142>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_60377_RXN-5781_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000066_reaction_2.7.7.15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_295975_CHOLINE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_295975> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -706,7 +684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -721,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -733,11 +711,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000050_YeastPathways_PWY3O-450/YeastPathways_PWY3O-450_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000050_YeastPathways_PWY3O-450/YeastPathways_PWY3O-450_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -752,11 +730,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002333_YLR133W-MONOMER_CHOLINE-KINASE-RXN_controller_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002333_YLR133W-MONOMER_CHOLINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -776,7 +754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -788,11 +766,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_17815_RXN-5781_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_17815_RXN-5781_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -820,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -832,11 +810,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000066_reaction_CHOLINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000066_reaction_CHOLINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -851,11 +829,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002333_YGR202C-MONOMER_2.7.7.15-RXN_controller_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002333_YGR202C-MONOMER_2.7.7.15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -869,23 +847,23 @@
 <http://identifiers.org/sgd/S000004123>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_58779_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-450>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_2.7.7.15-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002333_YNL130C-MONOMER_RXN-5781_controller_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -896,24 +874,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-450Protein22002> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_37563_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-450>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -928,11 +895,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002333_YNL130C-MONOMER_RXN-5781_controller_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002333_YNL130C-MONOMER_RXN-5781_controller_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -946,26 +913,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_60377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-450/YeastPathways_PWY3O-450_SGD_YeastPathways_PWY3O-450>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_456216_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_456216_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -979,6 +935,17 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000050_YeastPathways_PWY3O-450/YeastPathways_PWY3O-450_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -991,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -999,15 +966,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_16110_RXN-5781_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000066_reaction_RXN-5781_location_lociGO_0005829_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000066_reaction_RXN-5781_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1018,37 +996,18 @@
           <http://model.geneontology.org/reaction_RXN-5781_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_30616_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-450>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002413_RXN-5781_SGD_YeastPathways_PWY3O-450>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_456216>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-450/YeastPathways_PWY3O-450_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-450/YeastPathways_PWY3O-450_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1059,15 +1018,18 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-450/YeastPathways_PWY3O-450>
 ] .
 
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_58779_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_58779_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1078,21 +1040,70 @@
           <http://model.geneontology.org/CHEBI_58779_2.7.7.15-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_456216>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.obolibrary.org/obo/GO_0004105>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/reaction_RXN-5781_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-450/YeastPathways_PWY3O-450_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002333_YLR133W-MONOMER_CHOLINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_29888_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004105>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002413_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002413_RXN-5781_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1105,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1116,50 +1127,28 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-450>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_15354_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-450>
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_58779_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-450>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
+                "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_17815_RXN-5781_SGD_YeastPathways_PWY3O-450>
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002233_CHEBI_15354_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-450>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_16110_RXN-5781_SGD_YeastPathways_PWY3O-450>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
+                "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1170,11 +1159,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_60377_RXN-5781_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_60377_RXN-5781_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1185,14 +1174,14 @@
           <http://model.geneontology.org/CHEBI_60377_RXN-5781>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000066_reaction_RXN-5781_location_lociGO_0005829_SGD_YeastPathways_PWY3O-450>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000066_reaction_CHOLINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
+                "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1200,11 +1189,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1215,6 +1204,39 @@
           <http://model.geneontology.org/CHEBI_295975_CHOLINE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_15378_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_15378_RXN-5781_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_17815>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1222,11 +1244,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000050_YeastPathways_PWY3O-450/YeastPathways_PWY3O-450_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000050_YeastPathways_PWY3O-450/YeastPathways_PWY3O-450_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1247,7 +1269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1259,11 +1281,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_29888_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-450> ;
+          <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_29888_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1273,25 +1295,3 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_29888_2.7.7.15-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002413_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-450>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_29888_2.7.7.15-RXN_SGD_YeastPathways_PWY3O-450>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-48.ttl
+++ b/models/YeastPathways_PWY3O-48.ttl
@@ -1,17 +1,6 @@
 <http://identifiers.org/sgd/S000001315>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002333_YER062C-MONOMER_GLYCEROL-1-PHOSPHATASE-RXN_controller_SGD_YeastPathways_PWY3O-48>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_1.1.1.8-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -21,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -35,37 +24,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_231935>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000050_YeastPathways_PWY3O-48/YeastPathways_PWY3O-48_SGD_YeastPathways_PWY3O-48>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_15378_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-48>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57597_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-48> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57597_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,11 +47,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002234_CHEBI_17754_GLYCEROL-1-PHOSPHATASE-RXN_SGD_YeastPathways_PWY3O-48> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002234_CHEBI_17754_GLYCEROL-1-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,6 +65,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_BFO_0000066_reaction_GLYCEROL-1-PHOSPHATASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-48>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-48" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -108,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -125,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -133,14 +111,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_BFO_0000050_YeastPathways_PWY3O-48/YeastPathways_PWY3O-48_SGD_YeastPathways_PWY3O-48>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002411_GLYCEROL-1-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-48>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
+                "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -150,17 +128,28 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000066_reaction_1.1.1.8-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-48>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57945_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-48>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
+                "SGD_PWY:PWY3O-48" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57540_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-48>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -168,11 +157,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57540_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-48> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57540_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -191,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -199,11 +188,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002233_CHEBI_231935_GLYCEROL-1-PHOSPHATASE-RXN_SGD_YeastPathways_PWY3O-48> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002233_CHEBI_231935_GLYCEROL-1-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,28 +209,6 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002233_CHEBI_231935_GLYCEROL-1-PHOSPHATASE-RXN_SGD_YeastPathways_PWY3O-48>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57945_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-48>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_231935_GLYCEROL-1-PHOSPHATASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_231935> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -251,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -271,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -282,40 +249,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_17754>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YOL059W-MONOMER_1.1.1.8-RXN_controller_SGD_YeastPathways_PWY3O-48>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57540_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-48>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_15378_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-48>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-48" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000050_YeastPathways_PWY3O-48/YeastPathways_PWY3O-48_SGD_YeastPathways_PWY3O-48> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000050_YeastPathways_PWY3O-48/YeastPathways_PWY3O-48_SGD_PWY_YeastPathways_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,7 +294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycerol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -350,11 +306,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57945_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-48> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57945_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,11 +325,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002233_CHEBI_15377_GLYCEROL-1-PHOSPHATASE-RXN_SGD_YeastPathways_PWY3O-48> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002233_CHEBI_15377_GLYCEROL-1-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,6 +340,17 @@
           <http://model.geneontology.org/CHEBI_15377_GLYCEROL-1-PHOSPHATASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000066_reaction_1.1.1.8-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-48>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-48" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_GLYCEROL-1-PHOSPHATASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -393,7 +360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -404,6 +371,17 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57642_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-48>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-48" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-48/YeastPathways_PWY3O-48>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0006114> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -413,35 +391,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY3O-48" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YDL022W-MONOMER_1.1.1.8-RXN_controller_SGD_YeastPathways_PWY3O-48>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002333_YIL053W-MONOMER_GLYCEROL-1-PHOSPHATASE-RXN_controller_SGD_YeastPathways_PWY3O-48>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -450,11 +406,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002411_GLYCEROL-1-PHOSPHATASE-RXN_SGD_YeastPathways_PWY3O-48> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002411_GLYCEROL-1-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -472,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -484,11 +440,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002333_YIL053W-MONOMER_GLYCEROL-1-PHOSPHATASE-RXN_controller_SGD_YeastPathways_PWY3O-48> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002333_YIL053W-MONOMER_GLYCEROL-1-PHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -508,7 +464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -519,14 +475,25 @@
 <http://purl.obolibrary.org/obo/GO_0006114>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57642_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-48>
+<http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_BFO_0000050_YeastPathways_PWY3O-48/YeastPathways_PWY3O-48_SGD_PWY_YeastPathways_PWY3O-48>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
+                "SGD_PWY:PWY3O-48" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YDL022W-MONOMER_1.1.1.8-RXN_controller_SGD_PWY_YeastPathways_PWY3O-48>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -534,11 +501,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57642_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-48> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57642_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,26 +516,18 @@
           <http://model.geneontology.org/CHEBI_57642_1.1.1.8-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57597_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-48>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57945>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_BFO_0000066_reaction_GLYCEROL-1-PHOSPHATASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-48> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_BFO_0000066_reaction_GLYCEROL-1-PHOSPHATASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -579,17 +538,25 @@
           <http://model.geneontology.org/reaction_GLYCEROL-1-PHOSPHATASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57945>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002234_CHEBI_43474_GLYCEROL-1-PHOSPHATASE-RXN_SGD_YeastPathways_PWY3O-48>
+<http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002233_CHEBI_15377_GLYCEROL-1-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-48>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
+                "SGD_PWY:PWY3O-48" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YOL059W-MONOMER_1.1.1.8-RXN_controller_SGD_PWY_YeastPathways_PWY3O-48>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -602,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -619,20 +586,31 @@
 <http://purl.obolibrary.org/obo/GO_0004367>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002234_CHEBI_43474_GLYCEROL-1-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-48>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-48" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000002180>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002411_GLYCEROL-1-PHOSPHATASE-RXN_SGD_YeastPathways_PWY3O-48>
+<http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002333_YIL053W-MONOMER_GLYCEROL-1-PHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-48>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
+                "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -653,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -668,11 +646,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YOL059W-MONOMER_1.1.1.8-RXN_controller_SGD_YeastPathways_PWY3O-48> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YOL059W-MONOMER_1.1.1.8-RXN_controller_SGD_PWY_YeastPathways_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -683,18 +661,15 @@
           <http://model.geneontology.org/YOL059W-MONOMER_1.1.1.8-RXN_controller>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002333_YER062C-MONOMER_GLYCEROL-1-PHOSPHATASE-RXN_controller_SGD_YeastPathways_PWY3O-48> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002333_YER062C-MONOMER_GLYCEROL-1-PHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -705,29 +680,32 @@
           <http://model.geneontology.org/YER062C-MONOMER_GLYCEROL-1-PHOSPHATASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_BFO_0000066_reaction_GLYCEROL-1-PHOSPHATASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-48>
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000050_YeastPathways_PWY3O-48/YeastPathways_PWY3O-48_SGD_PWY_YeastPathways_PWY3O-48>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
+                "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_15378_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-48> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_15378_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -738,39 +716,15 @@
           <http://model.geneontology.org/CHEBI_15378_1.1.1.8-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_GLYCEROL-1-PHOSPHATASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/YOL059W-MONOMER_1.1.1.8-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005420> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glycerol-3-phosphate dehydrogenase (NAD+)" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-48Protein50659> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_BFO_0000050_YeastPathways_PWY3O-48/YeastPathways_PWY3O-48_SGD_YeastPathways_PWY3O-48> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_BFO_0000050_YeastPathways_PWY3O-48/YeastPathways_PWY3O-48_SGD_PWY_YeastPathways_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -780,6 +734,30 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-48/YeastPathways_PWY3O-48>
 ] .
+
+<http://model.geneontology.org/YOL059W-MONOMER_1.1.1.8-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005420> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "glycerol-3-phosphate dehydrogenase (NAD+)" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-48Protein50659> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/reaction_GLYCEROL-1-PHOSPHATASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/1.1.1.8-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004367> ;
@@ -800,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -811,17 +789,28 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002234_CHEBI_17754_GLYCEROL-1-PHOSPHATASE-RXN_SGD_YeastPathways_PWY3O-48>
+<http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002233_CHEBI_231935_GLYCEROL-1-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-48>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
+                "SGD_PWY:PWY3O-48" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002234_CHEBI_17754_GLYCEROL-1-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-48>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -838,11 +827,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YDL022W-MONOMER_1.1.1.8-RXN_controller_SGD_YeastPathways_PWY3O-48> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YDL022W-MONOMER_1.1.1.8-RXN_controller_SGD_PWY_YeastPathways_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -857,11 +846,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002234_CHEBI_43474_GLYCEROL-1-PHOSPHATASE-RXN_SGD_YeastPathways_PWY3O-48> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002234_CHEBI_43474_GLYCEROL-1-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -881,7 +870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -889,15 +878,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57597_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-48>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-48" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000066_reaction_1.1.1.8-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-48> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000066_reaction_1.1.1.8-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -923,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -934,17 +934,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002233_CHEBI_15377_GLYCEROL-1-PHOSPHATASE-RXN_SGD_YeastPathways_PWY3O-48>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YDL022W-MONOMER_1.1.1.8-RXN_controller>
         a       <http://identifiers.org/sgd/S000002180> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -952,10 +941,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-48Protein50665> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002333_YER062C-MONOMER_GLYCEROL-1-PHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-48>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-48" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-5.ttl
+++ b/models/YeastPathways_PWY3O-5.ttl
@@ -1,14 +1,3 @@
-<http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002333_YGR194C-MONOMER_XYLULOKIN-RXN_controller_SGD_YeastPathways_PWY3O-5>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_XYLULOKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -18,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -29,17 +18,6 @@
 <http://purl.obolibrary.org/obo/GO_0005998>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002234_CHEBI_57737_XYLULOKIN-RXN_SGD_YeastPathways_PWY3O-5>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_XYLULOKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -49,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -57,15 +35,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_BFO_0000066_reaction_XYLULOKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002234_CHEBI_15378_XYLULOKIN-RXN_SGD_YeastPathways_PWY3O-5> ;
+          <http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002234_CHEBI_15378_XYLULOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-5> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -88,13 +77,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "xylulose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002234_CHEBI_456216_XYLULOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-5>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -110,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -120,14 +120,25 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_BFO_0000050_YeastPathways_PWY3O-5/YeastPathways_PWY3O-5_SGD_YeastPathways_PWY3O-5>
+<http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002234_CHEBI_57737_XYLULOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-5>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5" ;
+                "SGD_PWY:PWY3O-5" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002234_CHEBI_15378_XYLULOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-5>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -135,11 +146,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002233_CHEBI_30616_XYLULOKIN-RXN_SGD_YeastPathways_PWY3O-5> ;
+          <http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002233_CHEBI_30616_XYLULOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-5> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -149,6 +160,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30616_XYLULOKIN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002233_CHEBI_30616_XYLULOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-5>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -162,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -172,6 +194,17 @@
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002233_CHEBI_17140_XYLULOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-5>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -188,7 +221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -200,11 +233,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002233_CHEBI_17140_XYLULOKIN-RXN_SGD_YeastPathways_PWY3O-5> ;
+          <http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002233_CHEBI_17140_XYLULOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-5> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -224,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -234,17 +267,6 @@
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_BFO_0000066_reaction_XYLULOKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -256,11 +278,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002333_YGR194C-MONOMER_XYLULOKIN-RXN_controller_SGD_YeastPathways_PWY3O-5> ;
+          <http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002333_YGR194C-MONOMER_XYLULOKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,26 +293,15 @@
           <http://model.geneontology.org/YGR194C-MONOMER_XYLULOKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002234_CHEBI_456216_XYLULOKIN-RXN_SGD_YeastPathways_PWY3O-5>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_BFO_0000066_reaction_XYLULOKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5> ;
+          <http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_BFO_0000066_reaction_XYLULOKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,11 +325,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002234_CHEBI_57737_XYLULOKIN-RXN_SGD_YeastPathways_PWY3O-5> ;
+          <http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002234_CHEBI_57737_XYLULOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-5> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -332,6 +343,17 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_BFO_0000050_YeastPathways_PWY3O-5/YeastPathways_PWY3O-5_SGD_PWY_YeastPathways_PWY3O-5>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_17140_XYLULOKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17140> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -341,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -369,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -377,14 +399,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002233_CHEBI_30616_XYLULOKIN-RXN_SGD_YeastPathways_PWY3O-5>
+<http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002333_YGR194C-MONOMER_XYLULOKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5" ;
+                "SGD_PWY:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -392,11 +414,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_BFO_0000050_YeastPathways_PWY3O-5/YeastPathways_PWY3O-5_SGD_YeastPathways_PWY3O-5> ;
+          <http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_BFO_0000050_YeastPathways_PWY3O-5/YeastPathways_PWY3O-5_SGD_PWY_YeastPathways_PWY3O-5> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,17 +431,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_57737>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002233_CHEBI_17140_XYLULOKIN-RXN_SGD_YeastPathways_PWY3O-5>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -437,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,17 +459,6 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002234_CHEBI_15378_XYLULOKIN-RXN_SGD_YeastPathways_PWY3O-5>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -466,11 +466,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002234_CHEBI_456216_XYLULOKIN-RXN_SGD_YeastPathways_PWY3O-5> ;
+          <http://model.geneontology.org/ev_w_id_XYLULOKIN-RXN_RO_0002234_CHEBI_456216_XYLULOKIN-RXN_SGD_PWY_YeastPathways_PWY3O-5> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-50.ttl
+++ b/models/YeastPathways_PWY3O-50.ttl
@@ -1,37 +1,26 @@
-<http://identifiers.org/sgd/S000005804>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_15378_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-50>
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_356416_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-50>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
+                "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002233_CHEBI_58126_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-50>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000005804>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_57287_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_57287_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -42,17 +31,6 @@
           <http://model.geneontology.org/CHEBI_57287_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_15378_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-50>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57845_OHMETHYLBILANESYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57845> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -62,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -74,11 +52,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002333_YGL040C-MONOMER_PORPHOBILSYNTH-RXN_controller_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002333_YGL040C-MONOMER_PORPHOBILSYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -93,11 +71,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002234_CHEBI_28938_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002234_CHEBI_28938_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -112,11 +90,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_16526_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_16526_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,20 +111,42 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_58126_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57308>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_57292>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_58126_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-50>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002413_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
+                "SGD_PWY:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002234_CHEBI_57308_UROGENIIISYN-RXN_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -171,11 +171,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002333_YOR278W-MONOMER_UROGENIIISYN-RXN_controller_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002333_YOR278W-MONOMER_UROGENIIISYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,13 +193,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-50Protein52357> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_BFO_0000050_YeastPathways_PWY3O-50/YeastPathways_PWY3O-50_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57287_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57287> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -210,7 +221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -221,37 +232,37 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002234_CHEBI_15377_UROGENIIISYN-RXN_SGD_YeastPathways_PWY3O-50>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_OHMETHYLBILANESYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_15378_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002234_CHEBI_28938_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-50>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002234_CHEBI_28938_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
+                "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -264,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -272,14 +283,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_BFO_0000050_YeastPathways_PWY3O-50/YeastPathways_PWY3O-50_SGD_YeastPathways_PWY3O-50>
+<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002233_CHEBI_356416_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-50>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
+                "SGD_PWY:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002333_YDL205C-MONOMER_OHMETHYLBILANESYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -287,11 +309,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_58126_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_58126_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -302,26 +324,15 @@
           <http://model.geneontology.org/CHEBI_58126_PORPHOBILSYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_57292_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-50>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002233_CHEBI_58126_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002233_CHEBI_58126_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -336,11 +347,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_57305_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_57305_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,11 +368,44 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002234_CHEBI_15377_UROGENIIISYN-RXN_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_BFO_0000066_reaction_PORPHOBILSYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000002640>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002333_YDR232W-MONOMER_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -373,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,11 +429,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002234_CHEBI_57308_UROGENIIISYN-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002234_CHEBI_57308_UROGENIIISYN-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -400,25 +444,14 @@
           <http://model.geneontology.org/CHEBI_57308_UROGENIIISYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_16526_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-50>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002233_CHEBI_57845_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002413_UROGENIIISYN-RXN_SGD_YeastPathways_PWY3O-50>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
+                "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -432,11 +465,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002233_CHEBI_57845_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002233_CHEBI_57845_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -447,17 +480,6 @@
           <http://model.geneontology.org/CHEBI_57845_OHMETHYLBILANESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002413_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-50>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY3O-50>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -467,32 +489,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "tetrapyrrole biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-50/YeastPathways_PWY3O-50_SGD_YeastPathways_PWY3O-50> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PORPHOBILSYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY3O-50/YeastPathways_PWY3O-50>
-] .
 
 <http://model.geneontology.org/CHEBI_57305_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57305> ;
@@ -503,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -511,8 +514,49 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-50/YeastPathways_PWY3O-50_SGD_PWY_YeastPathways_PWY3O-50> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PORPHOBILSYNTH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY3O-50/YeastPathways_PWY3O-50>
+] .
+
 <http://purl.obolibrary.org/obo/GO_0003870>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_57305_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002234_CHEBI_57845_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -521,11 +565,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_15378_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_15378_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -545,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -560,11 +604,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002233_CHEBI_15377_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002233_CHEBI_15377_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -594,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -602,32 +646,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/CHEBI_15377_PORPHOBILSYNTH-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-50/YeastPathways_PWY3O-50_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-50SmallMolecule52186> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_57292_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_57292_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -638,38 +676,33 @@
           <http://model.geneontology.org/CHEBI_57292_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002233_CHEBI_15377_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-50>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_356416_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-50>
+<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_15378_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-50>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
+                "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002413_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-50>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_15377_PORPHOBILSYNTH-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-50SmallMolecule52186> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_PORPHOBILSYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -680,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -691,63 +724,19 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000066_reaction_OHMETHYLBILANESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002333_YGL040C-MONOMER_PORPHOBILSYNTH-RXN_controller_SGD_YeastPathways_PWY3O-50>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000050_YeastPathways_PWY3O-50/YeastPathways_PWY3O-50_SGD_YeastPathways_PWY3O-50>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_BFO_0000066_reaction_UROGENIIISYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-50>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002233_CHEBI_356416_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-50>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000066_reaction_OHMETHYLBILANESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-50>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -758,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -775,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -788,18 +777,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002333_YDL205C-MONOMER_OHMETHYLBILANESYN-RXN_controller_SGD_YeastPathways_PWY3O-50>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002413_UROGENIIISYN-RXN_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
+                "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -810,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -822,11 +811,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002234_CHEBI_15377_UROGENIIISYN-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002234_CHEBI_15377_UROGENIIISYN-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -837,21 +826,18 @@
           <http://model.geneontology.org/CHEBI_15377_UROGENIIISYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_57287_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-50>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_15377_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
+                "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_356416>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_58126>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_PORPHOBILSYNTH-RXN_location_lociGO_0005829>
@@ -859,36 +845,72 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002333_YDR232W-MONOMER_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY3O-50>
+<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_BFO_0000066_reaction_UROGENIIISYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-50>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
+                "SGD_PWY:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58126>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002233_CHEBI_15377_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_16526_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-50/YeastPathways_PWY3O-50_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_BFO_0000066_reaction_UROGENIIISYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_BFO_0000066_reaction_UROGENIIISYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -903,11 +925,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" , "Provides Input For Rule. The relation '4 porphobilinogen + H<sub>2</sub>O &rarr; 4 ammonium + preuroporphyrinogen' 'null' 'preuroporphyrinogen &rarr; uroporphyrinogen-III + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002413_UROGENIIISYN-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002413_UROGENIIISYN-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -917,28 +939,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/UROGENIIISYN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-50/YeastPathways_PWY3O-50_SGD_YeastPathways_PWY3O-50>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_57305_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-50>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/5-AMINOLEVULINIC-ACID-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003870> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -959,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -971,11 +971,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_15377_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_15377_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -990,11 +990,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000066_reaction_OHMETHYLBILANESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000066_reaction_OHMETHYLBILANESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1009,11 +1009,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_15378_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_15378_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1033,7 +1033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1047,14 +1047,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_57845>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002333_YOR278W-MONOMER_UROGENIIISYN-RXN_controller_SGD_YeastPathways_PWY3O-50>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000050_YeastPathways_PWY3O-50/YeastPathways_PWY3O-50_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
+                "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1070,7 +1070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1082,11 +1082,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" , "Provides Input For Rule. The relation 'glycine + succinyl-CoA + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + 5-aminolevulinate + coenzyme A' 'null' '2 5-aminolevulinate &rarr; porphobilinogen + H<SUP>+</SUP> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002413_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002413_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1103,26 +1103,15 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_BFO_0000066_reaction_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-50>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_BFO_0000050_YeastPathways_PWY3O-50/YeastPathways_PWY3O-50_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_BFO_0000050_YeastPathways_PWY3O-50/YeastPathways_PWY3O-50_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1140,11 +1129,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002333_YDL205C-MONOMER_OHMETHYLBILANESYN-RXN_controller_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002333_YDL205C-MONOMER_OHMETHYLBILANESYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1168,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1185,7 +1174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1197,11 +1186,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002233_CHEBI_356416_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002233_CHEBI_356416_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1212,26 +1201,15 @@
           <http://model.geneontology.org/CHEBI_356416_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_15377_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-50>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000050_YeastPathways_PWY3O-50/YeastPathways_PWY3O-50_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000050_YeastPathways_PWY3O-50/YeastPathways_PWY3O-50_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1242,24 +1220,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-50/YeastPathways_PWY3O-50>
 ] .
 
-<http://model.geneontology.org/reaction_UROGENIIISYN-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_BFO_0000066_reaction_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_BFO_0000066_reaction_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1270,14 +1239,20 @@
           <http://model.geneontology.org/reaction_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/reaction_UROGENIIISYN-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000002364>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.obolibrary.org/obo/GO_0004852>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000003008>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1301,7 +1276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1309,28 +1284,42 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002233_CHEBI_57845_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-50>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004852>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-50/YeastPathways_PWY3O-50_SGD_YeastPathways_PWY3O-50>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_BFO_0000066_reaction_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
+                "SGD_PWY:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002333_YGL040C-MONOMER_PORPHOBILSYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_57287_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1343,7 +1332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1354,26 +1343,15 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002234_CHEBI_57845_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-50>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002333_YDR232W-MONOMER_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002333_YDR232W-MONOMER_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1391,11 +1369,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" , "Provides Input For Rule. The relation '2 5-aminolevulinate &rarr; porphobilinogen + H<SUP>+</SUP> + 2 H<sub>2</sub>O' 'null' '4 porphobilinogen + H<sub>2</sub>O &rarr; 4 ammonium + preuroporphyrinogen' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002413_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002413_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1406,26 +1384,15 @@
           <http://model.geneontology.org/OHMETHYLBILANESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_BFO_0000066_reaction_PORPHOBILSYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-50>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002234_CHEBI_57845_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002234_CHEBI_57845_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1453,7 +1420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1461,26 +1428,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002234_CHEBI_57308_UROGENIIISYN-RXN_SGD_YeastPathways_PWY3O-50>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_356416_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_356416_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1491,6 +1447,17 @@
           <http://model.geneontology.org/CHEBI_356416_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002333_YOR278W-MONOMER_UROGENIIISYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_28938_OHMETHYLBILANESYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_28938> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1500,7 +1467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1511,15 +1478,29 @@
 <http://purl.obolibrary.org/obo/GO_0033014>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_57292_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_BFO_0000066_reaction_PORPHOBILSYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_BFO_0000066_reaction_PORPHOBILSYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1530,18 +1511,26 @@
           <http://model.geneontology.org/reaction_PORPHOBILSYNTH-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002413_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-50/YeastPathways_PWY3O-50_SGD_YeastPathways_PWY3O-50> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-50/YeastPathways_PWY3O-50_SGD_PWY_YeastPathways_PWY3O-50> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1551,3 +1540,14 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-50/YeastPathways_PWY3O-50>
 ] .
+
+<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002233_CHEBI_58126_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-50>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-5268.ttl
+++ b/models/YeastPathways_PWY3O-5268.ttl
@@ -1,14 +1,3 @@
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002413_RXN-9666_SGD_YeastPathways_PWY3O-5268>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5268" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15379_1.14.19.1-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15379> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -18,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -30,11 +19,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_57387_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5268> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_57387_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5268> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -49,11 +38,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_15378_RXN-9666_SGD_YeastPathways_PWY3O-5268> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_15378_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5268> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,14 +62,25 @@
 <http://purl.obolibrary.org/obo/GO_0006636>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_15377_RXN-9666_SGD_YeastPathways_PWY3O-5268>
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000066_reaction_1.14.19.1-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5268>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5268" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_57394_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5268>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5268" ;
+                "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,13 +116,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5268SmallMolecule18110> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_FERROCYTOCHROME-B5_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5268>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5268" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_15377_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5268>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5268" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9666>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
@@ -139,13 +161,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5268BiochemicalReaction18123> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_15377_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5268>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5268" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_1.14.19.1-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -156,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -168,11 +201,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_15377_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5268> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_15377_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5268> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -187,11 +220,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_57387_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5268> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_57387_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5268> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -208,30 +241,8 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000066_reaction_RXN-9666_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5268>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5268" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_57387_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5268>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5268" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -245,7 +256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "oleate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -253,19 +264,19 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_FERRICYTOCHROME-B5_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5268>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/GO_0004768>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002413_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5268>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5268" ;
+                "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004768>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -274,11 +285,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000066_reaction_1.14.19.1-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5268> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000066_reaction_1.14.19.1-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5268> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -296,24 +307,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5268Protein18120> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_30823_RXN-9666_SGD_YeastPathways_PWY3O-5268>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5268" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_1.14.19.1-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -339,11 +339,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_FERROCYTOCHROME-B5_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5268> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_FERROCYTOCHROME-B5_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5268> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -354,15 +354,26 @@
           <http://model.geneontology.org/FERROCYTOCHROME-B5_1.14.19.1-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_30823_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5268>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5268" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_15377_RXN-9666_SGD_YeastPathways_PWY3O-5268> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_15377_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5268> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,30 +384,8 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-9666>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000050_YeastPathways_PWY3O-5268/YeastPathways_PWY3O-5268_SGD_YeastPathways_PWY3O-5268>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5268" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000050_YeastPathways_PWY3O-5268/YeastPathways_PWY3O-5268_SGD_YeastPathways_PWY3O-5268>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5268" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30823_RXN-9666>
         a       <http://purl.obolibrary.org/obo/CHEBI_30823> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -407,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -415,28 +404,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_57394_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5268>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5268" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_1.14.19.1-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_FERRICYTOCHROME-B5_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5268>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5268" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/FERRICYTOCHROME-B5_1.14.19.1-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -447,24 +436,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5268Protein18084> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15378_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5268>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5268" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30823>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -476,11 +454,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" , "Provides Input For Rule. The relation '2 a ferrocytochrome <i>b<SUB>5</SUB></i> + stearoyl-CoA + oxygen + 2 H<SUP>+</SUP> &rarr; 2 a ferricytochrome <i>b<sub>5</sub></i> + oleoyl-CoA + 2 H<sub>2</sub>O' 'null' 'oleoyl-CoA + H<sub>2</sub>O &rarr; oleate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002413_RXN-9666_SGD_YeastPathways_PWY3O-5268> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002413_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5268> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -495,11 +473,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000050_YeastPathways_PWY3O-5268/YeastPathways_PWY3O-5268_SGD_YeastPathways_PWY3O-5268> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000050_YeastPathways_PWY3O-5268/YeastPathways_PWY3O-5268_SGD_PWY_YeastPathways_PWY3O-5268> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -510,6 +488,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-5268/YeastPathways_PWY3O-5268>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15378_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5268>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5268" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57287_RXN-9666>
         a       <http://purl.obolibrary.org/obo/CHEBI_57287> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -519,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -531,11 +520,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_57394_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5268> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_57394_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5268> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,11 +539,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000066_reaction_RXN-9666_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5268> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000066_reaction_RXN-9666_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5268> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -565,11 +554,77 @@
           <http://model.geneontology.org/reaction_RXN-9666_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002333_YGL055W-MONOMER_1.14.19.1-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5268>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5268" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15379_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5268>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5268" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000050_YeastPathways_PWY3O-5268/YeastPathways_PWY3O-5268_SGD_PWY_YeastPathways_PWY3O-5268>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5268" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000066_reaction_RXN-9666_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5268>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5268" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57387>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_15378_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5268>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5268" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_57387_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5268>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5268" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -581,11 +636,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002333_YGL055W-MONOMER_1.14.19.1-RXN_controller_SGD_YeastPathways_PWY3O-5268> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002333_YGL055W-MONOMER_1.14.19.1-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5268> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -596,18 +651,15 @@
           <http://model.geneontology.org/YGL055W-MONOMER_1.14.19.1-RXN_controller>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_57287_RXN-9666_SGD_YeastPathways_PWY3O-5268> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_57287_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5268> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,16 +670,8 @@
           <http://model.geneontology.org/CHEBI_57287_RXN-9666>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002333_YGL055W-MONOMER_1.14.19.1-RXN_controller_SGD_YeastPathways_PWY3O-5268>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5268" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -647,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -659,11 +703,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15379_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5268> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15379_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5268> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -678,11 +722,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000050_YeastPathways_PWY3O-5268/YeastPathways_PWY3O-5268_SGD_YeastPathways_PWY3O-5268> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000050_YeastPathways_PWY3O-5268/YeastPathways_PWY3O-5268_SGD_PWY_YeastPathways_PWY3O-5268> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -693,81 +737,48 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-5268/YeastPathways_PWY3O-5268>
 ] .
 
-<http://identifiers.org/sgd/S000003023>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_57387_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5268>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5268" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN-9666_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_15377_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5268>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5268" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_15378_RXN-9666_SGD_YeastPathways_PWY3O-5268>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5268" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_FERROCYTOCHROME-B5_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5268>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5268" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000003023>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000066_reaction_1.14.19.1-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5268>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5268" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15379_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5268>
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_57287_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5268>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5268" ;
+                "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -776,11 +787,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_FERRICYTOCHROME-B5_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5268> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_FERRICYTOCHROME-B5_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5268> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -795,11 +806,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_30823_RXN-9666_SGD_YeastPathways_PWY3O-5268> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_30823_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5268> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -810,17 +821,6 @@
           <http://model.geneontology.org/CHEBI_30823_RXN-9666>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_57387_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5268>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5268" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/FERROCYTOCHROME-B5_1.14.19.1-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -830,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -840,6 +840,17 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000050_YeastPathways_PWY3O-5268/YeastPathways_PWY3O-5268_SGD_PWY_YeastPathways_PWY3O-5268>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5268" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/1.14.19.1-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004768> ;
@@ -860,7 +871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -877,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -892,11 +903,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15378_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5268> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15378_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5268> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -910,17 +921,6 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_57287_RXN-9666_SGD_YeastPathways_PWY3O-5268>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5268" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57394_1.14.19.1-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57394> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -930,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-592.ttl
+++ b/models/YeastPathways_PWY3O-592.ttl
@@ -1,12 +1,34 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_BFO_0000066_reaction_PRODISULFREDUCT-A-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-592>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-592" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-547_RO_0002413_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_PWY3O-592>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-592" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_PRODISULFREDUCT-A-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14,11 +36,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002234_Red-Glutaredoxins_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002234_Red-Glutaredoxins_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -29,6 +51,17 @@
           <http://model.geneontology.org/Red-Glutaredoxins_PRODISULFREDUCT-A-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002233_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-592>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-592" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YPL091W-MONOMER_GLUTATHIONE-REDUCT-NADPH-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006012> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -36,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -48,11 +81,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_58297_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_58297_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -66,17 +99,6 @@
 <http://identifiers.org/sgd/S000006012>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-547_BFO_0000050_YeastPathways_PWY3O-592/YeastPathways_PWY3O-592_SGD_YeastPathways_PWY3O-592>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -86,40 +108,29 @@
 <http://purl.obolibrary.org/obo/GO_0006749>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002413_RXN3O-547_SGD_YeastPathways_PWY3O-592>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-547_RO_0002234_Ox-Glutaredoxins_RXN3O-547_SGD_YeastPathways_PWY3O-592>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58297>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_PWY3O-592/YeastPathways_PWY3O-592_SGD_PWY_YeastPathways_PWY3O-592>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-592" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-547_RO_0002234_Ox-Glutaredoxins_RXN3O-547_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-547_RO_0002234_Ox-Glutaredoxins_RXN3O-547_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -153,25 +164,14 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-547_BFO_0000066_reaction_RXN3O-547_location_lociGO_0005829_SGD_YeastPathways_PWY3O-592>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002413_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_PWY3O-592>
+<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002413_RXN3O-547_SGD_PWY_YeastPathways_PWY3O-592>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
+                "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -180,22 +180,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_BFO_0000066_reaction_GLUTATHIONE-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-592>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-592" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002234_CHEBI_58297_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002234_CHEBI_58297_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -210,11 +221,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -234,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -255,11 +266,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-547_RO_0002234_CHEBI_10545_RXN3O-547_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-547_RO_0002234_CHEBI_10545_RXN3O-547_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -270,28 +281,6 @@
           <http://model.geneontology.org/CHEBI_10545_RXN3O-547>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002233_Ox-Glutaredoxins_RXN3O-547_SGD_YeastPathways_PWY3O-592>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002333_YPL091W-MONOMER_GLUTATHIONE-REDUCT-NADPH-RXN_controller_SGD_YeastPathways_PWY3O-592>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57783_GLUTATHIONE-REDUCT-NADPH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -301,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -313,11 +302,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-547_BFO_0000066_reaction_RXN3O-547_location_lociGO_0005829_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-547_BFO_0000066_reaction_RXN3O-547_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -335,11 +324,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 glutathione + NADP<sup>+</sup> &larr; glutathione disulfide + NADPH + H<SUP>+</SUP>' 'null' '2 glutathione + an oxidized glutaredoxin &rarr; glutathione disulfide + a reduced glutaredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002413_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002413_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -350,36 +339,14 @@
           <http://model.geneontology.org/PRODISULFREDUCT-A-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_BFO_0000066_reaction_PRODISULFREDUCT-A-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-592>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-592>
+<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_BFO_0000050_YeastPathways_PWY3O-592/YeastPathways_PWY3O-592_SGD_PWY_YeastPathways_PWY3O-592>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-592>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
+                "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -390,11 +357,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002233_Ox-Glutaredoxins_RXN3O-547_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002233_Ox-Glutaredoxins_RXN3O-547_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,11 +376,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -424,22 +391,33 @@
           <http://model.geneontology.org/CHEBI_15378_GLUTATHIONE-REDUCT-NADPH-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002413_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-592>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-547_RO_0002234_Ox-Glutaredoxins_RXN3O-547_SGD_PWY_YeastPathways_PWY3O-592>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
+                "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://purl.obolibrary.org/obo/CHEBI_10545>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002233_Ox-Glutaredoxins_RXN3O-547_SGD_PWY_YeastPathways_PWY3O-592>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-592" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -448,11 +426,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-547_RO_0002233_Red-Glutaredoxins_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-547_RO_0002233_Red-Glutaredoxins_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,6 +444,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_57925>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-547_RO_0002233_Red-Glutaredoxins_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_PWY3O-592>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-592" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -473,11 +462,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-547_BFO_0000050_YeastPathways_PWY3O-592/YeastPathways_PWY3O-592_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-547_BFO_0000050_YeastPathways_PWY3O-592/YeastPathways_PWY3O-592_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,6 +477,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-592/YeastPathways_PWY3O-592>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002413_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_PWY3O-592>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-592" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004362>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -495,11 +495,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002333_YPL091W-MONOMER_GLUTATHIONE-REDUCT-NADPH-RXN_controller_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002333_YPL091W-MONOMER_GLUTATHIONE-REDUCT-NADPH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -510,48 +510,15 @@
           <http://model.geneontology.org/YPL091W-MONOMER_GLUTATHIONE-REDUCT-NADPH-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-592>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-547_RO_0002233_Red-Glutaredoxins_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_PWY3O-592>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-547_RO_0002413_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_PWY3O-592>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002233_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002233_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -566,11 +533,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_BFO_0000066_reaction_GLUTATHIONE-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_BFO_0000066_reaction_GLUTATHIONE-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -581,14 +548,14 @@
           <http://model.geneontology.org/reaction_GLUTATHIONE-REDUCT-NADPH-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002233_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-592>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002234_Red-Glutaredoxins_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_PWY3O-592>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
+                "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -601,24 +568,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-592SmallMolecule58352> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002234_CHEBI_58297_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_PWY3O-592>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58349_GLUTATHIONE-REDUCT-NADPH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -629,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -657,13 +613,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-592BiochemicalReaction58346> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-547_BFO_0000050_YeastPathways_PWY3O-592/YeastPathways_PWY3O-592_SGD_PWY_YeastPathways_PWY3O-592>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-592" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -672,11 +639,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 glutathione + an oxidized glutaredoxin &rarr; glutathione disulfide + a reduced glutaredoxin' 'null' 'an oxidized glutaredoxin + 2 e<SUP>-</SUP> = a reduced glutaredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002413_RXN3O-547_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002413_RXN3O-547_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -691,11 +658,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,18 +679,40 @@
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-592>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-592" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-592>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-592" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_BFO_0000066_reaction_PRODISULFREDUCT-A-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_BFO_0000066_reaction_PRODISULFREDUCT-A-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -739,18 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002234_Red-Glutaredoxins_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_PWY3O-592>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -758,11 +736,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_PWY3O-592/YeastPathways_PWY3O-592_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_PWY3O-592/YeastPathways_PWY3O-592_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -773,47 +751,69 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-592/YeastPathways_PWY3O-592>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_BFO_0000066_reaction_GLUTATHIONE-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-592>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_PWY3O-592/YeastPathways_PWY3O-592_SGD_YeastPathways_PWY3O-592>
+<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002234_CHEBI_58297_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_PWY3O-592>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
+                "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-592>
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_58297_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_PWY3O-592>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
+                "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002333_YPL091W-MONOMER_GLUTATHIONE-REDUCT-NADPH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-592>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-592" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-592>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-592" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-547_RO_0002234_CHEBI_10545_RXN3O-547_SGD_PWY_YeastPathways_PWY3O-592>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-592" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -827,7 +827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -844,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutathione-glutaredoxin system - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -856,11 +856,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" , "Provides Input For Rule. The relation '2 glutathione + an oxidized glutaredoxin &rarr; glutathione disulfide + a reduced glutaredoxin' 'null' '2 glutathione + NADP<sup>+</sup> &larr; glutathione disulfide + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002413_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002413_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -875,11 +875,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -889,28 +889,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_BFO_0000050_YeastPathways_PWY3O-592/YeastPathways_PWY3O-592_SGD_YeastPathways_PWY3O-592>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_58297_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_PWY3O-592>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PRODISULFREDUCT-A-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
@@ -929,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -946,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -973,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -984,15 +962,18 @@
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_BFO_0000050_YeastPathways_PWY3O-592/YeastPathways_PWY3O-592_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_BFO_0000050_YeastPathways_PWY3O-592/YeastPathways_PWY3O-592_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1003,9 +984,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-592/YeastPathways_PWY3O-592>
 ] .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://model.geneontology.org/YeastPathways_PWY3O-592/YeastPathways_PWY3O-592>
         a       <http://purl.obolibrary.org/obo/GO_0006749> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1015,7 +993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1023,14 +1001,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-547_RO_0002234_CHEBI_10545_RXN3O-547_SGD_YeastPathways_PWY3O-592>
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-592>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-592" ;
+                "SGD_PWY:PWY3O-592" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002413_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-592>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1038,11 +1027,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" , "Provides Input For Rule. The relation 'an oxidized glutaredoxin + 2 e<SUP>-</SUP> = a reduced glutaredoxin' 'null' '2 glutathione + an oxidized glutaredoxin &rarr; glutathione disulfide + a reduced glutaredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-547_RO_0002413_PRODISULFREDUCT-A-RXN_SGD_YeastPathways_PWY3O-592> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-547_RO_0002413_PRODISULFREDUCT-A-RXN_SGD_PWY_YeastPathways_PWY3O-592> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1062,10 +1051,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-592SmallMolecule58315> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-547_BFO_0000066_reaction_RXN3O-547_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-592>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-592" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-5962.ttl
+++ b/models/YeastPathways_PWY3O-5962.ttl
@@ -1,3 +1,14 @@
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/RXN3O-1803>
         a       <http://purl.obolibrary.org/obo/GO_0004315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -17,7 +28,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -25,36 +36,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_57783_RXN-9633_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_ACP_RXN-9514_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_57387_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -73,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -86,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -99,24 +110,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962SmallMolecule67819> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000066_reaction_1.14.19.1-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -169,15 +169,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_CHEBI_15377_RXN-9634_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.58-RXN_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.58-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -187,6 +198,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YKL182W-MONOMER_4.2.1.58-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YER061C-MONOMER_RXN3O-1803_controller_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/1.14.19.1-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004768> ;
@@ -207,7 +240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -218,51 +251,18 @@
 <http://purl.obolibrary.org/obo/GO_0004321>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_FERRICYTOCHROME-B5_RXN-10664_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -277,11 +277,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -296,11 +296,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -320,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -332,11 +332,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -351,11 +351,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_CHEBI_15378_RXN3O-1803_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_CHEBI_15378_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -370,11 +370,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -385,6 +385,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_58349_RXN-9514_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_ACETYL-COA-CARBOXYLTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -394,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -406,11 +417,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_15378_RXN-10662_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_15378_RXN-10662_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,6 +432,17 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-10662>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001665> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -428,43 +450,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962Protein67850> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000066_reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_Stearoyl-ACPs_RXN3O-5293_SGD_YeastPathways_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-5293> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Stearoyl-ACPs_RXN3O-5293>
-] .
 
 <http://model.geneontology.org/RXN-10664>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004768> ;
@@ -485,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -493,14 +485,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002333_YKL182W-MONOMER_RXN-9634_controller_SGD_YeastPathways_PWY3O-5962>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_Stearoyl-ACPs_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-5293> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/Stearoyl-ACPs_RXN3O-5293>
+] .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -508,11 +519,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'acyl-carrier protein + acetyl-CoA &rarr; an acetyl-[acp] + coenzyme A' 'null' 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -527,11 +538,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_15378_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_15378_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -545,30 +556,41 @@
 <http://purl.obolibrary.org/obo/CHEBI_25629>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002413_RXN3O-5304_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002333_YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002413_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_CHEBI_15378_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -579,13 +601,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962Complex67963> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN-9624>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -596,13 +640,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962SmallMolecule67989> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002333_YGL055W-MONOMER_1.14.19.1-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_4.2.1.58-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -613,7 +679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -630,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -638,14 +704,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -653,11 +719,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -672,11 +738,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_58349_RXN3O-5293_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_58349_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -708,11 +774,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002333_YKL182W-MONOMER_ACP-S-ACETYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002333_YKL182W-MONOMER_ACP-S-ACETYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -723,14 +789,14 @@
           <http://model.geneontology.org/YKL182W-MONOMER_ACP-S-ACETYLTRANSFER-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -738,11 +804,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,6 +819,17 @@
           <http://model.geneontology.org/OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_17544_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YGL055W-MONOMER_1.14.19.1-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003023> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -760,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -772,11 +849,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Provides Input For Rule. The relation 'palmitoyl-CoA + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; palmitoleoyl-CoA + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' 'null' 'palmitoleoyl-CoA + H<sub>2</sub>O &rarr; palmitoleate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002413_RXN-10662_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002413_RXN-10662_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -787,26 +864,15 @@
           <http://model.geneontology.org/RXN-10662>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000066_reaction_RXN-9633_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -832,7 +898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -844,11 +910,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000066_reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000066_reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,11 +929,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_30823_RXN-9666_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_30823_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -887,13 +953,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962SmallMolecule68073> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002413_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002413_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -904,24 +992,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962SmallMolecule67989> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002333_YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005747> ;
@@ -930,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -942,11 +1019,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -957,25 +1034,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000066_reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN3O-9780_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -991,7 +1057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -999,39 +1065,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000004820_CPLX3O-102_component_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004315>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002413_RXN-9633_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1042,7 +1086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1050,26 +1094,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_15377_RXN-10662_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' 'null' 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1083,26 +1116,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_17544>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1122,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1130,15 +1152,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_FERROCYTOCHROME-B5_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_FERROCYTOCHROME-B5_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1153,11 +1186,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1168,15 +1201,26 @@
           <http://model.geneontology.org/CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000066_reaction_RXN-9633_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000066_reaction_RXN-9633_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1190,15 +1234,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_57288>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1213,11 +1268,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1228,14 +1283,14 @@
           <http://model.geneontology.org/reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000066_reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1243,11 +1298,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1258,26 +1313,15 @@
           <http://model.geneontology.org/reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_FERROCYTOCHROME-B5_RXN-10664_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_FERROCYTOCHROME-B5_RXN-10664_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1288,14 +1332,14 @@
           <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN-10664>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_456216_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002333_YGL055W-MONOMER_RXN-10664_controller_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1308,24 +1352,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962SmallMolecule67819> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1339,7 +1372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1352,18 +1385,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1376,13 +1409,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962SmallMolecule68032> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/FERROCYTOCHROME-B5_1.14.19.1-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1393,7 +1437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1404,14 +1448,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_32372>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_57287_RXN-10662_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000066_reaction_RXN-9666_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1424,7 +1468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1432,14 +1476,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_RXN-9624_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1452,7 +1507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1464,11 +1519,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1483,11 +1538,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1498,25 +1553,14 @@
           <http://model.geneontology.org/CHEBI_57379_RXN3O-9780>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002413_RXN3O-5293_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_15377_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1524,11 +1568,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_ACP_RXN3O-5304_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_ACP_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1548,7 +1592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1560,11 +1604,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1579,11 +1623,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1594,26 +1638,15 @@
           <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1628,11 +1661,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxyoctadecanoyl-[acp] &rarr; a (2<i>E</i>)-octadec-2-enoyl-[acp] + H<sub>2</sub>O' 'null' 'a stearoyl-[acp] + NADP<sup>+</sup> &larr; a (2<i>E</i>)-octadec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002413_RXN3O-5293_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002413_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1652,13 +1685,43 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962SmallMolecule67868> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.58-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.14.19.1-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962>
+] .
 
 <http://model.geneontology.org/YGL055W-MONOMER_RXN-10664_controller>
         a       <http://identifiers.org/sgd/S000003023> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1667,7 +1730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1679,41 +1742,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.14.19.1-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962>
-] .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1724,14 +1757,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002333_YKL182W-MONOMER_RXN-9634_controller_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1754,7 +1787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1762,52 +1795,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_57783_RXN-9633_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.58-RXN_controller_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0006633>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002413_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58349_RXN-9514>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1818,7 +1807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1826,25 +1815,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_CHEBI_57287_RXN3O-5304_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002411_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_57783_RXN-9514_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1867,7 +1845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1878,25 +1856,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002413_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002333_YKL182W-MONOMER_RXN3O-5304_controller_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1906,14 +1884,14 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_32372_RXN-10662_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1921,11 +1899,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1940,11 +1918,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_15377_RXN-9624_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_15377_RXN-9624_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1959,11 +1937,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_ACP_RXN3O-1803_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_ACP_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1974,25 +1952,25 @@
           <http://model.geneontology.org/ACP_RXN3O-1803>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_Stearoyl-ACPs_RXN3O-5293_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002413_RXN-9634_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002413_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2000,11 +1978,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002233_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002233_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2019,11 +1997,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_57287_RXN-10662_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_57287_RXN-10662_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2038,11 +2016,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a stearoyl-[acp] + NADP<sup>+</sup> &larr; a (2<i>E</i>)-octadec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a stearoyl-[acp] + coenzyme A &rarr; stearoyl-CoA + acyl-carrier protein' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002413_RXN3O-5304_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002413_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2057,11 +2035,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2072,15 +2050,26 @@
           <http://model.geneontology.org/SGD_S000005299_CPLX3O-8_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_61540_RXN-10664_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_456216_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_456216_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2095,11 +2084,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000066_reaction_RXN-9634_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000066_reaction_RXN-9634_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2119,7 +2108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2127,36 +2116,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002333_YKL182W-MONOMER_RXN3O-5293_controller_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2169,7 +2158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2177,14 +2166,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_Stearoyl-ACPs_RXN3O-5293_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2192,11 +2181,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_RXN-9514_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_RXN-9514_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2211,11 +2200,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2235,7 +2224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2243,37 +2232,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_ACP_RXN3O-1803_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000066_reaction_RXN3O-1803_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2284,26 +2251,15 @@
           <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_15377_RXN-10664_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000066_reaction_RXN-9514_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000066_reaction_RXN-9514_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2314,6 +2270,47 @@
           <http://model.geneontology.org/reaction_RXN-9514_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000066_reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN>
+] .
+
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2321,11 +2318,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN3O-9780_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2339,34 +2336,37 @@
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000066_reaction_RXN-10662_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2377,15 +2377,26 @@
           <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_CHEBI_58349_RXN-9515_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_CHEBI_58349_RXN-9515_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2400,11 +2411,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2414,6 +2425,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_25629_RXN-9624_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_61540_RXN-10664_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9666>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
@@ -2430,7 +2463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2445,11 +2478,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_17544_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_17544_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2460,14 +2493,14 @@
           <http://model.geneontology.org/CHEBI_17544_ACETYL-COA-CARBOXYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_30823_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2490,7 +2523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2498,36 +2531,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_Butanoyl-ACPs_RXN-9515_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_15377_RXN-10662_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002411_RXN3O-9780_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000066_reaction_RXN-9515_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_15377_RXN-10664_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2538,7 +2571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2555,7 +2588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2563,36 +2596,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_ACP_RXN3O-5304_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000066_reaction_1.14.19.1-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2615,7 +2626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2627,11 +2638,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_57387_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_57387_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2641,6 +2652,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57387_1.14.19.1-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2661,7 +2683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2673,11 +2695,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2688,26 +2710,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002333_YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_57783_RXN-9633_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_57783_RXN-9633_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2737,7 +2748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2745,14 +2756,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000066_reaction_RXN-9633_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2760,11 +2771,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_15378_RXN3O-5293_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_15378_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2779,11 +2790,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2798,11 +2809,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2817,11 +2828,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_61540_RXN-10664_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_61540_RXN-10664_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2841,7 +2852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2853,11 +2864,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Provides Input For Rule. The relation 'a stearoyl-[acp] + coenzyme A &rarr; stearoyl-CoA + acyl-carrier protein' 'null' 'stearoyl-CoA + H<sub>2</sub>O &rarr; stearate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_RXN-9624_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_RXN-9624_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2872,11 +2883,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002333_YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002333_YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2887,47 +2898,25 @@
           <http://model.geneontology.org/YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000066_reaction_RXN-9515_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_58349_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_RXN-9514_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000066_reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2950,7 +2939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2958,14 +2947,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000066_reaction_RXN3O-5304_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2981,7 +2992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2992,6 +3003,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_61540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_RXN-9634>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3001,46 +3023,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962SmallMolecule67989> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_RXN-9624_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_1.14.19.1-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3051,7 +3040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3062,6 +3051,17 @@
 <http://identifiers.org/sgd/S000001665>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3070,7 +3070,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3078,11 +3089,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002333_YKL182W-MONOMER_RXN3O-5304_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002333_YKL182W-MONOMER_RXN3O-5304_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3093,26 +3104,15 @@
           <http://model.geneontology.org/YKL182W-MONOMER_RXN3O-5304_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3127,11 +3127,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3142,26 +3142,15 @@
           <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_57394_RXN3O-5304_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3172,26 +3161,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000066_reaction_RXN-9666_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000066_reaction_RXN-9666_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3202,29 +3180,40 @@
           <http://model.geneontology.org/reaction_RXN-9666_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_RXN-9514_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15378_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15378_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3242,7 +3231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3257,11 +3246,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3272,37 +3261,15 @@
           <http://model.geneontology.org/CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_30823_RXN-9666_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YER061C-MONOMER_RXN3O-1803_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YER061C-MONOMER_RXN3O-1803_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3322,7 +3289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3334,11 +3301,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3349,14 +3316,25 @@
           <http://model.geneontology.org/CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_Crotonyl-ACPs_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002413_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3379,7 +3357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3396,7 +3374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of fatty acid biosynthesis, saturated and unsaturated - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3404,14 +3382,25 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000066_reaction_RXN3O-5304_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_CHEBI_57287_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3434,7 +3423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3445,14 +3434,14 @@
 <http://identifiers.org/sgd/S000005747>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002413_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3466,7 +3455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3474,15 +3463,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002411_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Provides Input For Rule. The relation 'a 2,3,4-saturated fatty acyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; acyl-carrier protein + a 3-oxoacyl-[acp] + CO<SUB>2</SUB>' 'null' 'a (3<i>R</i>)-3-hydroxyacyl-[acyl-carrier protein] + NADP<sup>+</sup> &larr; a 3-oxoacyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002413_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002413_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3500,7 +3522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3512,11 +3534,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_15378_RXN-9624_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_15378_RXN-9624_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3527,15 +3549,37 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-9624>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_57394_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3553,11 +3597,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000066_reaction_RXN-10664_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000066_reaction_RXN-10664_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3568,26 +3612,15 @@
           <http://model.geneontology.org/reaction_RXN-10664_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_25629_RXN-9624_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000066_reaction_RXN3O-5304_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000066_reaction_RXN3O-5304_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3607,7 +3640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3619,11 +3652,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000066_reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000066_reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3634,6 +3667,28 @@
           <http://model.geneontology.org/reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15378_RXN-10664_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller>
         a       <http://identifiers.org/sgd/S000001665> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3641,7 +3696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3653,11 +3708,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3672,11 +3727,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_57783_RXN-9514_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_57783_RXN-9514_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3687,14 +3742,14 @@
           <http://model.geneontology.org/CHEBI_57783_RXN-9514>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15379_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3702,11 +3757,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_CHEBI_15377_RXN-9634_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_CHEBI_15377_RXN-9634_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3717,25 +3772,25 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-9634>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000066_reaction_RXN-10664_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3748,7 +3803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3761,29 +3816,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_Octadec-2-enoyl-ACPs_RXN-9634_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3796,7 +3851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3811,7 +3866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3823,11 +3878,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3838,12 +3893,34 @@
           <http://model.geneontology.org/Crotonyl-ACPs_4.2.1.58-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_CHEBI_16526_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000004820_CPLX3O-102_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004820> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3852,7 +3929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3863,13 +3940,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962Protein67850> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN-10664>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -3880,7 +3968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3892,11 +3980,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3907,15 +3995,26 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_15378_RXN-9514_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_15378_RXN-9514_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3933,11 +4032,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3952,11 +4051,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3976,7 +4075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3988,11 +4087,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4007,11 +4106,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002411_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002411_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4022,15 +4121,26 @@
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_ACP_RXN3O-1803_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_ACP_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4041,18 +4151,26 @@
           <http://model.geneontology.org/ACP_RXN3O-1803>
 ] .
 
-<http://identifiers.org/sgd/S000003023>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Provides Input For Rule. The relation '2 a ferrocytochrome <i>b<SUB>5</SUB></i> + stearoyl-CoA + oxygen + 2 H<SUP>+</SUP> &rarr; 2 a ferricytochrome <i>b<sub>5</sub></i> + oleoyl-CoA + 2 H<sub>2</sub>O' 'null' 'oleoyl-CoA + H<sub>2</sub>O &rarr; oleate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002413_RXN-9666_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002413_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4063,15 +4181,40 @@
           <http://model.geneontology.org/RXN-9666>
 ] .
 
+<http://identifiers.org/sgd/S000003023>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_15378_RXN-9633_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_CHEBI_57394_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_61540_RXN-10664_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_61540_RXN-10664_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4082,14 +4225,14 @@
           <http://model.geneontology.org/CHEBI_61540_RXN-10664>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002333_YGL055W-MONOMER_1.14.19.1-RXN_controller_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000066_reaction_RXN-9514_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4097,11 +4240,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4121,35 +4264,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962SmallMolecule67806> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_15378_RXN-9633_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/Octadec-2-enoyl-ACPs_RXN-9634>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -4160,24 +4281,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962Protein68095> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_57394_RXN3O-5304_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_ACETYL-COA-CARBOXYLTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4188,7 +4298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4196,28 +4306,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15378_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_57287_RXN-9624_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002413_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_15378_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4227,15 +4348,26 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_58349_RXN-9633_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_58349_RXN-9633_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4250,11 +4382,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_Octadec-2-enoyl-ACPs_RXN-9634_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_Octadec-2-enoyl-ACPs_RXN-9634_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4265,26 +4397,15 @@
           <http://model.geneontology.org/Octadec-2-enoyl-ACPs_RXN-9634>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4304,7 +4425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4312,15 +4433,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000004820_CPLX3O-102_component_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4335,11 +4478,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002333_YGL055W-MONOMER_RXN-10664_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002333_YGL055W-MONOMER_RXN-10664_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4350,26 +4493,15 @@
           <http://model.geneontology.org/YGL055W-MONOMER_RXN-10664_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4387,11 +4519,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4402,25 +4534,25 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_43474_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_57783_RXN-9514_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4428,11 +4560,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_15378_RXN-9666_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_15378_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4452,7 +4584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4460,14 +4592,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4478,7 +4610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4495,7 +4627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4503,47 +4635,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_15377_RXN-9666_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_57783_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_ACP_RXN-9514_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4556,7 +4666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4567,6 +4677,17 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16526_RXN3O-1803>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4576,24 +4697,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962SmallMolecule68073> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_61540_RXN-10664_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -4604,13 +4714,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962SmallMolecule67819> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15378_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/4.2.1.58-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -4631,7 +4752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4642,14 +4763,14 @@
 <http://purl.obolibrary.org/obo/GO_0004314>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4662,7 +4783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4670,15 +4791,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002413_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4693,11 +4836,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4712,11 +4855,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_57387_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_57387_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4727,15 +4870,26 @@
           <http://model.geneontology.org/CHEBI_57387_1.14.19.1-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_Butanoyl-ACPs_RXN-9515_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_57394_RXN3O-5304_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_57394_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4753,11 +4907,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4777,7 +4931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4789,11 +4943,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4811,11 +4965,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Provides Input For Rule. The relation 'a palmitoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxooctadecanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein' 'null' 'a (3<i>R</i>)-3-hydroxyoctadecanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxooctadecanoyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002413_RXN-9633_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002413_RXN-9633_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4830,11 +4984,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4848,14 +5002,14 @@
 <http://identifiers.org/sgd/S000000863>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002413_RXN-9633_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_58349_RXN-9633_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4868,7 +5022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4876,14 +5030,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002413_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002333_YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4896,7 +5050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4904,55 +5058,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_57287_RXN-9666_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002333_YKL182W-MONOMER_RXN3O-5304_controller_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4967,7 +5077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4975,36 +5085,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_57387_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5013,29 +5101,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_Octadec-2-enoyl-ACPs_RXN-9634_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_CHEBI_15377_RXN-9634_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000066_reaction_RXN-10664_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5043,11 +5131,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxyacyl-[acyl-carrier protein] &rarr; a <i>trans</i>-2-enoyl-[acyl-carrier protein] + H<sub>2</sub>O' 'null' 'a 2,3,4-saturated fatty acyl-[acp] + NADP<sup>+</sup> &larr; a <i>trans</i>-2-enoyl-[acyl-carrier protein] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002413_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002413_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5058,6 +5146,17 @@
           <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15379_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_30823>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -5065,11 +5164,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15379_RXN-10664_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15379_RXN-10664_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5089,7 +5188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5097,22 +5196,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CHEBI_58349_RXN-9633>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NADP<sup>+</sup>" ;
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962SmallMolecule67839> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -5123,7 +5216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5135,11 +5228,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_Stearoyl-ACPs_RXN3O-5293_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_Stearoyl-ACPs_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5150,16 +5243,22 @@
           <http://model.geneontology.org/Stearoyl-ACPs_RXN3O-5293>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_58349_RXN-9633>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NADP<sup>+</sup>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962SmallMolecule67839> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57783_RXN-9514>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5170,7 +5269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5182,11 +5281,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5197,26 +5296,15 @@
           <http://model.geneontology.org/CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5231,11 +5319,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_58349_RXN-9514_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_58349_RXN-9514_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5253,11 +5341,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002333_YKL182W-MONOMER_RXN-9634_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002333_YKL182W-MONOMER_RXN-9634_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5272,11 +5360,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a palmitoyl-[acp] + coenzyme A &rarr; palmitoyl-CoA + acyl-carrier protein' 'null' 'palmitoyl-CoA + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; palmitoleoyl-CoA + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_RXN-10664_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_RXN-10664_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5287,15 +5375,26 @@
           <http://model.geneontology.org/RXN-10664>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'acyl-carrier protein + malonyl-CoA &rarr; a malonyl-[acp] + coenzyme A' 'null' 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5311,7 +5410,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002233_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5324,7 +5434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5341,7 +5451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5349,15 +5459,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O' 'null' 'a (2<i>E</i>)-but-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a butanoyl-[acp] + NADP<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5368,14 +5489,14 @@
           <http://model.geneontology.org/RXN-9515>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_15378_RXN-10662_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5388,7 +5509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5396,37 +5517,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a palmitoyl-[acp] + coenzyme A &rarr; palmitoyl-CoA + acyl-carrier protein' 'null' 'palmitoyl-CoA + H<sub>2</sub>O &rarr; palmitate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5441,11 +5540,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5460,11 +5559,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5474,17 +5573,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_57387_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5505,7 +5593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5513,25 +5601,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_61540_RXN-10664_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_FERRICYTOCHROME-B5_RXN-10664_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5539,11 +5616,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000066_reaction_RXN-9624_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000066_reaction_RXN-9624_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5558,11 +5635,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_Palmitoyl-ACPs_RXN3O-1803_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_Palmitoyl-ACPs_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5573,34 +5650,12 @@
           <http://model.geneontology.org/Palmitoyl-ACPs_RXN3O-1803>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002413_RXN-10662_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5608,11 +5663,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000066_reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000066_reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5627,11 +5682,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_32372_RXN-10662_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_32372_RXN-10662_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5642,23 +5697,23 @@
           <http://model.geneontology.org/CHEBI_32372_RXN-10662>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-5293_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_ACP_RXN3O-1803_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5666,11 +5721,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002333_YKL182W-MONOMER_RXN3O-5293_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002333_YKL182W-MONOMER_RXN3O-5293_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5685,11 +5740,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000004820_CPLX3O-102_component_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000004820_CPLX3O-102_component_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5700,17 +5755,6 @@
           <http://model.geneontology.org/SGD_S000004820_CPLX3O-102_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57287> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5720,7 +5764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5728,26 +5772,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_43474_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_43474_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5758,17 +5791,6 @@
           <http://model.geneontology.org/CHEBI_43474_ACETYL-COA-CARBOXYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000066_reaction_RXN3O-5293_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57287_RXN3O-5304>
         a       <http://purl.obolibrary.org/obo/CHEBI_57287> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5778,24 +5800,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962SmallMolecule68032> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5806,7 +5817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5814,83 +5825,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002333_YGL055W-MONOMER_RXN-10664_controller_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-CARBOXYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_Palmitoyl-ACPs_RXN3O-1803_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002333_YKL182W-MONOMER_ACP-S-ACETYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004820>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002413_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_FERRICYTOCHROME-B5_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5898,11 +5854,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5913,26 +5869,15 @@
           <http://model.geneontology.org/reaction_4.2.1.58-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_RXN-10664_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxyoctadecanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxooctadecanoyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (3<i>R</i>)-3-hydroxyoctadecanoyl-[acp] &rarr; a (2<i>E</i>)-octadec-2-enoyl-[acp] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002413_RXN-9634_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002413_RXN-9634_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5950,7 +5895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5967,7 +5912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5979,11 +5924,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5994,14 +5939,14 @@
           <http://model.geneontology.org/YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_FERROCYTOCHROME-B5_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6009,11 +5954,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6029,7 +5974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6042,7 +5987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6050,14 +5995,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6065,11 +6010,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6084,11 +6029,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6099,15 +6044,26 @@
           <http://model.geneontology.org/ACP_MALONYL-COA-ACP-TRANSACYL-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6118,17 +6074,6 @@
           <http://model.geneontology.org/reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000066_reaction_RXN-9634_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/GO_0006633> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6138,7 +6083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -6146,26 +6091,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_Butanoyl-ACPs_RXN-9515_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_Butanoyl-ACPs_RXN-9515_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6176,15 +6110,37 @@
           <http://model.geneontology.org/Butanoyl-ACPs_RXN-9515>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_57394_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_57287_RXN-9666_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_57287_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6195,36 +6151,14 @@
           <http://model.geneontology.org/CHEBI_57287_RXN-9666>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_15377_RXN-9624_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6237,7 +6171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6245,37 +6179,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_58349_RXN3O-5293_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002233_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-CARBOXYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-CARBOXYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6286,17 +6198,6 @@
           <http://model.geneontology.org/reaction_ACETYL-COA-CARBOXYLTRANSFER-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/R-3-hydroxystearoyl-ACPs_RXN-9633>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6306,7 +6207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6314,14 +6215,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002413_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6342,13 +6243,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962BiochemicalReaction68143> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -6361,29 +6273,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_FERROCYTOCHROME-B5_RXN-10664_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002413_RXN-9666_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6396,7 +6297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6404,15 +6305,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6427,11 +6339,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_Crotonyl-ACPs_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6442,6 +6354,28 @@
           <http://model.geneontology.org/Crotonyl-ACPs_4.2.1.58-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/3-oxo-stearoyl-ACPs_RXN3O-1803>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6451,7 +6385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6463,11 +6397,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_15377_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_15377_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6478,15 +6412,26 @@
           <http://model.geneontology.org/CHEBI_15377_1.14.19.1-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6497,14 +6442,14 @@
           <http://model.geneontology.org/CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_15378_RXN-9666_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000066_reaction_RXN-9634_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6512,11 +6457,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_15378_RXN-9633_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_15378_RXN-9633_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6534,11 +6479,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000066_reaction_RXN3O-5293_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000066_reaction_RXN3O-5293_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6553,11 +6498,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6568,15 +6513,26 @@
           <http://model.geneontology.org/ACP_ACP-S-ACETYLTRANSFER-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6606,7 +6562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6618,11 +6574,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_15377_RXN-10664_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_CHEBI_15377_RXN-10664_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6633,14 +6589,25 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-10664>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000066_reaction_RXN-9514_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6653,7 +6620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6661,25 +6628,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_57287_RXN-9624_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_15377_RXN-9624_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6692,24 +6659,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962SmallMolecule68284> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002333_YKL182W-MONOMER_RXN-9515_controller_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005299>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6721,24 +6677,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962Protein67850> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/Butanoyl-ACPs_RXN-9515>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -6749,13 +6694,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962Protein67824> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_1.14.19.1-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -6766,7 +6722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6774,36 +6730,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_FERRICYTOCHROME-B5_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-CARBOXYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_57783_RXN3O-5293_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6811,11 +6756,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_CHEBI_57394_RXN3O-5304_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_CHEBI_57394_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6826,15 +6771,26 @@
           <http://model.geneontology.org/CHEBI_57394_RXN3O-5304>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6845,14 +6801,14 @@
           <http://model.geneontology.org/ACP_ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_15378_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6860,11 +6816,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6875,15 +6831,26 @@
           <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_15378_RXN-9624_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002413_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002413_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6894,26 +6861,15 @@
           <http://model.geneontology.org/4.2.1.58-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_Octadec-2-enoyl-ACPs_RXN-9634_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6929,18 +6885,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002333_YKL182W-MONOMER_RXN3O-5293_controller_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6948,11 +6904,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000066_reaction_1.14.19.1-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_BFO_0000066_reaction_1.14.19.1-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6963,14 +6919,14 @@
           <http://model.geneontology.org/reaction_1.14.19.1-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6978,11 +6934,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6998,29 +6954,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_58349_RXN-9633_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_15378_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7028,11 +6973,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7047,11 +6992,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7062,25 +7007,14 @@
           <http://model.geneontology.org/CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15379_RXN-10664_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7093,7 +7027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7108,7 +7042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7116,14 +7050,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_15377_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002413_RXN-9634_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7136,7 +7070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7144,14 +7078,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_15377_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000066_reaction_RXN3O-1803_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7164,7 +7120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7181,24 +7137,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962SmallMolecule67819> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_58349_RXN-9514_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-1803>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -7209,13 +7154,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962SmallMolecule67819> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002333_YKL182W-MONOMER_ACP-S-ACETYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_Stearoyl-ACPs_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_25629_RXN-9624>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_25629> ;
@@ -7226,7 +7204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7241,7 +7219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7249,15 +7227,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7272,11 +7272,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_57394_RXN3O-5304_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_57394_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7306,7 +7306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7318,11 +7318,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_CHEBI_16526_RXN3O-1803_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_CHEBI_16526_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7340,11 +7340,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7355,14 +7355,14 @@
           <http://model.geneontology.org/CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_15378_RXN-10662_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_CHEBI_58349_RXN-9515_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7370,11 +7370,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7394,7 +7394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7402,15 +7402,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7426,7 +7437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7434,11 +7445,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7449,15 +7460,26 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_57387_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7468,15 +7490,26 @@
           <http://model.geneontology.org/CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7496,7 +7529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7504,14 +7537,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002411_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_ACP_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7523,7 +7556,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_57287_RXN-10662_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7532,30 +7576,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-9515_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7566,7 +7610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7579,7 +7623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7588,7 +7632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7596,11 +7640,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7611,29 +7655,40 @@
           <http://model.geneontology.org/CHEBI_15377_4.2.1.58-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_456216>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000066_reaction_RXN3O-5293_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_456216>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxyacyl-[acyl-carrier protein] + NADP<sup>+</sup> &larr; a 3-oxoacyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (3<i>R</i>)-3-hydroxyacyl-[acyl-carrier protein] &rarr; a <i>trans</i>-2-enoyl-[acyl-carrier protein] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002413_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002413_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7644,15 +7699,48 @@
           <http://model.geneontology.org/3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_Stearoyl-ACPs_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10664_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7663,29 +7751,29 @@
           <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15377>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_15378_RXN3O-5293_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7700,11 +7788,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7713,25 +7801,6 @@
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/ACP_MALONYL-COA-ACP-TRANSACYL-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-5962> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN>
@@ -7743,7 +7812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7751,26 +7820,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002333_YKL182W-MONOMER_RXN-9515_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002333_YKL182W-MONOMER_RXN-9515_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7781,12 +7858,34 @@
           <http://model.geneontology.org/YKL182W-MONOMER_RXN-9515_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-9624_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7794,11 +7893,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000066_reaction_RXN3O-1803_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000066_reaction_RXN3O-1803_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7809,17 +7908,6 @@
           <http://model.geneontology.org/reaction_RXN3O-1803_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000066_reaction_RXN-10662_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7829,7 +7917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7841,11 +7929,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002333_YGL055W-MONOMER_1.14.19.1-RXN_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002333_YGL055W-MONOMER_1.14.19.1-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7868,7 +7956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7880,11 +7968,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_15377_RXN-10662_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002233_CHEBI_15377_RXN-10662_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7904,7 +7992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7921,7 +8009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7929,14 +8017,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_456216_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_FERROCYTOCHROME-B5_RXN-10664_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7955,7 +8054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7967,11 +8066,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7981,50 +8080,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_CHEBI_58349_RXN-9515_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YER061C-MONOMER_RXN3O-1803_controller_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -8037,43 +8092,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_Octadec-2-enoyl-ACPs_RXN-9634_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000066_reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_15378_RXN-9624_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8096,13 +8129,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962BiochemicalReaction67781> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_Palmitoyl-ACPs_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/3-OXOACYL-ACP-REDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004316> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -8123,7 +8167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8135,11 +8179,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_FERRICYTOCHROME-B5_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_FERRICYTOCHROME-B5_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8154,11 +8198,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000066_reaction_RXN-10662_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000066_reaction_RXN-10662_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8176,11 +8220,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8191,15 +8235,26 @@
           <http://model.geneontology.org/3-oxo-stearoyl-ACPs_RXN3O-1803>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_ACP_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_57783_RXN3O-5293_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_57783_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8210,15 +8265,26 @@
           <http://model.geneontology.org/CHEBI_57783_RXN3O-5293>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_57287_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8229,26 +8295,15 @@
           <http://model.geneontology.org/ACP_ACP-S-ACETYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_15378_RXN-9514_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8263,11 +8318,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_FERRICYTOCHROME-B5_RXN-10664_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002234_FERRICYTOCHROME-B5_RXN-10664_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8278,37 +8333,15 @@
           <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN-10664>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9666_BFO_0000066_reaction_RXN-9666_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_17544_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a stearoyl-[acp] + coenzyme A &rarr; stearoyl-CoA + acyl-carrier protein' 'null' '2 a ferrocytochrome <i>b<SUB>5</SUB></i> + stearoyl-CoA + oxygen + 2 H<SUP>+</SUP> &rarr; 2 a ferricytochrome <i>b<sub>5</sub></i> + oleoyl-CoA + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8323,11 +8356,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002411_RXN3O-9780_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002411_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8338,91 +8371,69 @@
           <http://model.geneontology.org/RXN3O-9780>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YPL231W-MONOMER_RXN3O-1803_controller_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15379_RXN-10664_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_32372_RXN-10662_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YPL231W-MONOMER_RXN3O-1803_controller_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000066_reaction_RXN-9624_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_15378_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8433,7 +8444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8441,14 +8452,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10662_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002413_RXN-10662_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_RXN-10664_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8457,7 +8479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8465,11 +8487,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8484,11 +8506,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000066_reaction_RXN-9515_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000066_reaction_RXN-9515_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8499,14 +8521,14 @@
           <http://model.geneontology.org/reaction_RXN-9515_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_15378_RXN-9514_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8514,11 +8536,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_15377_RXN-9666_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002233_CHEBI_15377_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8529,26 +8551,15 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-9666>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000066_reaction_RXN-9624_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15379_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_CHEBI_15379_1.14.19.1-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8563,11 +8574,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8582,11 +8593,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_57287_RXN-9624_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_57287_RXN-9624_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8601,11 +8612,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YPL231W-MONOMER_RXN3O-1803_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YPL231W-MONOMER_RXN3O-1803_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8623,7 +8634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8635,11 +8646,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" , "Provides Input For Rule. The relation 'acetyl-CoA + ATP + hydrogencarbonate &rarr; ADP + malonyl-CoA + phosphate + H<SUP>+</SUP>' 'null' 'acyl-carrier protein + malonyl-CoA &rarr; a malonyl-[acp] + coenzyme A' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002413_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002413_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8650,23 +8661,56 @@
           <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_4.2.1.58-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_CHEBI_57394_RXN3O-5304_SGD_YeastPathways_PWY3O-5962>
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_ACP_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002333_YKL182W-MONOMER_RXN-9515_controller_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8677,7 +8721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8685,14 +8729,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_43474_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
+                "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8705,13 +8749,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5962SmallMolecule67839> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-5962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -8721,7 +8787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8734,7 +8800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8754,7 +8820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8771,7 +8837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8788,7 +8854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8800,11 +8866,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8819,11 +8885,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_25629_RXN-9624_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_25629_RXN-9624_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8834,17 +8900,6 @@
           <http://model.geneontology.org/CHEBI_25629_RXN-9624>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004768>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -8852,11 +8907,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002333_YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002333_YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8871,11 +8926,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15378_RXN-10664_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15378_RXN-10664_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8886,51 +8941,18 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-10664>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002233_CHEBI_15378_RXN-10664_SGD_YeastPathways_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002233_FERROCYTOCHROME-B5_1.14.19.1-RXN_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_CHEBI_16526_RXN3O-1803_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_CHEBI_57287_RXN3O-5304_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_CHEBI_57287_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8950,7 +8972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8958,26 +8980,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_CHEBI_15378_RXN3O-1803_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8988,26 +8999,15 @@
           <http://model.geneontology.org/CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-5962/YeastPathways_PWY3O-5962_SGD_YeastPathways_PWY3O-5962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9022,11 +9022,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_ACP_RXN-9514_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_ACP_RXN-9514_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9041,11 +9041,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_Octadec-2-enoyl-ACPs_RXN-9634_SGD_YeastPathways_PWY3O-5962> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_Octadec-2-enoyl-ACPs_RXN-9634_SGD_PWY_YeastPathways_PWY3O-5962> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9065,7 +9065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-6-1.ttl
+++ b/models/YeastPathways_PWY3O-6-1.ttl
@@ -1,79 +1,24 @@
-<http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002234_CHEBI_13392_RXN3O-9798_SGD_YeastPathways_PWY3O-6-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9797_BFO_0000066_reaction_RXN3O-9797_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_1.1.3.37-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_BFO_0000050_YeastPathways_PWY3O-6-1/YeastPathways_PWY3O-6-1_SGD_YeastPathways_PWY3O-6-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_57945_RXN3O-9797_SGD_YeastPathways_PWY3O-6-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003885>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9798_BFO_0000050_YeastPathways_PWY3O-6-1/YeastPathways_PWY3O-6-1_SGD_YeastPathways_PWY3O-6-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002234_CHEBI_13392_RXN3O-9798_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002234_CHEBI_13392_RXN3O-9798_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -93,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -105,11 +50,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002233_CHEBI_57540_RXN3O-9797_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002233_CHEBI_57540_RXN3O-9797_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -119,17 +64,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57540_RXN3O-9797>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9798_BFO_0000066_reaction_RXN3O-9798_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -146,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -154,43 +88,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002233_CHEBI_17108_RXN3O-9798_SGD_YeastPathways_PWY3O-6-1>
+<http://purl.obolibrary.org/obo/CHEBI_17108>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9797_BFO_0000066_reaction_RXN3O-9797_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
+                "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_17108>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/BFO_0000051>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002413_1.1.3.37-RXN_SGD_YeastPathways_PWY3O-6-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_BFO_0000050_YeastPathways_PWY3O-6-1/YeastPathways_PWY3O-6-1_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
+                "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002233_CHEBI_15379_1.1.3.37-RXN_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002233_CHEBI_15379_1.1.3.37-RXN_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -206,34 +140,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002233_CHEBI_13390_RXN3O-9798_SGD_YeastPathways_PWY3O-6-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002234_CHEBI_16240_1.1.3.37-RXN_SGD_YeastPathways_PWY3O-6-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-9798>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -244,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -258,15 +170,26 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9797_BFO_0000050_YeastPathways_PWY3O-6-1/YeastPathways_PWY3O-6-1_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002233_CHEBI_17108_RXN3O-9798_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002233_CHEBI_17108_RXN3O-9798_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -277,26 +200,15 @@
           <http://model.geneontology.org/CHEBI_17108_RXN3O-9798>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002234_CHEBI_17803_1.1.3.37-RXN_SGD_YeastPathways_PWY3O-6-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002233_CHEBI_17108_RXN3O-9797_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002233_CHEBI_17108_RXN3O-9797_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -316,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -333,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,8 +256,41 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002233_CHEBI_16292_RXN3O-9797_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002233_CHEBI_17108_RXN3O-9798_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_57945_RXN3O-9797_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -354,11 +299,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_BFO_0000066_reaction_1.1.3.37-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_BFO_0000066_reaction_1.1.3.37-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -395,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -415,7 +360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -427,11 +372,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-arabinose + NAD(P)<sup>+</sup> &rarr; D-arabinono-1,4-lactone + NAD(P)H + H<SUP>+</SUP>' 'null' 'D-arabinono-1,4-lactone + oxygen &rarr; hydrogen peroxide + dehydro-D-arabinono-1,4-lactone' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002413_1.1.3.37-RXN_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002413_1.1.3.37-RXN_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -449,11 +394,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002333_MONOMER3O-32_RXN3O-9797_controller_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002333_MONOMER3O-32_RXN3O-9797_controller_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -464,19 +409,19 @@
           <http://model.geneontology.org/MONOMER3O-32_RXN3O-9797_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002233_CHEBI_17108_RXN3O-9797_SGD_YeastPathways_PWY3O-6-1>
+<http://identifiers.org/sgd/S000004644>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002234_CHEBI_15378_RXN3O-9798_SGD_PWY_YeastPathways_PWY3O-6-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
+                "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000004644>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -485,11 +430,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002233_CHEBI_13390_RXN3O-9798_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002233_CHEBI_13390_RXN3O-9798_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -500,15 +445,26 @@
           <http://model.geneontology.org/CHEBI_13390_RXN3O-9798>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_BFO_0000066_reaction_1.1.3.37-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9797_BFO_0000066_reaction_RXN3O-9797_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9797_BFO_0000066_reaction_RXN3O-9797_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -526,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -543,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -555,11 +511,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002333_YML086C-MONOMER_1.1.3.37-RXN_controller_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002333_YML086C-MONOMER_1.1.3.37-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -573,12 +529,23 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002234_CHEBI_16240_1.1.3.37-RXN_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000000353_CPLX3O-20_component>
         a       <http://identifiers.org/sgd/S000000353> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -591,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "dehydro-D-arabinono-1,4-lactone biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -618,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -628,6 +595,17 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_13392>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002413_1.1.3.37-RXN_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -639,11 +617,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_BFO_0000050_YeastPathways_PWY3O-6-1/YeastPathways_PWY3O-6-1_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_BFO_0000050_YeastPathways_PWY3O-6-1/YeastPathways_PWY3O-6-1_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -671,40 +649,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002234_CHEBI_15378_RXN3O-9798_SGD_YeastPathways_PWY3O-6-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_15378_RXN3O-9797_SGD_PWY_YeastPathways_PWY3O-6-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002413_1.1.3.37-RXN_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002234_CHEBI_16292_RXN3O-9798_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002233_CHEBI_57540_RXN3O-9797_SGD_YeastPathways_PWY3O-6-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002333_CPLX3O-20_RXN3O-9798_controller_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002333_CPLX3O-20_RXN3O-9798_controller_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -719,11 +708,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_57945_RXN3O-9797_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_57945_RXN3O-9797_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,6 +723,17 @@
           <http://model.geneontology.org/CHEBI_57945_RXN3O-9797>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002233_CHEBI_57540_RXN3O-9797_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0070485>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -741,11 +741,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9798_BFO_0000066_reaction_RXN3O-9798_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9798_BFO_0000066_reaction_RXN3O-9798_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,14 +756,14 @@
           <http://model.geneontology.org/reaction_RXN3O-9798_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002234_CHEBI_16292_RXN3O-9798_SGD_YeastPathways_PWY3O-6-1>
+<http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002233_CHEBI_15379_1.1.3.37-RXN_SGD_PWY_YeastPathways_PWY3O-6-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
+                "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -771,11 +771,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9797_BFO_0000050_YeastPathways_PWY3O-6-1/YeastPathways_PWY3O-6-1_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9797_BFO_0000050_YeastPathways_PWY3O-6-1/YeastPathways_PWY3O-6-1_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -793,11 +793,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002234_CHEBI_17803_1.1.3.37-RXN_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002234_CHEBI_17803_1.1.3.37-RXN_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -807,6 +807,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_17803_1.1.3.37-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_16292_RXN3O-9797_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -830,7 +841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -838,18 +849,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://purl.obolibrary.org/obo/GO_0047816>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://identifiers.org/sgd/S000000353>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0047816>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002233_CHEBI_17108_RXN3O-9797_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002333_MONOMER3O-32_RXN3O-9797_controller_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-20_RXN3O-9798_controller_BFO_0000051_SGD_S000000353_CPLX3O-20_component_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN3O-9798_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -863,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -874,26 +918,15 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9797_BFO_0000050_YeastPathways_PWY3O-6-1/YeastPathways_PWY3O-6-1_SGD_YeastPathways_PWY3O-6-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002234_CHEBI_16292_RXN3O-9798_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002234_CHEBI_16292_RXN3O-9798_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -908,11 +941,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_16292_RXN3O-9797_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_16292_RXN3O-9797_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -935,15 +968,37 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9798_BFO_0000066_reaction_RXN3O-9798_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002234_CHEBI_13392_RXN3O-9798_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9798_BFO_0000050_YeastPathways_PWY3O-6-1/YeastPathways_PWY3O-6-1_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9798_BFO_0000050_YeastPathways_PWY3O-6-1/YeastPathways_PWY3O-6-1_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -958,11 +1013,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-20_RXN3O-9798_controller_BFO_0000051_SGD_S000000353_CPLX3O-20_component_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-20_RXN3O-9798_controller_BFO_0000051_SGD_S000000353_CPLX3O-20_component_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -973,40 +1028,18 @@
           <http://model.geneontology.org/SGD_S000000353_CPLX3O-20_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_15378_RXN3O-9797_SGD_YeastPathways_PWY3O-6-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16240>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002233_CHEBI_16292_RXN3O-9797_SGD_YeastPathways_PWY3O-6-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002234_CHEBI_16240_1.1.3.37-RXN_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002234_CHEBI_16240_1.1.3.37-RXN_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1017,34 +1050,34 @@
           <http://model.geneontology.org/CHEBI_16240_1.1.3.37-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002333_YML086C-MONOMER_1.1.3.37-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_13390>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002233_CHEBI_15379_1.1.3.37-RXN_SGD_YeastPathways_PWY3O-6-1>
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9798_BFO_0000050_YeastPathways_PWY3O-6-1/YeastPathways_PWY3O-6-1_SGD_PWY_YeastPathways_PWY3O-6-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002413_1.1.3.37-RXN_SGD_YeastPathways_PWY3O-6-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
+                "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1060,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1077,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1094,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1102,39 +1135,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_BFO_0000066_reaction_1.1.3.37-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_16292_RXN3O-9797_SGD_YeastPathways_PWY3O-6-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-20_RXN3O-9798_controller_BFO_0000051_SGD_S000000353_CPLX3O-20_component_SGD_YeastPathways_PWY3O-6-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002333_CPLX3O-20_RXN3O-9798_controller_SGD_PWY_YeastPathways_PWY3O-6-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
+                "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1142,11 +1153,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002234_CHEBI_15378_RXN3O-9798_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002234_CHEBI_15378_RXN3O-9798_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1161,11 +1172,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_15378_RXN3O-9797_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_15378_RXN3O-9797_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1188,7 +1199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1205,7 +1216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1213,15 +1224,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002233_CHEBI_13390_RXN3O-9798_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-arabinose + NAD<sup>+</sup> &rarr; D-arabinono-1,4-lactone + NADH + H<SUP>+</SUP>' 'null' 'D-arabinono-1,4-lactone + oxygen &rarr; hydrogen peroxide + dehydro-D-arabinono-1,4-lactone' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002413_1.1.3.37-RXN_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002413_1.1.3.37-RXN_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1235,37 +1257,15 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002333_YML086C-MONOMER_1.1.3.37-RXN_controller_SGD_YeastPathways_PWY3O-6-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002333_CPLX3O-20_RXN3O-9798_controller_SGD_YeastPathways_PWY3O-6-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002233_CHEBI_16292_RXN3O-9797_SGD_YeastPathways_PWY3O-6-1> ;
+          <http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002233_CHEBI_16292_RXN3O-9797_SGD_PWY_YeastPathways_PWY3O-6-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1293,7 +1293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1301,13 +1301,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002333_MONOMER3O-32_RXN3O-9797_controller_SGD_YeastPathways_PWY3O-6-1>
+<http://model.geneontology.org/ev_w_id_1.1.3.37-RXN_RO_0002234_CHEBI_17803_1.1.3.37-RXN_SGD_PWY_YeastPathways_PWY3O-6-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6-1" ;
+                "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-6336.ttl
+++ b/models/YeastPathways_PWY3O-6336.ttl
@@ -1,23 +1,12 @@
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_Palmitoyl-ACPs_RXN3O-1803_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_57287_RXN-9624_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_57287_RXN-9624_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,14 +17,14 @@
           <http://model.geneontology.org/CHEBI_57287_RXN-9624>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002413_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -43,11 +32,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,11 +51,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" , "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O' 'null' 'a (2<i>E</i>)-but-2-enoyl-[acp] + NADPH + H<SUP>+</SUP> &rarr; a butanoyl-[acp] + NADP<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -86,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -94,37 +83,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_57783_RXN3O-5293_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" , "Provides Input For Rule. The relation 'acetyl-CoA + ATP + hydrogencarbonate &rarr; ADP + malonyl-CoA + phosphate + H<SUP>+</SUP>' 'null' 'acyl-carrier protein + malonyl-CoA &rarr; a malonyl-[acp] + coenzyme A' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002413_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002413_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -154,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -166,11 +133,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -181,52 +148,19 @@
           <http://model.geneontology.org/OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002233_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_25629_RXN-9624_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/Octadec-2-enoyl-ACPs_RXN-9634>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -237,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -245,14 +179,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -265,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -277,11 +211,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a stearoyl-[acp] + NADP<sup>+</sup> &larr; a (2<i>E</i>)-octadec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a stearoyl-[acp] + coenzyme A &rarr; stearoyl-CoA + acyl-carrier protein' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002413_RXN3O-5304_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002413_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -292,24 +226,15 @@
           <http://model.geneontology.org/RXN3O-5304>
 ] .
 
-<http://model.geneontology.org/reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_CHEBI_15377_RXN-9634_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_CHEBI_15377_RXN-9634_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -320,25 +245,67 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-9634>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002333_YKL182W-MONOMER_RXN3O-5293_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_RXN-9624_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000066_reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -346,11 +313,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_58349_RXN-9514_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_58349_RXN-9514_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,11 +335,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000066_reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000066_reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -383,14 +350,14 @@
           <http://model.geneontology.org/reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000066_reaction_RXN-9624_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -398,11 +365,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -422,7 +389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -430,49 +397,35 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_Butanoyl-ACPs_RXN-9515_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9780> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/Palmitoyl-ACPs_RXN3O-9780>
+] .
 
 <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004315> ;
@@ -493,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -501,34 +454,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN3O-9780_SGD_YeastPathways_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9780> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Palmitoyl-ACPs_RXN3O-9780>
-] .
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000066_reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YER061C-MONOMER_RXN3O-1803_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YER061C-MONOMER_RXN3O-1803_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -548,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -563,11 +519,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,6 +534,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_ACP_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller>
         a       <http://identifiers.org/sgd/S000006152> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -585,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -612,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -620,25 +587,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002333_YKL182W-MONOMER_RXN-9515_controller_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -646,11 +602,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,11 +621,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' 'null' 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -680,17 +636,6 @@
           <http://model.geneontology.org/RXN-9514>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_15378_RXN-9514_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57287_ACP-S-ACETYLTRANSFER-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57287> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -700,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -708,25 +653,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YER061C-MONOMER_RXN3O-1803_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YER061C-MONOMER_RXN3O-1803_controller_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_Palmitoyl-ACPs_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -749,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -761,11 +717,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -780,11 +736,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -798,45 +754,45 @@
 <http://identifiers.org/sgd/S000005747>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_ACP_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-9780_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_RXN-9514_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002413_RXN-9633_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -845,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -853,11 +809,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_58349_RXN-9633_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_58349_RXN-9633_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,11 +828,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -887,25 +843,14 @@
           <http://model.geneontology.org/reaction_4.2.1.58-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_ACP_RXN3O-5304_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -914,18 +859,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -933,11 +878,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -952,11 +897,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,6 +911,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_57783_RXN-9633_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -989,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1001,11 +957,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1020,11 +976,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_57783_RXN3O-5293_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_57783_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1035,6 +991,17 @@
           <http://model.geneontology.org/CHEBI_57783_RXN3O-5293>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_CHEBI_57394_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ACP_ENOYL-ACP-REDUCT-NADPH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1044,13 +1011,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336Protein68821> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_58349_RXN-9633_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_57783_RXN-9514_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_ACETYL-COA-CARBOXYLTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1061,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,7 +1067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1095,7 +1084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1103,25 +1092,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_CHEBI_57287_RXN3O-5304_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_Stearoyl-ACPs_RXN3O-5293_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1134,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1142,15 +1120,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1161,28 +1150,17 @@
           <http://model.geneontology.org/ACP_MALONYL-COA-ACP-TRANSACYL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57384>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002413_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_58349_RXN-9514_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1193,11 +1171,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002333_YKL182W-MONOMER_RXN3O-5304_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002333_YKL182W-MONOMER_RXN3O-5304_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1208,26 +1186,15 @@
           <http://model.geneontology.org/YKL182W-MONOMER_RXN3O-5304_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YPL231W-MONOMER_RXN3O-1803_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_CHEBI_15378_RXN3O-1803_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_CHEBI_15378_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1238,14 +1205,36 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-1803>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_57287_RXN-9624_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1253,11 +1242,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_Crotonyl-ACPs_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1277,7 +1266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1285,15 +1274,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002233_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_43474_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_43474_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1307,26 +1307,15 @@
 <http://identifiers.org/sgd/S000000863>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002411_RXN3O-9780_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002411_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1342,7 +1331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1350,11 +1339,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1374,35 +1363,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336SmallMolecule68388> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_ACP_RXN3O-1803_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1413,7 +1380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1421,26 +1388,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002233_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002233_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1451,50 +1407,28 @@
           <http://model.geneontology.org/OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002411_RXN3O-9780_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000001538>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_Octadec-2-enoyl-ACPs_RXN-9634_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_15378_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002413_RXN-9634_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1503,7 +1437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1511,11 +1445,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1526,6 +1460,28 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_456216_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1535,13 +1491,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336SmallMolecule68401> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1552,7 +1519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1564,11 +1531,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1589,7 +1556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1600,15 +1567,26 @@
 <http://identifiers.org/sgd/S000006152>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_Butanoyl-ACPs_RXN-9515_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1628,7 +1606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1640,11 +1618,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1658,14 +1636,14 @@
 <http://purl.obolibrary.org/obo/GO_0019367>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.58-RXN_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_CHEBI_15378_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1678,13 +1656,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of fatty acid biosynthesis, saturated - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000066_reaction_RXN-9634_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1693,11 +1682,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1725,7 +1714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1737,11 +1726,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_Octadec-2-enoyl-ACPs_RXN-9634_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_Octadec-2-enoyl-ACPs_RXN-9634_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1755,28 +1744,28 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_58349>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_58349_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_58349>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1784,11 +1773,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1798,6 +1787,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YPL231W-MONOMER_RXN-9514_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002413_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACETYL-COA-CARBOXYLTRANSFER-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003989> ;
@@ -1818,7 +1818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1833,11 +1833,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1848,75 +1848,31 @@
           <http://model.geneontology.org/CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002413_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002411_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_58349_RXN3O-5293_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000066_reaction_RXN3O-1803_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002413_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1924,11 +1880,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YPL231W-MONOMER_RXN3O-1803_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YPL231W-MONOMER_RXN3O-1803_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1939,26 +1895,15 @@
           <http://model.geneontology.org/YPL231W-MONOMER_RXN3O-1803_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-CARBOXYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-CARBOXYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1969,17 +1914,6 @@
           <http://model.geneontology.org/reaction_ACETYL-COA-CARBOXYLTRANSFER-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_CHEBI_16526_RXN3O-1803_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58349_RXN-9514>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1989,13 +1923,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336SmallMolecule68421> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2006,7 +1951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2016,32 +1961,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000066_reaction_RXN-9624_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9624> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9624_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2052,12 +1978,53 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000066_reaction_RXN-9624_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9624> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN-9624_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002413_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2071,7 +2038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2079,37 +2046,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_ACP_RXN-9514_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2124,11 +2069,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2139,19 +2084,41 @@
           <http://model.geneontology.org/CHEBI_57379_RXN3O-9780>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_57783_RXN-9514_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_57783_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -2160,11 +2127,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2179,11 +2146,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_RXN-9514_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_RXN-9514_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2194,30 +2161,30 @@
           <http://model.geneontology.org/ACP_RXN-9514>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000004820_CPLX3O-102_component_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2226,11 +2193,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000066_reaction_RXN-9514_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000066_reaction_RXN-9514_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2245,11 +2212,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2260,6 +2227,28 @@
           <http://model.geneontology.org/B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_RXN-9514>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2269,35 +2258,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336SmallMolecule68401> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002333_YKL182W-MONOMER_RXN-9634_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57288>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2311,7 +2278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2319,15 +2286,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002333_YKL182W-MONOMER_ACP-S-ACETYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002333_YKL182W-MONOMER_ACP-S-ACETYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2338,15 +2316,26 @@
           <http://model.geneontology.org/YKL182W-MONOMER_ACP-S-ACETYLTRANSFER-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000066_reaction_RXN3O-5293_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_Octadec-2-enoyl-ACPs_RXN-9634_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_Octadec-2-enoyl-ACPs_RXN-9634_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2361,11 +2350,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxyoctadecanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxooctadecanoyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (3<i>R</i>)-3-hydroxyoctadecanoyl-[acp] &rarr; a (2<i>E</i>)-octadec-2-enoyl-[acp] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002413_RXN-9634_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002413_RXN-9634_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2376,36 +2365,36 @@
           <http://model.geneontology.org/RXN-9634>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_43474_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002411_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2413,11 +2402,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2428,25 +2417,25 @@
           <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN3O-9780_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000066_reaction_RXN-9514_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000066_reaction_RXN3O-5304_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2454,11 +2443,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'acyl-carrier protein + acetyl-CoA &rarr; an acetyl-[acp] + coenzyme A' 'null' 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2469,37 +2458,15 @@
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000066_reaction_RXN-9633_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2510,17 +2477,6 @@
           <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000863> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2528,24 +2484,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336Protein68664> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000066_reaction_RXN3O-5304_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YPL231W-MONOMER_RXN-9514_controller>
         a       <http://identifiers.org/sgd/S000006152> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2554,7 +2499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2566,11 +2511,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" , "Provides Input For Rule. The relation 'a stearoyl-[acp] + coenzyme A &rarr; stearoyl-CoA + acyl-carrier protein' 'null' 'stearoyl-CoA + H<sub>2</sub>O &rarr; stearate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_RXN-9624_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_RXN-9624_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2585,11 +2530,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_Palmitoyl-ACPs_RXN3O-1803_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_Palmitoyl-ACPs_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2605,7 +2550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2618,7 +2563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2630,11 +2575,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_Butanoyl-ACPs_RXN-9515_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_Butanoyl-ACPs_RXN-9515_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2652,7 +2597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2664,11 +2609,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_456216_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_456216_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2679,62 +2624,40 @@
           <http://model.geneontology.org/CHEBI_456216_ACETYL-COA-CARBOXYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002413_RXN-9634_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000066_reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_57783_RXN-9633_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2745,37 +2668,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002333_YKL182W-MONOMER_ACP-S-ACETYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2786,6 +2687,28 @@
           <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16526_RXN3O-1803>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2795,7 +2718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2803,15 +2726,59 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002333_YKL182W-MONOMER_RXN3O-5304_controller_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000066_reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2831,7 +2798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2839,36 +2806,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002413_RXN-9633_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2876,11 +2821,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000066_reaction_RXN-9633_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000066_reaction_RXN-9633_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2891,58 +2836,25 @@
           <http://model.geneontology.org/reaction_RXN-9633_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2950,11 +2862,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2965,58 +2877,14 @@
           <http://model.geneontology.org/CHEBI_57379_RXN3O-9780>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_CHEBI_58349_RXN-9515_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_17544_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3024,11 +2892,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3039,15 +2907,26 @@
           <http://model.geneontology.org/reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3061,74 +2940,22 @@
 <http://purl.obolibrary.org/obo/CHEBI_57379>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-CARBOXYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004314>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002333_YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000066_reaction_RXN3O-5304_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-5304> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-5304_location_lociGO_0005829>
-] .
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/RXN-9634>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3149,7 +2976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3159,13 +2986,32 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002333_YKL182W-MONOMER_RXN-9634_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000066_reaction_RXN3O-5304_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-5304> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-5304_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002333_YKL182W-MONOMER_RXN-9634_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3179,15 +3025,56 @@
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002333_YKL182W-MONOMER_RXN-9634_controller_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002413_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9514> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/4.2.1.58-RXN>
+] .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxyacyl-[acyl-carrier protein] + NADP<sup>+</sup> &larr; a 3-oxoacyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (3<i>R</i>)-3-hydroxyacyl-[acyl-carrier protein] &rarr; a <i>trans</i>-2-enoyl-[acyl-carrier protein] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002413_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002413_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3200,54 +3087,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] + NADP<sup>+</sup> &larr; an acetoacetyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (<i>3R</i>)-3-hydroxybutanoyl-[acp] &rarr; a (2<i>E</i>)-but-2-enoyl-[acp] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002413_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9514> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4.2.1.58-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_Stearoyl-ACPs_RXN3O-5293_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_15378_RXN3O-5293_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3262,11 +3108,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_CHEBI_57287_RXN3O-5304_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_CHEBI_57287_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3286,7 +3132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3301,7 +3147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3318,7 +3164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3335,7 +3181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3361,7 +3207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3369,14 +3215,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002413_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000066_reaction_4.2.1.58-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3384,11 +3230,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" , "Provides Input For Rule. The relation 'a palmitoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxooctadecanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein' 'null' 'a (3<i>R</i>)-3-hydroxyoctadecanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxooctadecanoyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002413_RXN-9633_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002413_RXN-9633_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3399,12 +3245,23 @@
           <http://model.geneontology.org/RXN-9633>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3412,11 +3269,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_17544_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_17544_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3436,7 +3293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3444,26 +3301,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_Octadec-2-enoyl-ACPs_RXN-9634_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_15377_RXN-9624_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_15377_RXN-9624_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3483,7 +3329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3491,26 +3337,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000004820_CPLX3O-102_component_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3521,17 +3356,6 @@
           <http://model.geneontology.org/reaction_3-OXOACYL-ACP-SYNTH-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YKL182W-MONOMER_RXN3O-5293_controller>
         a       <http://identifiers.org/sgd/S000001665> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3539,7 +3363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3551,11 +3375,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3570,11 +3394,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3585,41 +3409,19 @@
           <http://model.geneontology.org/YKL182W-MONOMER_RXN3O-9780_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000066_reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_CHEBI_57394_RXN3O-5304_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_Crotonyl-ACPs_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57783_RXN-9514>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3630,24 +3432,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336SmallMolecule68388> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_15378_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/Butanoyl-ACPs_RXN-9515>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -3658,7 +3449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3666,39 +3457,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17544>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3706,11 +3486,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3721,14 +3501,14 @@
           <http://model.geneontology.org/CHEBI_15377_4.2.1.58-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000066_reaction_RXN-9634_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3736,11 +3516,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3751,17 +3531,6 @@
           <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000066_reaction_RXN-9515_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_17544_ACETYL-COA-CARBOXYLTRANSFER-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17544> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3771,13 +3540,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336SmallMolecule68480> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-9515>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -3788,7 +3568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3796,26 +3576,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_58349_RXN3O-5293_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_58349_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3826,26 +3595,15 @@
           <http://model.geneontology.org/CHEBI_58349_RXN3O-5293>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_ACP_RXN3O-1803_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3856,6 +3614,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57384> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3865,7 +3634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3877,11 +3646,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_15378_RXN-9514_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_15378_RXN-9514_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3911,13 +3680,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336BiochemicalReaction68577> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000066_reaction_RXN3O-1803_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57394_RXN3O-5304>
         a       <http://purl.obolibrary.org/obo/CHEBI_57394> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3928,7 +3708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3945,7 +3725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3957,11 +3737,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000004820_CPLX3O-102_component_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000004820_CPLX3O-102_component_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3976,11 +3756,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3991,17 +3771,6 @@
           <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4011,7 +3780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4019,40 +3788,62 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_CHEBI_58349_RXN-9514_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004321>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_17544_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002413_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_15378_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4067,11 +3858,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_ACP_RXN3O-1803_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_ACP_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4082,14 +3873,14 @@
           <http://model.geneontology.org/ACP_RXN3O-1803>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4098,7 +3889,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_ACP_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_CHEBI_15377_RXN-9634_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4106,11 +3919,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_CHEBI_58349_RXN-9515_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_CHEBI_58349_RXN-9515_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4121,14 +3934,14 @@
           <http://model.geneontology.org/CHEBI_58349_RXN-9515>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002333_YKL182W-MONOMER_RXN3O-5304_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4137,7 +3950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4145,11 +3958,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4164,11 +3977,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000066_reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000066_reaction_MALONYL-COA-ACP-TRANSACYL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4188,7 +4001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4200,11 +4013,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4218,6 +4031,17 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002333_YKL182W-MONOMER_ACP-S-ACETYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -4228,7 +4052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4240,11 +4064,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4255,17 +4079,6 @@
           <http://model.geneontology.org/TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57287> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4275,7 +4088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4283,26 +4096,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_15377_RXN-9624_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_15378_RXN-9633_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_15378_RXN-9633_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4313,25 +4115,14 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-9633>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_CHEBI_15378_RXN3O-1803_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002234_CHEBI_15377_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4339,11 +4130,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4359,7 +4150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4367,11 +4158,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4382,17 +4173,6 @@
           <http://model.geneontology.org/ACP_ACP-S-ACETYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002234_CHEBI_58349_RXN-9633_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ACP_MALONYL-COA-ACP-TRANSACYL-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4402,7 +4182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4413,17 +4193,6 @@
 <http://purl.obolibrary.org/obo/GO_0004315>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/Crotonyl-ACPs_4.2.1.58-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4433,7 +4202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4450,7 +4219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4462,11 +4231,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxyoctadecanoyl-[acp] &rarr; a (2<i>E</i>)-octadec-2-enoyl-[acp] + H<sub>2</sub>O' 'null' 'a stearoyl-[acp] + NADP<sup>+</sup> &larr; a (2<i>E</i>)-octadec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002413_RXN3O-5293_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002413_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4487,7 +4256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4495,15 +4264,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.58-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000066_reaction_RXN-9633_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4518,11 +4309,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4540,7 +4331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4548,15 +4339,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YPL231W-MONOMER_RXN3O-1803_controller_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4571,11 +4384,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_Stearoyl-ACPs_RXN3O-5293_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_Stearoyl-ACPs_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4586,25 +4399,14 @@
           <http://model.geneontology.org/Stearoyl-ACPs_RXN3O-5293>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002333_YKL182W-MONOMER_RXN3O-5293_controller_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4617,7 +4419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4644,7 +4446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4657,7 +4459,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002411_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4665,11 +4478,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4684,11 +4497,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4699,14 +4512,14 @@
           <http://model.geneontology.org/CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4714,11 +4527,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_57394_RXN3O-5304_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_57394_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4733,11 +4546,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4748,17 +4561,6 @@
           <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YER061C-MONOMER_RXN3O-1803_controller>
         a       <http://identifiers.org/sgd/S000000863> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4766,7 +4568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4778,11 +4580,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4797,11 +4599,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a palmitoyl-[acp] + coenzyme A &rarr; palmitoyl-CoA + acyl-carrier protein' 'null' 'palmitoyl-CoA + H<sub>2</sub>O &rarr; palmitate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4812,6 +4614,28 @@
           <http://model.geneontology.org/PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_Stearoyl-ACPs_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_RXN-9514_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57783_RXN-9515>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4821,7 +4645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4829,15 +4653,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_57287_RXN-9624_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_15378_RXN-9624_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_15378_RXN-9624_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4848,6 +4683,17 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-9624>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_15377_RXN-9624_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57379_RXN3O-9780>
         a       <http://purl.obolibrary.org/obo/CHEBI_57379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4857,7 +4703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4870,7 +4716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4881,11 +4727,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" , "Provides Input For Rule. The relation 'acyl-carrier protein + malonyl-CoA &rarr; a malonyl-[acp] + coenzyme A' 'null' 'an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4900,11 +4746,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4924,7 +4770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4941,7 +4787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4953,11 +4799,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4972,11 +4818,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4996,13 +4842,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336SmallMolecule68655> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000066_reaction_RXN-9515_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_7896> ;
@@ -5013,7 +4870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5030,7 +4887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5038,14 +4895,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000066_reaction_RXN3O-5293_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_Octadec-2-enoyl-ACPs_RXN-9634_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5053,11 +4910,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_Stearoyl-ACPs_RXN3O-5293_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_Stearoyl-ACPs_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5072,11 +4929,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000066_reaction_RXN-9634_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000066_reaction_RXN-9634_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5090,14 +4947,58 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5113,7 +5014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5125,11 +5026,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_57783_RXN-9514_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_57783_RXN-9514_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5159,7 +5060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5167,18 +5068,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5189,26 +5123,15 @@
           <http://model.geneontology.org/SGD_S000005299_CPLX3O-8_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002413_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5224,7 +5147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5232,11 +5155,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5251,11 +5174,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_CHEBI_16526_RXN3O-1803_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_CHEBI_16526_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5269,14 +5192,14 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002333_YKL182W-MONOMER_RXN-9515_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_Stearoyl-ACPs_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5287,7 +5210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5299,11 +5222,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002333_YKL182W-MONOMER_RXN-9515_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002333_YKL182W-MONOMER_RXN-9515_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5323,7 +5246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5335,11 +5258,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5354,11 +5277,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5369,26 +5292,15 @@
           <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002333_YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002333_YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5411,7 +5323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5419,25 +5331,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002233_CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-CARBOXYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5445,11 +5346,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a 2,3,4-saturated fatty acyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; acyl-carrier protein + a 3-oxoacyl-[acp] + CO<SUB>2</SUB>' 'null' 'a (3<i>R</i>)-3-hydroxyacyl-[acyl-carrier protein] + NADP<sup>+</sup> &larr; a 3-oxoacyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002413_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002413_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5475,7 +5376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5487,11 +5388,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_57783_RXN-9633_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_57783_RXN-9633_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5511,7 +5412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5519,15 +5420,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_25629_RXN-9624_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5538,15 +5461,26 @@
           <http://model.geneontology.org/CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxyacyl-[acyl-carrier protein] &rarr; a <i>trans</i>-2-enoyl-[acyl-carrier protein] + H<sub>2</sub>O' 'null' 'a 2,3,4-saturated fatty acyl-[acp] + NADP<sup>+</sup> &larr; a <i>trans</i>-2-enoyl-[acyl-carrier protein] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002413_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002413_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5557,36 +5491,14 @@
           <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9634_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002333_YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5595,7 +5507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5603,11 +5515,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000066_reaction_RXN3O-5293_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000066_reaction_RXN3O-5293_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5618,15 +5530,24 @@
           <http://model.geneontology.org/reaction_RXN3O-5293_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5637,34 +5558,36 @@
           <http://model.geneontology.org/CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_15378_RXN-9624_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002413_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5676,18 +5599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002413_RXN3O-5304_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5695,11 +5607,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5710,23 +5622,12 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-1803_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5734,11 +5635,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000066_reaction_RXN-9515_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000066_reaction_RXN-9515_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5753,11 +5654,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5768,6 +5669,17 @@
           <http://model.geneontology.org/reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-102_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -5777,7 +5689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5804,7 +5716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5816,41 +5728,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_ACP_RXN3O-5304_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-5304> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_RXN3O-5304>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_15378_RXN-9624_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5861,27 +5743,24 @@
           <http://model.geneontology.org/ACP_ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002413_RXN3O-5293_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_43474_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_ACP_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-5304> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ACP_RXN3O-5304>
+] .
 
 <http://model.geneontology.org/Stearoyl-ACPs_RXN3O-5293>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5892,7 +5771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5900,25 +5779,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_57394_RXN3O-5304_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9514_BFO_0000066_reaction_RXN-9514_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5926,11 +5816,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5950,7 +5840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5965,13 +5855,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336Protein68432> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_CHEBI_16526_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -5980,11 +5881,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5995,18 +5896,51 @@
           <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57394>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_15378_RXN-9633_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6017,14 +5951,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002413_RXN-9624_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6037,13 +5971,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336Protein68595> , <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336Protein68635> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -6052,11 +5997,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_25629_RXN-9624_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_25629_RXN-9624_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6076,24 +6021,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336Protein68737> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_456216_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004314> ;
@@ -6114,7 +6048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6141,7 +6075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6168,7 +6102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6181,29 +6115,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_ACP_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9633_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002233_CHEBI_15378_RXN-9514_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6216,7 +6139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6224,15 +6147,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_Octadec-2-enoyl-ACPs_RXN-9634_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YKL055C-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002413_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6243,15 +6199,37 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002413_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.58-RXN_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.58-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6262,25 +6240,14 @@
           <http://model.geneontology.org/YKL182W-MONOMER_4.2.1.58-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6296,7 +6263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6304,15 +6271,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_ACP_RXN-9514_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002333_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6330,11 +6308,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6354,7 +6332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6366,11 +6344,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002333_YKL182W-MONOMER_RXN3O-5293_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002333_YKL182W-MONOMER_RXN3O-5293_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6385,11 +6363,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6409,7 +6387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6417,14 +6395,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002333_YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6435,11 +6413,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_ACP_RXN-9514_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002234_ACP_RXN-9514_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6450,14 +6428,36 @@
           <http://model.geneontology.org/ACP_RXN-9514>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_B-KETOACYL-ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_CHEBI_15378_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6465,11 +6465,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6480,26 +6480,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002333_YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6510,36 +6499,14 @@
           <http://model.geneontology.org/YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_RXN-9515_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002234_CHEBI_15377_RXN-9634_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6547,11 +6514,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6566,11 +6533,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002234_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6590,7 +6557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6607,7 +6574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6622,7 +6589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6634,11 +6601,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002411_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002411_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6649,28 +6616,28 @@
           <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_CHEBI_15378_RXN-9633_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005299>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6678,11 +6645,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002233_CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6696,28 +6663,6 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_BFO_0000066_reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-REDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6727,7 +6672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6739,11 +6684,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9633_RO_0002233_3-oxo-stearoyl-ACPs_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6754,26 +6699,15 @@
           <http://model.geneontology.org/3-oxo-stearoyl-ACPs_RXN3O-1803>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000066_reaction_3-OXOACYL-ACP-REDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6791,7 +6725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6799,17 +6733,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/CHEBI_43474>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9634_RO_0002233_R-3-hydroxystearoyl-ACPs_RXN-9633_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_43474>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6817,11 +6762,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6836,11 +6781,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6855,11 +6800,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6874,11 +6819,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_15378_RXN3O-5293_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002233_CHEBI_15378_RXN3O-5293_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6889,26 +6834,15 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-5293>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000066_reaction_RXN3O-1803_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_BFO_0000066_reaction_RXN3O-1803_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6919,14 +6853,14 @@
           <http://model.geneontology.org/reaction_RXN3O-1803_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336>
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002234_CHEBI_57287_MALONYL-COA-ACP-TRANSACYL-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6937,7 +6871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6945,43 +6879,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_ACP-S-ACETYLTRANSFER-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_YeastPathways_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9515> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-9515>
-] .
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YKL182W-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/OH-ACYL-ACP_3-OXOACYL-ACP-REDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -6992,7 +6899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7000,37 +6907,67 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/CHEBI_7896>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_ACP_RXN3O-1803_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_15378_RXN-9515_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-1803> ;
+          <http://model.geneontology.org/RXN-9515> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ACP_RXN3O-1803>
+          <http://model.geneontology.org/CHEBI_15378_RXN-9515>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002233_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ACP_ACP-S-ACETYLTRANSFER-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_7896>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_CHEBI_57287_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7045,11 +6982,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_CHEBI_57394_RXN3O-5304_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_CHEBI_57394_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7060,16 +6997,24 @@
           <http://model.geneontology.org/CHEBI_57394_RXN3O-5304>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_TRANS-D2-ENOYL-ACP_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_ACP_RXN3O-1803_SGD_PWY_YeastPathways_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-1803> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ACP_RXN3O-1803>
+] .
 
 <http://model.geneontology.org/YKL182W-MONOMER_RXN-9634_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001665> ;
@@ -7078,24 +7023,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336Protein68432> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_RO_0002333_YKL182W-MONOMER_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_controller_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58349_RXN-9633>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7106,7 +7040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7121,7 +7055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7129,15 +7063,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_Crotonyl-ACPs_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002233_CHEBI_57783_RXN-9515_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7147,20 +7095,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57783_RXN-9515>
 ] .
-
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ENOYL-ACP-REDUCT-NADPH-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7181,7 +7115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7193,11 +7127,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_15378_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002234_CHEBI_15378_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7208,6 +7142,39 @@
           <http://model.geneontology.org/CHEBI_15378_ACETYL-COA-CARBOXYLTRANSFER-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000066_reaction_RXN-9624_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58349_3-OXOACYL-ACP-REDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7217,7 +7184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7225,12 +7192,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-9633_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7238,11 +7216,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002333_YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002333_YKL182W-MONOMER_ENOYL-ACP-REDUCT-NADPH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7257,11 +7235,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002234_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7281,7 +7259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7289,14 +7267,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9515_RO_0002234_CHEBI_58349_RXN-9515_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7304,11 +7293,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000066_reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6336> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_BFO_0000066_reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7319,14 +7308,14 @@
           <http://model.geneontology.org/reaction_3-HYDROXYDECANOYL-ACP-DEHYDR-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5293_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002233_CHEBI_57394_RXN3O-5304_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
+                "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7339,7 +7328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7354,13 +7343,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336Protein68432> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002333_YOR221C-MONOMER_MALONYL-COA-ACP-TRANSACYL-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-9780>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7381,7 +7381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7398,7 +7398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-64.ttl
+++ b/models/YeastPathways_PWY3O-64.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002233_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002233_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,37 +17,15 @@
           <http://model.geneontology.org/CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_15378_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR208W-MONOMER_R15-RXN_controller_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR208W-MONOMER_R15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,15 +36,26 @@
           <http://model.geneontology.org/YHR208W-MONOMER_R15-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_15379_R147-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_58828_R145-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_58828_R145-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,6 +66,17 @@
           <http://model.geneontology.org/CHEBI_58828_R145-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000066_reaction_3.1.3.77-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YHR137W-MONOMER_R15-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001179> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -98,38 +98,38 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_15377_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0010309>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002333_MONOMER3O-186_R147-RXN_controller_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_58795_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_58795_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,14 +140,14 @@
           <http://model.geneontology.org/CHEBI_58795_3.1.3.77-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_35910_R15-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -155,11 +155,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15378_R147-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15378_R147-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -173,30 +173,19 @@
 <http://purl.obolibrary.org/obo/CHEBI_57844>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_16723_R147-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_58795_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15740>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_57844_R15-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -213,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -225,11 +214,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -244,11 +233,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_83813_R15-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_83813_R15-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -269,11 +258,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -284,14 +273,25 @@
           <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_16708_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-64>
+<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-64>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR137W-MONOMER_R15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -307,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -315,14 +315,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002333_MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller_SGD_YeastPathways_PWY3O-64>
+<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000066_reaction_5.3.1.23-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-64>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002333_MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -333,11 +344,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" , "Provides Input For Rule. The relation '<i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate &rarr; 5-(methylsulfanyl)-ribulose 1-phosphate' 'null' '5-(methylsulfanyl)-ribulose 1-phosphate &rarr; 5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002413_R145-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002413_R145-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -348,15 +359,26 @@
           <http://model.geneontology.org/R145-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002233_CHEBI_58548_5.3.1.23-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000066_reaction_3.1.3.77-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000066_reaction_3.1.3.77-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -367,14 +389,14 @@
           <http://model.geneontology.org/reaction_3.1.3.77-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_43474_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-64>
+<http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_PWY_YeastPathways_PWY3O-64>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -397,13 +419,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-64BiochemicalReaction50775> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_58828_R145-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_R147-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -414,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -422,14 +455,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_R15-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58548>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_43474_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -440,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,28 +495,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_58548>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_CPLX-9432_R15-RXN_controller_SGD_YeastPathways_PWY3O-64>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_16708_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002413_R145-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -477,11 +510,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -499,11 +532,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002333_MONOMER3O-186_R147-RXN_controller_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002333_MONOMER3O-186_R147-RXN_controller_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,21 +555,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_83813_R15-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0046570>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002413_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_15378_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -544,11 +588,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -563,11 +607,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_CPLX-9432_R15-RXN_controller_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_CPLX-9432_R15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -585,11 +629,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002233_CHEBI_58548_5.3.1.23-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002233_CHEBI_58548_5.3.1.23-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -609,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -620,47 +664,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_16723>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_15379_R147-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000066_reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-64>
+<http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000066_reaction_R147-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-64>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR208W-MONOMER_R15-RXN_controller_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YJR148W-MONOMER_R15-RXN_controller_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -671,11 +682,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_15378_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_15378_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -686,26 +697,15 @@
           <http://model.geneontology.org/CHEBI_15378_3.1.3.77-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000066_reaction_5.3.1.23-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_15379_R147-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_15379_R147-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -716,17 +716,6 @@
           <http://model.geneontology.org/CHEBI_15379_R147-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002234_CHEBI_58548_5.3.1.23-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/MONOMER3O-186_R147-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004611> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -734,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -744,6 +733,17 @@
 
 <http://identifiers.org/sgd/S000004007>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002413_5.3.1.23-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0046523>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -755,11 +755,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_43474_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_43474_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -779,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -791,11 +791,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000066_reaction_R15-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000066_reaction_R15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -823,19 +823,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002233_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/GO_0017061>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_15377_R145-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0017061>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15740_R147-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -849,24 +860,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-64SmallMolecule50710> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002413_R147-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-64>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -877,7 +877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "methionine salvage pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -889,11 +889,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002234_CHEBI_58548_5.3.1.23-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002234_CHEBI_58548_5.3.1.23-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -904,17 +904,6 @@
           <http://model.geneontology.org/CHEBI_58548_5.3.1.23-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002233_CHEBI_58548_5.3.1.23-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YJR148W-MONOMER_R15-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003909> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -922,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -934,11 +923,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YJR148W-MONOMER_R15-RXN_controller_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YJR148W-MONOMER_R15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -949,15 +938,37 @@
           <http://model.geneontology.org/YJR148W-MONOMER_R15-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YJR148W-MONOMER_R15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002413_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002333_MONOMER3O-169_R145-RXN_controller_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002333_MONOMER3O-169_R145-RXN_controller_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -975,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -983,40 +994,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002413_5.3.1.23-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_58795_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000066_reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002333_MONOMER3O-169_R145-RXN_controller_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_58795_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002333_MONOMER3O-175_3.1.3.77-RXN_controller_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002333_MONOMER3O-175_3.1.3.77-RXN_controller_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1027,6 +1049,17 @@
           <http://model.geneontology.org/MONOMER3O-175_3.1.3.77-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_43474_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0052656>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1034,11 +1067,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15740_R147-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15740_R147-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1048,6 +1081,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15740_R147-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002413_R147-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1066,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1082,7 +1126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1094,11 +1138,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002333_MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002333_MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1109,26 +1153,15 @@
           <http://model.geneontology.org/MONOMER3O-157_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR137W-MONOMER_R15-RXN_controller_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_35910_R15-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_35910_R15-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1143,11 +1176,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1158,17 +1191,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-64/YeastPathways_PWY3O-64>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002333_CPLX3O-113_5.3.1.23-RXN_controller_SGD_YeastPathways_PWY3O-64>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15379_R147-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1178,7 +1200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1195,7 +1217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1203,26 +1225,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_58828_R145-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_15377_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_15377_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1243,11 +1254,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1258,19 +1269,19 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-64/YeastPathways_PWY3O-64>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_15377_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-64>
+<http://purl.obolibrary.org/obo/CHEBI_17509>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002233_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-64>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_17509>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000000764>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1292,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1303,25 +1314,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_16708>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000066_reaction_3.1.3.77-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_17509_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1334,7 +1334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1342,15 +1342,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15378_R147-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000066_reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000066_reaction_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1365,11 +1376,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + oxygen &rarr; 4-(methylsulfanyl)-2-oxobutanoate + formate + H<SUP>+</SUP>' 'null' 'L-methionine + a 2-oxo carboxylate &larr; 4-(methylsulfanyl)-2-oxobutanoate + a proteinogenic amino acid' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002413_R15-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002413_R15-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1379,6 +1390,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/R15-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000066_reaction_R145-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/3.1.3.77-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0043874> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1399,13 +1421,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-64BiochemicalReaction50810> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002413_R145-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_83813_R15-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_83813> ;
@@ -1416,13 +1449,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-64SmallMolecule50924> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CPLX-9432_R15-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003909>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1432,18 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX-9432_R15-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_PWY3O-64>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1451,11 +1484,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000066_reaction_5.3.1.23-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000066_reaction_5.3.1.23-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1473,11 +1506,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR137W-MONOMER_R15-RXN_controller_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR137W-MONOMER_R15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1497,7 +1530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1505,26 +1538,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_YeastPathways_PWY3O-64>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_15377_R145-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_15377_R145-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1538,45 +1560,45 @@
 <http://purl.obolibrary.org/obo/CHEBI_83813>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000066_reaction_R147-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000003170>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_16723_R147-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_43474_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-64>
+<http://identifiers.org/sgd/S000003170>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_16723_R147-RXN_SGD_PWY_YeastPathways_PWY3O-64>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_16723_R147-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1584,11 +1606,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_43474_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_43474_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1603,11 +1625,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_58795_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_58795_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1627,7 +1649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1635,14 +1657,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002333_MONOMER3O-175_3.1.3.77-RXN_controller_SGD_YeastPathways_PWY3O-64>
+<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002333_MONOMER3O-175_3.1.3.77-RXN_controller_SGD_PWY_YeastPathways_PWY3O-64>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1653,11 +1675,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_16708_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_16708_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1672,11 +1694,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_16723_R147-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_16723_R147-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1694,11 +1716,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX-9432_R15-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-9432_R15-RXN_controller_BFO_0000051_SGD_S000003170_CPLX-9432_component_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1716,13 +1738,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-64Protein50840> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002234_CHEBI_58548_5.3.1.23-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002413_R15-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58533> ;
@@ -1733,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1744,17 +1788,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_15377_R145-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16708_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16708> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1764,13 +1797,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-64SmallMolecule50726> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002333_CPLX3O-113_5.3.1.23-RXN_controller_SGD_PWY_YeastPathways_PWY3O-64> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/5.3.1.23-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-113_5.3.1.23-RXN_controller>
+] .
 
 <http://model.geneontology.org/CPLX3O-113_5.3.1.23-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -1781,7 +1833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1793,41 +1845,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002333_CPLX3O-113_5.3.1.23-RXN_controller_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5.3.1.23-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-113_5.3.1.23-RXN_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002233_CHEBI_58795_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_YeastPathways_PWY3O-64> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1838,15 +1860,26 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-64/YeastPathways_PWY3O-64>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002234_CHEBI_43474_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '5-(methylsulfanyl)-ribulose 1-phosphate &rarr; 5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O' 'null' '5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O &rarr; 1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002413_3.1.3.77-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002413_3.1.3.77-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1857,26 +1890,26 @@
           <http://model.geneontology.org/3.1.3.77-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_YeastPathways_PWY3O-64>
+<http://identifiers.org/sgd/S000001179>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000066_reaction_R15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-64>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000001179>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_3.1.3.77-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1889,7 +1922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1901,11 +1934,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" , "Provides Input For Rule. The relation '5-(methylsulfanyl)-2,3-dioxopentyl 1-phosphate + H<sub>2</sub>O &rarr; 1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + phosphate + H<SUP>+</SUP>' 'null' '1,2-dihydroxy-5-(methylsulfanyl)pent-1-en-3-one + oxygen &rarr; 4-(methylsulfanyl)-2-oxobutanoate + formate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002413_R147-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002413_R147-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1920,11 +1953,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_16723_R147-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_16723_R147-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1938,17 +1971,6 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_83813_R15-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1961,39 +1983,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002333_MONOMER3O-169_R145-RXN_controller_SGD_YeastPathways_PWY3O-64>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000066_reaction_R15-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-64>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58828_R145-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58828> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2003,7 +1992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2011,14 +2000,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15740_R147-RXN_SGD_YeastPathways_PWY3O-64>
+<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_PWY_YeastPathways_PWY3O-64>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2026,11 +2015,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>S</i>-methyl-5'-thioadenosine + phosphate &rarr; adenine + <i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate' 'null' '<i>S</i>-methyl-5-thio-&alpha;-D-ribose 1-phosphate &rarr; 5-(methylsulfanyl)-ribulose 1-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002413_5.3.1.23-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002413_5.3.1.23-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2041,15 +2030,26 @@
           <http://model.geneontology.org/5.3.1.23-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_35910_R15-RXN_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_57844_R15-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_57844_R15-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2067,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2079,11 +2079,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000066_reaction_R145-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000066_reaction_R145-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2099,29 +2099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_58828_R145-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2144,7 +2122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2152,14 +2130,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000066_reaction_R145-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-64>
+<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_YHR208W-MONOMER_R15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002333_MONOMER3O-186_R147-RXN_controller_SGD_PWY_YeastPathways_PWY3O-64>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2167,11 +2167,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_58828_R145-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_RO_0002233_CHEBI_58828_R145-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2187,7 +2187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2195,11 +2195,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000066_reaction_R147-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R147-RXN_BFO_0000066_reaction_R147-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2210,36 +2210,36 @@
           <http://model.geneontology.org/reaction_R147-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002234_CHEBI_15378_R147-RXN_SGD_YeastPathways_PWY3O-64>
+<http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002333_CPLX3O-113_5.3.1.23-RXN_controller_SGD_PWY_YeastPathways_PWY3O-64>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_17509_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-64>
+<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_57844_R15-RXN_SGD_PWY_YeastPathways_PWY3O-64>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3.1.3.77-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_YeastPathways_PWY3O-64>
+<http://model.geneontology.org/ev_w_id_R145-RXN_RO_0002234_CHEBI_58828_R145-RXN_SGD_PWY_YeastPathways_PWY3O-64>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2250,7 +2250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2277,7 +2277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2289,11 +2289,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_17509_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002233_CHEBI_17509_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2311,11 +2311,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_R15-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2335,7 +2335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2343,30 +2343,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_YeastPathways_PWY3O-64>
+<http://purl.obolibrary.org/obo/CHEBI_35910>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002333_CPLX-9432_R15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_R145-RXN_BFO_0000050_YeastPathways_PWY3O-64/YeastPathways_PWY3O-64_SGD_PWY_YeastPathways_PWY3O-64>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
+                "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_R147-RXN_RO_0002413_R15-RXN_SGD_YeastPathways_PWY3O-64>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_35910>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/R147-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0010309> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2387,7 +2387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-6407.ttl
+++ b/models/YeastPathways_PWY3O-6407.ttl
@@ -1,25 +1,3 @@
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_CHEBI_57287_RXN3O-5279_SGD_YeastPathways_PWY3O-6407>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_17984_RXN-1623_SGD_YeastPathways_PWY3O-6407>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/MONOMER3O-4095_RXN3O-5279_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001775> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -27,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,6 +16,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002233_CHEBI_33184_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002333_MONOMER3O-4095_RXN3O-5279_controller_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-6407>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -47,7 +47,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidate biosynthesis I (the dihydroxyacetone pathway) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -55,15 +55,26 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002333_YDL052C-MONOMER_RXN-1623_controller_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002333_MONOMER3O-4105_RXN3O-5279_controller_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002333_MONOMER3O-4105_RXN3O-5279_controller_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,14 +85,17 @@
           <http://model.geneontology.org/MONOMER3O-4105_RXN3O-5279_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002333_MONOMER3O-4095_RXN3O-5279_controller_SGD_YeastPathways_PWY3O-6407>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/02e84e76-3798-4dcd-99ea-2e1ea97077ea_RXN3O-5279>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002413_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
+                "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -89,11 +103,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_29089_RXN-1623_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_29089_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -110,20 +124,27 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/MONOMER3O-4105_RXN3O-5279_controller>
-        a       <http://identifiers.org/sgd/S000000107> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "dihydroxyacetone phosphate acyltransferase [multifunctional]" ;
+<http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000066_reaction_RXN-1623_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6407Protein20833> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_29089_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57287_RXN3O-5279>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57287> ;
@@ -134,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -142,26 +163,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002411_RXN3O-9800_SGD_YeastPathways_PWY3O-6407>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/MONOMER3O-4105_RXN3O-5279_controller>
+        a       <http://identifiers.org/sgd/S000000107> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "dihydroxyacetone phosphate acyltransferase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6407Protein20833> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_16975_RXN3O-9800_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_16975_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -177,28 +202,6 @@
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_58349_RXN3O-9800_SGD_YeastPathways_PWY3O-6407>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_BFO_0000066_reaction_RXN3O-5279_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6407>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -220,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -228,32 +231,54 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_40274af2-2874-44cf-a9c6-6aaf87a59a88_RXN3O-5279_SGD_YeastPathways_PWY3O-6407>
+<http://purl.obolibrary.org/obo/CHEBI_29089>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002233_CHEBI_57642_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
+                "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_29089>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002333_YIL124W-MONOMER_RXN3O-9800_controller_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_15378_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002333_MONOMER3O-4095_RXN3O-5279_controller_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002333_MONOMER3O-4095_RXN3O-5279_controller_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,11 +296,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_17984_RXN-1623_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_17984_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -286,25 +311,25 @@
           <http://model.geneontology.org/CHEBI_17984_RXN-1623>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_BFO_0000050_YeastPathways_PWY3O-6407/YeastPathways_PWY3O-6407_SGD_YeastPathways_PWY3O-6407>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_57287_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
+                "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002333_YIL124W-MONOMER_RXN3O-9800_controller_SGD_YeastPathways_PWY3O-6407>
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_16975_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6407>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
+                "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -331,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -339,11 +364,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_15378_RXN3O-9800_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_15378_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -354,23 +379,12 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-9800>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_29089_RXN-1623_SGD_YeastPathways_PWY3O-6407>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-5279_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -383,7 +397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -391,25 +405,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002413_RXN-1623_SGD_YeastPathways_PWY3O-6407>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_02e84e76-3798-4dcd-99ea-2e1ea97077ea_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
+                "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002333_YDL052C-MONOMER_RXN-1623_controller_SGD_YeastPathways_PWY3O-6407>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000050_YeastPathways_PWY3O-6407/YeastPathways_PWY3O-6407_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
+                "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -421,18 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002333_MONOMER3O-4105_RXN3O-5279_controller_SGD_YeastPathways_PWY3O-6407>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -440,11 +443,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_CHEBI_57783_RXN3O-9800_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_CHEBI_57783_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,26 +461,15 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_d9c4d498-b03d-4e40-9175-9e4a0781ad34_RXN3O-5279_SGD_YeastPathways_PWY3O-6407>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_BFO_0000066_reaction_RXN3O-5279_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_BFO_0000066_reaction_RXN3O-5279_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,19 +480,22 @@
           <http://model.geneontology.org/reaction_RXN3O-5279_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/40274af2-2874-44cf-a9c6-6aaf87a59a88_RXN3O-5279>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_BFO_0000050_YeastPathways_PWY3O-6407/YeastPathways_PWY3O-6407_SGD_YeastPathways_PWY3O-6407>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/43a9a4d8-3aed-4ee3-a21a-3ebb5450574b_RXN3O-5279>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-acyl-dihydroxyacetone-phosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6407SmallMolecule20750> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -509,11 +504,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_d9c4d498-b03d-4e40-9175-9e4a0781ad34_RXN3O-5279_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_43a9a4d8-3aed-4ee3-a21a-3ebb5450574b_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -521,7 +516,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5279> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d9c4d498-b03d-4e40-9175-9e4a0781ad34_RXN3O-5279>
+          <http://model.geneontology.org/43a9a4d8-3aed-4ee3-a21a-3ebb5450574b_RXN3O-5279>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_RXN3O-9800>
@@ -533,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -550,7 +545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -562,11 +557,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_16975_RXN3O-9800_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_16975_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -576,6 +571,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16975_RXN3O-9800>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_16975_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -589,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -597,46 +603,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002233_CHEBI_57642_RXN3O-5279_SGD_YeastPathways_PWY3O-6407>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/d9c4d498-b03d-4e40-9175-9e4a0781ad34_RXN3O-5279>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-acyl-dihydroxyacetone-phosphate" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_BFO_0000066_reaction_RXN3O-5279_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6407SmallMolecule20750> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_40274af2-2874-44cf-a9c6-6aaf87a59a88_RXN3O-5279_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_02e84e76-3798-4dcd-99ea-2e1ea97077ea_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -644,7 +633,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9800> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/40274af2-2874-44cf-a9c6-6aaf87a59a88_RXN3O-5279>
+          <http://model.geneontology.org/02e84e76-3798-4dcd-99ea-2e1ea97077ea_RXN3O-5279>
 ] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -654,11 +643,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_BFO_0000066_reaction_RXN3O-9800_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_BFO_0000066_reaction_RXN3O-9800_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -676,11 +665,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_BFO_0000050_YeastPathways_PWY3O-6407/YeastPathways_PWY3O-6407_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_BFO_0000050_YeastPathways_PWY3O-6407/YeastPathways_PWY3O-6407_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -702,7 +691,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57642_RXN3O-5279> , <http://model.geneontology.org/CHEBI_33184_RXN3O-5279> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/d9c4d498-b03d-4e40-9175-9e4a0781ad34_RXN3O-5279> , <http://model.geneontology.org/CHEBI_57287_RXN3O-5279> ;
+                <http://model.geneontology.org/CHEBI_57287_RXN3O-5279> , <http://model.geneontology.org/43a9a4d8-3aed-4ee3-a21a-3ebb5450574b_RXN3O-5279> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-4105_RXN3O-5279_controller> , <http://model.geneontology.org/MONOMER3O-4095_RXN3O-5279_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -710,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -721,26 +710,15 @@
 <http://purl.obolibrary.org/obo/GO_0003841>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002233_CHEBI_33184_RXN3O-5279_SGD_YeastPathways_PWY3O-6407>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_CHEBI_57287_RXN3O-5279_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_CHEBI_57287_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -755,11 +733,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000066_reaction_RXN-1623_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000066_reaction_RXN-1623_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -779,7 +757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -791,11 +769,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" , "Provides Input For Rule. The relation '1-acyl-dihydroxyacetone-phosphate + NADPH &rarr; a 1-acyl-<i>sn</i>-glycerol 3-phosphate + NADP<sup>+</sup> + H<SUP>+</SUP>' 'null' 'an acyl-CoA + a 1-acyl-<i>sn</i>-glycerol 3-phosphate &rarr; a 1,2-diacyl-<i>sn</i>-glycerol 3-phosphate + coenzyme A' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002413_RXN-1623_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002413_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -809,20 +787,42 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002333_MONOMER3O-4105_RXN3O-5279_controller_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0016287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000001386>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_16975_RXN3O-9800_SGD_YeastPathways_PWY3O-6407>
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_58349_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6407>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
+                "SGD_PWY:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_BFO_0000050_YeastPathways_PWY3O-6407/YeastPathways_PWY3O-6407_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -839,11 +839,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_BFO_0000050_YeastPathways_PWY3O-6407/YeastPathways_PWY3O-6407_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_BFO_0000050_YeastPathways_PWY3O-6407/YeastPathways_PWY3O-6407_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -858,11 +858,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002333_YDL052C-MONOMER_RXN-1623_controller_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002333_YDL052C-MONOMER_RXN-1623_controller_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -879,17 +879,6 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_16975_RXN3O-9800_SGD_YeastPathways_PWY3O-6407>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16975_RXN3O-9800>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16975> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -899,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -910,26 +899,15 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000050_YeastPathways_PWY3O-6407/YeastPathways_PWY3O-6407_SGD_YeastPathways_PWY3O-6407>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002233_CHEBI_57642_RXN3O-5279_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002233_CHEBI_57642_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -944,11 +922,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000050_YeastPathways_PWY3O-6407/YeastPathways_PWY3O-6407_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000050_YeastPathways_PWY3O-6407/YeastPathways_PWY3O-6407_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -959,15 +937,37 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-6407/YeastPathways_PWY3O-6407>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_CHEBI_57287_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_CHEBI_57783_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002333_YIL124W-MONOMER_RXN3O-9800_controller_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002333_YIL124W-MONOMER_RXN3O-9800_controller_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -978,19 +978,19 @@
           <http://model.geneontology.org/YIL124W-MONOMER_RXN3O-9800_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_57287_RXN-1623_SGD_YeastPathways_PWY3O-6407>
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002411_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6407>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
+                "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://identifiers.org/sgd/S000002210>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1004,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1018,6 +1018,39 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_43a9a4d8-3aed-4ee3-a21a-3ebb5450574b_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_BFO_0000066_reaction_RXN3O-9800_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_17984_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_17984_RXN-1623>
         a       <http://purl.obolibrary.org/obo/CHEBI_17984> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1027,13 +1060,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6407SmallMolecule20692> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_BFO_0000050_YeastPathways_PWY3O-6407/YeastPathways_PWY3O-6407_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1042,11 +1086,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002411_RXN3O-9800_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002411_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1061,11 +1105,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_57287_RXN-1623_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_57287_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1085,7 +1129,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9800_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/40274af2-2874-44cf-a9c6-6aaf87a59a88_RXN3O-5279> , <http://model.geneontology.org/CHEBI_57783_RXN3O-9800> ;
+                <http://model.geneontology.org/02e84e76-3798-4dcd-99ea-2e1ea97077ea_RXN3O-5279> , <http://model.geneontology.org/CHEBI_57783_RXN3O-9800> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_58349_RXN3O-9800> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9800> , <http://model.geneontology.org/CHEBI_16975_RXN3O-9800> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1095,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1106,17 +1150,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_17984>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000066_reaction_RXN-1623_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6407>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YIL124W-MONOMER_RXN3O-9800_controller>
         a       <http://identifiers.org/sgd/S000001386> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1124,24 +1157,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6407Protein20800> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_BFO_0000066_reaction_RXN3O-9800_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6407>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YDL052C-MONOMER_RXN-1623_controller>
         a       <http://identifiers.org/sgd/S000002210> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1150,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1162,11 +1184,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002233_CHEBI_33184_RXN3O-5279_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002233_CHEBI_33184_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1189,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1206,7 +1228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1218,11 +1240,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_58349_RXN3O-9800_SGD_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_58349_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1232,25 +1254,3 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58349_RXN3O-9800>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_CHEBI_57783_RXN3O-9800_SGD_YeastPathways_PWY3O-6407>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_15378_RXN3O-9800_SGD_YeastPathways_PWY3O-6407>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-6499.ttl
+++ b/models/YeastPathways_PWY3O-6499.ttl
@@ -1,14 +1,3 @@
-<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002413_RXN-1623_SGD_YeastPathways_PWY3O-6499>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_1.1.1.8-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -18,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -26,15 +15,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002233_CHEBI_33184_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6499>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6499" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_57287_RXN-1623_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_57287_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -49,11 +49,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002234_CHEBI_16975_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002234_CHEBI_16975_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -70,14 +70,25 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002233_CHEBI_33184_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6499>
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_15378_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6499>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
+                "SGD_PWY:PWY3O-6499" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57945_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6499>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -88,11 +99,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57540_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57540_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -129,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -137,29 +148,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/CHEBI_29089>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002234_CHEBI_57287_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6499>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6499" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_15378_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6499>
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57597_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6499>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
+                "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_29089>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_29089_RXN-1623_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_29089_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -173,15 +195,24 @@
 <http://purl.obolibrary.org/obo/CHEBI_57642>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/reaction_1.1.1.8-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002233_CHEBI_57597_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002233_CHEBI_57597_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -192,26 +223,6 @@
           <http://model.geneontology.org/CHEBI_57597_1.1.1.8-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_1.1.1.8-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-6499/YeastPathways_PWY3O-6499_SGD_YeastPathways_PWY3O-6499>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/MONOMER3O-4095_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001775> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -219,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -236,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -244,11 +255,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://identifiers.org/sgd/S000000107>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://identifiers.org/sgd/S000000107>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57642_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6499>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6499" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16975_GLYCEROL-3-P-ACYLTRANSFER-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16975> ;
@@ -259,7 +281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -273,14 +295,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_16975>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002234_CHEBI_57287_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6499>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000066_reaction_GLYCEROL-3-P-ACYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6499>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
+                "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -291,11 +313,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57945_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57945_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -306,17 +328,6 @@
           <http://model.geneontology.org/CHEBI_57945_1.1.1.8-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57945_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6499>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57945_1.1.1.8-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -326,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -334,37 +345,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000066_reaction_1.1.1.8-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6499>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YOL059W-MONOMER_1.1.1.8-RXN_controller_SGD_YeastPathways_PWY3O-6499>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0008654>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_16975_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6499>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6499" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN-1623_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -372,11 +372,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_15378_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_15378_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -390,26 +390,15 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_57287_RXN-1623_SGD_YeastPathways_PWY3O-6499>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>sn</i>-glycerol 3-phosphate + a long-chain acyl-CoA &rarr; a 1-acyl-<i>sn</i>-glycerol 3-phosphate + coenzyme A' 'null' 'an acyl-CoA + a 1-acyl-<i>sn</i>-glycerol 3-phosphate &rarr; a 1,2-diacyl-<i>sn</i>-glycerol 3-phosphate + coenzyme A' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002413_RXN-1623_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002413_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -423,25 +412,6 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_17984_RXN-1623_SGD_YeastPathways_PWY3O-6499> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-1623> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17984_RXN-1623>
-] .
-
 <http://model.geneontology.org/CHEBI_29089_RXN-1623>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29089> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -451,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -463,11 +433,41 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002233_CHEBI_33184_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_17984_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-1623> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17984_RXN-1623>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_17984_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6499>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6499" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002233_CHEBI_33184_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6499> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -478,15 +478,26 @@
           <http://model.geneontology.org/CHEBI_33184_GLYCEROL-3-P-ACYLTRANSFER-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YOL059W-MONOMER_1.1.1.8-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6499>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6499" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" , "Provides Input For Rule. The relation '<i>sn</i>-glycerol 3-phosphate + NAD<sup>+</sup> &larr; glycerone phosphate + NADH + H<SUP>+</SUP>' 'null' '<i>sn</i>-glycerol 3-phosphate + a long-chain acyl-CoA &rarr; a 1-acyl-<i>sn</i>-glycerol 3-phosphate + coenzyme A' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002413_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002413_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -500,40 +511,18 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57540_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6499>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000066_reaction_RXN-1623_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6499>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57642_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57642_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -544,29 +533,43 @@
           <http://model.geneontology.org/CHEBI_57642_1.1.1.8-RXN>
 ] .
 
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002333_MONOMER3O-4095_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-6499>
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000066_reaction_1.1.1.8-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6499>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
+                "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002413_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6499>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6499" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_33184>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000066_reaction_1.1.1.8-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000066_reaction_1.1.1.8-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -577,18 +580,37 @@
           <http://model.geneontology.org/reaction_1.1.1.8-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_33184>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002234_CHEBI_16975_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6499>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6499" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-6499/YeastPathways_PWY3O-6499_SGD_PWY_YeastPathways_PWY3O-6499>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6499" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002333_MONOMER3O-4105_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002333_MONOMER3O-4105_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -602,28 +624,6 @@
 <http://purl.obolibrary.org/obo/GO_0003841>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57642_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6499>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_17984_RXN-1623_SGD_YeastPathways_PWY3O-6499>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/MONOMER3O-4105_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000107> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -639,15 +639,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002233_CHEBI_57597_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6499>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6499" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_16975_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_16975_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -662,11 +673,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000066_reaction_GLYCEROL-3-P-ACYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000066_reaction_GLYCEROL-3-P-ACYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -689,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidate biosynthesis II (the glycerol-3-phosphate pathway) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -701,11 +712,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YOL059W-MONOMER_1.1.1.8-RXN_controller_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YOL059W-MONOMER_1.1.1.8-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -716,28 +727,6 @@
           <http://model.geneontology.org/YOL059W-MONOMER_1.1.1.8-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57597_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6499>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002333_MONOMER3O-4105_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-6499>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57597_1.1.1.8-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57597> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -747,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -755,42 +744,64 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002333_YDL052C-MONOMER_RXN-1623_controller_SGD_PWY_YeastPathways_PWY3O-6499>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6499" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0004367>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000002180>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000050_YeastPathways_PWY3O-6499/YeastPathways_PWY3O-6499_SGD_YeastPathways_PWY3O-6499>
+<http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000066_reaction_RXN-1623_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6499>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
+                "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57287>
+<http://identifiers.org/sgd/S000002180>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000050_YeastPathways_PWY3O-6499/YeastPathways_PWY3O-6499_SGD_YeastPathways_PWY3O-6499>
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_29089_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6499>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
+                "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YDL022W-MONOMER_1.1.1.8-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6499>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6499" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_57287>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -799,11 +810,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000050_YeastPathways_PWY3O-6499/YeastPathways_PWY3O-6499_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000050_YeastPathways_PWY3O-6499/YeastPathways_PWY3O-6499_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -818,11 +829,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002333_MONOMER3O-4095_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002333_MONOMER3O-4095_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -844,33 +855,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_16975_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6499>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000066_reaction_RXN-1623_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000066_reaction_RXN-1623_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -888,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -905,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -917,11 +917,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-6499/YeastPathways_PWY3O-6499_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-6499/YeastPathways_PWY3O-6499_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -930,6 +930,25 @@
           <http://model.geneontology.org/GLYCEROL-3-P-ACYLTRANSFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-6499/YeastPathways_PWY3O-6499>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YDL022W-MONOMER_1.1.1.8-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6499> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.1.1.8-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YDL022W-MONOMER_1.1.1.8-RXN_controller>
 ] .
 
 <http://model.geneontology.org/GLYCEROL-3-P-ACYLTRANSFER-RXN>
@@ -951,32 +970,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6499BiochemicalReaction21440> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YDL022W-MONOMER_1.1.1.8-RXN_controller_SGD_YeastPathways_PWY3O-6499> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.1.1.8-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDL022W-MONOMER_1.1.1.8-RXN_controller>
-] .
 
 <http://model.geneontology.org/1.1.1.8-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004367> ;
@@ -997,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1011,6 +1011,17 @@
 <http://identifiers.org/sgd/S000002210>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000050_YeastPathways_PWY3O-6499/YeastPathways_PWY3O-6499_SGD_PWY_YeastPathways_PWY3O-6499>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6499" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57287_RXN-1623>
         a       <http://purl.obolibrary.org/obo/CHEBI_57287> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1020,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1028,50 +1039,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YDL022W-MONOMER_1.1.1.8-RXN_controller_SGD_YeastPathways_PWY3O-6499>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000066_reaction_GLYCEROL-3-P-ACYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6499>
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_57287_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6499>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002234_CHEBI_16975_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6499>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002413_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6499>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
+                "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1087,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1095,18 +1073,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000050_YeastPathways_PWY3O-6499/YeastPathways_PWY3O-6499_SGD_PWY_YeastPathways_PWY3O-6499>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6499" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002333_MONOMER3O-4105_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6499>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6499" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002333_YDL052C-MONOMER_RXN-1623_controller_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002333_YDL052C-MONOMER_RXN-1623_controller_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1117,26 +1117,15 @@
           <http://model.geneontology.org/YDL052C-MONOMER_RXN-1623_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_29089_RXN-1623_SGD_YeastPathways_PWY3O-6499>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002234_CHEBI_57287_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002234_CHEBI_57287_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1146,6 +1135,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57287_GLYCEROL-3-P-ACYLTRANSFER-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57540_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6499>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6499" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17984>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1159,7 +1159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1167,14 +1167,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002333_YDL052C-MONOMER_RXN-1623_controller_SGD_YeastPathways_PWY3O-6499>
+<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002333_MONOMER3O-4095_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6499>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
+                "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1187,13 +1187,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6499SmallMolecule21448> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002413_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6499>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6499" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YDL052C-MONOMER_RXN-1623_controller>
         a       <http://identifiers.org/sgd/S000002210> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1202,7 +1213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1214,11 +1225,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000050_YeastPathways_PWY3O-6499/YeastPathways_PWY3O-6499_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000050_YeastPathways_PWY3O-6499/YeastPathways_PWY3O-6499_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1244,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1256,11 +1267,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57597_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6499> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57597_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1271,17 +1282,6 @@
           <http://model.geneontology.org/CHEBI_57597_1.1.1.8-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002233_CHEBI_57597_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6499>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YDL022W-MONOMER_1.1.1.8-RXN_controller>
         a       <http://identifiers.org/sgd/S000002180> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1289,7 +1289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-661.ttl
+++ b/models/YeastPathways_PWY3O-661.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15,26 +15,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-661>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-661" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-661> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-661> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,6 +33,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-661>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-661" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -60,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -68,28 +68,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-661>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-661" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-661>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-661" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/GO_0034079>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-661>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-661" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000056>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -98,11 +109,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-661> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-661> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -116,17 +127,6 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_YeastPathways_PWY3O-661>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-661" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -160,11 +160,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PWY3O-661> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-661> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -193,24 +193,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "butanediol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-661>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-661" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -219,11 +208,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-661> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-661> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -259,18 +248,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-661>
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-661>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-661" ;
+                "SGD_PWY:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -281,11 +270,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-661> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-661> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -296,17 +285,6 @@
           <http://model.geneontology.org/CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-661>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-661" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16982> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -316,7 +294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -328,11 +306,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-661/YeastPathways_PWY3O-661_SGD_YeastPathways_PWY3O-661> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-661/YeastPathways_PWY3O-661_SGD_PWY_YeastPathways_PWY3O-661> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -358,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -369,17 +347,6 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PWY3O-661>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-661" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -387,11 +354,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-661> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-661> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -412,11 +379,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_YeastPathways_PWY3O-661> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY_YeastPathways_PWY3O-661> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -430,33 +397,33 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-661/YeastPathways_PWY3O-661_SGD_YeastPathways_PWY3O-661>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY_YeastPathways_PWY3O-661>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-661" ;
+                "SGD_PWY:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-661>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/GO_0000721>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-661>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-661" ;
+                "SGD_PWY:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0000721>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -467,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -495,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -513,11 +480,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-661> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-661> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -528,5 +495,38 @@
           <http://model.geneontology.org/CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-661>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-661" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-661>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-661" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-661/YeastPathways_PWY3O-661_SGD_PWY_YeastPathways_PWY3O-661>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-661" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-6635.ttl
+++ b/models/YeastPathways_PWY3O-6635.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_BFO_0000066_reaction_RXN3O-9800_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_BFO_0000066_reaction_RXN3O-9800_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,11 +21,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002333_MONOMER3O-4095_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002333_MONOMER3O-4095_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -70,31 +70,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57597_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6635>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57642_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6635>
+<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002233_CHEBI_57597_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6635>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000066_reaction_GLYCEROL-3-P-ACYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -102,11 +102,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -117,15 +117,26 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002333_MONOMER3O-4105_RXN3O-5279_controller_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_29089_RXN-1623_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_29089_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -136,17 +147,6 @@
           <http://model.geneontology.org/CHEBI_29089_RXN-1623>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_BFO_0000066_reaction_RXN3O-9800_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6635>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57287_RXN-1623>
         a       <http://purl.obolibrary.org/obo/CHEBI_57287> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -166,6 +166,17 @@
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -182,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -194,11 +205,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YOL059W-MONOMER_1.1.1.8-RXN_controller_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YOL059W-MONOMER_1.1.1.8-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -213,11 +224,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_95e409af-1d74-4515-91f6-e141d6918957_RXN3O-5279_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_2b920b82-82ba-4ceb-bbb5-0837500b2cf5_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -225,20 +236,20 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5279> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/95e409af-1d74-4515-91f6-e141d6918957_RXN3O-5279>
+          <http://model.geneontology.org/2b920b82-82ba-4ceb-bbb5-0837500b2cf5_RXN3O-5279>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_YeastPathways_PWY3O-6635>
+<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002234_CHEBI_16975_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6635>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
+                "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -246,11 +257,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000066_reaction_GLYCEROL-3-P-ACYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000066_reaction_GLYCEROL-3-P-ACYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -261,14 +272,25 @@
           <http://model.geneontology.org/reaction_GLYCEROL-3-P-ACYLTRANSFER-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002233_CHEBI_33184_RXN3O-5279_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_CHEBI_57287_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_17984_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -280,33 +302,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003841>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_15378_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6635>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_15378_RXN3O-9800_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_15378_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -339,17 +350,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_57597>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57540_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6635>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GLYCEROL-3-P-ACYLTRANSFER-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -370,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,11 +385,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57642_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57642_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -400,6 +400,17 @@
           <http://model.geneontology.org/CHEBI_57642_1.1.1.8-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_16975_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -407,11 +418,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -422,72 +433,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002233_CHEBI_33184_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000066_reaction_RXN-1623_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6635>
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_2b920b82-82ba-4ceb-bbb5-0837500b2cf5_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000066_reaction_GLYCEROL-3-P-ACYLTRANSFER-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_16975_RXN3O-9800_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_CHEBI_57287_RXN3O-5279_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002333_YDL052C-MONOMER_RXN-1623_controller_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
+                "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -503,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -520,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -532,11 +488,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002411_RXN3O-9800_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002411_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,26 +506,15 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YDL022W-MONOMER_1.1.1.8-RXN_controller_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002234_CHEBI_16975_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002234_CHEBI_16975_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -594,7 +539,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57642_RXN3O-5279> , <http://model.geneontology.org/CHEBI_33184_RXN3O-5279> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/95e409af-1d74-4515-91f6-e141d6918957_RXN3O-5279> , <http://model.geneontology.org/CHEBI_57287_RXN3O-5279> ;
+                <http://model.geneontology.org/CHEBI_57287_RXN3O-5279> , <http://model.geneontology.org/2b920b82-82ba-4ceb-bbb5-0837500b2cf5_RXN3O-5279> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-4105_RXN3O-5279_controller> , <http://model.geneontology.org/MONOMER3O-4095_RXN3O-5279_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -602,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -610,14 +555,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002333_YIL124W-MONOMER_RXN3O-9800_controller_SGD_YeastPathways_PWY3O-6635>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002234_CHEBI_57287_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
+                "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -628,11 +573,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002333_YIL124W-MONOMER_RXN3O-9800_controller_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002333_YIL124W-MONOMER_RXN3O-9800_controller_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,11 +592,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_16975_RXN3O-9800_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_16975_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -680,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -698,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -713,11 +658,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57597_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57597_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -732,11 +677,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002233_CHEBI_57642_RXN3O-5279_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002233_CHEBI_57642_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,17 +694,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_29089>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002233_CHEBI_57642_RXN3O-5279_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-1623>
         a       <http://purl.obolibrary.org/obo/GO_0003841> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -778,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -791,12 +725,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YOL059W-MONOMER_1.1.1.8-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-9800>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -807,7 +752,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9800_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/f1c676c6-6a16-42ca-b456-b1690c7716f4_RXN3O-5279> , <http://model.geneontology.org/CHEBI_57783_RXN3O-9800> ;
+                <http://model.geneontology.org/3eeae05a-eed9-41f3-b2d4-3228fcc53ee6_RXN3O-5279> , <http://model.geneontology.org/CHEBI_57783_RXN3O-9800> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_58349_RXN3O-9800> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9800> , <http://model.geneontology.org/CHEBI_16975_RXN3O-9800> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -817,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -832,11 +777,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_CHEBI_57783_RXN3O-9800_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_CHEBI_57783_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -856,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -864,26 +809,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_f1c676c6-6a16-42ca-b456-b1690c7716f4_RXN3O-5279_SGD_YeastPathways_PWY3O-6635>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002333_MONOMER3O-4105_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002333_MONOMER3O-4105_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -894,14 +828,25 @@
           <http://model.geneontology.org/MONOMER3O-4105_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_15378_RXN3O-9800_SGD_YeastPathways_PWY3O-6635>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_15378_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_15378_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -917,7 +862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -929,11 +874,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000066_reaction_1.1.1.8-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000066_reaction_1.1.1.8-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -944,15 +889,26 @@
           <http://model.geneontology.org/reaction_1.1.1.8-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57597_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_57287_RXN-1623_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_57287_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -963,33 +919,25 @@
           <http://model.geneontology.org/CHEBI_57287_RXN-1623>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002413_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
+                "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/3eeae05a-eed9-41f3-b2d4-3228fcc53ee6_RXN3O-5279>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 <http://purl.obolibrary.org/obo/GO_0006654>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002333_MONOMER3O-4095_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-6635>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -999,17 +947,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002333_MONOMER3O-4095_RXN3O-5279_controller_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1021,11 +958,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" , "Provides Input For Rule. The relation '<i>sn</i>-glycerol 3-phosphate + NAD<sup>+</sup> &larr; glycerone phosphate + NADH + H<SUP>+</SUP>' 'null' '<i>sn</i>-glycerol 3-phosphate + a long-chain acyl-CoA &rarr; a 1-acyl-<i>sn</i>-glycerol 3-phosphate + coenzyme A' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002413_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002413_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1036,12 +973,23 @@
           <http://model.geneontology.org/GLYCEROL-3-P-ACYLTRANSFER-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000066_reaction_1.1.1.8-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-1623_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1049,11 +997,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002333_MONOMER3O-4095_RXN3O-5279_controller_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002333_MONOMER3O-4095_RXN3O-5279_controller_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1063,6 +1011,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/MONOMER3O-4095_RXN3O-5279_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57540_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1074,11 +1033,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002233_CHEBI_33184_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002233_CHEBI_33184_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,66 +1048,18 @@
           <http://model.geneontology.org/CHEBI_33184_GLYCEROL-3-P-ACYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002413_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_BFO_0000066_reaction_RXN3O-5279_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6635>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002411_RXN3O-9800_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/MONOMER3O-4105_RXN3O-5279_controller>
-        a       <http://identifiers.org/sgd/S000000107> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "dihydroxyacetone phosphate acyltransferase [multifunctional]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6635Protein37736> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_16975_RXN3O-9800_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_16975_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1159,6 +1070,32 @@
           <http://model.geneontology.org/CHEBI_16975_RXN3O-9800>
 ] .
 
+<http://model.geneontology.org/MONOMER3O-4105_RXN3O-5279_controller>
+        a       <http://identifiers.org/sgd/S000000107> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "dihydroxyacetone phosphate acyltransferase [multifunctional]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6635Protein37736> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002333_YIL124W-MONOMER_RXN3O-9800_controller_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-6635>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1168,7 +1105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of phosphatidate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1180,11 +1117,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1202,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1210,14 +1147,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002234_CHEBI_16975_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6635>
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002411_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6635>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YDL022W-MONOMER_1.1.1.8-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1230,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1238,26 +1186,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_57287_RXN-1623_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57945_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57945_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1272,11 +1209,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_BFO_0000066_reaction_RXN3O-5279_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_BFO_0000066_reaction_RXN3O-5279_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1294,7 +1231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1302,8 +1239,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/2b920b82-82ba-4ceb-bbb5-0837500b2cf5_RXN3O-5279>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-acyl-dihydroxyacetone-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6635SmallMolecule37625> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/GO_0004367>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_CHEBI_57783_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57287_RXN3O-5279>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57287> ;
@@ -1314,7 +1279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1329,7 +1294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1342,7 +1307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1355,7 +1320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1367,11 +1332,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1382,6 +1347,28 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002233_CHEBI_57642_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_57287_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0016287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1389,11 +1376,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002234_CHEBI_57287_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002234_CHEBI_57287_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1403,6 +1390,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57287_GLYCEROL-3-P-ACYLTRANSFER-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57945_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1414,7 +1412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1422,14 +1420,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002413_RXN-1623_SGD_YeastPathways_PWY3O-6635>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
+                "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1440,11 +1438,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '1-acyl-dihydroxyacetone-phosphate + NADPH &rarr; a 1-acyl-<i>sn</i>-glycerol 3-phosphate + NADP<sup>+</sup> + H<SUP>+</SUP>' 'null' 'an acyl-CoA + a 1-acyl-<i>sn</i>-glycerol 3-phosphate &rarr; a 1,2-diacyl-<i>sn</i>-glycerol 3-phosphate + coenzyme A' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002413_RXN-1623_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002413_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1459,11 +1457,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_17984_RXN-1623_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_17984_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1474,14 +1472,25 @@
           <http://model.geneontology.org/CHEBI_17984_RXN-1623>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002413_RXN-1623_SGD_YeastPathways_PWY3O-6635>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002233_CHEBI_33184_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_3eeae05a-eed9-41f3-b2d4-3228fcc53ee6_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1494,7 +1503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1502,22 +1511,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/95e409af-1d74-4515-91f6-e141d6918957_RXN3O-5279>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-acyl-dihydroxyacetone-phosphate" ;
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_29089_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6635SmallMolecule37625> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1529,11 +1532,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YDL022W-MONOMER_1.1.1.8-RXN_controller_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YDL022W-MONOMER_1.1.1.8-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1553,7 +1556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1565,11 +1568,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_CHEBI_57287_RXN3O-5279_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_CHEBI_57287_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1580,14 +1583,14 @@
           <http://model.geneontology.org/CHEBI_57287_RXN3O-5279>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002234_CHEBI_57287_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002333_MONOMER3O-4095_RXN3O-5279_controller_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
+                "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1595,11 +1598,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1610,18 +1613,59 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635>
 ] .
 
-<http://model.geneontology.org/f1c676c6-6a16-42ca-b456-b1690c7716f4_RXN3O-5279>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002333_MONOMER3O-4095_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002233_CHEBI_33184_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000066_reaction_RXN-1623_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_f1c676c6-6a16-42ca-b456-b1690c7716f4_RXN3O-5279_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_3eeae05a-eed9-41f3-b2d4-3228fcc53ee6_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1629,28 +1673,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9800> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f1c676c6-6a16-42ca-b456-b1690c7716f4_RXN3O-5279>
+          <http://model.geneontology.org/3eeae05a-eed9-41f3-b2d4-3228fcc53ee6_RXN3O-5279>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_17984_RXN-1623_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_YeastPathways_PWY3O-6635>
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_BFO_0000066_reaction_RXN3O-5279_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6635>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
+                "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1658,11 +1691,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>sn</i>-glycerol 3-phosphate + a long-chain acyl-CoA &rarr; a 1-acyl-<i>sn</i>-glycerol 3-phosphate + coenzyme A' 'null' 'an acyl-CoA + a 1-acyl-<i>sn</i>-glycerol 3-phosphate &rarr; a 1,2-diacyl-<i>sn</i>-glycerol 3-phosphate + coenzyme A' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002413_RXN-1623_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002413_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1673,6 +1706,17 @@
           <http://model.geneontology.org/RXN-1623>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002333_MONOMER3O-4105_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000002180>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1680,11 +1724,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_15378_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_15378_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1704,7 +1748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1716,11 +1760,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002333_YDL052C-MONOMER_RXN-1623_controller_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002333_YDL052C-MONOMER_RXN-1623_controller_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1741,7 +1785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1759,7 +1803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1779,7 +1823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1806,7 +1850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1814,37 +1858,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_16975_RXN3O-9800_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YOL059W-MONOMER_1.1.1.8-RXN_controller_SGD_YeastPathways_PWY3O-6635>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002333_MONOMER3O-4105_RXN3O-5279_controller_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002333_MONOMER3O-4105_RXN3O-5279_controller_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1864,7 +1886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1876,11 +1898,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002233_CHEBI_57597_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002233_CHEBI_57597_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1891,28 +1913,39 @@
           <http://model.geneontology.org/CHEBI_57597_1.1.1.8-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57783>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002233_CHEBI_57597_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6635>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002413_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
+                "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_95e409af-1d74-4515-91f6-e141d6918957_RXN3O-5279_SGD_YeastPathways_PWY3O-6635>
+<http://purl.obolibrary.org/obo/CHEBI_57783>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_58349_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6635>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57642_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1925,7 +1958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1937,11 +1970,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_58349_RXN3O-9800_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_58349_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1956,11 +1989,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000066_reaction_RXN-1623_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000066_reaction_RXN-1623_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1971,36 +2004,47 @@
           <http://model.geneontology.org/reaction_RXN-1623_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_58349_RXN3O-9800_SGD_YeastPathways_PWY3O-6635>
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_BFO_0000066_reaction_RXN3O-9800_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6635>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
+                "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000066_reaction_1.1.1.8-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002333_YDL052C-MONOMER_RXN-1623_controller_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
+                "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_YeastPathways_PWY3O-6635>
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_PWY_YeastPathways_PWY3O-6635>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_16975_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2008,11 +2052,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57540_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_57540_1.1.1.8-RXN_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2023,26 +2067,15 @@
           <http://model.geneontology.org/CHEBI_57540_1.1.1.8-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_29089_RXN-1623_SGD_YeastPathways_PWY3O-6635>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002233_CHEBI_33184_RXN3O-5279_SGD_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002233_CHEBI_33184_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2053,58 +2086,25 @@
           <http://model.geneontology.org/CHEBI_33184_RXN3O-5279>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57945_1.1.1.8-RXN_SGD_YeastPathways_PWY3O-6635>
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002413_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_PWY_YeastPathways_PWY3O-6635>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002333_MONOMER3O-4105_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_CHEBI_57783_RXN3O-9800_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_BFO_0000050_YeastPathways_PWY3O-6635/YeastPathways_PWY3O-6635_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002333_MONOMER3O-4105_RXN3O-5279_controller_SGD_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
+                "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 

--- a/models/YeastPathways_PWY3O-69.ttl
+++ b/models/YeastPathways_PWY3O-69.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002234_CHEBI_57309_UROGENDECARBOX-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002234_CHEBI_57309_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,15 +17,26 @@
           <http://model.geneontology.org/CHEBI_57309_UROGENDECARBOX-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_BFO_0000066_reaction_PROTOHEMEFERROCHELAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13403_BFO_0000066_reaction_RXN-13403_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13403_BFO_0000066_reaction_RXN-13403_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,7 +56,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -59,26 +70,15 @@
 <http://identifiers.org/sgd/S000002454>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_57309_UROGENDECARBOX-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002233_CHEBI_15377_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002233_CHEBI_15377_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -89,29 +89,40 @@
           <http://model.geneontology.org/CHEBI_15377_OHMETHYLBILANESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002413_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002413_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_BFO_0000066_reaction_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_BFO_0000066_reaction_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -122,6 +133,17 @@
           <http://model.geneontology.org/reaction_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_15378_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0006783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -129,11 +151,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_57309_UROGENDECARBOX-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_57309_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -147,14 +169,14 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_15378_RXN-13403_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-13403_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -162,11 +184,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002333_YGL040C-MONOMER_PORPHOBILSYNTH-RXN_controller_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002333_YGL040C-MONOMER_PORPHOBILSYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -186,7 +208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -194,14 +216,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002413_PROTOHEMEFERROCHELAT-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002413_RXN-13403_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_57307_RXN0-1461_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -209,11 +253,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -244,15 +288,26 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002413_PROTOHEMEFERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002333_MONOMER3O-106_SIROHEME-FERROCHELAT-RXN_controller_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002333_MONOMER3O-106_SIROHEME-FERROCHELAT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -280,26 +335,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002333_MONOMER3O-47_RXN-13403_controller_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002233_CHEBI_57307_RXN0-1461_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002233_CHEBI_57307_RXN0-1461_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -340,17 +384,6 @@
 <http://purl.obolibrary.org/obo/GO_0051266>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002233_CHEBI_356416_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YDR047W-MONOMER_UROGENDECARBOX-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002454> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -358,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -375,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -392,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -400,26 +433,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_15378_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002234_CHEBI_15377_UROGENIIISYN-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002234_CHEBI_15377_UROGENIIISYN-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -430,17 +452,6 @@
           <http://model.geneontology.org/CHEBI_15377_UROGENIIISYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15379_PROTOPORGENOXI-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15379> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -450,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -458,29 +469,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002233_CHEBI_29033_SIROHEME-FERROCHELAT-RXN_SGD_YeastPathways_PWY3O-69>
+<http://identifiers.org/sgd/S000002364>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002234_CHEBI_57309_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_PWY3O-69>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000002364>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002333_MONOMER3O-47_RXN-13403_controller_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002333_MONOMER3O-47_RXN-13403_controller_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -491,17 +502,6 @@
           <http://model.geneontology.org/MONOMER3O-47_RXN-13403_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002234_CHEBI_57845_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -509,11 +509,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -527,25 +527,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_15377_RXN0-1461_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_58827_RXN-13403_SGD_YeastPathways_PWY3O-69>
+<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002333_YOR176W-MONOMER_PROTOHEMEFERROCHELAT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-69>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -556,7 +545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -564,26 +553,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002233_CHEBI_59789_RXN-13403_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002333_YDR232W-MONOMER_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002333_YDR232W-MONOMER_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -620,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -628,14 +606,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002233_CHEBI_58126_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-69>
+<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_BFO_0000066_reaction_UROGENIIISYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_58126_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -646,7 +635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -658,11 +647,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_BFO_0000066_reaction_SIROHEME-FERROCHELAT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_BFO_0000066_reaction_SIROHEME-FERROCHELAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -682,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -690,15 +679,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_16526_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_58351_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_58351_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -709,14 +709,25 @@
           <http://model.geneontology.org/CHEBI_58351_DIMETHUROPORDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002333_YGL040C-MONOMER_PORPHOBILSYNTH-RXN_controller_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002233_CHEBI_57306_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002333_YDR044W-MONOMER_RXN0-1461_controller_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -724,11 +735,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002234_CHEBI_17627_PROTOHEMEFERROCHELAT-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002234_CHEBI_17627_PROTOHEMEFERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -758,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -766,19 +777,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/CHEBI_356416>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_356416_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-69>
+<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002233_CHEBI_29033_SIROHEME-FERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY3O-69>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_356416>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_16240>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -787,11 +798,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002333_YDR047W-MONOMER_UROGENDECARBOX-RXN_controller_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002333_YDR047W-MONOMER_UROGENDECARBOX-RXN_controller_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -802,23 +813,34 @@
           <http://model.geneontology.org/YDR047W-MONOMER_UROGENDECARBOX-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002413_UROGENIIISYN-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_PORPHOBILSYNTH-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_16526_RXN0-1461_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002233_CHEBI_57845_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -834,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -846,11 +868,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002233_CHEBI_57308_UROGENIIISYN-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002233_CHEBI_57308_UROGENIIISYN-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -861,19 +883,19 @@
           <http://model.geneontology.org/CHEBI_57308_UROGENIIISYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57306>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002233_CHEBI_29033_PROTOHEMEFERROCHELAT-RXN_SGD_YeastPathways_PWY3O-69>
+<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002333_YER014W-MONOMER_PROTOPORGENOXI-RXN_controller_SGD_PWY_YeastPathways_PWY3O-69>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57306>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/PORPHOBILSYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004655> ;
@@ -894,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -902,26 +924,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_BFO_0000066_reaction_UROGENDECARBOX-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002233_CHEBI_58126_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002233_CHEBI_58126_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -942,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -954,11 +965,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_15378_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_15378_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -972,14 +983,14 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002234_CHEBI_28938_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-69>
+<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -987,11 +998,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_15377_RXN0-1461_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_15377_RXN0-1461_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1009,11 +1020,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" , "Provides Input For Rule. The relation '2 5-aminolevulinate &rarr; porphobilinogen + H<SUP>+</SUP> + 2 H<sub>2</sub>O' 'null' '4 porphobilinogen + H<sub>2</sub>O &rarr; 4 ammonium + preuroporphyrinogen' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002413_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002413_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1024,32 +1035,32 @@
           <http://model.geneontology.org/OHMETHYLBILANESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002233_CHEBI_57306_PROTOPORGENOXI-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_57287_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_BFO_0000066_reaction_DIMETHUROPORDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_BFO_0000066_reaction_DIMETHUROPORDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1067,7 +1078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1084,7 +1095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1092,26 +1103,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_BFO_0000066_reaction_PROTOHEMEFERROCHELAT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1134,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1146,11 +1146,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002234_CHEBI_16240_PROTOPORGENOXI-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002234_CHEBI_16240_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1161,6 +1161,17 @@
           <http://model.geneontology.org/CHEBI_16240_PROTOPORGENOXI-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16526_UROGENDECARBOX-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1170,7 +1181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1181,14 +1192,14 @@
 <http://purl.obolibrary.org/obo/GO_0004729>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002333_YER014W-MONOMER_PROTOPORGENOXI-RXN_controller_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1201,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1209,26 +1220,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_57305_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002234_CHEBI_57308_UROGENIIISYN-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002234_CHEBI_57308_UROGENIIISYN-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1254,7 +1254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1262,15 +1262,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002234_CHEBI_16526_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_15378_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 <i>S</i>-adenosyl-L-methionine + uroporphyrinogen-III &rarr; 2 <i>S</i>-adenosyl-L-homocysteine + precorrin-2 + H<SUP>+</SUP>' 'null' 'precorrin-2 + NAD<sup>+</sup> &rarr; sirohydrochlorin + NADH + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002413_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002413_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1290,7 +1312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1298,15 +1320,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-13403_BFO_0000066_reaction_RXN-13403_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_BFO_0000066_reaction_PORPHOBILSYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_BFO_0000066_reaction_PORPHOBILSYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1321,11 +1354,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002333_YOR278W-MONOMER_UROGENIIISYN-RXN_controller_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002333_YOR278W-MONOMER_UROGENIIISYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1336,17 +1369,6 @@
           <http://model.geneontology.org/YOR278W-MONOMER_UROGENIIISYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002413_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1356,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1364,32 +1386,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CHEBI_15377_OHMETHYLBILANESYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-69SmallMolecule38322> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1400,14 +1405,31 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-69/YeastPathways_PWY3O-69>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_BFO_0000066_reaction_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69>
+<http://model.geneontology.org/CHEBI_15377_OHMETHYLBILANESYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-69SmallMolecule38322> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1415,11 +1437,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002233_CHEBI_356416_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002233_CHEBI_356416_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1430,17 +1452,6 @@
           <http://model.geneontology.org/CHEBI_356416_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_57945_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57292_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57292> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1450,7 +1461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1458,26 +1469,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1461_BFO_0000066_reaction_RXN0-1461_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" , "Provides Input For Rule. The relation 'glycine + succinyl-CoA + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + 5-aminolevulinate + coenzyme A' 'null' '2 5-aminolevulinate &rarr; porphobilinogen + H<SUP>+</SUP> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002413_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002413_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1488,25 +1488,14 @@
           <http://model.geneontology.org/PORPHOBILSYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_BFO_0000066_reaction_SIROHEME-FERROCHELAT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002413_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002413_RXN0-1461_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1514,11 +1503,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002233_CHEBI_29033_SIROHEME-FERROCHELAT-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002233_CHEBI_29033_SIROHEME-FERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1533,11 +1522,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002333_MONOMER3O-106_DIMETHUROPORDEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002333_MONOMER3O-106_DIMETHUROPORDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1552,11 +1541,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002333_YOR176W-MONOMER_PROTOHEMEFERROCHELAT-RXN_controller_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002333_YOR176W-MONOMER_PROTOHEMEFERROCHELAT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1567,36 +1556,14 @@
           <http://model.geneontology.org/YOR176W-MONOMER_PROTOHEMEFERROCHELAT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002413_RXN-13403_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69>
+<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_15379_RXN0-1461_SGD_PWY_YeastPathways_PWY3O-69>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1605,18 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1461_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1629,7 +1585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1646,7 +1602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1663,7 +1619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1671,26 +1627,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'uroporphyrinogen-III + 4 H<SUP>+</SUP> &rarr; 4 CO<SUB>2</SUB> + coproporphyrinogen III' 'null' 'coproporphyrinogen III + oxygen + 2 H<SUP>+</SUP> &rarr; protoporphyrinogen IX + 2 CO<SUB>2</SUB> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002413_RXN0-1461_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002413_RXN0-1461_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1720,7 +1665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1728,21 +1673,54 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002333_MONOMER3O-106_SIROHEME-FERROCHELAT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004851>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_57307>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002413_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002234_CHEBI_60052_SIROHEME-FERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002233_CHEBI_59789_RXN-13403_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002233_CHEBI_59789_RXN-13403_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1760,7 +1738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1773,29 +1751,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_BFO_0000066_reaction_PROTOPORGENOXI-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_BFO_0000066_reaction_PORPHOBILSYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002234_CHEBI_57306_PROTOPORGENOXI-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002234_CHEBI_15378_PROTOHEMEFERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1803,11 +1781,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002234_CHEBI_28938_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002234_CHEBI_28938_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1818,42 +1796,31 @@
           <http://model.geneontology.org/CHEBI_28938_OHMETHYLBILANESYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57856>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002234_CHEBI_57309_UROGENDECARBOX-RXN_SGD_YeastPathways_PWY3O-69>
+<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002234_CHEBI_17627_PROTOHEMEFERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY3O-69>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57856>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000000816>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_57307_RXN0-1461_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002233_CHEBI_356416_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1869,7 +1836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1881,11 +1848,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_57292_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_57292_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1899,34 +1866,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_58827>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_BFO_0000066_reaction_UROGENIIISYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_OHMETHYLBILANESYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_BFO_0000066_reaction_PORPHOBILSYNTH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1934,11 +1879,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_16526_RXN0-1461_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_16526_RXN0-1461_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1949,6 +1894,17 @@
           <http://model.geneontology.org/CHEBI_16526_RXN0-1461>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_58827_RXN-13403_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_59789_RXN-13403>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59789> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1958,7 +1914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1966,26 +1922,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002234_CHEBI_16240_PROTOPORGENOXI-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1999,14 +1944,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_58351>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002333_YOR176W-MONOMER_PROTOHEMEFERROCHELAT-RXN_controller_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002413_RXN0-1461_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2017,11 +1962,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002233_CHEBI_57540_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002233_CHEBI_57540_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2039,7 +1984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2047,14 +1992,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002333_MONOMER3O-106_DIMETHUROPORDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2067,7 +2012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2075,15 +2020,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_15378_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_BFO_0000066_reaction_UROGENDECARBOX-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_BFO_0000066_reaction_UROGENDECARBOX-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2094,14 +2050,36 @@
           <http://model.geneontology.org/reaction_UROGENDECARBOX-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000066_reaction_OHMETHYLBILANESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69>
+<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_57308_UROGENIIISYN-RXN_SGD_PWY_YeastPathways_PWY3O-69>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002234_CHEBI_57308_UROGENIIISYN-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2109,11 +2087,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002234_CHEBI_57306_PROTOPORGENOXI-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002234_CHEBI_57306_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2124,17 +2102,6 @@
           <http://model.geneontology.org/CHEBI_57306_PROTOPORGENOXI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002233_CHEBI_15377_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY3O-69/YeastPathways_PWY3O-69>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0006783> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2144,7 +2111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2152,30 +2119,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_15377_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002333_YDL205C-MONOMER_OHMETHYLBILANESYN-RXN_controller_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002333_YDR047W-MONOMER_UROGENDECARBOX-RXN_controller_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005804>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2185,7 +2141,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_BFO_0000066_reaction_DIMETHUROPORDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2198,7 +2165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2206,41 +2173,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002234_CHEBI_15378_SIROHEME-FERROCHELAT-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000002451>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_15378_RXN0-1461_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_15379_RXN0-1461_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_UROGENDECARBOX-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -2251,7 +2185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2259,25 +2193,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002233_CHEBI_57540_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_57945_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_15378_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2285,11 +2208,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" , "Provides Input For Rule. The relation 'preuroporphyrinogen &rarr; uroporphyrinogen-III + H<sub>2</sub>O' 'null' '2 <i>S</i>-adenosyl-L-methionine + uroporphyrinogen-III &rarr; 2 <i>S</i>-adenosyl-L-homocysteine + precorrin-2 + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002413_RXN-13403_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002413_RXN-13403_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2300,6 +2223,28 @@
           <http://model.geneontology.org/RXN-13403>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002233_CHEBI_15379_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002233_CHEBI_58126_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YDR044W-MONOMER_RXN0-1461_controller>
         a       <http://identifiers.org/sgd/S000002451> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2307,7 +2252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2315,26 +2260,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002333_YDR232W-MONOMER_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_controller_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_BFO_0000066_reaction_RXN0-1461_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_BFO_0000066_reaction_RXN0-1461_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2353,7 +2287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2364,11 +2298,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_15377_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_15377_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2379,29 +2313,29 @@
           <http://model.geneontology.org/CHEBI_15377_PORPHOBILSYNTH-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000005702>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_15378_UROGENDECARBOX-RXN_SGD_YeastPathways_PWY3O-69>
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_57292_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-69>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000005702>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002233_CHEBI_58351_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002233_CHEBI_58351_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2431,7 +2365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2443,11 +2377,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'precorrin-2 + NAD<sup>+</sup> &rarr; sirohydrochlorin + NADH + 2 H<SUP>+</SUP>' 'null' 'sirohydrochlorin + Fe<SUP>2+</SUP> &rarr; siroheme + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002413_SIROHEME-FERROCHELAT-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002413_SIROHEME-FERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2462,11 +2396,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2477,33 +2411,22 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-69/YeastPathways_PWY3O-69>
 ] .
 
+<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_15378_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002233_CHEBI_15379_PROTOPORGENOXI-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_57308_UROGENIIISYN-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57845>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2512,11 +2435,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2536,13 +2459,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-69SmallMolecule38441> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_16526_RXN0-1461_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004852>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2551,11 +2485,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_15378_RXN-13403_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_15378_RXN-13403_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2566,29 +2500,29 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-13403>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57308>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002234_CHEBI_15378_PROTOHEMEFERROCHELAT-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_BFO_0000066_reaction_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57308>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002234_CHEBI_57845_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002234_CHEBI_57845_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2599,29 +2533,29 @@
           <http://model.geneontology.org/CHEBI_57845_OHMETHYLBILANESYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15379>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_BFO_0000066_reaction_DIMETHUROPORDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_BFO_0000066_reaction_SIROHEME-FERROCHELAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15379>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_57305_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_57305_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2632,6 +2566,17 @@
           <http://model.geneontology.org/CHEBI_57305_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002234_CHEBI_57845_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YDL205C-MONOMER_OHMETHYLBILANESYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002364> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2639,7 +2584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2651,11 +2596,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_57307_RXN0-1461_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_57307_RXN0-1461_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2675,7 +2620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2683,25 +2628,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002234_CHEBI_57308_UROGENIIISYN-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002233_CHEBI_59789_RXN-13403_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002233_CHEBI_57307_RXN0-1461_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002234_CHEBI_57306_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2709,11 +2654,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_BFO_0000066_reaction_PROTOHEMEFERROCHELAT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_BFO_0000066_reaction_PROTOHEMEFERROCHELAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2724,48 +2669,15 @@
           <http://model.geneontology.org/reaction_PROTOHEMEFERROCHELAT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_57292_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002333_YDR044W-MONOMER_RXN0-1461_controller_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002233_CHEBI_58827_RXN-13403_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002233_CHEBI_58827_RXN-13403_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2780,11 +2692,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_15378_UROGENDECARBOX-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_15378_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2795,15 +2707,26 @@
           <http://model.geneontology.org/CHEBI_15378_UROGENDECARBOX-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002333_YER014W-MONOMER_PROTOPORGENOXI-RXN_controller_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002333_YER014W-MONOMER_PROTOPORGENOXI-RXN_controller_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2814,15 +2737,26 @@
           <http://model.geneontology.org/YER014W-MONOMER_PROTOPORGENOXI-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_356416_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_57308_UROGENIIISYN-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_57308_UROGENIIISYN-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2852,7 +2786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2864,11 +2798,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'protoporphyrinogen IX + 3 oxygen &rarr; protoporphyrin IX + 3 hydrogen peroxide' 'null' 'ferroheme <i>b</i> + 2 H<SUP>+</SUP> &larr; protoporphyrin IX + Fe<SUP>2+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002413_PROTOHEMEFERROCHELAT-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002413_PROTOHEMEFERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2879,19 +2813,19 @@
           <http://model.geneontology.org/PROTOHEMEFERROCHELAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002233_CHEBI_58351_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY3O-69>
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002233_CHEBI_58351_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-69>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_15378_RXN0-1461>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2902,7 +2836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2910,26 +2844,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002333_MONOMER3O-106_DIMETHUROPORDEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2940,37 +2863,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-69/YeastPathways_PWY3O-69>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_15378_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002413_UROGENIIISYN-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" , "Provides Input For Rule. The relation 'preuroporphyrinogen &rarr; uroporphyrinogen-III + H<sub>2</sub>O' 'null' 'uroporphyrinogen-III + 4 H<SUP>+</SUP> &rarr; 4 CO<SUB>2</SUB> + coproporphyrinogen III' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002413_UROGENDECARBOX-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002413_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2984,17 +2885,6 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002333_MONOMER3O-106_SIROHEME-FERROCHELAT-RXN_controller_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/MONOMER3O-47_RXN-13403_controller>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3002,7 +2892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3017,11 +2907,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_15378_RXN0-1461_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_15378_RXN0-1461_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3039,11 +2929,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_15378_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_15378_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3054,6 +2944,28 @@
           <http://model.geneontology.org/CHEBI_15378_PORPHOBILSYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002233_CHEBI_29033_PROTOHEMEFERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1461_BFO_0000066_reaction_RXN0-1461_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004418>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3062,33 +2974,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003870>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_57287_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002234_CHEBI_15378_SIROHEME-FERROCHELAT-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002234_CHEBI_15378_SIROHEME-FERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3108,7 +3009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3125,7 +3026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3142,7 +3043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3154,11 +3055,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_BFO_0000066_reaction_PROTOPORGENOXI-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_BFO_0000066_reaction_PROTOPORGENOXI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3169,40 +3070,51 @@
           <http://model.geneontology.org/reaction_PROTOPORGENOXI-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002234_CHEBI_15377_UROGENIIISYN-RXN_SGD_YeastPathways_PWY3O-69>
+<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002333_YGL040C-MONOMER_PORPHOBILSYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-69>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002333_YOR278W-MONOMER_UROGENIIISYN-RXN_controller_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002233_CHEBI_57540_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002234_CHEBI_15377_UROGENIIISYN-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_BFO_0000066_reaction_UROGENIIISYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_BFO_0000066_reaction_UROGENIIISYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3213,12 +3125,34 @@
           <http://model.geneontology.org/reaction_UROGENIIISYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_57309_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1461_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_DIMETHUROPORDEHYDROG-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3231,7 +3165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3242,15 +3176,26 @@
 <http://purl.obolibrary.org/obo/GO_0004853>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002233_CHEBI_57307_RXN0-1461_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_57856_RXN-13403_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_57856_RXN-13403_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3268,11 +3213,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002333_YDL205C-MONOMER_OHMETHYLBILANESYN-RXN_controller_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002333_YDL205C-MONOMER_OHMETHYLBILANESYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3283,26 +3228,15 @@
           <http://model.geneontology.org/YDL205C-MONOMER_OHMETHYLBILANESYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002413_UROGENDECARBOX-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_16526_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_16526_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3317,11 +3251,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002333_YDR044W-MONOMER_RXN0-1461_controller_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002333_YDR044W-MONOMER_RXN0-1461_controller_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3332,17 +3266,6 @@
           <http://model.geneontology.org/YDR044W-MONOMER_RXN0-1461_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_16526_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_DIMETHUROPORDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3352,7 +3275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3363,14 +3286,25 @@
 <http://identifiers.org/sgd/S000002640>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_15377_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-69>
+<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_BFO_0000066_reaction_UROGENDECARBOX-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002234_CHEBI_15377_RXN0-1461_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3378,11 +3312,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002233_CHEBI_29033_PROTOHEMEFERROCHELAT-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002233_CHEBI_29033_PROTOHEMEFERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3396,26 +3330,15 @@
 <http://purl.obolibrary.org/obo/GO_0043115>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002233_CHEBI_57845_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_15378_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_15378_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3426,14 +3349,14 @@
           <http://model.geneontology.org/CHEBI_15378_DIMETHUROPORDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002413_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002233_CHEBI_57308_UROGENIIISYN-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3446,7 +3369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3457,14 +3380,14 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002234_CHEBI_17627_PROTOHEMEFERROCHELAT-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_15378_RXN-13403_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3477,24 +3400,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-69SmallMolecule38322> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002413_PROTOPORGENOXI-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -3503,11 +3415,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002234_CHEBI_16526_UROGENDECARBOX-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002234_CHEBI_16526_UROGENDECARBOX-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3518,14 +3430,14 @@
           <http://model.geneontology.org/CHEBI_16526_UROGENDECARBOX-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-13403_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002233_CHEBI_15377_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3533,11 +3445,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13403_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13403_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3548,18 +3460,62 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-69/YeastPathways_PWY3O-69>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002413_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000066_reaction_OHMETHYLBILANESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002333_YDL205C-MONOMER_OHMETHYLBILANESYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002233_CHEBI_58827_RXN-13403_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000066_reaction_OHMETHYLBILANESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000066_reaction_OHMETHYLBILANESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3570,26 +3526,15 @@
           <http://model.geneontology.org/reaction_OHMETHYLBILANESYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002233_CHEBI_57308_UROGENIIISYN-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3600,14 +3545,25 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-69/YeastPathways_PWY3O-69>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002234_CHEBI_60052_SIROHEME-FERROCHELAT-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002234_CHEBI_28938_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3618,11 +3574,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_15379_RXN0-1461_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_15379_RXN0-1461_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3633,17 +3589,6 @@
           <http://model.geneontology.org/CHEBI_15379_RXN0-1461>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002413_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57292>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3651,11 +3596,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_58126_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_58126_PORPHOBILSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3665,6 +3610,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58126_PORPHOBILSYNTH-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002234_CHEBI_15378_SIROHEME-FERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-13403>
         a       <http://purl.obolibrary.org/obo/GO_0004851> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3685,7 +3641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3710,7 +3666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3727,7 +3683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3739,11 +3695,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002234_CHEBI_60052_SIROHEME-FERROCHELAT-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_RO_0002234_CHEBI_60052_SIROHEME-FERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3754,6 +3710,17 @@
           <http://model.geneontology.org/CHEBI_60052_SIROHEME-FERROCHELAT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_57856_RXN-13403_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57945_DIMETHUROPORDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3763,7 +3730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3778,7 +3745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3790,11 +3757,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002233_CHEBI_15379_PROTOPORGENOXI-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002233_CHEBI_15379_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3805,14 +3772,14 @@
           <http://model.geneontology.org/CHEBI_15379_PROTOPORGENOXI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002234_CHEBI_16526_UROGENDECARBOX-RXN_SGD_YeastPathways_PWY3O-69>
+<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_RO_0002234_CHEBI_16240_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_PWY3O-69>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3831,7 +3798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3843,11 +3810,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002233_CHEBI_57845_OHMETHYLBILANESYN-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002233_CHEBI_57845_OHMETHYLBILANESYN-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3862,11 +3829,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_58827_RXN-13403_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_58827_RXN-13403_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3877,17 +3844,6 @@
           <http://model.geneontology.org/CHEBI_58827_RXN-13403>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_57856_RXN-13403_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY3O-69>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3897,7 +3853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of heme and siroheme biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3905,14 +3861,14 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002234_CHEBI_58126_PORPHOBILSYNTH-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002413_SIROHEME-FERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3920,11 +3876,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" , "Provides Input For Rule. The relation '4 porphobilinogen + H<sub>2</sub>O &rarr; 4 ammonium + preuroporphyrinogen' 'null' 'preuroporphyrinogen &rarr; uroporphyrinogen-III + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002413_UROGENIIISYN-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_RO_0002413_UROGENIIISYN-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3935,38 +3891,71 @@
           <http://model.geneontology.org/UROGENIIISYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002333_YDR047W-MONOMER_UROGENDECARBOX-RXN_controller_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_58351_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002233_CHEBI_15378_RXN0-1461_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002333_YDR232W-MONOMER_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_UROGENIIISYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_60052>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002233_CHEBI_58827_RXN-13403_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_356416_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_356416_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3984,11 +3973,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'coproporphyrinogen III + oxygen + 2 H<SUP>+</SUP> &rarr; protoporphyrinogen IX + 2 CO<SUB>2</SUB> + 2 H<sub>2</sub>O' 'null' 'protoporphyrinogen IX + 3 oxygen &rarr; protoporphyrin IX + 3 hydrogen peroxide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002413_PROTOPORGENOXI-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1461_RO_0002413_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4002,26 +3991,15 @@
 <http://purl.obolibrary.org/obo/GO_0004655>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002413_SIROHEME-FERROCHELAT-RXN_SGD_YeastPathways_PWY3O-69>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002233_CHEBI_57306_PROTOPORGENOXI-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002233_CHEBI_57306_PROTOPORGENOXI-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4036,11 +4014,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_57287_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002234_CHEBI_57287_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4070,7 +4048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4078,14 +4056,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-13403_BFO_0000066_reaction_RXN-13403_location_lociGO_0005829_SGD_YeastPathways_PWY3O-69>
+<http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002333_YOR278W-MONOMER_UROGENIIISYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-69>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4093,11 +4071,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4108,17 +4086,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-69/YeastPathways_PWY3O-69>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SIROHEME-FERROCHELAT-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_YeastPathways_PWY3O-69>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -4126,11 +4093,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_57945_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_57945_DIMETHUROPORDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4141,15 +4108,26 @@
           <http://model.geneontology.org/CHEBI_57945_DIMETHUROPORDEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002333_MONOMER3O-47_RXN-13403_controller_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002234_CHEBI_15378_PROTOHEMEFERROCHELAT-RXN_SGD_YeastPathways_PWY3O-69> ;
+          <http://model.geneontology.org/ev_w_id_PROTOHEMEFERROCHELAT-RXN_RO_0002234_CHEBI_15378_PROTOHEMEFERROCHELAT-RXN_SGD_PWY_YeastPathways_PWY3O-69> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4160,26 +4138,37 @@
           <http://model.geneontology.org/CHEBI_15378_PROTOHEMEFERROCHELAT-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_59789>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_RO_0002234_CHEBI_58351_DIMETHUROPORDEHYDROG-RXN_SGD_YeastPathways_PWY3O-69>
+<http://model.geneontology.org/ev_w_id_PROTOPORGENOXI-RXN_BFO_0000066_reaction_PROTOPORGENOXI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-69>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-69" ;
+                "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_RO_0002233_CHEBI_57305_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_59789>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_PROTOHEMEFERROCHELAT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4202,10 +4191,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-69BiochemicalReaction38296> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_BFO_0000050_YeastPathways_PWY3O-69/YeastPathways_PWY3O-69_SGD_PWY_YeastPathways_PWY3O-69>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-69" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-697.ttl
+++ b/models/YeastPathways_PWY3O-697.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -27,11 +27,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_e431d07d-093a-45f7-8332-1e4d9f518ced_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_e2298fd4-7bcf-496e-a869-26e40e68468a_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,22 +39,22 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e431d07d-093a-45f7-8332-1e4d9f518ced_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/e2298fd4-7bcf-496e-a869-26e40e68468a_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57305>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57305>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -77,11 +77,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -92,29 +92,29 @@
           <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -125,14 +125,25 @@
           <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_2a3a6f2f-8de5-4963-b971-2e4641c628e3_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -140,11 +151,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,43 +169,15 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_ca8b3fbe-d6e7-4dfd-be53-7242e3bd9d1e_GCVMULTI-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/04b27d79-bd24-4678-81a1-90ae89792185_THYMIDYLATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66168> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_f16c9440-de5b-4bde-a85c-82bb8a9fa023_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_fad9bd29-0a6e-4b78-9be5-109cb79efe46_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -202,15 +185,59 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f16c9440-de5b-4bde-a85c-82bb8a9fa023_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/fad9bd29-0a6e-4b78-9be5-109cb79efe46_FORMATETHFLIG-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_1df332bd-3896-4c38-b9d2-3645b40f6cb9_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_a4c32e6f-b251-4529-924d-2e1dd7a0fb7e_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -218,11 +245,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -238,7 +265,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -246,11 +284,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_28b96cca-399a-430c-8409-b762f2efc1e9_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_fd3decd4-5a0e-4a57-a365-8b5d94384dfd_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,20 +296,20 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/28b96cca-399a-430c-8409-b762f2efc1e9_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/fd3decd4-5a0e-4a57-a365-8b5d94384dfd_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -279,11 +317,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_3cf75b87-1cdd-47c1-b395-312144c61e83_GCVMULTI-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_268c5702-6a78-4434-bb94-89ba90da193f_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -291,46 +329,21 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3cf75b87-1cdd-47c1-b395-312144c61e83_GCVMULTI-RXN>
+          <http://model.geneontology.org/268c5702-6a78-4434-bb94-89ba90da193f_GCVMULTI-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004801>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_28b96cca-399a-430c-8409-b762f2efc1e9_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/6f836277-6f3d-4a7a-9191-fa0fcdfc2b4f_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -345,11 +358,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -360,28 +373,6 @@
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_6f836277-6f3d-4a7a-9191-fa0fcdfc2b4f_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -389,11 +380,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,58 +395,97 @@
           <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_4be66b3f-175d-4ef4-91c1-a6c32d32d582_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YPL023C-MONOMER_1.5.1.20-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/48dbacae-14be-4fc1-a0c0-5fea9d98f939_GLYOHMETRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/SGD_S000001788_CPLX3O-317_component>
         a       <http://identifiers.org/sgd/S000001788> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57540_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57540_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,14 +496,36 @@
           <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -481,11 +533,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -508,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -523,7 +575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -535,11 +587,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,14 +602,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-697/YeastPathways_PWY3O-697>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -566,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -580,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -592,11 +644,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,18 +664,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57540_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -636,7 +688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -644,15 +696,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_0d65720f-b838-4853-92c9-f240f9920093_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_930713d3-1d92-44de-880b-f77ba9ba8f31_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,8 +723,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0d65720f-b838-4853-92c9-f240f9920093_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/930713d3-1d92-44de-880b-f77ba9ba8f31_GLYOHMETRANS-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001876>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -670,11 +744,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -688,26 +762,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_246422>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_def448e9-eac3-43fe-a510-3f029d3b155b_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_c92a9bca-ffda-4719-b6ab-7db29cf76c30_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -715,19 +778,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/def448e9-eac3-43fe-a510-3f029d3b155b_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/c92a9bca-ffda-4719-b6ab-7db29cf76c30_DIHYDROFOLATEREDUCT-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/FORMATETHFLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004329> ;
@@ -738,9 +790,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/2a3a6f2f-8de5-4963-b971-2e4641c628e3_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/a8aadad0-1db2-4598-86e1-5ad1053dfd62_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> , <http://model.geneontology.org/f16c9440-de5b-4bde-a85c-82bb8a9fa023_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> , <http://model.geneontology.org/fad9bd29-0a6e-4b78-9be5-109cb79efe46_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -748,7 +800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -768,7 +820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -785,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -797,11 +849,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -818,32 +870,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/489476bb-b2c9-432e-a7c5-5f1a6397dd2f_1.5.1.15-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_6f836277-6f3d-4a7a-9191-fa0fcdfc2b4f_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_1df332bd-3896-4c38-b9d2-3645b40f6cb9_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -851,7 +897,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6f836277-6f3d-4a7a-9191-fa0fcdfc2b4f_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/1df332bd-3896-4c38-b9d2-3645b40f6cb9_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
@@ -863,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -880,7 +926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -892,11 +938,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -907,8 +953,39 @@
           <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
 ] .
 
+<http://model.geneontology.org/7ebb1585-e640-47b2-8e83-dbfabffe2b10_1.5.1.20-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66298> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15740>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/1b9e96a5-d34e-4d93-ab79-9fc9dd65183c_GCVMULTI-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -916,15 +993,18 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/b93b6eb0-a5ee-4a50-939e-7fde4a2b4f5e_THYMIDYLATESYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -935,15 +1015,26 @@
           <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,9 +1057,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/379596fc-995b-48de-af63-940e36768a13_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/a4e2ee46-1013-45d3-aca0-77533ce3bf95_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/28b96cca-399a-430c-8409-b762f2efc1e9_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/fd3decd4-5a0e-4a57-a365-8b5d94384dfd_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -976,7 +1067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -988,11 +1079,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1012,9 +1103,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/0d65720f-b838-4853-92c9-f240f9920093_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/930713d3-1d92-44de-880b-f77ba9ba8f31_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/04b27d79-bd24-4678-81a1-90ae89792185_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/4be66b3f-175d-4ef4-91c1-a6c32d32d582_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1022,7 +1113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1039,7 +1130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1047,43 +1138,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/fe89ace8-cc92-41d2-ab2d-adf2317aa17c_1.5.1.20-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66298> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1100,40 +1163,21 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/930713d3-1d92-44de-880b-f77ba9ba8f31_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1144,25 +1188,14 @@
           <http://model.geneontology.org/THYMIDYLATESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_15740_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1170,11 +1203,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_43474_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1189,11 +1222,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1204,43 +1237,15 @@
           <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/3cf75b87-1cdd-47c1-b395-312144c61e83_GCVMULTI-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.15-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1256,7 +1261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1269,7 +1274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1281,11 +1286,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_456216_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1296,14 +1301,25 @@
           <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_9ec909b1-41f5-41c3-a681-f4e4ed243a23_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YGL125W-MONOMER_1.5.1.20-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1311,11 +1327,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_fe89ace8-cc92-41d2-ab2d-adf2317aa17c_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_7ebb1585-e640-47b2-8e83-dbfabffe2b10_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1323,8 +1339,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fe89ace8-cc92-41d2-ab2d-adf2317aa17c_1.5.1.20-RXN>
+          <http://model.geneontology.org/7ebb1585-e640-47b2-8e83-dbfabffe2b10_1.5.1.20-RXN>
 ] .
+
+<http://model.geneontology.org/eea64a52-2b45-4f7a-bb83-5b51ebfa4589_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004477> ;
@@ -1335,9 +1354,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/6f836277-6f3d-4a7a-9191-fa0fcdfc2b4f_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/1df332bd-3896-4c38-b9d2-3645b40f6cb9_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/4d775572-680d-4784-95c4-ed49c6f0d4d6_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/463d8b31-eb18-4494-acdb-8343920932dc_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1345,7 +1364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1357,11 +1376,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1372,49 +1391,15 @@
           <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ce2c6b9e-22d2-4ad0-8ee0-9c0c7fe92be5_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/f16c9440-de5b-4bde-a85c-82bb8a9fa023_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1430,7 +1415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1441,11 +1426,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_9ec909b1-41f5-41c3-a681-f4e4ed243a23_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_a4c32e6f-b251-4529-924d-2e1dd7a0fb7e_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1453,50 +1438,56 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9ec909b1-41f5-41c3-a681-f4e4ed243a23_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/a4c32e6f-b251-4529-924d-2e1dd7a0fb7e_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57540_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/463d8b31-eb18-4494-acdb-8343920932dc_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66382> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_930713d3-1d92-44de-880b-f77ba9ba8f31_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_489476bb-b2c9-432e-a7c5-5f1a6397dd2f_1.5.1.15-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1504,11 +1495,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1519,17 +1510,28 @@
           <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_63528>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_63528>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_b93b6eb0-a5ee-4a50-939e-7fde4a2b4f5e_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1537,11 +1539,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1556,11 +1558,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1571,25 +1573,16 @@
           <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "thymidylate synthase" ;
-        <http://purl.obolibrary.org/obo/BFO_0000051>
-                <http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component> ;
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697Complex66173> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
-
-<http://identifiers.org/sgd/S000002426>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1600,7 +1593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1608,18 +1601,52 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "thymidylate synthase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697Complex66173> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Complex" .
+
+<http://identifiers.org/sgd/S000002426>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_c92a9bca-ffda-4719-b6ab-7db29cf76c30_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1630,18 +1657,48 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-697/YeastPathways_PWY3O-697>
 ] .
 
-<http://purl.obolibrary.org/obo/BFO_0000051>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_1b9e96a5-d34e-4d93-ab79-9fc9dd65183c_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_a8aadad0-1db2-4598-86e1-5ad1053dfd62_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1652,37 +1709,15 @@
           <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GCVMULTI-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1693,57 +1728,43 @@
           <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004048>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/0d65720f-b838-4853-92c9-f240f9920093_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1754,20 +1775,6 @@
           <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_15378_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/17f23a77-9713-4640-a37d-168a920a33d6_THYMIDYLATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
         a       <http://identifiers.org/sgd/S000005762> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1775,7 +1782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1783,37 +1790,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1824,14 +1809,25 @@
           <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_eea64a52-2b45-4f7a-bb83-5b51ebfa4589_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1839,11 +1835,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_1.5.1.15-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1854,64 +1850,40 @@
           <http://model.geneontology.org/1.5.1.15-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_def448e9-eac3-43fe-a510-3f029d3b155b_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/2a3a6f2f-8de5-4963-b971-2e4641c628e3_METHENYLTHFCYCLOHYDRO-RXN>
+<http://model.geneontology.org/a4c32e6f-b251-4529-924d-2e1dd7a0fb7e_DIHYDROFOLATEREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/e2298fd4-7bcf-496e-a869-26e40e68468a_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/b0a86b3a-5069-4b58-b50c-fd6d18c2ebac_1.5.1.15-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YPL023C-MONOMER_1.5.1.20-RXN_controller_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_30616_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1919,11 +1891,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_ca8b3fbe-d6e7-4dfd-be53-7242e3bd9d1e_GCVMULTI-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_1b9e96a5-d34e-4d93-ab79-9fc9dd65183c_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1931,7 +1903,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ca8b3fbe-d6e7-4dfd-be53-7242e3bd9d1e_GCVMULTI-RXN>
+          <http://model.geneontology.org/1b9e96a5-d34e-4d93-ab79-9fc9dd65183c_GCVMULTI-RXN>
 ] .
 
 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller>
@@ -1941,7 +1913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1949,26 +1921,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_4d775572-680d-4784-95c4-ed49c6f0d4d6_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1982,43 +1943,38 @@
 <http://identifiers.org/sgd/S000005762>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_2d7d9c2b-4e72-4a83-8247-a7fb7486e923_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004477>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004477>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/fd3decd4-5a0e-4a57-a365-8b5d94384dfd_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_2a3a6f2f-8de5-4963-b971-2e4641c628e3_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_a8aadad0-1db2-4598-86e1-5ad1053dfd62_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2026,26 +1982,15 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2a3a6f2f-8de5-4963-b971-2e4641c628e3_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/a8aadad0-1db2-4598-86e1-5ad1053dfd62_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_43474_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
         a       <http://identifiers.org/sgd/S000004801> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2053,11 +1998,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YGL125W-MONOMER_1.5.1.20-RXN_controller_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YGL125W-MONOMER_1.5.1.20-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2077,9 +2022,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/e431d07d-093a-45f7-8332-1e4d9f518ced_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/e2298fd4-7bcf-496e-a869-26e40e68468a_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/ce2c6b9e-22d2-4ad0-8ee0-9c0c7fe92be5_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/48dbacae-14be-4fc1-a0c0-5fea9d98f939_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2087,7 +2032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2095,14 +2040,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2115,7 +2060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2127,11 +2072,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2142,15 +2087,26 @@
           <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2164,26 +2120,15 @@
 <http://purl.obolibrary.org/obo/GO_0004489>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2194,42 +2139,64 @@
           <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_fe89ace8-cc92-41d2-ab2d-adf2317aa17c_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_48dbacae-14be-4fc1-a0c0-5fea9d98f939_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2237,11 +2204,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_04b27d79-bd24-4678-81a1-90ae89792185_THYMIDYLATESYN-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_4be66b3f-175d-4ef4-91c1-a6c32d32d582_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2249,36 +2216,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/04b27d79-bd24-4678-81a1-90ae89792185_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/4be66b3f-175d-4ef4-91c1-a6c32d32d582_THYMIDYLATESYN-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_ce2c6b9e-22d2-4ad0-8ee0-9c0c7fe92be5_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-697> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ce2c6b9e-22d2-4ad0-8ee0-9c0c7fe92be5_GLYOHMETRANS-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_17f23a77-9713-4640-a37d-168a920a33d6_THYMIDYLATESYN-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2286,11 +2234,52 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GCVMULTI-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_48dbacae-14be-4fc1-a0c0-5fea9d98f939_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/48dbacae-14be-4fc1-a0c0-5fea9d98f939_GLYOHMETRANS-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2301,17 +2290,6 @@
           <http://model.geneontology.org/GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2321,7 +2299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2332,25 +2310,25 @@
 <http://identifiers.org/sgd/S000005600>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2358,11 +2336,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2382,7 +2360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2390,26 +2368,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_4d775572-680d-4784-95c4-ed49c6f0d4d6_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_463d8b31-eb18-4494-acdb-8343920932dc_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2417,22 +2384,33 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4d775572-680d-4784-95c4-ed49c6f0d4d6_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/463d8b31-eb18-4494-acdb-8343920932dc_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000467>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003093> ;
@@ -2441,7 +2419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2453,11 +2431,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2473,7 +2451,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_e2298fd4-7bcf-496e-a869-26e40e68468a_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2485,18 +2474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2509,9 +2487,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/ca8b3fbe-d6e7-4dfd-be53-7242e3bd9d1e_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/1b9e96a5-d34e-4d93-ab79-9fc9dd65183c_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/489476bb-b2c9-432e-a7c5-5f1a6397dd2f_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/b0a86b3a-5069-4b58-b50c-fd6d18c2ebac_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2519,7 +2497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2527,37 +2505,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/a8aadad0-1db2-4598-86e1-5ad1053dfd62_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2568,18 +2538,37 @@
           <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
 ] .
 
-<http://model.geneontology.org/2d7d9c2b-4e72-4a83-8247-a7fb7486e923_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_a4e2ee46-1013-45d3-aca0-77533ce3bf95_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2595,26 +2584,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/def448e9-eac3-43fe-a510-3f029d3b155b_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005944> ;
@@ -2623,7 +2606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2631,15 +2614,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/fad9bd29-0a6e-4b78-9be5-109cb79efe46_FORMATETHFLIG-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2650,26 +2650,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-697/YeastPathways_PWY3O-697>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_3cf75b87-1cdd-47c1-b395-312144c61e83_GCVMULTI-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2687,13 +2676,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697Protein66501> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2704,7 +2715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2716,11 +2727,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2741,11 +2752,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2756,17 +2767,6 @@
           <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_ce2c6b9e-22d2-4ad0-8ee0-9c0c7fe92be5_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57305> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2776,7 +2776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2788,11 +2788,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2806,6 +2806,39 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -2813,11 +2846,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2828,25 +2861,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-697/YeastPathways_PWY3O-697>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2862,7 +2884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2873,15 +2895,26 @@
 <http://identifiers.org/sgd/S000005944>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_15740_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_15740_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2892,15 +2925,26 @@
           <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YPL023C-MONOMER_1.5.1.20-RXN_controller_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YPL023C-MONOMER_1.5.1.20-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2923,7 +2967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2935,11 +2979,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_379596fc-995b-48de-af63-940e36768a13_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_a4e2ee46-1013-45d3-aca0-77533ce3bf95_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2947,18 +2991,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/379596fc-995b-48de-af63-940e36768a13_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/a4e2ee46-1013-45d3-aca0-77533ce3bf95_GLYOHMETRANS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2969,26 +3013,81 @@
           <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_b0a86b3a-5069-4b58-b50c-fd6d18c2ebac_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_30616_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_268c5702-6a78-4434-bb94-89ba90da193f_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2996,11 +3095,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3011,15 +3110,26 @@
           <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3030,28 +3140,6 @@
           <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000467> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3059,7 +3147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3067,32 +3155,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/28b96cca-399a-430c-8409-b762f2efc1e9_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3103,47 +3174,25 @@
           <http://model.geneontology.org/GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_7ebb1585-e640-47b2-8e83-dbfabffe2b10_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YGL125W-MONOMER_1.5.1.20-RXN_controller_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3151,11 +3200,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_15378_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_15378_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3166,14 +3215,17 @@
           <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.15-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/1df332bd-3896-4c38-b9d2-3645b40f6cb9_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_15740_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3184,11 +3236,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3199,14 +3251,14 @@
           <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_456216_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3214,11 +3266,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3229,19 +3281,27 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-697/YeastPathways_PWY3O-697>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_f16c9440-de5b-4bde-a85c-82bb8a9fa023_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/379596fc-995b-48de-af63-940e36768a13_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_463d8b31-eb18-4494-acdb-8343920932dc_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -3252,7 +3312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "folate interconversions - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3264,11 +3324,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3288,7 +3348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3299,6 +3359,39 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_28938> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3308,7 +3401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3325,24 +3418,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66412> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -3356,9 +3438,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/9ec909b1-41f5-41c3-a681-f4e4ed243a23_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/a4c32e6f-b251-4529-924d-2e1dd7a0fb7e_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> , <http://model.geneontology.org/3cf75b87-1cdd-47c1-b395-312144c61e83_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/268c5702-6a78-4434-bb94-89ba90da193f_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3366,7 +3448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3378,11 +3460,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3400,7 +3482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3408,37 +3490,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3452,26 +3512,15 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_17f23a77-9713-4640-a37d-168a920a33d6_THYMIDYLATESYN-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_b93b6eb0-a5ee-4a50-939e-7fde4a2b4f5e_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3479,7 +3528,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/17f23a77-9713-4640-a37d-168a920a33d6_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/b93b6eb0-a5ee-4a50-939e-7fde4a2b4f5e_THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
@@ -3491,9 +3540,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/17f23a77-9713-4640-a37d-168a920a33d6_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/b93b6eb0-a5ee-4a50-939e-7fde4a2b4f5e_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/def448e9-eac3-43fe-a510-3f029d3b155b_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/c92a9bca-ffda-4719-b6ab-7db29cf76c30_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3501,7 +3550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3509,26 +3558,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_489476bb-b2c9-432e-a7c5-5f1a6397dd2f_1.5.1.15-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_b0a86b3a-5069-4b58-b50c-fd6d18c2ebac_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3536,40 +3574,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/489476bb-b2c9-432e-a7c5-5f1a6397dd2f_1.5.1.15-RXN>
+          <http://model.geneontology.org/b0a86b3a-5069-4b58-b50c-fd6d18c2ebac_1.5.1.15-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_04b27d79-bd24-4678-81a1-90ae89792185_THYMIDYLATESYN-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3580,14 +3596,14 @@
           <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3595,11 +3611,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_30616_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_30616_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3610,37 +3626,37 @@
           <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://identifiers.org/sgd/S000003436>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://identifiers.org/sgd/S000003436>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001876> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3653,15 +3669,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> , <http://model.geneontology.org/2d7d9c2b-4e72-4a83-8247-a7fb7486e923_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> , <http://model.geneontology.org/eea64a52-2b45-4f7a-bb83-5b51ebfa4589_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/fe89ace8-cc92-41d2-ab2d-adf2317aa17c_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/7ebb1585-e640-47b2-8e83-dbfabffe2b10_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller> , <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3669,15 +3685,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/4be66b3f-175d-4ef4-91c1-a6c32d32d582_THYMIDYLATESYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66168> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3695,7 +3728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3710,7 +3743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3727,7 +3760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3735,37 +3768,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3776,9 +3787,6 @@
           <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/e431d07d-093a-45f7-8332-1e4d9f518ced_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3787,23 +3795,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_15378_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004799>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3817,7 +3825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3825,15 +3833,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_fd3decd4-5a0e-4a57-a365-8b5d94384dfd_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3844,27 +3863,22 @@
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_1.5.1.15-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/268c5702-6a78-4434-bb94-89ba90da193f_GCVMULTI-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3873,11 +3887,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3888,6 +3902,23 @@
           <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/c92a9bca-ffda-4719-b6ab-7db29cf76c30_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3897,7 +3928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3909,11 +3940,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3924,35 +3955,37 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-697/YeastPathways_PWY3O-697>
 ] .
 
-<http://model.geneontology.org/ca8b3fbe-d6e7-4dfd-be53-7242e3bd9d1e_GCVMULTI-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/4d775572-680d-4784-95c4-ed49c6f0d4d6_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66382> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_1.5.1.20-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3972,7 +4005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3987,11 +4020,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4002,15 +4035,18 @@
           <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
 ] .
 
+<http://model.geneontology.org/a4e2ee46-1013-45d3-aca0-77533ce3bf95_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4021,15 +4057,26 @@
           <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_2d7d9c2b-4e72-4a83-8247-a7fb7486e923_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_eea64a52-2b45-4f7a-bb83-5b51ebfa4589_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4037,19 +4084,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2d7d9c2b-4e72-4a83-8247-a7fb7486e923_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/eea64a52-2b45-4f7a-bb83-5b51ebfa4589_GLYOHMETRANS-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004329>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4058,11 +4094,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4082,7 +4118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4102,7 +4138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4110,26 +4146,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_0d65720f-b838-4853-92c9-f240f9920093_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4149,7 +4174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4157,25 +4182,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002333_CPLX3O-213_GCVMULTI-RXN_controller_SGD_YeastPathways_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_fad9bd29-0a6e-4b78-9be5-109cb79efe46_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_379596fc-995b-48de-af63-940e36768a13_GLYOHMETRANS-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4183,11 +4197,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4207,7 +4221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4224,24 +4238,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY3O-697" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/9ec909b1-41f5-41c3-a681-f4e4ed243a23_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_e431d07d-093a-45f7-8332-1e4d9f518ced_DIHYDROFOLATEREDUCT-RXN_SGD_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-7.ttl
+++ b/models/YeastPathways_PWY3O-7.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -36,11 +36,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-aspartate + ATP &rarr; L-aspartyl-4-phosphate + ADP' 'null' 'L-aspartate 4-semialdehyde + NADP<sup>+</sup> + phosphate &larr; L-aspartyl-4-phosphate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,11 +58,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,47 +73,36 @@
           <http://model.geneontology.org/YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_30616_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -123,15 +112,26 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,15 +145,30 @@
 <http://purl.obolibrary.org/obo/GO_0004413>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller>
+        a       <http://identifiers.org/sgd/S000002565> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "aspartic beta semi-aldehyde dehydrogenase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-7Protein39560> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -164,29 +179,14 @@
           <http://model.geneontology.org/YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller>
-        a       <http://identifiers.org/sgd/S000002565> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "aspartic beta semi-aldehyde dehydrogenase" ;
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002333_YCR053W-MONOMER_THRESYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-7Protein39560> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -194,11 +194,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -208,6 +208,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_57590_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -224,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -232,15 +243,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002333_YCR053W-MONOMER_THRESYN-RXN_controller_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002333_YCR053W-MONOMER_THRESYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -255,11 +277,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_57590_HOMOSERKIN-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_57590_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -289,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -301,11 +323,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -316,19 +338,19 @@
           <http://model.geneontology.org/CHEBI_29991_ASPAMINOTRANS-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004736> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -349,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -361,11 +383,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -379,17 +401,6 @@
 <http://identifiers.org/sgd/S000004017>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -402,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -419,13 +430,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-7SmallMolecule39277> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_43474_THRESYN-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001589> ;
@@ -434,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -446,11 +468,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,15 +483,26 @@
           <http://model.geneontology.org/CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -489,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -497,19 +530,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57476>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57476>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -520,7 +564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -535,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -552,13 +596,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-7SmallMolecule39307> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003900>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -571,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -579,11 +634,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000066_reaction_THRESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000066_reaction_THRESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -601,11 +656,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000066_reaction_HOMOSERKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000066_reaction_HOMOSERKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -623,11 +678,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -641,25 +696,14 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-7>
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_PWY_YeastPathways_PWY3O-7>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_30616_HOMOSERKIN-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -672,24 +716,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-7SmallMolecule39292> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERKIN-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57926>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -703,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -711,22 +744,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16452>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0009088>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_537519> ;
@@ -737,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -749,11 +782,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,11 +801,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -790,11 +823,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -805,25 +838,14 @@
           <http://model.geneontology.org/CHEBI_16810_ASPAMINOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-7>
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002333_YHR025W-MONOMER_HOMOSERKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-7>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -832,9 +854,34 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_29991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0004069>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -843,11 +890,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -865,11 +912,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -880,35 +927,26 @@
           <http://model.geneontology.org/CHEBI_13390_HOMOSERDEHYDROG-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_29991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_30616_ASPARTATEKIN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-7SmallMolecule39264> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,6 +957,34 @@
           <http://model.geneontology.org/CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_30616_ASPARTATEKIN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-7SmallMolecule39264> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_HOMOSERKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -928,7 +994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -943,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -951,39 +1017,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_57926_THRESYN-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-7>
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-7>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0004795>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-7>
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_15378_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -997,11 +1049,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_43474_THRESYN-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_43474_THRESYN-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1012,26 +1064,18 @@
           <http://model.geneontology.org/CHEBI_43474_THRESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004795>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_15378_HOMOSERKIN-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_15378_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1046,11 +1090,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,7 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,14 +1122,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002413_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1098,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of threonine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1106,28 +1150,17 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1135,11 +1168,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1155,18 +1188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1174,11 +1196,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1198,7 +1220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1210,11 +1232,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1225,39 +1247,28 @@
           <http://model.geneontology.org/YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003030>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-7>
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-7>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1270,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1285,7 +1296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1303,11 +1314,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" , "Provides Input For Rule. The relation 'hydrogencarbonate + pyruvate + ATP &rarr; oxaloacetate + ADP + phosphate + H<SUP>+</SUP>' 'null' '2-oxoglutarate + L-aspartate &harr; oxaloacetate + L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_ASPAMINOTRANS-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1327,7 +1338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1339,11 +1350,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-homoserine + NAD(P)<sup>+</sup> &larr; L-aspartate 4-semialdehyde + NAD(P)H + H<SUP>+</SUP>' 'null' 'L-homoserine + ATP &rarr; O-phospho-L-homoserine + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERKIN-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1354,26 +1365,15 @@
           <http://model.geneontology.org/HOMOSERKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1389,7 +1389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1402,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1419,7 +1419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1427,22 +1427,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ASPAMINOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004069> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1463,7 +1463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1474,29 +1474,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_57590_HOMOSERKIN-RXN_SGD_YeastPathways_PWY3O-7>
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_57590_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002333_YHR025W-MONOMER_HOMOSERKIN-RXN_controller_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002333_YHR025W-MONOMER_HOMOSERKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1507,40 +1507,18 @@
           <http://model.geneontology.org/YHR025W-MONOMER_HOMOSERKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_13392>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1554,15 +1532,26 @@
 <http://identifiers.org/sgd/S000000422>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1583,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1600,7 +1589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1608,25 +1597,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_15377_THRESYN-RXN_SGD_YeastPathways_PWY3O-7>
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-7>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1643,7 +1643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1660,7 +1660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1668,15 +1668,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_15377_THRESYN-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1696,7 +1707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1711,7 +1722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1723,11 +1734,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1742,11 +1753,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1766,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1783,7 +1794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1791,51 +1802,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_ASPAMINOTRANS-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_15378_HOMOSERKIN-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_15377_THRESYN-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_15377_THRESYN-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1845,6 +1823,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_THRESYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57535>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1858,7 +1847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1870,11 +1859,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_30616_HOMOSERKIN-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_30616_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1889,11 +1878,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1909,7 +1898,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1930,24 +1941,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-7BiochemicalReaction39402> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_537519>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1961,7 +1961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1969,15 +1969,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1988,15 +1999,26 @@
           <http://model.geneontology.org/reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2007,15 +2029,32 @@
           <http://model.geneontology.org/YER052C-MONOMER_ASPARTATEKIN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_43474>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2026,46 +2065,81 @@
           <http://model.geneontology.org/CHEBI_29991_ASPAMINOTRANS-RXN>
 ] .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/CHEBI_43474>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-7>
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-7>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_YeastPathways_PWY3O-7>
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000066_reaction_HOMOSERKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000066_reaction_THRESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-7>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0004412>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2076,37 +2150,29 @@
           <http://model.geneontology.org/YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_456216_HOMOSERKIN-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004412>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2124,11 +2190,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2138,6 +2204,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57535_ASPARTATEKIN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004073> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2158,7 +2235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2175,7 +2252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2183,39 +2260,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002413_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000066_reaction_THRESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-7>
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-7>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2223,11 +2278,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_57926_THRESYN-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_57926_THRESYN-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2242,11 +2297,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_456216_HOMOSERKIN-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_456216_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2260,15 +2315,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_13390>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2279,15 +2345,26 @@
           <http://model.geneontology.org/reaction_ASPARTATEKIN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2298,28 +2375,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-7/YeastPathways_PWY3O-7>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-7>
+<http://identifiers.org/sgd/S000000854>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-7>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000000854>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_43474_THRESYN-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2327,11 +2393,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2346,11 +2412,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2365,11 +2431,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" , "Provides Input For Rule. The relation '2-oxoglutarate + L-aspartate &harr; oxaloacetate + L-glutamate' 'null' 'L-aspartate + ATP &rarr; L-aspartyl-4-phosphate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002413_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002413_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2380,50 +2446,6 @@
           <http://model.geneontology.org/ASPARTATEKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002333_YHR025W-MONOMER_HOMOSERKIN-RXN_controller_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2433,7 +2455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2441,40 +2463,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004073>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2488,15 +2488,26 @@
 <http://identifiers.org/sgd/S000000649>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_57926_THRESYN-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2505,6 +2516,25 @@
           <http://model.geneontology.org/HOMOSERKIN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-7/YeastPathways_PWY3O-7>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_HOMOSERDEHYDROG-RXN>
@@ -2516,7 +2546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2524,51 +2554,54 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-7> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-7>
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-7>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2581,7 +2614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2589,26 +2622,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-homoserine + ATP &rarr; O-phospho-L-homoserine + ADP + H<SUP>+</SUP>' 'null' 'O-phospho-L-homoserine + H<sub>2</sub>O &rarr; L-threonine + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2626,11 +2648,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2648,11 +2670,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2663,25 +2685,14 @@
           <http://model.geneontology.org/CHEBI_29985_ASPAMINOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000066_reaction_HOMOSERKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_456216_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2707,7 +2718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2719,11 +2730,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2734,15 +2745,37 @@
           <http://model.geneontology.org/CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2757,11 +2790,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2772,36 +2805,47 @@
           <http://model.geneontology.org/reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002333_YCR053W-MONOMER_THRESYN-RXN_controller_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-7>
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-7>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2814,7 +2858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2826,11 +2870,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_57590_HOMOSERKIN-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_57590_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2840,17 +2884,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57590_HOMOSERKIN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/HOMOSERDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004412> ;
@@ -2871,7 +2904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2883,11 +2916,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2898,6 +2931,17 @@
           <http://model.geneontology.org/CHEBI_57476_HOMOSERDEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_HOMOSERKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2907,7 +2951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2919,11 +2963,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-aspartate 4-semialdehyde + NADP<sup>+</sup> + phosphate &larr; L-aspartyl-4-phosphate + NADPH + H<SUP>+</SUP>' 'null' 'L-homoserine + NAD(P)<sup>+</sup> &larr; L-aspartate 4-semialdehyde + NAD(P)H + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-7> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-7> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2939,64 +2983,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_57590_HOMOSERKIN-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
+                "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-70.ttl
+++ b/models/YeastPathways_PWY3O-70.ttl
@@ -1,14 +1,3 @@
-<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-70/YeastPathways_PWY3O-70_SGD_YeastPathways_PWY3O-70>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-70" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_30089>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -22,11 +11,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_CHEBI_30089_CHITIN-DEACETYLASE-RXN_SGD_YeastPathways_PWY3O-70> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_CHEBI_30089_CHITIN-DEACETYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-70> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,17 +26,28 @@
           <http://model.geneontology.org/CHEBI_30089_CHITIN-DEACETYLASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002333_YLR307W-MONOMER_CHITIN-DEACETYLASE-RXN_controller_SGD_YeastPathways_PWY3O-70>
+<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_5946d03c-e92b-45b3-8083-645ac6c82601_CHITIN-DEACETYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-70>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-70" ;
+                "SGD_PWY:PWY3O-70" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002333_YLR307W-MONOMER_CHITIN-DEACETYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-70>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -60,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -71,6 +71,17 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002233_CHEBI_17029_CHITIN-DEACETYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-70>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-70" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -78,11 +89,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002233_CHEBI_17029_CHITIN-DEACETYLASE-RXN_SGD_YeastPathways_PWY3O-70> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002233_CHEBI_17029_CHITIN-DEACETYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-70> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -92,6 +103,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_17029_CHITIN-DEACETYLASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002233_CHEBI_15377_CHITIN-DEACETYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-70>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-70" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -104,6 +126,23 @@
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/5946d03c-e92b-45b3-8083-645ac6c82601_CHITIN-DEACETYLASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "chitosan" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-70SmallMolecule69333> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -118,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -135,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -155,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -167,11 +206,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002233_CHEBI_15377_CHITIN-DEACETYLASE-RXN_SGD_YeastPathways_PWY3O-70> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002233_CHEBI_15377_CHITIN-DEACETYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-70> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,6 +224,17 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002333_YLR308W-MONOMER_CHITIN-DEACETYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-70>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-70" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-70>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -194,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "chitosan biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -209,11 +259,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002333_YLR308W-MONOMER_CHITIN-DEACETYLASE-RXN_controller_SGD_YeastPathways_PWY3O-70> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002333_YLR308W-MONOMER_CHITIN-DEACETYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-70> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -231,11 +281,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_BFO_0000066_reaction_CHITIN-DEACETYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-70> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_BFO_0000066_reaction_CHITIN-DEACETYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-70> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,36 +296,14 @@
           <http://model.geneontology.org/reaction_CHITIN-DEACETYLASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002233_CHEBI_15377_CHITIN-DEACETYLASE-RXN_SGD_YeastPathways_PWY3O-70>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-70" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002233_CHEBI_17029_CHITIN-DEACETYLASE-RXN_SGD_YeastPathways_PWY3O-70>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-70" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_BFO_0000066_reaction_CHITIN-DEACETYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-70>
+<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_CHEBI_30089_CHITIN-DEACETYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-70>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-70" ;
+                "SGD_PWY:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -284,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -294,26 +322,15 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002333_YLR308W-MONOMER_CHITIN-DEACETYLASE-RXN_controller_SGD_YeastPathways_PWY3O-70>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-70" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002333_YLR307W-MONOMER_CHITIN-DEACETYLASE-RXN_controller_SGD_YeastPathways_PWY3O-70> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002333_YLR307W-MONOMER_CHITIN-DEACETYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-70> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -334,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -359,13 +376,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15377_CHITIN-DEACETYLASE-RXN> , <http://model.geneontology.org/CHEBI_17029_CHITIN-DEACETYLASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_30089_CHITIN-DEACETYLASE-RXN> , <http://model.geneontology.org/9e4e007c-8dc2-4911-a059-63a6bf389d74_CHITIN-DEACETYLASE-RXN> ;
+                <http://model.geneontology.org/CHEBI_30089_CHITIN-DEACETYLASE-RXN> , <http://model.geneontology.org/5946d03c-e92b-45b3-8083-645ac6c82601_CHITIN-DEACETYLASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR307W-MONOMER_CHITIN-DEACETYLASE-RXN_controller> , <http://model.geneontology.org/YLR308W-MONOMER_CHITIN-DEACETYLASE-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -377,11 +394,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-70/YeastPathways_PWY3O-70_SGD_YeastPathways_PWY3O-70> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-70/YeastPathways_PWY3O-70_SGD_PWY_YeastPathways_PWY3O-70> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -398,60 +415,43 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_CHEBI_30089_CHITIN-DEACETYLASE-RXN_SGD_YeastPathways_PWY3O-70>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-70" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_9e4e007c-8dc2-4911-a059-63a6bf389d74_CHITIN-DEACETYLASE-RXN_SGD_YeastPathways_PWY3O-70>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-70" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/9e4e007c-8dc2-4911-a059-63a6bf389d74_CHITIN-DEACETYLASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "chitosan" ;
+<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_BFO_0000066_reaction_CHITIN-DEACETYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-70>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-70SmallMolecule69333> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-70/YeastPathways_PWY3O-70_SGD_PWY_YeastPathways_PWY3O-70>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-70" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_9e4e007c-8dc2-4911-a059-63a6bf389d74_CHITIN-DEACETYLASE-RXN_SGD_YeastPathways_PWY3O-70> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_5946d03c-e92b-45b3-8083-645ac6c82601_CHITIN-DEACETYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-70> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -459,7 +459,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CHITIN-DEACETYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9e4e007c-8dc2-4911-a059-63a6bf389d74_CHITIN-DEACETYLASE-RXN>
+          <http://model.geneontology.org/5946d03c-e92b-45b3-8083-645ac6c82601_CHITIN-DEACETYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-70/YeastPathways_PWY3O-70>
@@ -471,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>

--- a/models/YeastPathways_PWY3O-743.ttl
+++ b/models/YeastPathways_PWY3O-743.ttl
@@ -1,37 +1,26 @@
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002411_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-743>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002333_YJR133W-MONOMER_XANPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
+                "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57464>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -42,26 +31,30 @@
           <http://model.geneontology.org/CHEBI_29888_GUANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002807> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "hypoxanthine guanine phosphoribosyltransferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-743Protein47990> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_16235_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_16235_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,20 +65,16 @@
           <http://model.geneontology.org/CHEBI_16235_GUANINE-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002807> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "hypoxanthine guanine phosphoribosyltransferase" ;
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-743Protein47990> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -105,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,11 +106,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -147,24 +136,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-743SmallMolecule47911> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-743>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GUANINE-DEAMINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008892> ;
@@ -187,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -198,50 +176,39 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002413_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16235_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-743>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-743>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-743/YeastPathways_PWY3O-743_SGD_YeastPathways_PWY3O-743>
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000066_reaction_GUANINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-743>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
+                "SGD_PWY:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -249,11 +216,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,11 +235,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -300,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -311,17 +278,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_16235_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -330,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -339,6 +295,17 @@
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_57464_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004422> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -357,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -365,15 +332,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16235_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -387,17 +365,6 @@
 <http://purl.obolibrary.org/obo/GO_0004422>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_57464_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_17712_GUANINE-DEAMINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17712> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -407,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -422,7 +389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -440,11 +407,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -460,7 +427,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -468,11 +446,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002411_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002411_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -483,50 +461,6 @@
           <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-743/YeastPathways_PWY3O-743_SGD_YeastPathways_PWY3O-743>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-743>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002333_MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller_SGD_YeastPathways_PWY3O-743>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_28938_GUANINE-DEAMINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_28938> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -536,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -551,11 +485,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16235_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16235_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -566,15 +500,26 @@
           <http://model.geneontology.org/CHEBI_16235_GUANPRIBOSYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -591,28 +536,6 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-743>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15377_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -620,11 +543,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -634,6 +557,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_17712_GUANINE-DEAMINASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17712>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -647,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -662,11 +596,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-743/YeastPathways_PWY3O-743_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-743/YeastPathways_PWY3O-743_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -681,11 +615,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002333_MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002333_MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -701,40 +635,40 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-743/YeastPathways_PWY3O-743_SGD_YeastPathways_PWY3O-743>
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-743>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
+                "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002333_YJR133W-MONOMER_XANPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-743>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-743>
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002333_MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-743>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
+                "SGD_PWY:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -742,11 +676,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -764,11 +698,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000066_reaction_GUANINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000066_reaction_GUANINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -788,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -805,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -813,17 +747,50 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-743>
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_58017_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
+                "SGD_PWY:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002411>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002411_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-743/YeastPathways_PWY3O-743_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_15378_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -833,29 +800,29 @@
 <http://purl.obolibrary.org/obo/GO_0043101>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000066_reaction_XANPRIBOSYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-743>
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-743/YeastPathways_PWY3O-743_SGD_PWY_YeastPathways_PWY3O-743>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
+                "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -866,28 +833,6 @@
           <http://model.geneontology.org/YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000066_reaction_GUANINE-DEAMINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16235_GUANPRIBOSYLTRAN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16235> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -897,7 +842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -909,11 +854,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -939,13 +884,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-743SmallMolecule47911> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002413_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58115_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-743/YeastPathways_PWY3O-743>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0043101> ;
@@ -956,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -968,11 +946,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-743/YeastPathways_PWY3O-743_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-743/YeastPathways_PWY3O-743_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -987,11 +965,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-743/YeastPathways_PWY3O-743_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000050_YeastPathways_PWY3O-743/YeastPathways_PWY3O-743_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1006,11 +984,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002333_YJR133W-MONOMER_XANPRIBOSYLTRAN-RXN_controller_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002333_YJR133W-MONOMER_XANPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1036,6 +1014,17 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-743/YeastPathways_PWY3O-743_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1046,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1061,11 +1050,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58115_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58115_GUANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1074,6 +1063,25 @@
           <http://model.geneontology.org/GUANPRIBOSYLTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58115_GUANPRIBOSYLTRAN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-743> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17712_GUANINE-DEAMINASE-RXN>
 ] .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-743>
@@ -1085,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of guanine, xanthine and their nucleosides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1093,24 +1101,27 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_YeastPathways_PWY3O-743> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GUANINE-DEAMINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17712_GUANINE-DEAMINASE-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_16235_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002397>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1124,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1136,11 +1147,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" , "Provides Input For Rule. The relation 'guanine + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; ammonium + xanthine' 'null' 'XMP + diphosphate &larr; xanthine + 5-phospho-&alpha;-D-ribose 1-diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002413_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002413_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1163,7 +1174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1175,11 +1186,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_57464_XANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-743> ;
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_57464_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1190,17 +1201,6 @@
           <http://model.geneontology.org/CHEBI_57464_XANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58115_GUANPRIBOSYLTRAN-RXN_SGD_YeastPathways_PWY3O-743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58017_XANPRIBOSYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58017> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1210,7 +1210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-8.ttl
+++ b/models/YeastPathways_PWY3O-8.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13,14 +13,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002233_CHEBI_17151_RXN-8773_SGD_YeastPathways_PWY3O-8>
+<http://model.geneontology.org/ev_w_id_RXN-8773_BFO_0000050_YeastPathways_PWY3O-8/YeastPathways_PWY3O-8_SGD_PWY_YeastPathways_PWY3O-8>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8" ;
+                "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -33,54 +33,16 @@
 <http://purl.obolibrary.org/obo/GO_0042732>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_BFO_0000066_reaction_D-XYLULOSE-REDUCTASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-8>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002234_CHEBI_58349_RXN-8773_SGD_PWY_YeastPathways_PWY3O-8>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8" ;
+                "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002234_CHEBI_58349_RXN-8773_SGD_YeastPathways_PWY3O-8> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-8773> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_RXN-8773>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002234_CHEBI_15378_D-XYLULOSE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-8> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/D-XYLULOSE-REDUCTASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_D-XYLULOSE-REDUCTASE-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_57540_D-XYLULOSE-REDUCTASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
@@ -91,13 +53,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-8SmallMolecule61293> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002234_CHEBI_58349_RXN-8773_SGD_PWY_YeastPathways_PWY3O-8> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-8773> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58349_RXN-8773>
+] .
 
 <http://model.geneontology.org/CHEBI_57783_RXN-8773>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -108,13 +89,43 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-8SmallMolecule61255> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002333_YLR070C-MONOMER_D-XYLULOSE-REDUCTASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-8>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002234_CHEBI_15378_D-XYLULOSE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-8> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/D-XYLULOSE-REDUCTASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_D-XYLULOSE-REDUCTASE-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_17151>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -128,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -142,44 +153,22 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002234_CHEBI_17151_RXN-8773_SGD_YeastPathways_PWY3O-8>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002233_CHEBI_53455_RXN-8773_SGD_YeastPathways_PWY3O-8>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002234_CHEBI_58349_RXN-8773_SGD_YeastPathways_PWY3O-8>
+<http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002234_CHEBI_15378_D-XYLULOSE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-8>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8" ;
+                "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_58349_RXN-8773>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -190,24 +179,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-8SmallMolecule61233> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002333_YLR070C-MONOMER_D-XYLULOSE-REDUCTASE-RXN_controller_SGD_YeastPathways_PWY3O-8>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -216,11 +194,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002234_CHEBI_17151_RXN-8773_SGD_YeastPathways_PWY3O-8> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002234_CHEBI_17151_RXN-8773_SGD_PWY_YeastPathways_PWY3O-8> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -235,11 +213,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002233_CHEBI_57540_D-XYLULOSE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-8> ;
+          <http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002233_CHEBI_57540_D-XYLULOSE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-8> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -253,9 +231,6 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 <http://model.geneontology.org/CHEBI_57945_D-XYLULOSE-REDUCTASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -265,7 +240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -273,55 +248,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8773_BFO_0000066_reaction_RXN-8773_location_lociGO_0005829_SGD_YeastPathways_PWY3O-8>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002233_CHEBI_15378_RXN-8773_SGD_YeastPathways_PWY3O-8>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_BFO_0000050_YeastPathways_PWY3O-8/YeastPathways_PWY3O-8_SGD_YeastPathways_PWY3O-8>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002233_CHEBI_57540_D-XYLULOSE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-8>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002233_CHEBI_57540_D-XYLULOSE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-8>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8" ;
+                "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/RXN-8773>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004032> ;
@@ -342,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -354,11 +299,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8773_BFO_0000050_YeastPathways_PWY3O-8/YeastPathways_PWY3O-8_SGD_YeastPathways_PWY3O-8> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8773_BFO_0000050_YeastPathways_PWY3O-8/YeastPathways_PWY3O-8_SGD_PWY_YeastPathways_PWY3O-8> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -395,13 +340,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-8SmallMolecule61309> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002233_CHEBI_53455_RXN-8773_SGD_PWY_YeastPathways_PWY3O-8>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004060>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -413,11 +369,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002233_CHEBI_57783_RXN-8773_SGD_YeastPathways_PWY3O-8> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002233_CHEBI_57783_RXN-8773_SGD_PWY_YeastPathways_PWY3O-8> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -435,11 +391,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002233_CHEBI_17151_RXN-8773_SGD_YeastPathways_PWY3O-8> ;
+          <http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002233_CHEBI_17151_RXN-8773_SGD_PWY_YeastPathways_PWY3O-8> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,31 +406,31 @@
           <http://model.geneontology.org/CHEBI_17151_RXN-8773>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002333_YHR104W-MONOMER_RXN-8773_controller_SGD_YeastPathways_PWY3O-8>
+<http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002234_CHEBI_17140_D-XYLULOSE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-8>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8" ;
+                "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8773_BFO_0000050_YeastPathways_PWY3O-8/YeastPathways_PWY3O-8_SGD_YeastPathways_PWY3O-8>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002234_CHEBI_57945_D-XYLULOSE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-8>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8" ;
+                "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -488,11 +444,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002333_YLR070C-MONOMER_D-XYLULOSE-REDUCTASE-RXN_controller_SGD_YeastPathways_PWY3O-8> ;
+          <http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002333_YLR070C-MONOMER_D-XYLULOSE-REDUCTASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-8> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -512,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "xylose metabolism - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -524,11 +480,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002233_CHEBI_53455_RXN-8773_SGD_YeastPathways_PWY3O-8> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002233_CHEBI_53455_RXN-8773_SGD_PWY_YeastPathways_PWY3O-8> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,26 +495,15 @@
           <http://model.geneontology.org/CHEBI_53455_RXN-8773>
 ] .
 
-<http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002234_CHEBI_57945_D-XYLULOSE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-8>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_BFO_0000066_reaction_D-XYLULOSE-REDUCTASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-8> ;
+          <http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_BFO_0000066_reaction_D-XYLULOSE-REDUCTASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-8> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -579,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -590,14 +535,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002234_CHEBI_17140_D-XYLULOSE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-8>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002233_CHEBI_57783_RXN-8773_SGD_PWY_YeastPathways_PWY3O-8>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8" ;
+                "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -614,11 +559,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'xylitol + NADP<sup>+</sup> &harr; D-xylopyranose + NADPH + H<SUP>+</SUP>' 'null' 'xylitol + NAD<sup>+</sup> &rarr; D-xylulose + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002413_D-XYLULOSE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-8> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002413_D-XYLULOSE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-8> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -636,11 +581,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002234_CHEBI_57945_D-XYLULOSE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-8> ;
+          <http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002234_CHEBI_57945_D-XYLULOSE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-8> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -656,21 +601,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002234_CHEBI_15378_D-XYLULOSE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-8>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002413_D-XYLULOSE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-8>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8" ;
+                "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -678,11 +623,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002233_CHEBI_15378_RXN-8773_SGD_YeastPathways_PWY3O-8> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002233_CHEBI_15378_RXN-8773_SGD_PWY_YeastPathways_PWY3O-8> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -702,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -717,11 +662,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_BFO_0000050_YeastPathways_PWY3O-8/YeastPathways_PWY3O-8_SGD_YeastPathways_PWY3O-8> ;
+          <http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_BFO_0000050_YeastPathways_PWY3O-8/YeastPathways_PWY3O-8_SGD_PWY_YeastPathways_PWY3O-8> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -732,29 +677,29 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-8/YeastPathways_PWY3O-8>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002233_CHEBI_57783_RXN-8773_SGD_YeastPathways_PWY3O-8>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_BFO_0000066_reaction_D-XYLULOSE-REDUCTASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-8>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-8773_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -767,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -778,6 +723,28 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002233_CHEBI_15378_RXN-8773_SGD_PWY_YeastPathways_PWY3O-8>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8773_BFO_0000066_reaction_RXN-8773_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-8>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -785,11 +752,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002333_YHR104W-MONOMER_RXN-8773_controller_SGD_YeastPathways_PWY3O-8> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002333_YHR104W-MONOMER_RXN-8773_controller_SGD_PWY_YeastPathways_PWY3O-8> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -800,15 +767,26 @@
           <http://model.geneontology.org/YHR104W-MONOMER_RXN-8773_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002333_YHR104W-MONOMER_RXN-8773_controller_SGD_PWY_YeastPathways_PWY3O-8>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002234_CHEBI_17140_D-XYLULOSE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-8> ;
+          <http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002234_CHEBI_17140_D-XYLULOSE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-8> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -819,6 +797,28 @@
           <http://model.geneontology.org/CHEBI_17140_D-XYLULOSE-REDUCTASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002234_CHEBI_17151_RXN-8773_SGD_PWY_YeastPathways_PWY3O-8>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_BFO_0000050_YeastPathways_PWY3O-8/YeastPathways_PWY3O-8_SGD_PWY_YeastPathways_PWY3O-8>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-8/YeastPathways_PWY3O-8>
         a       <http://purl.obolibrary.org/obo/GO_0042732> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -853,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -861,15 +861,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002233_CHEBI_17151_RXN-8773_SGD_PWY_YeastPathways_PWY3O-8>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8773_BFO_0000066_reaction_RXN-8773_location_lociGO_0005829_SGD_YeastPathways_PWY3O-8> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8773_BFO_0000066_reaction_RXN-8773_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-8> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -882,14 +893,3 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-8773_RO_0002413_D-XYLULOSE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-8>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-8514.ttl
+++ b/models/YeastPathways_PWY3O-8514.ttl
@@ -1,12 +1,23 @@
+<http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002233_CHEBI_15378_RXN-9539_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.61-RXN_controller_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.61-RXN_controller_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,11 +32,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9542_BFO_0000066_reaction_RXN-9542_location_lociGO_0005829_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9542_BFO_0000066_reaction_RXN-9542_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,14 +47,14 @@
           <http://model.geneontology.org/reaction_RXN-9542_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.61-RXN_controller_SGD_YeastPathways_PWY3O-8514>
+<http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_PWY_YeastPathways_PWY3O-8514>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -51,11 +62,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,47 +82,47 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002233_2-Hexadecenoyl-ACPs_4.2.1.61-RXN_SGD_YeastPathways_PWY3O-8514>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002234_CHEBI_58349_RXN-9542_SGD_YeastPathways_PWY3O-8514>
+<http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002233_2-Hexadecenoyl-ACPs_4.2.1.61-RXN_SGD_PWY_YeastPathways_PWY3O-8514>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002333_YPL231W-MONOMER_RXN-9539_controller_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -122,15 +133,37 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9539_BFO_0000066_reaction_RXN-9539_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002234_CHEBI_16526_RXN-9539_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002234_CHEBI_16526_RXN-9539_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -141,47 +174,14 @@
           <http://model.geneontology.org/CHEBI_16526_RXN-9539>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9539_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_YeastPathways_PWY3O-8514>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_7896>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_YeastPathways_PWY3O-8514>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YKL182W-MONOMER_RXN-9542_controller>
         a       <http://identifiers.org/sgd/S000001665> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -202,11 +202,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -248,11 +248,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002233_3-oxo-palmitoyl-ACPs_RXN-9539_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002233_3-oxo-palmitoyl-ACPs_RXN-9539_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -270,11 +270,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -288,25 +288,14 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002233_CHEBI_15378_RXN-9542_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002233_ACP_RXN-9540_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9540_BFO_0000066_reaction_RXN-9540_location_lociGO_0005829_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -314,11 +303,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002233_2-Hexadecenoyl-ACPs_4.2.1.61-RXN_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002233_2-Hexadecenoyl-ACPs_4.2.1.61-RXN_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,39 +318,6 @@
           <http://model.geneontology.org/2-Hexadecenoyl-ACPs_4.2.1.61-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9542_BFO_0000066_reaction_RXN-9542_location_lociGO_0005829_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002234_ACP_RXN-9539_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_YeastPathways_PWY3O-8514>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YPL231W-MONOMER_RXN-9539_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006152> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -369,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -377,36 +333,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002413_RXN3O-9780_SGD_YeastPathways_PWY3O-8514>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -419,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -431,11 +365,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN-9542_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN-9542_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -449,15 +383,26 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002234_CHEBI_15377_4.2.1.61-RXN_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" , "Provides Input For Rule. The relation 'a myristoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxohexadecanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein' 'null' 'a (3<i>R</i>)-3-hydroxyhexadecanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxohexadecanoyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002413_RXN-9540_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002413_RXN-9540_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -471,12 +416,45 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002413_RXN-9540_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9542_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-9540_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -484,11 +462,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002234_CHEBI_15377_4.2.1.61-RXN_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002234_CHEBI_15377_4.2.1.61-RXN_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -518,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,11 +508,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" , "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxyhexadecanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxohexadecanoyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a (3<i>R</i>)-3-hydroxyhexadecanoyl-[acp] &rarr; a (2<i>E</i>)-hexadec-2-enoyl-[acp] + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002413_4.2.1.61-RXN_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002413_4.2.1.61-RXN_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -545,17 +523,6 @@
           <http://model.geneontology.org/4.2.1.61-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_BFO_0000066_reaction_4.2.1.61-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-8514>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -563,11 +530,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,17 +545,6 @@
           <http://model.geneontology.org/CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002234_ACP_RXN-9540_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_RXN-9539>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -598,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -606,19 +562,52 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002233_CHEBI_15378_RXN-9539_SGD_YeastPathways_PWY3O-8514>
+<http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002413_RXN-9542_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002333_YKL182W-MONOMER_RXN-9542_controller_SGD_PWY_YeastPathways_PWY3O-8514>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57379>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002413_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002234_CHEBI_58349_RXN-9542_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -627,11 +616,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002333_YKL182W-MONOMER_RXN-9542_controller_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002333_YKL182W-MONOMER_RXN-9542_controller_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -646,11 +635,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002233_Myristoyl-ACPs_RXN-9539_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002233_Myristoyl-ACPs_RXN-9539_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,9 +650,6 @@
           <http://model.geneontology.org/Myristoyl-ACPs_RXN-9539>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57287>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -673,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -681,14 +667,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_57287>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002233_CHEBI_57783_RXN-9540_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -699,11 +688,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -718,11 +707,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002233_CHEBI_15378_RXN-9540_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002233_CHEBI_15378_RXN-9540_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -748,13 +737,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-8514BiochemicalReaction18959> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002233_3-oxo-palmitoyl-ACPs_RXN-9539_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -767,18 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002413_4.2.1.61-RXN_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -791,7 +780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -799,26 +788,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002234_Palmitoyl-ACPs_RXN-9542_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a (3<i>R</i>)-3-hydroxyhexadecanoyl-[acp] &rarr; a (2<i>E</i>)-hexadec-2-enoyl-[acp] + H<sub>2</sub>O' 'null' 'a palmitoyl-[acp] + NADP<sup>+</sup> &larr; a (2<i>E</i>)-hexadec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002413_RXN-9542_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002413_RXN-9542_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,11 +811,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002233_CHEBI_15378_RXN-9542_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002233_CHEBI_15378_RXN-9542_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -848,6 +826,17 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-9542>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002234_ACP_RXN-9539_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YKL182W-MONOMER_4.2.1.61-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001665> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -855,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -867,11 +856,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9539_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9539_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -882,17 +871,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-8514>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_RXN-9542>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -902,7 +880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -919,7 +897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -939,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -951,11 +929,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000066_reaction_RXN3O-9780_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,15 +944,37 @@
           <http://model.geneontology.org/reaction_RXN3O-9780_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002234_3-oxo-palmitoyl-ACPs_RXN-9539_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002234_3-oxo-palmitoyl-ACPs_RXN-9539_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -985,49 +985,19 @@
           <http://model.geneontology.org/3-oxo-palmitoyl-ACPs_RXN-9539>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_YeastPathways_PWY3O-8514>
+<http://model.geneontology.org/ev_w_id_RXN-9540_BFO_0000066_reaction_RXN-9540_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-8514>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002233_3-oxo-palmitoyl-ACPs_RXN-9539_SGD_YeastPathways_PWY3O-8514>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002233_CHEBI_57783_RXN-9540_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1035,11 +1005,19 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/GO_0006633>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_15378_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACP_RXN3O-9780>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1050,24 +1028,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-8514Protein19026> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1076,11 +1043,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_BFO_0000066_reaction_4.2.1.61-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_BFO_0000066_reaction_4.2.1.61-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1090,6 +1057,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_4.2.1.61-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-9540>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
@@ -1108,7 +1086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1120,11 +1098,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002234_ACP_RXN-9540_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002234_ACP_RXN-9540_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1135,15 +1113,37 @@
           <http://model.geneontology.org/ACP_RXN-9540>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9540_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1154,17 +1154,6 @@
           <http://model.geneontology.org/CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002333_YPL231W-MONOMER_RXN-9539_controller_SGD_YeastPathways_PWY3O-8514>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_4.2.1.61-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1174,7 +1163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1191,7 +1180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1199,19 +1188,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002233_ACP_RXN-9540_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_58349>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002413_4.2.1.61-RXN_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58349>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1220,11 +1209,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002234_CHEBI_58349_RXN-9542_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002234_CHEBI_58349_RXN-9542_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1242,7 +1231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1255,7 +1244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1266,11 +1255,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002233_ACP_RXN-9539_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002233_ACP_RXN-9539_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1281,14 +1270,58 @@
           <http://model.geneontology.org/ACP_RXN-9539>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002234_CHEBI_58349_RXN-9540_SGD_YeastPathways_PWY3O-8514>
+<http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002233_CHEBI_15378_RXN-9542_SGD_PWY_YeastPathways_PWY3O-8514>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002234_ACP_RXN-9540_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002234_CHEBI_16526_RXN-9539_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN-9542_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1314,7 +1347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1326,11 +1359,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_ACP_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1345,11 +1378,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9540_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9540_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1369,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1377,15 +1410,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_BFO_0000066_reaction_4.2.1.61-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002234_2-Hexadecenoyl-ACPs_4.2.1.61-RXN_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002234_2-Hexadecenoyl-ACPs_4.2.1.61-RXN_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1400,11 +1444,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9542_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9542_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1415,37 +1459,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000066_reaction_PALMITOYL-COA-HYDROLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-8514>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002233_Myristoyl-ACPs_RXN-9539_SGD_YeastPathways_PWY3O-8514>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1455,6 +1477,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002233_Myristoyl-ACPs_RXN-9539_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1468,7 +1501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1476,25 +1509,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002233_CHEBI_15378_RXN-9540_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002234_CHEBI_16526_RXN-9539_SGD_YeastPathways_PWY3O-8514>
+<http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002234_CHEBI_58349_RXN-9540_SGD_PWY_YeastPathways_PWY3O-8514>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1507,13 +1540,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-8514SmallMolecule18930> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/Palmitoyl-ACPs_RXN-9542>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -1524,7 +1568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1540,7 +1584,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9539_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1548,11 +1603,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a palmitoyl-[acp] + NADP<sup>+</sup> &larr; a (2<i>E</i>)-hexadec-2-enoyl-[acp] + NADPH + H<SUP>+</SUP>' 'null' 'a palmitoyl-[acp] + coenzyme A &rarr; palmitoyl-CoA + acyl-carrier protein' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002413_RXN3O-9780_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002413_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1563,26 +1618,15 @@
           <http://model.geneontology.org/RXN3O-9780>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002234_ACP_RXN-9539_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002234_ACP_RXN-9539_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1593,25 +1637,14 @@
           <http://model.geneontology.org/ACP_RXN-9539>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_YeastPathways_PWY3O-8514>
+<http://model.geneontology.org/ev_w_id_RXN-9542_BFO_0000066_reaction_RXN-9542_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-8514>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1627,7 +1660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1639,11 +1672,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" , "Provides Input For Rule. The relation 'a palmitoyl-[acp] + coenzyme A &rarr; palmitoyl-CoA + acyl-carrier protein' 'null' 'palmitoyl-CoA + H<sub>2</sub>O &rarr; palmitate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002413_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1658,11 +1691,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002233_CHEBI_57783_RXN-9540_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002233_CHEBI_57783_RXN-9540_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1673,14 +1706,14 @@
           <http://model.geneontology.org/CHEBI_57783_RXN-9540>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002234_2-Hexadecenoyl-ACPs_4.2.1.61-RXN_SGD_YeastPathways_PWY3O-8514>
+<http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002234_2-Hexadecenoyl-ACPs_4.2.1.61-RXN_SGD_PWY_YeastPathways_PWY3O-8514>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1688,11 +1721,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1703,17 +1736,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002333_YKL182W-MONOMER_RXN-9542_controller_SGD_YeastPathways_PWY3O-8514>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58349_RXN-9540>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1723,7 +1745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1740,7 +1762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1757,7 +1779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1774,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1785,26 +1807,15 @@
 <http://identifiers.org/sgd/S000006152>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002413_RXN-9540_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002233_CHEBI_57783_RXN-9542_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002233_CHEBI_57783_RXN-9542_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1819,11 +1830,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9539_BFO_0000066_reaction_RXN-9539_location_lociGO_0005829_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9539_BFO_0000066_reaction_RXN-9539_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1842,18 +1853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_Palmitoyl-ACPs_RXN-9542_SGD_YeastPathways_PWY3O-8514>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1876,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1888,11 +1888,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1907,11 +1907,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002333_YPL231W-MONOMER_RXN-9539_controller_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002333_YPL231W-MONOMER_RXN-9539_controller_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1934,7 +1934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "palmitate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1942,43 +1942,32 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-9542_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_YeastPathways_PWY3O-8514>
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002233_CHEBI_57287_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-8514>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_15377_PALMITOYL-COA-HYDROLASE-RXN_SGD_YeastPathways_PWY3O-8514>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002233_ACP_RXN-9540_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002233_ACP_RXN-9540_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1993,11 +1982,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002234_CHEBI_58349_RXN-9540_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002234_CHEBI_58349_RXN-9540_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2017,7 +2006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2025,26 +2014,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002234_CHEBI_15377_4.2.1.61-RXN_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002233_CHEBI_57379_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2055,6 +2033,17 @@
           <http://model.geneontology.org/CHEBI_57379_RXN3O-9780>
 ] .
 
+<http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.61-RXN_controller_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57287_PALMITOYL-COA-HYDROLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57287> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2064,7 +2053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2075,15 +2064,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9540_RO_0002233_CHEBI_15378_RXN-9540_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-8514" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002234_Palmitoyl-ACPs_RXN-9542_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002234_Palmitoyl-ACPs_RXN-9542_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2094,14 +2094,14 @@
           <http://model.geneontology.org/Palmitoyl-ACPs_RXN-9542>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9540_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002233_ACP_RXN-9539_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2109,11 +2109,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002233_CHEBI_15378_RXN-9539_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002233_CHEBI_15378_RXN-9539_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2124,14 +2124,14 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-9539>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002233_ACP_RXN-9539_SGD_YeastPathways_PWY3O-8514>
+<http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002234_Palmitoyl-ACPs_RXN-9542_SGD_PWY_YeastPathways_PWY3O-8514>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2144,7 +2144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2152,25 +2152,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002233_CHEBI_57783_RXN-9542_SGD_YeastPathways_PWY3O-8514>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_BFO_0000050_YeastPathways_PWY3O-8514/YeastPathways_PWY3O-8514_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002234_3-oxo-palmitoyl-ACPs_RXN-9539_SGD_YeastPathways_PWY3O-8514>
+<http://model.geneontology.org/ev_w_id_RXN-9539_RO_0002234_3-oxo-palmitoyl-ACPs_RXN-9539_SGD_PWY_YeastPathways_PWY3O-8514>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2178,11 +2178,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002234_CHEBI_57379_RXN3O-9780_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2193,14 +2193,14 @@
           <http://model.geneontology.org/CHEBI_57379_RXN3O-9780>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9539_BFO_0000066_reaction_RXN-9539_location_lociGO_0005829_SGD_YeastPathways_PWY3O-8514>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9542_RO_0002233_CHEBI_57783_RXN-9542_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2208,11 +2208,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9540_BFO_0000066_reaction_RXN-9540_location_lociGO_0005829_SGD_YeastPathways_PWY3O-8514> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9540_BFO_0000066_reaction_RXN-9540_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-8514> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2232,7 +2232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2240,13 +2240,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.61-RXN_RO_0002413_RXN-9542_SGD_YeastPathways_PWY3O-8514>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_PWY_YeastPathways_PWY3O-8514>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-8514" ;
+                "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-862.ttl
+++ b/models/YeastPathways_PWY3O-862.ttl
@@ -1,12 +1,23 @@
+<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_61473_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002234_CHEBI_12876_RXN3O-1118_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002234_CHEBI_12876_RXN3O-1118_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,11 +32,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002233_CHEBI_128769_RXN-8813_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002233_CHEBI_128769_RXN-8813_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,28 +47,39 @@
           <http://model.geneontology.org/CHEBI_128769_RXN-8813>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004161>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_15378_RXN3O-12_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_29888_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_15379_RXN3O-12_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/GO_0004161>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002413_RXN3O-1118_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -65,11 +87,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_29888_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_29888_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -84,11 +106,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_64253_RXN3O-75_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_64253_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -108,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,11 +145,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_15378_RXN3O-54_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_15378_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -143,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -152,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -160,11 +182,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57945_RXN3O-1120_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57945_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -175,25 +197,14 @@
           <http://model.geneontology.org/CHEBI_57945_RXN3O-1120>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_57856_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_57945_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002234_CHEBI_12876_RXN3O-1118_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -206,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of ubiquinone biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -214,37 +225,15 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-58_BFO_0000066_reaction_RXN3O-58_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_15339_RXN3O-75_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'all-<i>trans</i>-hexaprenyl diphosphate + 4-hydroxybenzoate &rarr; 3-hexaprenyl-4-hydroxybenzoate + diphosphate' 'null' '3-hexaprenyl-4-hydroxybenzoate + 2 a reduced ferredoxin [iron-sulfur] cluster + oxygen + 2 H<SUP>+</SUP> &rarr; 3,4-dihydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + 2 an oxidized ferredoxin [iron-sulfur] cluster + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002413_RXN3O-58_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002413_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -255,29 +244,40 @@
           <http://model.geneontology.org/RXN3O-58>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002234_CHEBI_12876_RXN3O-1118_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_RXN3O-1116_BFO_0000066_reaction_RXN3O-1116_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -292,11 +292,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000066_reaction_2.1.1.114-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000066_reaction_2.1.1.114-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,6 +310,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_58179>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_BFO_0000066_reaction_FARNESYLTRANSTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30616_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57945_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -319,24 +341,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51525> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003703>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -348,11 +359,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_58373_RXN3O-58_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_58373_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -367,11 +378,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_15379_RXN3O-12_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_15379_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,6 +393,17 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-12>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_15379_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -389,11 +411,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,25 +426,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-862/YeastPathways_PWY3O-862>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_GPPSYN-RXN_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002233_CHEBI_59789_RXN3O-54_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -445,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -453,56 +464,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_61473_RXN3O-54_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1116_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000005651>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002233_CHEBI_58373_RXN3O-58_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002234_CHEBI_16134_RXN3O-1116_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.114-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58373_RXN3O-58>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002234_CHEBI_16134_RXN3O-1116_SGD_YeastPathways_PWY3O-862> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,16 +486,24 @@
           <http://model.geneontology.org/CHEBI_16134_RXN3O-1116>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-12_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002233_CHEBI_58373_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-862> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.114-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58373_RXN3O-58>
+] .
 
 <http://model.geneontology.org/CHEBI_29888_FARNESYLTRANSTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -533,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -541,8 +522,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000005651>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_29888_RXN-8813_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -556,7 +545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -564,26 +553,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_30763_RXN3O-1121_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_57945_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_57945_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -594,15 +572,26 @@
           <http://model.geneontology.org/CHEBI_57945_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002233_CHEBI_64253_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_Reduced-ferredoxins_RXN3O-58_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_Reduced-ferredoxins_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,17 +602,6 @@
           <http://model.geneontology.org/Reduced-ferredoxins_RXN3O-58>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_RXN-9003>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -633,13 +611,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51611> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YNR041C-MONOMER_RXN-9003_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005324> ;
@@ -648,7 +637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -656,14 +645,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -671,11 +660,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_15499_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_15499_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -690,11 +679,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_15499_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_15499_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,7 +701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -720,29 +709,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/CHEBI_52970>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_57856_RXN3O-54_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002333_YGR255C-MONOMER_RXN3O-58_controller_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_52970>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9003_BFO_0000066_reaction_RXN-9003_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9003_BFO_0000066_reaction_RXN-9003_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -757,11 +746,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_15379_RXN3O-75_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_15379_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -781,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -792,28 +781,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_58373>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-54_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57945_RXN3O-1120_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YBR003W-MONOMER_RXN3O-9805_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000207> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -821,7 +788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -837,33 +804,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_29888_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -878,11 +834,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2-hexaprenyl-6-methoxyphenol + NADPH + oxygen + H<SUP>+</SUP> &rarr; 2-methoxy-6-<i>all trans</i>-hexaprenyl-1,4-benzoquinol + NADP<sup>+</sup> + H<sub>2</sub>O' 'null' '<i>S</i>-adenosyl-L-methionine + 2-methoxy-6-<i>all trans</i>-hexaprenyl-1,4-benzoquinol &rarr; 6-methoxy-3-methyl-2-<i>all-trans</i>-hexaprenyl-1,4-benzoquinol + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002413_RXN3O-54_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002413_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -902,13 +858,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51882> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_15339_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_10980> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -919,24 +886,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51479> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002234_CHEBI_16134_RXN3O-1116_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008412>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -948,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -956,45 +912,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_175763_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-1116_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002233_CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-75_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1007,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1015,26 +949,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_29888_RXN3O-9805_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_29888_RXN3O-9805_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1045,6 +968,17 @@
           <http://model.geneontology.org/CHEBI_29888_RXN3O-9805>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_36242_RXN3O-1116>
         a       <http://purl.obolibrary.org/obo/CHEBI_36242> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1054,7 +988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1062,29 +996,62 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002333_YML110C-MONOMER_RXN3O-54_controller_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_17499_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_15379_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_29888_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_Apo-Ferredoxins_RXN3O-58_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_Apo-Ferredoxins_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1099,11 +1066,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '4-hydroxybenzoyl-CoA + acetyl-CoA &rarr; 4-hydroxybenzoate' 'null' 'all-<i>trans</i>-hexaprenyl diphosphate + 4-hydroxybenzoate &rarr; 3-hexaprenyl-4-hydroxybenzoate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002413_RXN-9003_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002413_RXN-9003_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1114,14 +1081,14 @@
           <http://model.geneontology.org/RXN-9003>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002234_CHEBI_84492_RXN-9003_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002233_CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1129,11 +1096,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_57856_RXN3O-102_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_57856_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1153,7 +1120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1165,11 +1132,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Provides Input For Rule. The relation 'chorismate &rarr; 4-hydroxybenzoate + pyruvate' 'null' 'all-<i>trans</i>-hexaprenyl diphosphate + 4-hydroxybenzoate &rarr; 3-hexaprenyl-4-hydroxybenzoate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002413_RXN-9003_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002413_RXN-9003_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1180,15 +1147,26 @@
           <http://model.geneontology.org/RXN-9003>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002233_CHEBI_59789_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'dimethylallyl diphosphate + isopentenyl diphosphate &rarr; geranyl diphosphate + diphosphate' 'null' 'geranyl diphosphate + isopentenyl diphosphate &rarr; (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1206,11 +1184,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + 3,4-dihydroxy-5-<i>all-trans</i>-hexaprenylbenzoate &rarr; <i>S</i>-adenosyl-L-homocysteine + 3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + H<SUP>+</SUP>' 'null' '3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + H<SUP>+</SUP> &rarr; 2-hexaprenyl-6-methoxyphenol + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002413_RXN3O-73_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002413_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1240,24 +1218,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862BiochemicalReaction52124> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58349_RXN3O-12>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1268,7 +1235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1280,11 +1247,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002233_CHEBI_57916_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002233_CHEBI_57916_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1294,17 +1261,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57916_2.1.1.114-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1121_BFO_0000066_reaction_RXN3O-1121_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-9805>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -1325,24 +1281,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862BiochemicalReaction51761> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-12_BFO_0000066_reaction_RXN3O-12_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_2.1.1.114-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -1353,7 +1298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1365,11 +1310,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002234_CHEBI_15377_RXN3O-1118_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002234_CHEBI_15377_RXN3O-1118_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1380,29 +1325,43 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-1118>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_175763>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_61473_RXN3O-54_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-12_BFO_0000066_reaction_RXN3O-12_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002333_MONOMER3O-164_RXN3O-75_controller_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_175763>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0016207>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002233_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002233_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1413,79 +1372,29 @@
           <http://model.geneontology.org/CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9003_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002233_CHEBI_59789_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_15377_RXN3O-58_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_15378_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_12876_RXN3O-1118_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0016207>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0008689>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_58349>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002333_YNR041C-MONOMER_RXN-9003_controller_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1496,18 +1405,15 @@
           <http://model.geneontology.org/CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15377>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002333_MONOMER3O-164_RXN3O-75_controller_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002333_MONOMER3O-164_RXN3O-75_controller_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1518,77 +1424,14 @@
           <http://model.geneontology.org/MONOMER3O-164_RXN3O-75_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002234_CHEBI_57540_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Provides Input For Rule. The relation '(<i>E</i>)-4-coumaroyl-CoA + coenzyme A + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; 4-hydroxybenzoyl-CoA + acetyl-CoA + NADH + H<SUP>+</SUP>' 'null' '4-hydroxybenzoyl-CoA + acetyl-CoA &rarr; 4-hydroxybenzoate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002413_RXN3O-1121_SGD_YeastPathways_PWY3O-862> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-1120> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-1121>
-] .
-
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_BFO_0000066_reaction_CHORPYRLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_57856_RXN3O-54_SGD_YeastPathways_PWY3O-862> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-54> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57856_RXN3O-54>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-75_BFO_0000066_reaction_RXN3O-75_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1609,7 +1452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1617,47 +1460,61 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000066_reaction_RXN3O-73_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002234_CHEBI_1109_RXN3O-73_SGD_YeastPathways_PWY3O-862>
+<http://purl.obolibrary.org/obo/CHEBI_58349>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_57856_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-862> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-54> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57856_RXN3O-54>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Provides Input For Rule. The relation '(<i>E</i>)-4-coumaroyl-CoA + coenzyme A + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; 4-hydroxybenzoyl-CoA + acetyl-CoA + NADH + H<SUP>+</SUP>' 'null' '4-hydroxybenzoyl-CoA + acetyl-CoA &rarr; 4-hydroxybenzoate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002413_RXN3O-1121_SGD_PWY_YeastPathways_PWY3O-862> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-1120> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-1121>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000066_reaction_RXN3O-73_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002234_CHEBI_30763_CHORPYRLY-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1670,35 +1527,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51956> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_BFO_0000066_reaction_CHORPYRLY-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002333_YOL096C-MONOMER_RXN3O-102_controller_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-12>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -1709,7 +1544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1734,7 +1569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1742,34 +1577,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_15378_RXN3O-54_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_2.1.1.114-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8813_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1777,11 +1590,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-102_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-102_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1792,28 +1605,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-862/YeastPathways_PWY3O-862>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_15499_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002233_CHEBI_59789_RXN3O-102_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_128769_RXN3O-9805>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_128769> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1823,7 +1614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1835,11 +1626,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1850,14 +1641,14 @@
           <http://model.geneontology.org/reaction_GPPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_BFO_0000066_reaction_RXN3O-1120_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-58_BFO_0000066_reaction_RXN3O-58_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1870,7 +1661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1887,7 +1678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1898,18 +1689,40 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_15377_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-8813_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_57783_RXN3O-12_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_57783_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1920,15 +1733,26 @@
           <http://model.geneontology.org/CHEBI_57783_RXN3O-12>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-102_BFO_0000066_reaction_RXN3O-102_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_BFO_0000066_reaction_CHORPYRLY-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_BFO_0000066_reaction_CHORPYRLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1948,7 +1772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1956,25 +1780,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002234_CHEBI_15377_RXN3O-1118_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_15377_RXN3O-75_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57945_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1982,11 +1806,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002234_CHEBI_36242_RXN3O-1116_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002234_CHEBI_36242_RXN3O-1116_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2001,11 +1825,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002233_CHEBI_59789_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002233_CHEBI_59789_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2022,45 +1846,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_36242>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_29888_RXN-8813_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002234_CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002333_YGR255C-MONOMER_RXN3O-58_controller_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002333_YGR255C-MONOMER_RXN3O-58_controller_SGD_YeastPathways_PWY3O-862> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2071,14 +1865,55 @@
           <http://model.geneontology.org/YGR255C-MONOMER_RXN3O-58_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_29888_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-862>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002234_CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_Reduced-ferredoxins_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_36242_RXN3O-1116_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2087,17 +1922,6 @@
 
 <http://identifiers.org/sgd/S000005990>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_128769_FPPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_128769> ;
@@ -2108,7 +1932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2116,28 +1940,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002413_RXN3O-1118_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_57287_RXN3O-1120_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_57856_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2145,11 +1958,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_57287_RXN3O-1120_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_57287_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2172,7 +1985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2184,11 +1997,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_29888_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_29888_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2199,43 +2012,21 @@
           <http://model.geneontology.org/CHEBI_29888_4-COUMARATE--COA-LIGASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-54_BFO_0000066_reaction_RXN3O-54_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000004578>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8813_BFO_0000066_reaction_RXN-8813_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_30763_RXN3O-1121_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_30763_RXN3O-1121_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2250,11 +2041,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_17499_RXN3O-75_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_17499_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2268,45 +2059,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57288>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/CHEBI_84492_RXN-9003>
-        a       <http://purl.obolibrary.org/obo/CHEBI_84492> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-hexaprenyl-4-hydroxybenzoate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51898> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_57916_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15378_RXN3O-58_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30763_RXN3O-1121>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30763> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2316,7 +2068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2324,15 +2076,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/CHEBI_84492_RXN-9003>
+        a       <http://purl.obolibrary.org/obo/CHEBI_84492> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-hexaprenyl-4-hydroxybenzoate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51898> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_61472_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2343,14 +2123,36 @@
           <http://model.geneontology.org/CHEBI_58057_GPPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_GPPSYN-RXN_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_BFO_0000066_reaction_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15379_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002234_CHEBI_15377_RXN3O-1118_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2363,7 +2165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2375,11 +2177,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-54_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-54_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2394,11 +2196,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_57540_RXN3O-1120_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_57540_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2409,29 +2211,51 @@
           <http://model.geneontology.org/CHEBI_57540_RXN3O-1120>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_Reduced-ferredoxins_RXN3O-58_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_Apo-Ferredoxins_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002234_CHEBI_84492_RXN-9003_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57916>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-58_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_58179_RXN3O-9805_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_58179_RXN3O-9805_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2451,7 +2275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2468,7 +2292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2485,7 +2309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2502,7 +2326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2514,11 +2338,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2533,11 +2357,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_58179_RXN3O-9805_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_58179_RXN3O-9805_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2548,6 +2372,39 @@
           <http://model.geneontology.org/CHEBI_58179_RXN3O-9805>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-75_BFO_0000066_reaction_RXN3O-75_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_15377_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002413_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29888_FPPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2557,7 +2414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2565,26 +2422,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9003_BFO_0000066_reaction_RXN-9003_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15378_RXN3O-58_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15378_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2599,11 +2445,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2614,25 +2460,25 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-862/YeastPathways_PWY3O-862>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002413_RXN-8813_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000066_reaction_GPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_84492_RXN-9003_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002333_YOL096C-MONOMER_2.1.1.114-RXN_controller_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2640,11 +2486,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002333_YOL096C-MONOMER_RXN3O-102_controller_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002333_YOL096C-MONOMER_RXN3O-102_controller_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2659,11 +2505,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2674,57 +2520,38 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-862/YeastPathways_PWY3O-862>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_BFO_0000066_reaction_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002413_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_57540_RXN3O-1120_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002234_CHEBI_16526_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002413_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_57907_RXN-8813_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY3O-862/YeastPathways_PWY3O-862>
-] .
 
 <http://model.geneontology.org/YGR255C-MONOMER_RXN3O-58_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003487> ;
@@ -2733,7 +2560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2745,11 +2572,30 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY3O-862/YeastPathways_PWY3O-862>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2760,14 +2606,36 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-862/YeastPathways_PWY3O-862>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-102_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_15377_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002413_RXN-9003_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2780,7 +2648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2788,26 +2656,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002333_YPL069C-MONOMER_FARNESYLTRANSTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002234_CHEBI_1109_RXN3O-73_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002234_CHEBI_1109_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2817,6 +2674,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_1109_RXN3O-73>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002233_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/4-COUMARATE--COA-LIGASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0016207> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2835,7 +2703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2843,26 +2711,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_15378_RXN3O-1120_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(R)-3-(4-hydroxyphenyl)lactate &rarr; 4-coumarate + H<sub>2</sub>O' 'null' '4-coumarate + ATP + coenzyme A &rarr; (<i>E</i>)-4-coumaroyl-CoA + AMP + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002413_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002413_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2873,14 +2730,14 @@
           <http://model.geneontology.org/4-COUMARATE--COA-LIGASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_57907_RXN-8813_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_15378_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2891,11 +2748,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_29888_RXN-8813_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_29888_RXN-8813_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2911,7 +2768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2924,13 +2781,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51538> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_57287_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_84492_RXN-9003_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_61472>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2939,11 +2829,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002333_YPL069C-MONOMER_FARNESYLTRANSTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002333_YPL069C-MONOMER_FARNESYLTRANSTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2958,11 +2848,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '6-methoxy-3-methyl-2-<i>all-trans</i>-hexaprenyl-1,4-benzoquinol + a reduced electron acceptor + oxygen &rarr; 3-demethylubiquinol-6 + an oxidized electron acceptor + H<sub>2</sub>O' 'null' '<i>S</i>-adenosyl-L-methionine + 3-demethylubiquinol-6 &rarr; <i>S</i>-adenosyl-L-homocysteine + ubiquinol-6 + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002413_RXN3O-102_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002413_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2983,7 +2873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3000,13 +2890,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY3O-862" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8813_BFO_0000066_reaction_RXN-8813_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3016,18 +2917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3036,7 +2926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3044,11 +2934,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_61473_RXN3O-54_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_61473_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3063,11 +2953,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1121_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1121_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3078,25 +2968,58 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-862/YeastPathways_PWY3O-862>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_15378_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002233_CHEBI_29748_CHORPYRLY-RXN_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-75_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1116_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_15378_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3109,7 +3032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3134,7 +3057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3146,11 +3069,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-102_BFO_0000066_reaction_RXN3O-102_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-102_BFO_0000066_reaction_RXN3O-102_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3165,11 +3088,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3180,14 +3103,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-862/YeastPathways_PWY3O-862>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-58_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_58373_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3196,7 +3119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3204,11 +3127,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_GPPSYN-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3223,11 +3146,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002333_YML110C-MONOMER_RXN3O-54_controller_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002333_YML110C-MONOMER_RXN3O-54_controller_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3247,7 +3170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3274,13 +3197,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862BiochemicalReaction52030> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_58179_RXN3O-9805_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002413_RXN3O-9805_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -3289,11 +3245,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_15377_RXN3O-12_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_15377_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3304,15 +3260,26 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-12>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_30763_RXN3O-1121_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002233_CHEBI_29748_CHORPYRLY-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002233_CHEBI_29748_CHORPYRLY-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3332,7 +3299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3347,7 +3314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3355,26 +3322,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_57907_RXN-8813_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Provides Input For Rule. The relation 'L-tyrosine &rarr; 3-(4-hydroxyphenyl)pyruvate + ammonia' 'null' '(R)-3-(4-hydroxyphenyl)lactate + NAD<sup>+</sup> &larr; 3-(4-hydroxyphenyl)pyruvate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002413_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002413_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3389,11 +3345,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_15378_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_15378_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3423,7 +3379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3435,11 +3391,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '3-hexaprenyl-4-hydroxybenzoate + 2 a reduced ferredoxin [iron-sulfur] cluster + oxygen + 2 H<SUP>+</SUP> &rarr; 3,4-dihydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + 2 an oxidized ferredoxin [iron-sulfur] cluster + H<sub>2</sub>O' 'null' '<i>S</i>-adenosyl-L-methionine + 3,4-dihydroxy-5-<i>all-trans</i>-hexaprenylbenzoate &rarr; <i>S</i>-adenosyl-L-homocysteine + 3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002413_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002413_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3459,7 +3415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3484,7 +3440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3496,11 +3452,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002234_CHEBI_57540_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002234_CHEBI_57540_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3516,63 +3472,52 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_12876>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002413_RXN-9003_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002413_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002234_CHEBI_16526_RXN3O-73_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_BFO_0000066_reaction_RXN3O-1120_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000207>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1118_BFO_0000066_reaction_RXN3O-1118_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002333_YPL069C-MONOMER_FARNESYLTRANSTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3580,11 +3525,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_456215_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_456215_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3595,14 +3540,14 @@
           <http://model.geneontology.org/CHEBI_456215_4-COUMARATE--COA-LIGASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_1109_RXN3O-73_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002413_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3610,11 +3555,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_61473_RXN3O-54_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_61473_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3625,29 +3570,29 @@
           <http://model.geneontology.org/CHEBI_61473_RXN3O-54>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15499>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000066_reaction_RXN3O-9805_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_15377_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15499>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-54_BFO_0000066_reaction_RXN3O-54_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-54_BFO_0000066_reaction_RXN3O-54_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3662,11 +3607,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_15378_RXN3O-1120_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_15378_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3677,42 +3622,31 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-1120>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002413_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0044687>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1121_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_30763>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002233_CHEBI_15378_RXN3O-73_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002413_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3720,11 +3654,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002234_CHEBI_29888_RXN-9003_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002234_CHEBI_29888_RXN-9003_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3754,7 +3688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3769,11 +3703,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3784,15 +3718,26 @@
           <http://model.geneontology.org/CHEBI_29888_FPPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_64253_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002333_YBR003W-MONOMER_RXN3O-9805_controller_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002333_YBR003W-MONOMER_RXN3O-9805_controller_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3807,11 +3752,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15379_RXN3O-58_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15379_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3826,11 +3771,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_BFO_0000066_reaction_RXN3O-12_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_BFO_0000066_reaction_RXN3O-12_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3853,7 +3798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3870,7 +3815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3882,11 +3827,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1116_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1116_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3897,26 +3842,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-862/YeastPathways_PWY3O-862>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002413_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_BFO_0000066_reaction_FARNESYLTRANSTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_BFO_0000066_reaction_FARNESYLTRANSTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3927,15 +3861,26 @@
           <http://model.geneontology.org/reaction_FARNESYLTRANSTRANSFERASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_128769_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_BFO_0000066_reaction_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_BFO_0000066_reaction_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3946,6 +3891,17 @@
           <http://model.geneontology.org/reaction_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-54_BFO_0000066_reaction_RXN3O-54_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29888_RXN-8813>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3955,7 +3911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3963,15 +3919,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_1109_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_BFO_0000066_reaction_4-COUMARATE--COA-LIGASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_BFO_0000066_reaction_4-COUMARATE--COA-LIGASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3991,7 +3958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4002,38 +3969,19 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002234_CHEBI_36242_RXN3O-1116_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_58179_RXN3O-9805_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002234_CHEBI_16526_RXN3O-73_SGD_YeastPathways_PWY3O-862> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-73> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN3O-73>
-] .
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/2.1.1.114-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4054,7 +4002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4062,25 +4010,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002233_CHEBI_29748_CHORPYRLY-RXN_SGD_YeastPathways_PWY3O-862>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002234_CHEBI_16526_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-862> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-73> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16526_RXN3O-73>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_15378_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_175763_FPPSYN-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4093,7 +4049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4110,7 +4066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4118,14 +4074,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15379_RXN3O-58_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_57287_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_58349_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4133,11 +4100,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4148,26 +4115,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-862/YeastPathways_PWY3O-862>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_58373_RXN3O-58_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_57907_RXN-8813_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_57907_RXN-8813_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4178,14 +4134,14 @@
           <http://model.geneontology.org/CHEBI_57907_RXN-8813>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002333_YOL096C-MONOMER_2.1.1.114-RXN_controller_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_15378_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4196,7 +4152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4204,65 +4160,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_BFO_0000066_reaction_FARNESYLTRANSTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_57945_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_61473>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0006744>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1116_BFO_0000066_reaction_RXN3O-1116_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_61473>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'isopentenyl diphosphate + (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate &rarr; geranylgeranyl diphosphate + diphosphate' 'null' 'geranylgeranyl diphosphate + isopentenyl diphosphate &rarr; geranylfarnesyl diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002413_RXN-8813_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002413_RXN-8813_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4272,6 +4195,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN-8813>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002234_CHEBI_16134_RXN3O-1116_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_BFO_0000066_reaction_4-COUMARATE--COA-LIGASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-1118>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4290,7 +4235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4305,11 +4250,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1121_BFO_0000066_reaction_RXN3O-1121_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1121_BFO_0000066_reaction_RXN3O-1121_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4320,14 +4265,36 @@
           <http://model.geneontology.org/reaction_RXN3O-1121_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_17499_RXN3O-75_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002413_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002333_YNR041C-MONOMER_RXN-9003_controller_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002234_CHEBI_30763_RXN3O-1121_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4348,7 +4315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4356,15 +4323,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/reaction_GPPSYN-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000066_reaction_RXN3O-9805_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000066_reaction_RXN3O-9805_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4384,7 +4360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4396,11 +4372,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002233_CHEBI_59789_RXN3O-102_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002233_CHEBI_59789_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4411,34 +4387,36 @@
           <http://model.geneontology.org/CHEBI_59789_RXN3O-102>
 ] .
 
-<http://model.geneontology.org/reaction_GPPSYN-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-54_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002234_CHEBI_30763_RXN3O-1121_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-102_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002333_YML110C-MONOMER_RXN3O-54_controller_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_15499_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4451,7 +4429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4463,11 +4441,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_GPPSYN-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_57623_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4482,11 +4460,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + 2-methoxy-6-<i>all trans</i>-hexaprenyl-1,4-benzoquinol &rarr; 6-methoxy-3-methyl-2-<i>all-trans</i>-hexaprenyl-1,4-benzoquinol + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' '6-methoxy-3-methyl-2-<i>all-trans</i>-hexaprenyl-1,4-benzoquinol + a reduced electron acceptor + oxygen &rarr; 3-demethylubiquinol-6 + an oxidized electron acceptor + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002413_RXN3O-75_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002413_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4506,7 +4484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4517,17 +4495,6 @@
 <http://purl.obolibrary.org/obo/GO_0008813>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_15379_RXN3O-75_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57540_RXN3O-1120>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4537,7 +4504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4548,26 +4515,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_1109>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002413_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_58349_RXN3O-12_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_58349_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4578,26 +4534,15 @@
           <http://model.geneontology.org/CHEBI_58349_RXN3O-12>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002413_RXN3O-12_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002234_CHEBI_15361_CHORPYRLY-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002234_CHEBI_15361_CHORPYRLY-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4608,14 +4553,25 @@
           <http://model.geneontology.org/CHEBI_15361_CHORPYRLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002413_RXN3O-58_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_15378_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9003_BFO_0000066_reaction_RXN-9003_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4623,11 +4579,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1118_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1118_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4642,11 +4598,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_57856_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_57856_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4657,12 +4613,23 @@
           <http://model.geneontology.org/CHEBI_57856_2.1.1.114-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-9003_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4675,7 +4642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4683,37 +4650,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002333_YBR003W-MONOMER_RXN3O-9805_controller_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002413_RXN3O-75_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Provides Input For Rule. The relation '(R)-3-(4-hydroxyphenyl)lactate + NAD<sup>+</sup> &larr; 3-(4-hydroxyphenyl)pyruvate + NADH + H<SUP>+</SUP>' 'null' '(R)-3-(4-hydroxyphenyl)lactate &rarr; 4-coumarate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002413_RXN3O-1118_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002413_RXN3O-1118_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4728,11 +4673,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4743,14 +4688,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-862/YeastPathways_PWY3O-862>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002233_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_57540_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4763,7 +4708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4771,40 +4716,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002413_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58756>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002233_CHEBI_57288_RXN3O-1120_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1118_BFO_0000066_reaction_RXN3O-1118_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1118_BFO_0000066_reaction_RXN3O-1118_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4815,6 +4738,17 @@
           <http://model.geneontology.org/reaction_RXN3O-1118_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002233_CHEBI_58373_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_RXN3O-1118>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4824,13 +4758,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51689> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15378_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002234_CHEBI_1109_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -4839,11 +4795,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8813_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8813_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4858,11 +4814,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Provides Input For Rule. The relation '4-coumarate + ATP + coenzyme A &rarr; (<i>E</i>)-4-coumaroyl-CoA + AMP + diphosphate' 'null' '(<i>E</i>)-4-coumaroyl-CoA + coenzyme A + NAD<sup>+</sup> + H<sub>2</sub>O &rarr; 4-hydroxybenzoyl-CoA + acetyl-CoA + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002413_RXN3O-1120_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002413_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4878,29 +4834,40 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002233_CHEBI_61472_RXN3O-12_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_15378_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002233_CHEBI_57916_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002234_CHEBI_36242_RXN3O-1116_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4908,11 +4875,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_128769_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_128769_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4923,26 +4890,15 @@
           <http://model.geneontology.org/CHEBI_128769_FARNESYLTRANSTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002233_CHEBI_58315_RXN3O-1116_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_15339_RXN3O-75_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_15339_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4953,6 +4909,42 @@
           <http://model.geneontology.org/CHEBI_15339_RXN3O-75>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002333_YBR003W-MONOMER_RXN3O-9805_controller_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_29888_RXN3O-9805_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15379_RXN3O-58>
         a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4962,7 +4954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4974,11 +4966,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002233_CHEBI_59789_RXN3O-54_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002233_CHEBI_59789_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4993,11 +4985,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57288_RXN3O-1120_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57288_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5008,8 +5000,16 @@
           <http://model.geneontology.org/CHEBI_57288_RXN3O-1120>
 ] .
 
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000066_reaction_2.1.1.114-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YPL069C-MONOMER_FARNESYLTRANSTRANSFERASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000005990> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5018,24 +5018,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862Protein51843> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002233_CHEBI_128769_RXN-8813_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004161> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5056,7 +5045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5067,15 +5056,26 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_61473_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002234_CHEBI_84492_RXN-9003_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002234_CHEBI_84492_RXN-9003_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5092,14 +5092,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002234_CHEBI_15361_CHORPYRLY-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_57907_RXN-8813_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5107,11 +5107,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002333_YJL167W-MONOMER_FPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5126,11 +5126,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Provides Input For Rule. The relation 'geranylfarnesyl diphosphate + isopentenyl diphosphate &rarr; all-<i>trans</i>-hexaprenyl diphosphate + diphosphate' 'null' 'all-<i>trans</i>-hexaprenyl diphosphate + 4-hydroxybenzoate &rarr; 3-hexaprenyl-4-hydroxybenzoate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002413_RXN-9003_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002413_RXN-9003_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5141,17 +5141,6 @@
           <http://model.geneontology.org/RXN-9003>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YJL167W-MONOMER_FPPSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000003703> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -5159,24 +5148,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862Protein51866> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_57783_RXN3O-12_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YML110C-MONOMER_RXN3O-54_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004578> ;
@@ -5185,7 +5163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5197,11 +5175,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_84492_RXN-9003_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_84492_RXN-9003_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5216,11 +5194,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_1109_RXN3O-73_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_1109_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5242,18 +5220,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002233_CHEBI_59789_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5261,11 +5239,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1116_BFO_0000066_reaction_RXN3O-1116_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1116_BFO_0000066_reaction_RXN3O-1116_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5276,15 +5254,26 @@
           <http://model.geneontology.org/reaction_RXN3O-1116_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_57856_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_15378_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_15378_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5299,11 +5288,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_12876_RXN3O-1118_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_12876_RXN3O-1118_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5314,47 +5303,14 @@
           <http://model.geneontology.org/CHEBI_12876_RXN3O-1118>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_15377_RXN3O-1120_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-12_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1118_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30616_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002333_YGR255C-MONOMER_RXN3O-58_controller_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5362,11 +5318,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Provides Input For Rule. The relation '3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + H<SUP>+</SUP> &rarr; 2-hexaprenyl-6-methoxyphenol + CO<SUB>2</SUB>' 'null' '2-hexaprenyl-6-methoxyphenol + NADPH + oxygen + H<SUP>+</SUP> &rarr; 2-methoxy-6-<i>all trans</i>-hexaprenyl-1,4-benzoquinol + NADP<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002413_RXN3O-12_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002413_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5380,25 +5336,36 @@
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002234_CHEBI_29888_RXN-9003_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002413_RXN-9003_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_64253_RXN3O-75_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002413_RXN-8813_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_57856_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5406,11 +5373,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_BFO_0000066_reaction_RXN3O-1120_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_BFO_0000066_reaction_RXN3O-1120_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5421,15 +5388,26 @@
           <http://model.geneontology.org/reaction_RXN3O-1120_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_12876_RXN3O-1118_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30616_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_30616_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5440,45 +5418,37 @@
           <http://model.geneontology.org/CHEBI_30616_4-COUMARATE--COA-LIGASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002413_RXN-9003_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_15499_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_456215_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-75> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY3O-862/YeastPathways_PWY3O-862>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Provides Input For Rule. The relation 'geranylgeranyl diphosphate + isopentenyl diphosphate &rarr; geranylfarnesyl diphosphate + diphosphate' 'null' 'geranylfarnesyl diphosphate + isopentenyl diphosphate &rarr; all-<i>trans</i>-hexaprenyl diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002413_RXN3O-9805_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002413_RXN3O-9805_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5489,14 +5459,33 @@
           <http://model.geneontology.org/RXN3O-9805>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002413_RXN3O-54_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-75> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY3O-862/YeastPathways_PWY3O-862>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002413_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5504,11 +5493,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5519,15 +5508,26 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-862/YeastPathways_PWY3O-862>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_128769_RXN3O-9805_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_61472_RXN3O-12_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_61472_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5538,50 +5538,6 @@
           <http://model.geneontology.org/CHEBI_61472_RXN3O-12>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_15378_RXN3O-102_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_Apo-Ferredoxins_RXN3O-58_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_128769_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_61472_RXN3O-12_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57856_RXN3O-54>
         a       <http://purl.obolibrary.org/obo/CHEBI_57856> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5591,7 +5547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5599,14 +5555,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-102_BFO_0000066_reaction_RXN3O-102_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-1118_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5614,11 +5570,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002233_CHEBI_57288_RXN3O-1120_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002233_CHEBI_57288_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5629,6 +5585,17 @@
           <http://model.geneontology.org/CHEBI_57288_RXN3O-1120>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002233_CHEBI_57288_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_RXN3O-12>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5638,7 +5605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5650,11 +5617,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002233_CHEBI_64253_RXN3O-75_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002233_CHEBI_64253_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5669,11 +5636,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_128769_RXN3O-9805_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_128769_RXN3O-9805_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5693,7 +5660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5720,7 +5687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5728,12 +5695,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_4-COUMARATE--COA-LIGASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5754,7 +5732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5766,11 +5744,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_29888_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5785,11 +5763,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5800,30 +5778,19 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-862/YeastPathways_PWY3O-862>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_BFO_0000066_reaction_4-COUMARATE--COA-LIGASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002413_RXN3O-1121_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58057>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58373_RXN3O-58>
         a       <http://purl.obolibrary.org/obo/CHEBI_58373> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5834,7 +5801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5842,40 +5809,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_57856_RXN3O-102_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_64253>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002234_CHEBI_30763_CHORPYRLY-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002234_CHEBI_30763_CHORPYRLY-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5886,6 +5853,17 @@
           <http://model.geneontology.org/CHEBI_30763_CHORPYRLY-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_57916_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57916_2.1.1.114-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57916> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5895,24 +5873,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule52090> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002333_MONOMER3O-164_RXN3O-75_controller_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -5921,11 +5888,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_57916_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_57916_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5936,25 +5903,14 @@
           <http://model.geneontology.org/CHEBI_57916_2.1.1.114-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_58349_RXN3O-12_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002411_RXN3O-1121_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002233_CHEBI_128769_RXN-8813_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5967,7 +5923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5975,15 +5931,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002234_CHEBI_57540_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000066_reaction_RXN3O-73_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000066_reaction_RXN3O-73_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6003,24 +5970,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51640> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_175763_FPPSYN-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -6030,7 +5986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6038,11 +5994,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002233_CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002233_CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6053,32 +6009,62 @@
           <http://model.geneontology.org/CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-1121_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002411_RXN3O-1121_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57288_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57907>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_29748>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002234_CHEBI_15361_CHORPYRLY-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8813_BFO_0000066_reaction_RXN-8813_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8813_BFO_0000066_reaction_RXN-8813_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6089,38 +6075,8 @@
           <http://model.geneontology.org/reaction_RXN-8813_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_52970_RXN3O-102_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002234_CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002233_CHEBI_57916_2.1.1.114-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_29748>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -6132,11 +6088,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_175763_FPPSYN-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_175763_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6151,11 +6107,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_15377_RXN3O-75_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_15377_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6175,7 +6131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6192,7 +6148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6212,7 +6168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6224,11 +6180,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002233_CHEBI_61472_RXN3O-12_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002233_CHEBI_61472_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6243,11 +6199,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57356_RXN3O-1120_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57356_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6258,14 +6214,14 @@
           <http://model.geneontology.org/CHEBI_57356_RXN3O-1120>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_58179_RXN3O-9805_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6278,7 +6234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6289,15 +6245,26 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_57783_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002333_YNR041C-MONOMER_RXN-9003_controller_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002333_YNR041C-MONOMER_RXN-9003_controller_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6308,14 +6275,14 @@
           <http://model.geneontology.org/YNR041C-MONOMER_RXN-9003_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002413_RXN3O-1121_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002233_CHEBI_57356_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6328,7 +6295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6340,11 +6307,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Provides Input For Rule. The relation 'geranyl diphosphate + isopentenyl diphosphate &rarr; (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate + diphosphate' 'null' 'isopentenyl diphosphate + (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate &rarr; geranylgeranyl diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002413_FARNESYLTRANSTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002413_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6359,11 +6326,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6374,14 +6341,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-862/YeastPathways_PWY3O-862>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_58179_RXN3O-9805_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-1121_BFO_0000066_reaction_RXN3O-1121_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6394,7 +6361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6406,11 +6373,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_15377_RXN3O-58_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_15377_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6425,11 +6392,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_15378_RXN3O-12_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_15378_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6440,18 +6407,40 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-12>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1118_BFO_0000066_reaction_RXN3O-1118_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_84492>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002233_CHEBI_58315_RXN3O-1116_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002233_CHEBI_58315_RXN3O-1116_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6462,48 +6451,15 @@
           <http://model.geneontology.org/CHEBI_58315_RXN3O-1116>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002233_CHEBI_58373_RXN3O-58_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002234_CHEBI_456215_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002413_RXN3O-102_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_36242_RXN3O-1116_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_36242_RXN3O-1116_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6517,12 +6473,23 @@
 <http://purl.obolibrary.org/obo/GO_0043333>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_52970_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-1121_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6541,7 +6508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6552,14 +6519,14 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_15377_RXN3O-12_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002413_RXN-9003_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6568,7 +6535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6581,7 +6548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6589,15 +6556,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002234_CHEBI_10980_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_15377_RXN3O-1120_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_15377_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6612,11 +6590,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_57287_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_57287_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6630,32 +6608,26 @@
 <http://purl.obolibrary.org/obo/GO_0008682>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/CHEBI_57856_RXN3O-102>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57856> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "SAH" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57356_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51956> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9003_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9003_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6666,26 +6638,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-862/YeastPathways_PWY3O-862>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002233_CHEBI_64253_RXN3O-75_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-75_BFO_0000066_reaction_RXN3O-75_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-75_BFO_0000066_reaction_RXN3O-75_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6696,14 +6657,42 @@
           <http://model.geneontology.org/reaction_RXN3O-75_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57288_RXN3O-1120_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/CHEBI_57856_RXN3O-102>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57856> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "SAH" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51956> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002234_CHEBI_30763_CHORPYRLY-RXN_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002413_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6712,7 +6701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6725,7 +6714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6733,15 +6722,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002333_YGR255C-MONOMER_RXN3O-12_controller_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6756,11 +6756,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002333_YGR255C-MONOMER_RXN3O-12_controller_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002333_YGR255C-MONOMER_RXN3O-12_controller_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6780,7 +6780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6788,12 +6788,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002413_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_FARNESYLTRANSTRANSFERASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6806,7 +6817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6814,25 +6825,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_29888_RXN3O-9805_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002233_CHEBI_58315_RXN3O-1116_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_57287_4-COUMARATE--COA-LIGASE-RXN_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN-9003_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002234_CHEBI_29888_RXN-9003_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6840,11 +6862,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002233_CHEBI_57356_RXN3O-1120_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002233_CHEBI_57356_RXN3O-1120_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6855,17 +6877,6 @@
           <http://model.geneontology.org/CHEBI_57356_RXN3O-1120>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002413_RXN-9003_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456215_4-COUMARATE--COA-LIGASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456215> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6875,24 +6886,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51627> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000066_reaction_2.1.1.114-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-75>
         a       <http://purl.obolibrary.org/obo/GO_0008682> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6913,7 +6913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6921,14 +6921,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_128769_RXN3O-9805_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002233_CHEBI_61472_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6939,11 +6939,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_15378_RXN3O-102_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_15378_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6954,43 +6954,15 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-102>
 ] .
 
-<http://model.geneontology.org/CHEBI_61473_RXN3O-54>
-        a       <http://purl.obolibrary.org/obo/CHEBI_61473> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "6-methoxy-3-methyl-2-<i>all-trans</i>-hexaprenyl-1,4-benzoquinol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51974> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002233_CHEBI_57356_RXN3O-1120_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_57907_RXN-8813_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_57907_RXN-8813_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7001,6 +6973,34 @@
           <http://model.geneontology.org/CHEBI_57907_RXN-8813>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002233_CHEBI_59789_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_61473_RXN3O-54>
+        a       <http://purl.obolibrary.org/obo/CHEBI_61473> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "6-methoxy-3-methyl-2-<i>all-trans</i>-hexaprenyl-1,4-benzoquinol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51974> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_59789_RXN3O-54>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59789> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7010,7 +7010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7027,7 +7027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7035,14 +7035,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002413_RXN3O-73_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002413_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7066,7 +7066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7074,25 +7074,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002413_RXN3O-1120_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002413_RXN3O-9805_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7100,11 +7089,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7119,11 +7108,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_BFO_0000066_reaction_RXN3O-58_location_lociGO_0005829_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_BFO_0000066_reaction_RXN3O-58_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7138,11 +7127,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002234_CHEBI_30763_RXN3O-1121_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1121_RO_0002234_CHEBI_30763_RXN3O-1121_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7153,6 +7142,17 @@
           <http://model.geneontology.org/CHEBI_30763_RXN3O-1121>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002233_CHEBI_15499_4-COUMARATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_RXN3O-58>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7162,13 +7162,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51538> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_128769_GPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_128769> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7179,7 +7190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7191,11 +7202,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_52970_RXN3O-102_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_52970_RXN3O-102_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7208,6 +7219,17 @@
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002233_CHEBI_15378_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/FPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004337> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7228,7 +7250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7240,11 +7262,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002411_RXN3O-1121_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002411_RXN3O-1121_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7264,7 +7286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7276,11 +7298,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7291,26 +7313,15 @@
           <http://model.geneontology.org/YJL167W-MONOMER_GPPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002333_YGR255C-MONOMER_RXN3O-12_controller_SGD_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002333_YOL096C-MONOMER_2.1.1.114-RXN_controller_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002333_YOL096C-MONOMER_2.1.1.114-RXN_controller_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7324,14 +7335,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_59789>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_36242_RXN3O-1116_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000066_reaction_RXN3O-9805_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7339,11 +7350,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002233_CHEBI_15378_RXN3O-73_SGD_YeastPathways_PWY3O-862> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002233_CHEBI_15378_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7354,24 +7365,13 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-73>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002234_CHEBI_57356_RXN3O-1120_SGD_YeastPathways_PWY3O-862>
+<http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002333_YOL096C-MONOMER_RXN3O-102_controller_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-94.ttl
+++ b/models/YeastPathways_PWY3O-94.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -19,11 +19,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000066_reaction_MALSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000066_reaction_MALSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,28 +37,6 @@
 <http://identifiers.org/sgd/S000006205>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002333_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -68,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of TCA cycle and glyoxylate cycle - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -80,11 +58,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-742_component_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-742_component_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -95,17 +73,6 @@
           <http://model.geneontology.org/SGD_S000003964_CPLX3O-742_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002333_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CPLX3O-83_MALATE-DEH-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -115,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,14 +90,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57945_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-742_component_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -142,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -150,11 +128,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -171,34 +149,12 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002411_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-44_component_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000001631_CPLX3O-742_component>
         a       <http://identifiers.org/sgd/S000001631> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -206,11 +162,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_30031_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_30031_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -225,11 +181,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -240,17 +196,6 @@
           <http://model.geneontology.org/CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_36655_ISOCIT-CLEAV-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_36655> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -260,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -275,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -287,11 +232,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000066_reaction_ISOCIT-CLEAV-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000066_reaction_ISOCIT-CLEAV-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -305,14 +250,14 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -320,11 +265,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_16947_CITSYN-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_16947_CITSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,29 +283,51 @@
 <http://purl.obolibrary.org/obo/GO_0044238>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_15377_ACONITATEHYDR-RXN_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16389>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_15562_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -375,11 +342,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_43474_SUCCCOASYN-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_43474_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,7 +376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -421,11 +388,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -439,15 +406,26 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_29806_FUMHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,14 +439,14 @@
 <http://purl.obolibrary.org/obo/GO_0004451>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000004982_CPLX3O-679_component_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -476,11 +454,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -495,11 +473,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57945_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57945_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -510,25 +488,14 @@
           <http://model.geneontology.org/CHEBI_57945_2OXOGLUTARATEDEH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -541,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -556,7 +523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -568,11 +535,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_57287_MALSYN-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_57287_MALSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,36 +550,25 @@
           <http://model.geneontology.org/CHEBI_57287_MALSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002413_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000066_reaction_SUCCCOASYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002413_MALATE-DEH-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -620,11 +576,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_15377_FUMHYDR-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_15377_FUMHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,11 +595,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_57945_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_57945_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -657,17 +613,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_30031>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000066_reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_SUCCCOASYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -677,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -691,6 +636,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YNR001C-MONOMER_CITSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -698,11 +654,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -717,11 +673,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002333_CPLX3O-690_SUCCCOASYN-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002333_CPLX3O-690_SUCCCOASYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -741,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -749,25 +705,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YCR005C-MONOMER_CITSYN-RXN_controller_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -776,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -787,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -795,14 +740,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -815,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -823,12 +768,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_30031_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000003476_CPLX3O-690_component>
         a       <http://identifiers.org/sgd/S000003476> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -839,11 +795,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000066_reaction_2OXOGLUTARATEDEH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000066_reaction_2OXOGLUTARATEDEH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -858,11 +814,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -873,6 +829,17 @@
           <http://model.geneontology.org/YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000066_reaction_MALSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000004982>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -880,11 +847,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,11 +866,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -945,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -957,11 +924,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-33_component_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-33_component_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -975,17 +942,6 @@
 <http://identifiers.org/sgd/S000001568>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57945_MALATE-DEH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -995,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1012,7 +968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1029,7 +985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1056,7 +1012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1073,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1085,11 +1041,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1109,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1117,14 +1073,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002333_CPLX3O-690_SUCCCOASYN-RXN_controller_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_57288_CITSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002333_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1135,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1148,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1156,11 +1123,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_15377_MALSYN-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_15377_MALSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1171,28 +1138,6 @@
           <http://model.geneontology.org/CHEBI_15377_MALSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-44_component_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000001876>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1200,11 +1145,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1215,23 +1160,23 @@
           <http://model.geneontology.org/SGD_S000002236_CPLX3O-83_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000004982_CPLX3O-679_component_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000005668_CPLX3O-690_component>
         a       <http://identifiers.org/sgd/S000005668> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1240,7 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1249,18 +1194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_57287_MALSYN-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1268,11 +1202,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002234_CHEBI_15562_ACONITATEHYDR-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002234_CHEBI_15562_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1293,11 +1227,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1308,15 +1242,26 @@
           <http://model.geneontology.org/CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002411_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1336,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1348,11 +1293,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002233_CHEBI_15562_ACONITATEHYDR-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002233_CHEBI_15562_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1363,25 +1308,47 @@
           <http://model.geneontology.org/CHEBI_15562_ACONITATEHYDR-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002333_YPL262W-MONOMER_FUMHYDR-RXN_controller_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_15377_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-44_component_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-742_component_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1389,11 +1356,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_57287_CITSYN-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_57287_CITSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1404,17 +1371,6 @@
           <http://model.geneontology.org/CHEBI_57287_CITSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1424,13 +1380,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94SmallMolecule63590> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1442,11 +1409,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_456216_SUCCCOASYN-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_456216_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,7 +1443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1493,7 +1460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1505,11 +1472,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000066_reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000066_reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1520,17 +1487,6 @@
           <http://model.geneontology.org/reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1540,7 +1496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1548,15 +1504,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YNL117W-MONOMER_MALSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1571,11 +1549,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000003476_CPLX3O-690_component_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000003476_CPLX3O-690_component_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1590,11 +1568,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002333_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002333_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1605,19 +1583,30 @@
           <http://model.geneontology.org/CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000066_reaction_ACONITATEHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-33_component_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1628,7 +1617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1643,11 +1632,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YIR031C-MONOMER_MALSYN-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YIR031C-MONOMER_MALSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1666,7 +1655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1675,7 +1664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1684,7 +1673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1700,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1712,11 +1701,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_29806_FUMHYDR-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_29806_FUMHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1731,11 +1720,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002333_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002333_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1746,32 +1735,7 @@
           <http://model.geneontology.org/CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_16526_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_456216_SUCCCOASYN-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0008177>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_57288>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15377_FUMHYDR-RXN>
@@ -1783,7 +1747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1791,26 +1755,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000066_reaction_2OXOGLUTARATEDEH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57288>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000066_reaction_CITSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000066_reaction_CITSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1825,11 +1781,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002411_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002411_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1844,11 +1800,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YNL117W-MONOMER_MALSYN-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YNL117W-MONOMER_MALSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1859,14 +1815,14 @@
           <http://model.geneontology.org/YNL117W-MONOMER_MALSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_15377_CITSYN-RXN_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000003476_CPLX3O-690_component_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1875,18 +1831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002233_CHEBI_15562_ACONITATEHYDR-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1898,18 +1843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002413_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1917,11 +1851,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002234_CHEBI_15589_FUMHYDR-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002234_CHEBI_15589_FUMHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1938,28 +1872,6 @@
 <http://identifiers.org/sgd/S000005284>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_15377_FUMHYDR-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_ACONITATEDEHYDR-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1969,7 +1881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1977,15 +1889,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_15377_CITSYN-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_15377_CITSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2005,13 +1928,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94SmallMolecule63381> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002411_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_MALATE-DEH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2022,7 +1956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2034,11 +1968,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2053,11 +1987,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57287_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57287_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2067,6 +2001,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57287_2OXOGLUTARATEDEH-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003581_CPLX3O-44_component_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACONITATEHYDR-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003994> ;
@@ -2089,7 +2034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2106,7 +2051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2117,26 +2062,15 @@
 <http://purl.obolibrary.org/obo/GO_0003994>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_FUMHYDR-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_FUMHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2153,15 +2087,26 @@
 <http://identifiers.org/sgd/S000000598>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_FUMHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'citrate &harr; <i>cis</i>-aconitate + H<sub>2</sub>O' 'null' '<i>cis</i>-aconitate + H<sub>2</sub>O &harr; D-<i>threo</i>-isocitrate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002413_ACONITATEHYDR-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002413_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2175,28 +2120,6 @@
 <http://purl.obolibrary.org/obo/GO_0005886>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000066_reaction_MALSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2204,11 +2127,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000002555_CPLX3O-33_component_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000002555_CPLX3O-33_component_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2219,6 +2142,17 @@
           <http://model.geneontology.org/SGD_S000002555_CPLX3O-33_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002333_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_CITSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2228,7 +2162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2236,25 +2170,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002413_MALSYN-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_CITSYN-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2265,11 +2188,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000066_reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000066_reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2283,26 +2206,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_16452>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_15562_ACONITATEHYDR-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2313,14 +2225,14 @@
           <http://model.geneontology.org/CHEBI_36655_ISOCIT-CLEAV-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2329,7 +2241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2339,26 +2251,15 @@
 <http://identifiers.org/sgd/S000006183>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2369,23 +2270,12 @@
           <http://model.geneontology.org/SGD_S000001568_CPLX3O-85_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57287_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_CITSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2395,15 +2285,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_29806>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YPR001W-MONOMER_CITSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEHYDR-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEHYDR-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2414,17 +2315,6 @@
           <http://model.geneontology.org/YLR304C-MONOMER_ACONITATEHYDR-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000066_reaction_CITSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57288_CITSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2434,7 +2324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2442,19 +2332,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15589>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000066_reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15589>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2468,7 +2358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2480,11 +2370,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2499,11 +2389,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2522,18 +2412,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000005662_CPLX3O-679_component_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002413_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2556,7 +2446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2568,11 +2458,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_30031_ISOCIT-CLEAV-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_30031_ISOCIT-CLEAV-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2592,7 +2482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2600,25 +2490,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_57288_CITSYN-RXN_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2626,11 +2505,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YCR005C-MONOMER_CITSYN-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YCR005C-MONOMER_CITSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2645,11 +2524,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2665,33 +2544,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2702,15 +2570,26 @@
           <http://model.geneontology.org/CHEBI_57292_2OXOGLUTARATEDEH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_CITSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002233_CHEBI_16947_CITSYN-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002233_CHEBI_16947_CITSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2721,14 +2600,14 @@
           <http://model.geneontology.org/CHEBI_16947_CITSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000002555_CPLX3O-33_component_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2736,11 +2615,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2760,7 +2639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2768,36 +2647,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_43474_SUCCCOASYN-RXN_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2810,7 +2667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2818,15 +2675,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000066_reaction_SUCCCOASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000005668_CPLX3O-690_component_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000005668_CPLX3O-690_component_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000005668_CPLX3O-690_component_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2841,11 +2720,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002411_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002411_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2871,13 +2750,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94SmallMolecule63337> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002333_CPLX3O-690_SUCCCOASYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000003030> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2886,7 +2776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2906,7 +2796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2923,13 +2813,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94SmallMolecule63513> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000066_reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -2940,13 +2852,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94SmallMolecule63366> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001631>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2955,11 +2878,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" , "Provides Input For Rule. The relation 'D-<i>threo</i>-isocitrate + NAD<sup>+</sup> &rarr; 2-oxoglutarate + CO<SUB>2</SUB> + NADH' 'null' '2-oxoglutarate + coenzyme A + NAD<sup>+</sup> &rarr; succinyl-CoA + CO<SUB>2</SUB> + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002413_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002413_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2979,7 +2902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2996,7 +2919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3007,26 +2930,15 @@
 <http://identifiers.org/sgd/S000003030>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_57945_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3041,11 +2953,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'acetyl-CoA + glyoxylate + H<sub>2</sub>O &rarr; (<i>S</i>)-malate + coenzyme A + H<SUP>+</SUP>' 'null' '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002413_MALATE-DEH-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002413_MALATE-DEH-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3065,7 +2977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3076,25 +2988,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_16947>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002333_YPL262W-MONOMER_FUMHYDR-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3103,29 +3004,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002413_ACONITATEDEHYDR-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-742_component_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3133,11 +3023,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002333_YPL262W-MONOMER_FUMHYDR-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002333_YPL262W-MONOMER_FUMHYDR-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3148,25 +3038,36 @@
           <http://model.geneontology.org/YPL262W-MONOMER_FUMHYDR-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002413_ISOCIT-CLEAV-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_57288_MALSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002411_FUMHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3174,11 +3075,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3196,24 +3097,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94Protein63213> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57287_2OXOGLUTARATEDEH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57287> ;
@@ -3224,24 +3114,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94SmallMolecule63290> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002413_MALATE-DEH-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16452> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3252,7 +3131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3260,26 +3139,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-33_component_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57540_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57540_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3290,15 +3158,26 @@
           <http://model.geneontology.org/CHEBI_57540_2OXOGLUTARATEDEH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002333_YER065C-MONOMER_ISOCIT-CLEAV-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'hydrogencarbonate + pyruvate + ATP &rarr; oxaloacetate + ADP + phosphate + H<SUP>+</SUP>' 'null' 'oxaloacetate + acetyl-CoA + H<sub>2</sub>O &rarr; citrate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_CITSYN-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_CITSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3309,14 +3188,23 @@
           <http://model.geneontology.org/CITSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002234_CHEBI_15562_ACONITATEHYDR-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000003581_CPLX3O-44_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003581> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3324,11 +3212,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3339,6 +3227,17 @@
           <http://model.geneontology.org/CHEBI_57540_MALATE-DEH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_CITSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57292_2OXOGLUTARATEDEH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57292> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3348,7 +3247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3356,12 +3255,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/SGD_S000003581_CPLX3O-44_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003581> ;
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-44_component_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3369,11 +3281,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3387,26 +3299,15 @@
 <http://identifiers.org/sgd/S000003476>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-44_component_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-44_component_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3416,17 +3317,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/SGD_S000001624_CPLX3O-44_component>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_15378_CITSYN-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CITSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004108> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3447,7 +3337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3470,7 +3360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3481,15 +3371,26 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002413_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_15562_ACONITATEHYDR-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_15562_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3500,15 +3401,26 @@
           <http://model.geneontology.org/CHEBI_15562_ACONITATEHYDR-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_30616_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_57288_MALSYN-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_57288_MALSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3524,18 +3436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000066_reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3558,7 +3459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3566,15 +3467,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002413_MALATE-DEH-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3594,7 +3506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3602,14 +3514,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15589_MALSYN-RXN_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_43474_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3617,11 +3529,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002411_ACONITATEDEHYDR-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002411_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3637,18 +3549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3661,7 +3562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3669,14 +3570,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_29806_FUMHYDR-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_16389_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3684,11 +3596,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3699,6 +3611,28 @@
           <http://model.geneontology.org/CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_57945_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002233_CHEBI_15562_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30031_SUCCCOASYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30031> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3708,7 +3642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3716,34 +3650,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_30031_SUCCCOASYN-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000005662_CPLX3O-679_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005662> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3751,11 +3663,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3785,7 +3697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3793,36 +3705,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001631_CPLX3O-742_component_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002233_CHEBI_16947_CITSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_15377_MALSYN-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3833,11 +3723,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YNR001C-MONOMER_CITSYN-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YNR001C-MONOMER_CITSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3852,11 +3742,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3867,36 +3757,36 @@
           <http://model.geneontology.org/CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000003476_CPLX3O-690_component_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000066_reaction_ISOCIT-CLEAV-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002411_ACONITATEDEHYDR-RXN_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_15377_FUMHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-33_component_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3904,11 +3794,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_30031_SUCCCOASYN-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_30031_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3923,11 +3813,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_15377_ACONITATEDEHYDR-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_15377_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3936,6 +3826,25 @@
           <http://model.geneontology.org/ACONITATEDEHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_ACONITATEDEHYDR-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_MALSYN-RXN>
@@ -3947,7 +3856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3955,55 +3864,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEHYDR-RXN_controller_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_FUMHYDR-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57540_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4026,7 +3894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4038,11 +3906,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-742_component_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-742_component_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4057,11 +3925,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" , "Provides Input For Rule. The relation '2-oxoglutarate + coenzyme A + NAD<sup>+</sup> &rarr; succinyl-CoA + CO<SUB>2</SUB> + NADH' 'null' 'succinate + ATP + coenzyme A &harr; succinyl-CoA + ADP + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002413_SUCCCOASYN-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002413_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4072,37 +3940,15 @@
           <http://model.geneontology.org/SUCCCOASYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002413_ACONITATEHYDR-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YPR001W-MONOMER_CITSYN-RXN_controller_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" , "Provides Input For Rule. The relation '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' 'null' 'oxaloacetate + acetyl-CoA + H<sub>2</sub>O &rarr; citrate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_CITSYN-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_CITSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4122,13 +3968,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94Complex63471> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
+
+<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_57287_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YNR001C-MONOMER_CITSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000005284> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4137,7 +4005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4148,29 +4016,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000066_reaction_FUMHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001631_CPLX3O-742_component_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001631_CPLX3O-742_component_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4181,15 +4049,48 @@
           <http://model.geneontology.org/SGD_S000001631_CPLX3O-742_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15589_MALSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_30031_ISOCIT-CLEAV-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000066_reaction_ACONITATEHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000066_reaction_ACONITATEHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4200,36 +4101,25 @@
           <http://model.geneontology.org/reaction_ACONITATEHYDR-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002233_CHEBI_16947_CITSYN-RXN_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_57287_CITSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000002555_CPLX3O-33_component_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_15377_CITSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4237,11 +4127,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000066_reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000066_reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4256,11 +4146,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4279,21 +4169,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-742_component_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_57287_SUCCCOASYN-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4301,11 +4202,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" , "Provides Input For Rule. The relation '(<i>S</i>)-malate &larr; fumarate + H<sub>2</sub>O' 'null' '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002413_MALATE-DEH-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002413_MALATE-DEH-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4316,29 +4217,29 @@
           <http://model.geneontology.org/MALATE-DEH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000066_reaction_ISOCIT-CLEAV-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94>
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001631_CPLX3O-742_component_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_57288_CITSYN-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_57288_CITSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4349,26 +4250,15 @@
           <http://model.geneontology.org/CHEBI_57288_CITSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4383,11 +4273,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4397,6 +4287,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-94/YeastPathways_PWY3O-94>
 ] .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -4422,7 +4323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4430,14 +4331,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_57288_MALSYN-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_16526_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4445,11 +4357,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4460,15 +4372,26 @@
           <http://model.geneontology.org/CHEBI_15378_MALATE-DEH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_456216_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-44_component_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-44_component_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4479,14 +4402,25 @@
           <http://model.geneontology.org/SGD_S000002585_CPLX3O-44_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000066_reaction_FUMHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002234_CHEBI_15589_FUMHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4494,11 +4428,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4518,7 +4452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4526,15 +4460,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15378_MALSYN-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15378_MALSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4545,6 +4512,17 @@
           <http://model.geneontology.org/CHEBI_15378_MALSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_15377_MALSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4554,7 +4532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4566,11 +4544,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4585,11 +4563,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4600,17 +4578,6 @@
           <http://model.geneontology.org/CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57945_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4620,24 +4587,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94SmallMolecule63381> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002234_CHEBI_30031_ISOCIT-CLEAV-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57540_2OXOGLUTARATEDEH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4648,7 +4604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4660,11 +4616,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>cis</i>-aconitate + H<sub>2</sub>O &harr; D-<i>threo</i>-isocitrate' 'null' 'D-<i>threo</i>-isocitrate &rarr; glyoxylate + succinate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002413_ISOCIT-CLEAV-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002413_ISOCIT-CLEAV-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4679,11 +4635,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_30616_SUCCCOASYN-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_30616_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4694,6 +4650,17 @@
           <http://model.geneontology.org/CHEBI_30616_SUCCCOASYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller>
         a       <http://identifiers.org/sgd/S000003736> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4701,7 +4668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4709,25 +4676,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-742_component_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_16389_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4738,7 +4716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4750,11 +4728,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4773,7 +4751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4786,7 +4764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4798,11 +4776,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002333_YER065C-MONOMER_ISOCIT-CLEAV-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002333_YER065C-MONOMER_ISOCIT-CLEAV-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4813,21 +4791,54 @@
           <http://model.geneontology.org/YER065C-MONOMER_ISOCIT-CLEAV-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_36655>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000002555>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_15378_CITSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002413_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YPR001W-MONOMER_CITSYN-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YPR001W-MONOMER_CITSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4842,11 +4853,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002411_FUMHYDR-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002411_FUMHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4864,7 +4875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4880,7 +4891,40 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000005662_CPLX3O-679_component_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YIR031C-MONOMER_MALSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4888,11 +4932,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4906,17 +4950,6 @@
 <http://identifiers.org/sgd/S000001470>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -4927,7 +4960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4935,14 +4968,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002413_ISOCIT-CLEAV-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4965,7 +4998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4977,11 +5010,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000004982_CPLX3O-679_component_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000004982_CPLX3O-679_component_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5001,24 +5034,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94SmallMolecule63322> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003581_CPLX3O-44_component_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30031_ISOCIT-CLEAV-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30031> ;
@@ -5029,7 +5051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5045,7 +5067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5053,11 +5075,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5068,40 +5090,40 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-94/YeastPathways_PWY3O-94>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YNL117W-MONOMER_MALSYN-RXN_controller_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002413_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15378_MALSYN-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005486>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-742_component_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-742_component_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5121,7 +5143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5137,7 +5159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5145,11 +5167,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_15377_ACONITATEHYDR-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_15377_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5160,15 +5182,26 @@
           <http://model.geneontology.org/CHEBI_15377_ACONITATEHYDR-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15378_MALSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_16389_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_16389_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5183,11 +5216,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5201,9 +5234,6 @@
 <http://identifiers.org/sgd/S000003581>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004295> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -5211,7 +5241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5219,62 +5249,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_16947_CITSYN-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0004775>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5284,6 +5273,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-94/YeastPathways_PWY3O-94>
 ] .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57292>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5297,7 +5297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5309,11 +5309,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_15378_CITSYN-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_15378_CITSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5324,48 +5324,15 @@
           <http://model.geneontology.org/CHEBI_15378_CITSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002411_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-742_component_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002234_CHEBI_15589_FUMHYDR-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_16526_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_16526_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5380,11 +5347,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000066_reaction_SUCCCOASYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000066_reaction_SUCCCOASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5395,14 +5362,25 @@
           <http://model.geneontology.org/reaction_SUCCCOASYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000066_reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEHYDR-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5410,11 +5388,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5428,14 +5406,36 @@
 <http://identifiers.org/sgd/S000000867>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002413_MALATE-DEH-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002234_CHEBI_15562_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000066_reaction_2OXOGLUTARATEDEH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5444,7 +5444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5452,11 +5452,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003581_CPLX3O-44_component_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003581_CPLX3O-44_component_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5467,46 +5467,57 @@
           <http://model.geneontology.org/SGD_S000003581_CPLX3O-44_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_16947_CITSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YCR005C-MONOMER_CITSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000002236>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57540_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_57287_CITSYN-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000005668_CPLX3O-690_component_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15589_MALSYN-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15589_MALSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5520,51 +5531,29 @@
 <http://identifiers.org/sgd/S000005662>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-33_component_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YNR001C-MONOMER_CITSYN-RXN_controller_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002413_SUCCCOASYN-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000066_reaction_FUMHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000066_reaction_FUMHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5579,11 +5568,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5594,34 +5583,26 @@
           <http://model.geneontology.org/CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_57287_SUCCCOASYN-RXN_SGD_YeastPathways_PWY3O-94> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_SUCCCOASYN-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" , "Provides Input For Rule. The relation '<i>cis</i>-aconitate + H<sub>2</sub>O &harr; D-<i>threo</i>-isocitrate' 'null' 'D-<i>threo</i>-isocitrate + NAD<sup>+</sup> &rarr; 2-oxoglutarate + CO<SUB>2</SUB> + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002413_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002413_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5632,16 +5613,24 @@
           <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002411_FUMHYDR-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_57287_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SUCCCOASYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57287_SUCCCOASYN-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16452> ;
@@ -5652,7 +5641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5660,25 +5649,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000066_reaction_CITSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002413_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002413_MALSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5691,7 +5680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5703,11 +5692,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5718,29 +5707,29 @@
           <http://model.geneontology.org/CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_CITSYN-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/GO_0004474>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_15377_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004474>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" , "Provides Input For Rule. The relation 'D-<i>threo</i>-isocitrate &rarr; glyoxylate + succinate' 'null' 'acetyl-CoA + glyoxylate + H<sub>2</sub>O &rarr; (<i>S</i>)-malate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002413_MALSYN-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002413_MALSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5751,14 +5740,47 @@
           <http://model.geneontology.org/MALSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000066_reaction_ACONITATEHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000066_reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002411_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5769,11 +5791,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'oxaloacetate + acetyl-CoA + H<sub>2</sub>O &rarr; citrate + coenzyme A + H<SUP>+</SUP>' 'null' 'citrate &harr; <i>cis</i>-aconitate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002413_ACONITATEDEHYDR-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002413_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5788,11 +5810,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5807,11 +5829,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5822,29 +5844,37 @@
           <http://model.geneontology.org/CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_57287_MALSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5855,27 +5885,8 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-94/YeastPathways_PWY3O-94>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_30616_SUCCCOASYN-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_YeastPathways_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_456216_SUCCCOASYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -5886,7 +5897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5898,11 +5909,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5918,7 +5929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5926,11 +5937,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-33_component_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-33_component_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5941,36 +5952,36 @@
           <http://model.geneontology.org/SGD_S000001387_CPLX3O-33_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002333_YIR031C-MONOMER_MALSYN-RXN_controller_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_30031_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_RO_0002333_YER065C-MONOMER_ISOCIT-CLEAV-RXN_controller_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_ISOCIT-CLEAV-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5978,11 +5989,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000005662_CPLX3O-679_component_SGD_YeastPathways_PWY3O-94> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000005662_CPLX3O-679_component_SGD_PWY_YeastPathways_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5993,46 +6004,35 @@
           <http://model.geneontology.org/SGD_S000005662_CPLX3O-679_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_30031_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_YeastPathways_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57287_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_15377_ACONITATEDEHYDR-RXN_SGD_YeastPathways_PWY3O-94>
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57945_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-954.ttl
+++ b/models/YeastPathways_PWY3O-954.ttl
@@ -1,23 +1,12 @@
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,15 +17,24 @@
           <http://model.geneontology.org/CHEBI_57476_HOMOSERDEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-aspartate + ATP &rarr; L-aspartyl-4-phosphate + ADP' 'null' 'L-aspartate 4-semialdehyde + NADP<sup>+</sup> + phosphate &larr; L-aspartyl-4-phosphate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -47,27 +45,40 @@
           <http://model.geneontology.org/ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,36 +89,25 @@
           <http://model.geneontology.org/CHEBI_58199_ACETYLHOMOSER-CYS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002333_YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller_SGD_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58140>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_YeastPathways_PWY3O-954>
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_58140>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_30616_RXN3O-22>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -118,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -126,26 +126,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -156,15 +145,26 @@
           <http://model.geneontology.org/CHEBI_30616_RXN3O-22>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002411_RXN3O-22_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002411_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -182,7 +182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -194,11 +194,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -208,6 +208,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57844>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -221,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -232,8 +243,30 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16136>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -247,13 +280,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule64108> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ASPARTATEKIN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004072> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -274,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -286,11 +341,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,26 +356,15 @@
           <http://model.geneontology.org/YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,11 +382,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000066_reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000066_reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,25 +397,14 @@
           <http://model.geneontology.org/reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_YeastPathways_PWY3O-954>
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -384,13 +417,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule64238> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_RXN3O-22>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
@@ -401,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -421,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -429,14 +473,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_15378_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -444,11 +499,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -468,7 +523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -476,15 +531,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_522f1a83-5d01-4769-abf9-df706214bba1_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -518,6 +584,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_30089>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_ASPARTATEKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -527,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -546,7 +623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -554,11 +631,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -569,14 +646,14 @@
           <http://model.geneontology.org/CHEBI_456216_RXN3O-22>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_YeastPathways_PWY3O-954>
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -584,11 +661,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,17 +676,6 @@
           <http://model.geneontology.org/CHEBI_13392_HOMOSERDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -617,11 +683,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -635,56 +701,6 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/333c90aa-89a9-412b-a7f9-21e06bd26189_RXN3O-22>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule63884> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_57476_HOMOSERDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57476> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -694,35 +710,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule64031> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -733,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -750,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -762,11 +756,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,15 +771,26 @@
           <http://model.geneontology.org/reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,30 +801,19 @@
           <http://model.geneontology.org/CHEBI_57535_ASPARTATEKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_a1f10660-c37a-4e54-8315-5e8e4eb2abe0_RXN3O-22_SGD_YeastPathways_PWY3O-954>
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-22>
         a       <http://purl.obolibrary.org/obo/GO_0004326> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -830,9 +824,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/333c90aa-89a9-412b-a7f9-21e06bd26189_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/522f1a83-5d01-4769-abf9-df706214bba1_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/a1f10660-c37a-4e54-8315-5e8e4eb2abe0_RXN3O-22> , <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> , <http://model.geneontology.org/5360fbde-5ab3-4e5c-9568-d8c4a203e3f4_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -840,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -852,11 +846,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_15378_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_15378_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -876,24 +870,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY3O-954" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58140_HOMOCYSMET-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58140> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -904,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -917,7 +900,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -925,11 +919,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -939,6 +933,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -950,11 +955,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -984,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1001,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1013,11 +1018,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1028,19 +1033,30 @@
           <http://model.geneontology.org/CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-954>
+<http://purl.obolibrary.org/obo/CHEBI_57287>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57287>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1049,11 +1065,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1071,11 +1087,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1086,14 +1102,14 @@
           <http://model.geneontology.org/CHEBI_13390_HOMOSERDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_58199_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000066_reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1101,11 +1117,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1116,14 +1132,14 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-954/YeastPathways_PWY3O-954>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1136,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1144,14 +1160,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1161,26 +1177,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_57716>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1195,11 +1200,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1219,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1231,11 +1236,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002333_YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002333_YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,19 +1251,19 @@
           <http://model.geneontology.org/YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller>
 ] .
 
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/GO_0004072>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1267,11 +1272,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_333c90aa-89a9-412b-a7f9-21e06bd26189_RXN3O-22_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_522f1a83-5d01-4769-abf9-df706214bba1_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1279,7 +1284,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/333c90aa-89a9-412b-a7f9-21e06bd26189_RXN3O-22>
+          <http://model.geneontology.org/522f1a83-5d01-4769-abf9-df706214bba1_RXN3O-22>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004414>
@@ -1289,11 +1294,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1304,6 +1309,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-954/YeastPathways_PWY3O-954>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YER091C-MONOMER_HOMOCYSMET-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000893> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1311,7 +1327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1323,11 +1339,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1357,7 +1373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1365,36 +1381,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-954>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -1405,7 +1410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of methionine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1420,16 +1425,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954Protein64245> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://purl.obolibrary.org/obo/GO_0009086>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_43474_RXN3O-22>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -1440,7 +1442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1451,29 +1453,21 @@
 <http://identifiers.org/sgd/S000004294>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0009086>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" , "Provides Input For Rule. The relation 'L-homoserine + NAD(P)<sup>+</sup> &larr; L-aspartate 4-semialdehyde + NAD(P)H + H<SUP>+</SUP>' 'null' 'L-homoserine + acetyl-CoA &rarr; <i>O</i>-acetyl-L-homoserine + coenzyme A' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1491,11 +1485,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1513,11 +1507,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1531,6 +1525,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller>
         a       <http://identifiers.org/sgd/S000003900> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1538,7 +1543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1549,31 +1554,20 @@
 <http://purl.obolibrary.org/obo/CHEBI_58207>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_30089_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58199>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-954>
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002333_YNL277W-MONOMER_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1586,7 +1580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1601,7 +1595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1609,26 +1603,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" , "Provides Input For Rule. The relation 'L-homoserine + acetyl-CoA &rarr; <i>O</i>-acetyl-L-homoserine + coenzyme A' 'null' '<i>O</i>-acetyl-L-homoserine + hydrogen sulfide &rarr; L-homocysteine + acetate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1639,15 +1622,26 @@
           <http://model.geneontology.org/ACETYLHOMOSER-CYS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1662,11 +1656,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1677,6 +1671,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-954/YeastPathways_PWY3O-954>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57844_HOMOCYSMET-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57844> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1686,13 +1691,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule63997> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
@@ -1703,7 +1719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1711,65 +1727,54 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000066_reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-954>
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_456216>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0003871>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_456216>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002413_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_a1f10660-c37a-4e54-8315-5e8e4eb2abe0_RXN3O-22_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_5360fbde-5ab3-4e5c-9568-d8c4a203e3f4_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1777,7 +1782,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a1f10660-c37a-4e54-8315-5e8e4eb2abe0_RXN3O-22>
+          <http://model.geneontology.org/5360fbde-5ab3-4e5c-9568-d8c4a203e3f4_RXN3O-22>
 ] .
 
 <http://model.geneontology.org/CHEBI_58207_HOMOCYSMET-RXN>
@@ -1789,7 +1794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1804,11 +1809,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1823,11 +1828,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1838,25 +1843,25 @@
           <http://model.geneontology.org/YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002411_RXN3O-22_SGD_YeastPathways_PWY3O-954>
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1872,7 +1877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1888,18 +1893,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1907,11 +1912,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1926,11 +1931,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1941,14 +1946,25 @@
           <http://model.geneontology.org/YER052C-MONOMER_ASPARTATEKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-954>
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1956,11 +1972,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_30089_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_30089_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1977,26 +1993,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2014,11 +2019,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2029,14 +2034,14 @@
           <http://model.geneontology.org/YER091C-MONOMER_HOMOCYSMET-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000066_reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-954>
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2044,11 +2049,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2059,19 +2064,30 @@
           <http://model.geneontology.org/CHEBI_57535_ASPARTATEKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-954>
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57288>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004073> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2092,7 +2108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2105,22 +2121,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002411_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2131,17 +2169,6 @@
           <http://model.geneontology.org/CHEBI_57476_HOMOSERDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_13390>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2149,11 +2176,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2163,17 +2190,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_ASPARTATEKIN-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002413_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/HOMOCYSMET-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003871> ;
@@ -2194,7 +2210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2206,11 +2222,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2221,71 +2237,71 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-954/YeastPathways_PWY3O-954>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_HOMOCYSMET-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_YeastPathways_PWY3O-954>
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_15378_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY3O-954>
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000854>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2296,15 +2312,26 @@
           <http://model.geneontology.org/CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2322,11 +2349,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>O</i>-acetyl-L-homoserine + hydrogen sulfide &rarr; L-homocysteine + acetate + H<SUP>+</SUP>' 'null' 'L-homocysteine + 5-methyltetrahydropteroyl tri-L-glutamate &harr; L-methionine + tetrahydropteroyl tri-L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002413_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002413_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2337,17 +2364,6 @@
           <http://model.geneontology.org/HOMOCYSMET-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_SGD_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_RXN3O-22>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2357,7 +2373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2365,18 +2381,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0004073>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2387,15 +2400,18 @@
           <http://model.geneontology.org/CHEBI_43474_RXN3O-22>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0004073>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2406,17 +2422,6 @@
           <http://model.geneontology.org/reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_HOMOSERDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2426,7 +2431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2438,11 +2443,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2456,17 +2461,6 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29991_ASPARTATEKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2476,7 +2470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2484,62 +2478,57 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_YeastPathways_PWY3O-954>
+<http://model.geneontology.org/522f1a83-5d01-4769-abf9-df706214bba1_RXN3O-22>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule63884> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_ACETYLHOMOSER-CYS-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2552,7 +2541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2560,14 +2549,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2578,7 +2567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2590,11 +2579,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2609,11 +2598,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2624,15 +2613,26 @@
           <http://model.geneontology.org/CHEBI_456216_ASPARTATEKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_5360fbde-5ab3-4e5c-9568-d8c4a203e3f4_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2646,17 +2646,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58199_ACETYLHOMOSER-CYS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58199> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2666,7 +2655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2674,15 +2663,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_PWY3O-954/YeastPathways_PWY3O-954_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2697,11 +2697,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2712,14 +2712,14 @@
           <http://model.geneontology.org/CHEBI_57844_HOMOCYSMET-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-954>
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_30089_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2727,11 +2727,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2742,38 +2742,74 @@
           <http://model.geneontology.org/reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-954>
+<http://model.geneontology.org/5360fbde-5ab3-4e5c-9568-d8c4a203e3f4_RXN3O-22>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule63884> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_333c90aa-89a9-412b-a7f9-21e06bd26189_RXN3O-22_SGD_YeastPathways_PWY3O-954>
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_YeastPathways_PWY3O-954>
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002333_YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY_YeastPathways_PWY3O-954> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-22> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller>
+] .
 
 <http://model.geneontology.org/HOMOSERDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004412> ;
@@ -2794,7 +2830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2809,41 +2845,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-22> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-954> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2858,11 +2864,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-aspartate 4-semialdehyde + NADP<sup>+</sup> + phosphate &larr; L-aspartyl-4-phosphate + NADPH + H<SUP>+</SUP>' 'null' 'L-homoserine + NAD(P)<sup>+</sup> &larr; L-aspartate 4-semialdehyde + NAD(P)H + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2873,36 +2879,30 @@
           <http://model.geneontology.org/HOMOSERDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_YeastPathways_PWY3O-954>
+<http://purl.obolibrary.org/obo/GO_0004326>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0004326>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/a1f10660-c37a-4e54-8315-5e8e4eb2abe0_RXN3O-22>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule63884> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005767> ;
@@ -2911,7 +2911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-96.ttl
+++ b/models/YeastPathways_PWY3O-96.ttl
@@ -1,14 +1,3 @@
-<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_57720_RXN0-7092_SGD_YeastPathways_PWY3O-96>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-96" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY3O-96/YeastPathways_PWY3O-96>
         a       <http://purl.obolibrary.org/obo/GO_0034356> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -18,13 +7,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY3O-96" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_15378_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-96>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-96" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN0-7092>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,37 +43,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_15378_RXN-8441_SGD_YeastPathways_PWY3O-96>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-96" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-7092_BFO_0000066_reaction_RXN0-7092_location_lociGO_0005829_SGD_YeastPathways_PWY3O-96>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-96" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_17154_RXN0-7092_SGD_YeastPathways_PWY3O-96> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_17154_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-96> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -84,26 +62,15 @@
           <http://model.geneontology.org/CHEBI_17154_RXN0-7092>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002333_YDR400W-MONOMER_RXN-8441_controller_SGD_YeastPathways_PWY3O-96>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-96" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_15378_RXN-8441_SGD_YeastPathways_PWY3O-96> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_15378_RXN-8441_SGD_PWY_YeastPathways_PWY3O-96> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -114,11 +81,33 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-8441>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002233_CHEBI_15927_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-96>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-96" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002233_CHEBI_15927_RXN-8441_SGD_PWY_YeastPathways_PWY3O-96>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-96" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN-8441>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -129,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -162,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -170,25 +159,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002333_YLR209C-MONOMER_RXN0-7092_controller_SGD_YeastPathways_PWY3O-96>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-96" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_47013_RXN-8441_SGD_YeastPathways_PWY3O-96>
+<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002233_CHEBI_43474_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-96>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-96" ;
+                "SGD_PWY:PWY3O-96" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_17154_RXN-8441_SGD_PWY_YeastPathways_PWY3O-96>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -201,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -209,15 +198,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002411_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-96>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-96" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_15378_RXN0-7092_SGD_YeastPathways_PWY3O-96> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_15378_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-96> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,11 +232,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002233_CHEBI_15927_RXN-8441_SGD_YeastPathways_PWY3O-96> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002233_CHEBI_15927_RXN-8441_SGD_PWY_YeastPathways_PWY3O-96> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -276,13 +276,57 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-96BiochemicalReaction69570> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_17154_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-96>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-96" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-7092_BFO_0000066_reaction_RXN0-7092_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-96>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-96" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8441_BFO_0000050_YeastPathways_PWY3O-96/YeastPathways_PWY3O-96_SGD_PWY_YeastPathways_PWY3O-96>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-96" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_15378_RXN-8441_SGD_PWY_YeastPathways_PWY3O-96>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-96" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -291,11 +335,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002411_RXN0-7092_SGD_YeastPathways_PWY3O-96> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002411_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-96> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -306,17 +350,6 @@
           <http://model.geneontology.org/RXN0-7092>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-7092_BFO_0000050_YeastPathways_PWY3O-96/YeastPathways_PWY3O-96_SGD_YeastPathways_PWY3O-96>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-96" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -324,11 +357,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002233_CHEBI_43474_RXN0-7092_SGD_YeastPathways_PWY3O-96> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002233_CHEBI_43474_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-96> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -342,15 +375,37 @@
 <http://identifiers.org/sgd/S000004199>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002233_CHEBI_15377_RXN-8441_SGD_PWY_YeastPathways_PWY3O-96>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-96" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_47013_RXN-8441_SGD_PWY_YeastPathways_PWY3O-96>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-96" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002233_CHEBI_15377_RXN-8441_SGD_YeastPathways_PWY3O-96> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002233_CHEBI_15377_RXN-8441_SGD_PWY_YeastPathways_PWY3O-96> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -399,39 +454,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57720>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_17154_RXN-8441_SGD_YeastPathways_PWY3O-96>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-96" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002411_RXN0-7092_SGD_YeastPathways_PWY3O-96>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-96" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002233_CHEBI_15927_RXN0-7092_SGD_YeastPathways_PWY3O-96>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-96" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY3O-96>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -441,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "nicotinamide riboside salvage pathway II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -449,35 +471,50 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002233_CHEBI_43474_RXN0-7092_SGD_YeastPathways_PWY3O-96>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-96" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/GO_0034356>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-8441_BFO_0000066_reaction_RXN-8441_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-96>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-96" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_17154>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/YDR400W-MONOMER_RXN-8441_controller>
+        a       <http://identifiers.org/sgd/S000002808> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "nicotinic acid riboside hydrolase [multifunctional]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-96Protein69687> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002333_YDR400W-MONOMER_RXN-8441_controller_SGD_YeastPathways_PWY3O-96> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002333_YDR400W-MONOMER_RXN-8441_controller_SGD_PWY_YeastPathways_PWY3O-96> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,21 +525,6 @@
           <http://model.geneontology.org/YDR400W-MONOMER_RXN-8441_controller>
 ] .
 
-<http://model.geneontology.org/YDR400W-MONOMER_RXN-8441_controller>
-        a       <http://identifiers.org/sgd/S000002808> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "nicotinic acid riboside hydrolase [multifunctional]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-96Protein69687> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://model.geneontology.org/CHEBI_57720_RXN0-7092>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57720> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -512,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -520,29 +542,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002233_CHEBI_15927_RXN-8441_SGD_YeastPathways_PWY3O-96>
+<http://purl.obolibrary.org/obo/CHEBI_47013>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002333_YDR400W-MONOMER_RXN-8441_controller_SGD_PWY_YeastPathways_PWY3O-96>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-96" ;
+                "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_47013>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002233_CHEBI_15927_RXN0-7092_SGD_YeastPathways_PWY3O-96> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002233_CHEBI_15927_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-96> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -562,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -574,11 +596,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_BFO_0000066_reaction_RXN-8441_location_lociGO_0005829_SGD_YeastPathways_PWY3O-96> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8441_BFO_0000066_reaction_RXN-8441_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-96> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,22 +611,22 @@
           <http://model.geneontology.org/reaction_RXN-8441_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_57720_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-96>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-96" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000002808>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_15378_RXN0-7092_SGD_YeastPathways_PWY3O-96>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-96" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -612,14 +634,14 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_17154_RXN0-7092_SGD_YeastPathways_PWY3O-96>
+<http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002333_YLR209C-MONOMER_RXN0-7092_controller_SGD_PWY_YeastPathways_PWY3O-96>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-96" ;
+                "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -627,11 +649,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002333_YLR209C-MONOMER_RXN0-7092_controller_SGD_YeastPathways_PWY3O-96> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002333_YLR209C-MONOMER_RXN0-7092_controller_SGD_PWY_YeastPathways_PWY3O-96> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -646,11 +668,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_47013_RXN-8441_SGD_YeastPathways_PWY3O-96> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_47013_RXN-8441_SGD_PWY_YeastPathways_PWY3O-96> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,15 +689,26 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN0-7092_BFO_0000050_YeastPathways_PWY3O-96/YeastPathways_PWY3O-96_SGD_PWY_YeastPathways_PWY3O-96>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-96" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-7092_BFO_0000066_reaction_RXN0-7092_location_lociGO_0005829_SGD_YeastPathways_PWY3O-96> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-7092_BFO_0000066_reaction_RXN0-7092_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-96> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -690,11 +723,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_BFO_0000050_YeastPathways_PWY3O-96/YeastPathways_PWY3O-96_SGD_YeastPathways_PWY3O-96> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8441_BFO_0000050_YeastPathways_PWY3O-96/YeastPathways_PWY3O-96_SGD_PWY_YeastPathways_PWY3O-96> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -710,23 +743,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002233_CHEBI_15377_RXN-8441_SGD_YeastPathways_PWY3O-96>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-96" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -740,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -754,26 +776,15 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8441_BFO_0000050_YeastPathways_PWY3O-96/YeastPathways_PWY3O-96_SGD_YeastPathways_PWY3O-96>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-96" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_57720_RXN0-7092_SGD_YeastPathways_PWY3O-96> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-7092_RO_0002234_CHEBI_57720_RXN0-7092_SGD_PWY_YeastPathways_PWY3O-96> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -788,11 +799,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_17154_RXN-8441_SGD_YeastPathways_PWY3O-96> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002234_CHEBI_17154_RXN-8441_SGD_PWY_YeastPathways_PWY3O-96> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -812,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -826,18 +837,15 @@
 <http://purl.obolibrary.org/obo/GO_0045437>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-7092_BFO_0000050_YeastPathways_PWY3O-96/YeastPathways_PWY3O-96_SGD_YeastPathways_PWY3O-96> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-7092_BFO_0000050_YeastPathways_PWY3O-96/YeastPathways_PWY3O-96_SGD_PWY_YeastPathways_PWY3O-96> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -848,23 +856,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-96/YeastPathways_PWY3O-96>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8441_BFO_0000066_reaction_RXN-8441_location_lociGO_0005829_SGD_YeastPathways_PWY3O-96>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-96" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/reaction_RXN-8441_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -880,7 +880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -897,7 +897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-981.ttl
+++ b/models/YeastPathways_PWY3O-981.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,11 +21,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN0-2022_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN0-2022_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,11 +40,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_7942aa3a-f142-4402-9841-d34668c4cd11_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_e5e16a70-d20c-4c12-a478-60e063b22c74_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -52,7 +52,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ACETOINDEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7942aa3a-f142-4402-9841-d34668c4cd11_ACETOINDEHYDROG-RXN>
+          <http://model.geneontology.org/e5e16a70-d20c-4c12-a478-60e063b22c74_ACETOINDEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-58_RXN-6161_controller>
@@ -64,7 +64,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -97,25 +97,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000066_reaction_ACETOLACTSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-118_RXN0-2022_controller_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -129,11 +118,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002411_RXN0-2022_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002411_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -148,11 +137,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -188,26 +177,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -218,14 +196,14 @@
           <http://model.geneontology.org/CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -233,11 +211,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_16526_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_16526_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -260,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -268,16 +246,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15378_RXN-6161_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_24431>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -288,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -296,8 +269,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_58476_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15686> ;
@@ -308,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -316,26 +297,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
         a       <http://identifiers.org/sgd/S000004124> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-67_RXN0-2022_controller_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -348,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -356,26 +334,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-470_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_b85a8769-64c5-4a00-8a9c-63d4a8ba07ad_RXN0-2022_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_33b665e5-606c-492a-a994-beb81fb17f9c_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -383,26 +350,15 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b85a8769-64c5-4a00-8a9c-63d4a8ba07ad_RXN0-2022>
+          <http://model.geneontology.org/33b665e5-606c-492a-a994-beb81fb17f9c_RXN0-2022>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_16526_RXN0-2022_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
         a       <http://identifiers.org/sgd/S000004034> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -410,11 +366,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_58476_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_58476_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -430,18 +386,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-470_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_17499_RXN-6081_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -449,11 +405,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -467,15 +423,26 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002411_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_BFO_0000066_reaction_ACETOINDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_BFO_0000066_reaction_ACETOINDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -486,6 +453,15 @@
           <http://model.geneontology.org/reaction_ACETOINDEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/reaction_RXN-6081_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16526_RXN-6081>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -495,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -503,26 +479,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_RXN-6081_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000004714>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000066_reaction_RXN3O-470_location_lociGO_0005829_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -536,11 +514,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_c6f493d1-985c-4db8-b1db-9377b4d8ca28_RXN3O-470_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_6627bdf9-21a2-4b0a-a082-455d0290ebc7_RXN3O-470_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -548,29 +526,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-470> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c6f493d1-985c-4db8-b1db-9377b4d8ca28_RXN3O-470>
+          <http://model.geneontology.org/6627bdf9-21a2-4b0a-a082-455d0290ebc7_RXN3O-470>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-58_RXN0-2022_controller_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15378_RXN-6161_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15378_RXN-6161_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -581,15 +548,26 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-6161>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000066_reaction_ACETOLACTSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -600,58 +578,36 @@
           <http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000066_reaction_RXN-6081_location_lociGO_0005829_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15343_RXN0-2022_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002413_RXN-6081_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN0-2022_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15378_RXN-6081_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN0-2022_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002411_RXN0-2022_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -664,7 +620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -676,11 +632,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000066_reaction_RXN0-2022_location_lociGO_0005829_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000066_reaction_RXN0-2022_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -695,11 +651,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -717,11 +673,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" , "Provides Input For Rule. The relation '2 pyruvate + H<SUP>+</SUP> &rarr; (<i>S</i>)-2-acetolactate + CO<SUB>2</SUB>' 'null' '(<i>S</i>)-2-acetolactate + an oxidized electron acceptor + H<SUP>+</SUP> &rarr; diacetyl + CO<SUB>2</SUB> + a reduced electron acceptor' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002413_RXN-6081_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002413_RXN-6081_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -732,14 +688,14 @@
           <http://model.geneontology.org/RXN-6081>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002413_RXN-6081_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_33b665e5-606c-492a-a994-beb81fb17f9c_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -757,7 +713,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57945_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_15378_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_16583_RXN-6081> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/7942aa3a-f142-4402-9841-d34668c4cd11_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/e5e16a70-d20c-4c12-a478-60e063b22c74_ACETOINDEHYDROG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-79_ACETOINDEHYDROG-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -765,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -773,12 +729,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/e5e16a70-d20c-4c12-a478-60e063b22c74_ACETOINDEHYDROG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15378_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN0-2022_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -791,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -799,43 +783,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/7942aa3a-f142-4402-9841-d34668c4cd11_ACETOINDEHYDROG-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN0-2022_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-67_RXN0-2022_controller_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-67_RXN0-2022_controller_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -850,11 +806,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_17499_RXN-6081_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_17499_RXN-6081_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,11 +828,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-470_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-470_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -896,7 +852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -907,33 +863,23 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_57945_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-981> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ACETOINDEHYDROG-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_ACETOINDEHYDROG-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002411_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000056> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -946,7 +892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -954,14 +900,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000056> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_57945_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ACETOINDEHYDROG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57945_ACETOINDEHYDROG-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_15361_RXN0-2022>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
@@ -972,7 +928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -989,24 +945,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64722> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_58476_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58476_ACETOLACTSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58476> ;
@@ -1017,7 +962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1025,36 +970,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_7942aa3a-f142-4402-9841-d34668c4cd11_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN-6161_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-67_RXN3O-470_controller_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1063,18 +997,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-470_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1082,11 +1027,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-67_RXN3O-470_controller_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-67_RXN3O-470_controller_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1100,14 +1045,14 @@
 <http://identifiers.org/sgd/S000003319>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002413_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_16526_RXN-6161_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1115,11 +1060,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1137,11 +1082,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1152,15 +1097,26 @@
           <http://model.geneontology.org/CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000066_reaction_RXN0-2022_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15361_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15361_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1171,14 +1127,14 @@
           <http://model.geneontology.org/CHEBI_15361_ACETOLACTSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_17499_RXN-6081_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002411_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1191,7 +1147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1199,51 +1155,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-58_RXN3O-470_controller_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_58476_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15378_RXN0-2022_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15378_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1254,14 +1188,36 @@
           <http://model.geneontology.org/CHEBI_15378_RXN0-2022>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-118_RXN3O-470_controller_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002413_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15361_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1269,11 +1225,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15339_RXN-6081_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15339_RXN-6081_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1293,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1301,15 +1257,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002333_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-470_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-470_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1326,28 +1293,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000066_reaction_RXN0-2022_location_lociGO_0005829_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002411_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -1360,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1377,7 +1322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1385,15 +1330,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000066_reaction_RXN3O-470_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000066_reaction_RXN3O-470_location_lociGO_0005829_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000066_reaction_RXN3O-470_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1404,14 +1360,14 @@
           <http://model.geneontology.org/reaction_RXN3O-470_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_16526_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1424,7 +1380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1432,26 +1388,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000066_reaction_RXN-6161_location_lociGO_0005829_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000066_reaction_RXN-6161_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1462,14 +1407,14 @@
           <http://model.geneontology.org/reaction_RXN-6161_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1477,11 +1422,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-470_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-470_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1492,14 +1437,14 @@
           <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_b85a8769-64c5-4a00-8a9c-63d4a8ba07ad_RXN0-2022_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-67_RXN0-2022_controller_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1507,11 +1452,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002333_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002333_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1522,25 +1467,53 @@
           <http://model.geneontology.org/CPLX3O-79_ACETOINDEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_57945_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-67_RXN3O-470_controller_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_c6f493d1-985c-4db8-b1db-9377b4d8ca28_RXN3O-470_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/33b665e5-606c-492a-a994-beb81fb17f9c_RXN0-2022>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-118_RXN0-2022_controller_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1553,7 +1526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1569,7 +1542,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_57945_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1577,11 +1561,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" , "Provides Input For Rule. The relation 'pyruvate + H<SUP>+</SUP> &rarr; acetaldehyde + CO<SUB>2</SUB>' 'null' '2 acetaldehyde &rarr; acetoin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-470_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-470_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1611,7 +1595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1623,11 +1607,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1638,15 +1622,26 @@
           <http://model.geneontology.org/CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_58476_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_58476_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1657,22 +1652,44 @@
           <http://model.geneontology.org/CHEBI_58476_ACETOLACTSYN-RXN>
 ] .
 
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16526_RXN-6081_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_16583_RXN-6081_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN-6161_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002411_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1680,49 +1697,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002333_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_ACETOLACTSYN-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-118_RXN0-2022_controller_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-118_RXN0-2022_controller_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1732,6 +1715,18 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller>
 ] .
+
+<http://model.geneontology.org/reaction_ACETOLACTSYN-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1745,7 +1740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1757,11 +1752,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16526_RXN-6081_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16526_RXN-6081_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1772,15 +1767,18 @@
           <http://model.geneontology.org/CHEBI_16526_RXN-6081>
 ] .
 
+<http://purl.obolibrary.org/obo/RO_0002411>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN-6161_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN-6161_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1791,8 +1789,27 @@
           <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-79_ACETOINDEHYDROG-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1803,7 +1820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1811,15 +1828,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-58_RXN0-2022_controller_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-58_RXN3O-470_controller_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_15378_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_15378_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1830,41 +1869,41 @@
           <http://model.geneontology.org/CHEBI_15378_ACETOINDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN0-2022_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-470_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16583_RXN-6081_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_ACETOINDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -1875,7 +1914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1887,11 +1926,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-118_RXN3O-470_controller_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-118_RXN3O-470_controller_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1902,6 +1941,9 @@
           <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_16526_RXN-6161>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1911,7 +1953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1923,11 +1965,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1938,35 +1980,37 @@
           <http://model.geneontology.org/CHEBI_15343_RXN-6161>
 ] .
 
-<http://model.geneontology.org/b85a8769-64c5-4a00-8a9c-63d4a8ba07ad_RXN0-2022>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1981,11 +2025,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2005,7 +2049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2016,28 +2060,45 @@
 <http://purl.obolibrary.org/obo/GO_0003984>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/6627bdf9-21a2-4b0a-a082-455d0290ebc7_RXN3O-470>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0000721>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN-6161_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15361_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2048,11 +2109,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15343_RXN0-2022_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15343_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2074,7 +2135,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15343_RXN-6161> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/c6f493d1-985c-4db8-b1db-9377b4d8ca28_RXN3O-470> ;
+                <http://model.geneontology.org/6627bdf9-21a2-4b0a-a082-455d0290ebc7_RXN3O-470> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller> , <http://model.geneontology.org/CPLX3O-67_RXN3O-470_controller> , <http://model.geneontology.org/CPLX3O-58_RXN3O-470_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2082,7 +2143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2094,11 +2155,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2109,37 +2170,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-981/YeastPathways_PWY3O-981>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN-6161_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN-6161_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN-6161_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2150,28 +2189,17 @@
           <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-470_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000004034>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15361_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN0-2022_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2184,7 +2212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2192,15 +2220,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15339_RXN-6081_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002411_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002411_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2215,11 +2254,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" , "Provides Input For Rule. The relation '(<i>S</i>)-2-acetolactate + an oxidized electron acceptor + H<SUP>+</SUP> &rarr; diacetyl + CO<SUB>2</SUB> + a reduced electron acceptor' 'null' 'acetoin + NAD<sup>+</sup> &larr; diacetyl + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002413_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002413_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2230,15 +2269,26 @@
           <http://model.geneontology.org/ACETOINDEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15378_RXN-6161_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2253,11 +2303,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_57540_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_57540_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2271,14 +2321,25 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16526_RXN-6081_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2286,11 +2347,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002411_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002411_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2301,28 +2362,6 @@
           <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57945_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000066_reaction_RXN-6161_location_lociGO_0005829_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2330,11 +2369,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2345,23 +2384,23 @@
           <http://model.geneontology.org/CPLX3O-58_RXN-6161_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003319> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15343_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2369,11 +2408,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2388,11 +2427,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2412,7 +2451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2420,40 +2459,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002233_CHEBI_15343_RXN-6161_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_16583_RXN-6081_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002333_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002411_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_16526_RXN0-2022_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_16526_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2464,26 +2514,15 @@
           <http://model.geneontology.org/CHEBI_16526_RXN0-2022>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15378_RXN0-2022_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15378_RXN-6081_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15378_RXN-6081_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2498,11 +2537,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2513,25 +2552,25 @@
           <http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002411_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_6627bdf9-21a2-4b0a-a082-455d0290ebc7_RXN3O-470_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-470_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2539,11 +2578,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2563,7 +2602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2580,35 +2619,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64521> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16583_RXN-6081_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_15378_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-981>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -2619,7 +2636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of acetoin and butanediol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2627,30 +2644,8 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_BFO_0000066_reaction_ACETOINDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACETOLACTSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003984> ;
@@ -2671,7 +2666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2683,11 +2678,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002233_CHEBI_15343_RXN-6161_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002233_CHEBI_15343_RXN-6161_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2698,6 +2693,17 @@
           <http://model.geneontology.org/CHEBI_15343_RXN-6161>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_16526_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16982>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2705,11 +2711,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2724,11 +2730,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2739,15 +2745,37 @@
           <http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_57540_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000066_reaction_RXN-6161_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002411_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002411_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2758,17 +2786,6 @@
           <http://model.geneontology.org/RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_57540_ACETOINDEHYDROG-RXN_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15361_RXN-6161>
         a       <http://purl.obolibrary.org/obo/CHEBI_15361> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2778,13 +2795,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64624> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_e5e16a70-d20c-4c12-a478-60e063b22c74_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-67_RXN-6161_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -2795,24 +2823,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981Complex64673> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15339_RXN-6081_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-118_RXN-6161_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2823,7 +2840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2831,23 +2848,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_16526_RXN-6161_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_ACETOINDEHYDROG-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2858,11 +2864,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2880,11 +2886,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2904,7 +2910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2912,26 +2918,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_58476_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2948,42 +2943,53 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-470_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://identifiers.org/sgd/S000000515>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_16526_ACETOLACTSYN-RXN_SGD_YeastPathways_PWY3O-981>
+<http://identifiers.org/sgd/S000000515>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_BFO_0000066_reaction_ACETOINDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2992,7 +2998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3000,11 +3006,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-58_RXN0-2022_controller_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-58_RXN0-2022_controller_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3024,7 +3030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3036,11 +3042,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16583_RXN-6081_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002234_CHEBI_16583_RXN-6081_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3051,14 +3057,14 @@
           <http://model.geneontology.org/CHEBI_16583_RXN-6081>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-470_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_16982_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3066,11 +3072,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN0-2022_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN0-2022_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3090,7 +3096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3102,11 +3108,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_16583_RXN-6081_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_16583_RXN-6081_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3117,17 +3123,6 @@
           <http://model.geneontology.org/CHEBI_16583_RXN-6081>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-118_RXN3O-470_controller_SGD_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_RXN0-2022>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3137,7 +3132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3145,26 +3140,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-58_RXN3O-470_controller_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-58_RXN3O-470_controller_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3179,11 +3163,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_16526_RXN-6161_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_16526_RXN-6161_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3197,15 +3181,26 @@
 <http://purl.obolibrary.org/obo/GO_1902652>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000066_reaction_RR-BUTANEDIOL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3220,11 +3215,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000066_reaction_ACETOLACTSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000066_reaction_ACETOLACTSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3246,7 +3241,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15361_RXN0-2022> , <http://model.geneontology.org/CHEBI_15343_RXN0-2022> , <http://model.geneontology.org/CHEBI_15378_RXN0-2022> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/b85a8769-64c5-4a00-8a9c-63d4a8ba07ad_RXN0-2022> , <http://model.geneontology.org/CHEBI_16526_RXN0-2022> ;
+                <http://model.geneontology.org/CHEBI_16526_RXN0-2022> , <http://model.geneontology.org/33b665e5-606c-492a-a994-beb81fb17f9c_RXN0-2022> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-58_RXN0-2022_controller> , <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller> , <http://model.geneontology.org/CPLX3O-67_RXN0-2022_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3254,13 +3249,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981BiochemicalReaction64642> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN0-2022_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002233_CHEBI_15343_RXN-6161_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-981/YeastPathways_PWY3O-981>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_1902652> ;
@@ -3271,7 +3288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3284,7 +3301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3297,7 +3314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3305,26 +3322,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15361_RXN0-2022_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15361_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3335,15 +3341,26 @@
           <http://model.geneontology.org/CHEBI_15361_RXN0-2022>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000066_reaction_RXN-6081_location_lociGO_0005829_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000066_reaction_RXN-6081_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3363,7 +3380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3375,11 +3392,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN0-2022_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN0-2022_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3390,68 +3407,51 @@
           <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
 ] .
 
-<http://model.geneontology.org/c6f493d1-985c-4db8-b1db-9377b4d8ca28_RXN3O-470>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_YeastPathways_PWY3O-981>
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_CHEBI_15378_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15361_RXN0-2022_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
+                "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15378_RXN-6081_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6081_BFO_0000066_reaction_RXN-6081_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000050_YeastPathways_PWY3O-981/YeastPathways_PWY3O-981_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWYQT-4432.ttl
+++ b/models/YeastPathways_PWYQT-4432.ttl
@@ -1,14 +1,3 @@
-<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_57305_RXN-6622_SGD_YeastPathways_PWYQT-4432>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_RXN-6622>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -18,24 +7,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWYQT-4432SmallMolecule62641> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_57925_RXN-6601_SGD_YeastPathways_PWYQT-4432>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0006751>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -57,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -69,11 +47,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_57305_RXN-6622_SGD_YeastPathways_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_57305_RXN-6622_SGD_PWY_YeastPathways_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -88,11 +66,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_83813_RXN-6601_SGD_YeastPathways_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_83813_RXN-6601_SGD_PWY_YeastPathways_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -109,8 +87,36 @@
 <http://purl.obolibrary.org/obo/CHEBI_61694>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-5_RXN-6622_controller_BFO_0000051_SGD_S000001940_CPLX3O-5_component_SGD_PWY_YeastPathways_PWYQT-4432>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWYQT-4432" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/b71a5da3-d7b2-47d2-8226-bbf89bdb517b_RXN-6601>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an &alpha;-(&gamma;-L-glutamyl)-L-amino acid" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWYQT-4432SmallMolecule62604> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN-6601>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -123,7 +129,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57925_RXN-6601> , <http://model.geneontology.org/CHEBI_83813_RXN-6601> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_61694_RXN-6601> , <http://model.geneontology.org/51b767e1-1b2f-4531-a59a-3b4f6f051574_RXN-6601> ;
+                <http://model.geneontology.org/b71a5da3-d7b2-47d2-8226-bbf89bdb517b_RXN-6601> , <http://model.geneontology.org/CHEBI_61694_RXN-6601> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR299W-MONOMER_RXN-6601_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -131,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -144,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -160,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutathione degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -171,14 +177,14 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_83813_RXN-6601_SGD_YeastPathways_PWYQT-4432>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002413_RXN-6622_SGD_PWY_YeastPathways_PWYQT-4432>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
+                "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -191,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -203,11 +209,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_35235_RXN-6622_SGD_YeastPathways_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_35235_RXN-6622_SGD_PWY_YeastPathways_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -218,15 +224,26 @@
           <http://model.geneontology.org/CHEBI_35235_RXN-6622>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000050_YeastPathways_PWYQT-4432/YeastPathways_PWYQT-4432_SGD_PWY_YeastPathways_PWYQT-4432>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWYQT-4432" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_57925_RXN-6601_SGD_YeastPathways_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_57925_RXN-6601_SGD_PWY_YeastPathways_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -256,6 +273,17 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000050_YeastPathways_PWYQT-4432/YeastPathways_PWYQT-4432_SGD_PWY_YeastPathways_PWYQT-4432>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWYQT-4432" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -272,25 +300,25 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_15377_RXN-6622_SGD_YeastPathways_PWYQT-4432>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_61694_RXN-6601_SGD_YeastPathways_PWYQT-4432>
+<http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000066_reaction_RXN-6622_location_lociGO_0005829_SGD_PWY_YeastPathways_PWYQT-4432>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
+                "SGD_PWY:PWYQT-4432" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_b71a5da3-d7b2-47d2-8226-bbf89bdb517b_RXN-6601_SGD_PWY_YeastPathways_PWYQT-4432>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -304,11 +332,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'glutathione + a proteinogenic amino acid &rarr; an &alpha;-(&gamma;-L-glutamyl)-L-amino acid + L-cysteinylglycine' 'null' 'L-cysteinylglycine + H<sub>2</sub>O &rarr; L-cysteine + glycine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002413_RXN-6622_SGD_YeastPathways_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002413_RXN-6622_SGD_PWY_YeastPathways_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,11 +354,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_61694_RXN-6601_SGD_YeastPathways_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_61694_RXN-6601_SGD_PWY_YeastPathways_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -345,11 +373,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000066_reaction_RXN-6601_location_lociGO_0005829_SGD_YeastPathways_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000066_reaction_RXN-6601_location_lociGO_0005829_SGD_PWY_YeastPathways_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -360,39 +388,66 @@
           <http://model.geneontology.org/reaction_RXN-6601_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_57305_RXN-6622_SGD_PWY_YeastPathways_PWYQT-4432>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWYQT-4432" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002333_YLR299W-MONOMER_RXN-6601_controller_SGD_YeastPathways_PWYQT-4432>
+<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_35235_RXN-6622_SGD_PWY_YeastPathways_PWYQT-4432>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
+                "SGD_PWY:PWYQT-4432" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_15377_RXN-6622_SGD_PWY_YeastPathways_PWYQT-4432>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWYQT-4432" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002333_CPLX3O-5_RXN-6622_controller_SGD_PWY_YeastPathways_PWYQT-4432>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWYQT-4432" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002333_YLR299W-MONOMER_RXN-6601_controller_SGD_PWY_YeastPathways_PWYQT-4432>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/51b767e1-1b2f-4531-a59a-3b4f6f051574_RXN-6601>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an &alpha;-(&gamma;-L-glutamyl)-L-amino acid" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWYQT-4432SmallMolecule62604> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57925>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -400,14 +455,14 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_51b767e1-1b2f-4531-a59a-3b4f6f051574_RXN-6601_SGD_YeastPathways_PWYQT-4432>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_61694_RXN-6601_SGD_PWY_YeastPathways_PWYQT-4432>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
+                "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -415,11 +470,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002333_YLR299W-MONOMER_RXN-6601_controller_SGD_YeastPathways_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002333_YLR299W-MONOMER_RXN-6601_controller_SGD_PWY_YeastPathways_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -430,6 +485,17 @@
           <http://model.geneontology.org/YLR299W-MONOMER_RXN-6601_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_CHEBI_61694_RXN-6601_SGD_PWY_YeastPathways_PWYQT-4432>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWYQT-4432" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YLR299W-MONOMER_RXN-6601_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004290> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -437,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -449,11 +515,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_15377_RXN-6622_SGD_YeastPathways_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002233_CHEBI_15377_RXN-6622_SGD_PWY_YeastPathways_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -468,11 +534,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000050_YeastPathways_PWYQT-4432/YeastPathways_PWYQT-4432_SGD_YeastPathways_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000050_YeastPathways_PWYQT-4432/YeastPathways_PWYQT-4432_SGD_PWY_YeastPathways_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -482,28 +548,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWYQT-4432/YeastPathways_PWYQT-4432>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000066_reaction_RXN-6601_location_lociGO_0005829_SGD_YeastPathways_PWYQT-4432>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000050_YeastPathways_PWYQT-4432/YeastPathways_PWYQT-4432_SGD_YeastPathways_PWYQT-4432>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_35235>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -516,29 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-5_RXN-6622_controller_BFO_0000051_SGD_S000001940_CPLX3O-5_component_SGD_YeastPathways_PWYQT-4432>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002333_CPLX3O-5_RXN-6622_controller_SGD_YeastPathways_PWYQT-4432>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -554,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -569,11 +591,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_51b767e1-1b2f-4531-a59a-3b4f6f051574_RXN-6601_SGD_YeastPathways_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_b71a5da3-d7b2-47d2-8226-bbf89bdb517b_RXN-6601_SGD_PWY_YeastPathways_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -581,7 +603,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/51b767e1-1b2f-4531-a59a-3b4f6f051574_RXN-6601>
+          <http://model.geneontology.org/b71a5da3-d7b2-47d2-8226-bbf89bdb517b_RXN-6601>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -597,11 +619,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000066_reaction_RXN-6622_location_lociGO_0005829_SGD_YeastPathways_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000066_reaction_RXN-6622_location_lociGO_0005829_SGD_PWY_YeastPathways_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -616,11 +638,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-5_RXN-6622_controller_BFO_0000051_SGD_S000001940_CPLX3O-5_component_SGD_YeastPathways_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-5_RXN-6622_controller_BFO_0000051_SGD_S000001940_CPLX3O-5_component_SGD_PWY_YeastPathways_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,17 +653,6 @@
           <http://model.geneontology.org/SGD_S000001940_CPLX3O-5_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002413_RXN-6622_SGD_YeastPathways_PWYQT-4432>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CPLX3O-5_RXN-6622_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -651,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -662,31 +673,31 @@
 <http://purl.obolibrary.org/obo/CHEBI_83813>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002234_CHEBI_35235_RXN-6622_SGD_YeastPathways_PWYQT-4432>
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_57925_RXN-6601_SGD_PWY_YeastPathways_PWYQT-4432>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
+                "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000066_reaction_RXN-6622_location_lociGO_0005829_SGD_YeastPathways_PWYQT-4432>
+<http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000066_reaction_RXN-6601_location_lociGO_0005829_SGD_PWY_YeastPathways_PWYQT-4432>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
+                "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -698,7 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -711,24 +722,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWYQT-4432SmallMolecule62617> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_CHEBI_61694_RXN-6601_SGD_YeastPathways_PWYQT-4432>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -737,11 +737,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002333_CPLX3O-5_RXN-6622_controller_SGD_YeastPathways_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_RO_0002333_CPLX3O-5_RXN-6622_controller_SGD_PWY_YeastPathways_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -761,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -773,11 +773,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_CHEBI_61694_RXN-6601_SGD_YeastPathways_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_CHEBI_61694_RXN-6601_SGD_PWY_YeastPathways_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -797,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -805,26 +805,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-6601_BFO_0000050_YeastPathways_PWYQT-4432/YeastPathways_PWYQT-4432_SGD_YeastPathways_PWYQT-4432>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000050_YeastPathways_PWYQT-4432/YeastPathways_PWYQT-4432_SGD_YeastPathways_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6622_BFO_0000050_YeastPathways_PWYQT-4432/YeastPathways_PWYQT-4432_SGD_PWY_YeastPathways_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -840,3 +829,14 @@
 
 <http://identifiers.org/sgd/S000004290>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002233_CHEBI_83813_RXN-6601_SGD_PWY_YeastPathways_PWYQT-4432>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWYQT-4432" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PYRIMID-RNTSYN-PWY.ttl
+++ b/models/YeastPathways_PYRIMID-RNTSYN-PWY.ttl
@@ -1,12 +1,23 @@
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,32 +28,26 @@
           <http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_456216_UDPKIN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ADP" ;
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46195> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,48 +61,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -108,17 +80,6 @@
           <http://model.geneontology.org/CHEBI_43474_ASPCARBTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004152> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -126,9 +87,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000050>
                 <http://model.geneontology.org/YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN> , <http://model.geneontology.org/1cd848c5-da22-43cd-ad28-a1944787fd84_DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
+                <http://model.geneontology.org/d4a6f66a-9881-4c57-a002-75ed8a866537_DIHYDROOROTATE-DEHYDROGENASE-RXN> , <http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN> , <http://model.geneontology.org/2d9bcc72-afbe-4172-bea4-fb2f35774574_DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
+                <http://model.geneontology.org/CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN> , <http://model.geneontology.org/9f4b4e09-6a17-4222-8b72-48e2a538d7bd_DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YKL216W-MONOMER_DIHYDROOROTATE-DEHYDROGENASE-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -136,13 +97,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYBiochemicalReaction46222> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/UDPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004550> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -161,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -169,25 +152,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_OROTPDECARB-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002333_YKL216W-MONOMER_DIHYDROOROTATE-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -203,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -218,11 +190,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,14 +205,25 @@
           <http://model.geneontology.org/YKL024C-MONOMER_RXN-12002_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -248,11 +231,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,43 +246,26 @@
           <http://model.geneontology.org/CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15378_DIHYDROOROT-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_30616_CARBPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46163> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,14 +276,31 @@
           <http://model.geneontology.org/CHEBI_43474_CTPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_30616_CARBPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46163> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -328,11 +311,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,47 +326,41 @@
           <http://model.geneontology.org/CHEBI_30616_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/2d9bcc72-afbe-4172-bea4-fb2f35774574_DIHYDROOROTATE-DEHYDROGENASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in GO:0005886" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46251> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000747>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -401,11 +378,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" , "Provides Input For Rule. The relation 'UDP + ATP &rarr; UTP + ADP' 'null' 'L-glutamine + UTP + ATP + H<sub>2</sub>O &rarr; ADP + CTP + L-glutamate + phosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -416,36 +393,14 @@
           <http://model.geneontology.org/CTPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_58017_OROPRIBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -453,11 +408,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -489,11 +444,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15377_DIHYDROOROT-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15377_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,15 +459,26 @@
           <http://model.geneontology.org/CHEBI_15377_DIHYDROOROT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -526,17 +492,6 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_43474_CTPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_46398_UDPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_46398> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -546,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -563,7 +518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -575,11 +530,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -597,13 +552,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYProtein46470> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58359_CARBPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58359> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -614,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -622,12 +588,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_CTPSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -647,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -659,11 +636,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -683,7 +660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -695,11 +672,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_2d9bcc72-afbe-4172-bea4-fb2f35774574_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_9f4b4e09-6a17-4222-8b72-48e2a538d7bd_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,8 +684,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2d9bcc72-afbe-4172-bea4-fb2f35774574_DIHYDROOROTATE-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/9f4b4e09-6a17-4222-8b72-48e2a538d7bd_DIHYDROOROTATE-DEHYDROGENASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -719,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "de novo biosynthesis of pyrimidine ribonucleotides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -731,11 +719,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_UDPKIN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_UDPKIN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -746,37 +734,48 @@
           <http://model.geneontology.org/CHEBI_46398_UDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004550>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_DIHYDROOROT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_d4a6f66a-9881-4c57-a002-75ed8a866537_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -784,11 +783,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,26 +798,15 @@
           <http://model.geneontology.org/reaction_UDPKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_57538_OROPRIBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,11 +821,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -867,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -878,15 +866,26 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -900,23 +899,12 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN-12002_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -929,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -946,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -954,25 +942,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -985,7 +962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1000,7 +977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1012,11 +989,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1031,11 +1008,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" , "Provides Input For Rule. The relation '(<i>S</i>)-dihydroorotate + H<sub>2</sub>O &harr; <i>N</i>-carbamoyl-L-aspartate + H<SUP>+</SUP>' 'null' '(<i>S</i>)-dihydroorotate + an electron-transfer quinone<SUB>[inner membrane]</SUB> &rarr; orotate + an electron-transfer quinol<SUB>[inner membrane]</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002413_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002413_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1049,26 +1026,15 @@
 <http://identifiers.org/sgd/S000003666>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1082,14 +1048,14 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_2d9bcc72-afbe-4172-bea4-fb2f35774574_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_UDPKIN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1097,11 +1063,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_15378_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1112,50 +1078,39 @@
           <http://model.geneontology.org/CHEBI_15378_ASPCARBTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002413_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15377_DIHYDROOROT-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1163,11 +1118,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_456216_RXN-12002_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1181,18 +1136,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_29991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000004412>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1215,7 +1167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1227,11 +1179,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1242,6 +1194,9 @@
           <http://model.geneontology.org/CHEBI_29985_CTPSYN-RXN>
 ] .
 
+<http://identifiers.org/sgd/S000004412>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/CHEBI_30839>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1249,11 +1204,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1264,36 +1219,25 @@
           <http://model.geneontology.org/CHEBI_15377_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002413_OROPRIBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002333_YKL216W-MONOMER_DIHYDROOROTATE-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1304,7 +1248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1315,6 +1259,17 @@
 <http://purl.obolibrary.org/obo/GO_0004127>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1322,11 +1277,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1340,15 +1295,26 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" , "Provides Input For Rule. The relation 'orotidine 5'-phosphate + diphosphate &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + orotate' 'null' 'orotidine 5'-phosphate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + UMP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002413_OROTPDECARB-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002413_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1359,15 +1325,26 @@
           <http://model.geneontology.org/OROTPDECARB-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15378_DIHYDROOROT-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15378_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1378,15 +1355,26 @@
           <http://model.geneontology.org/CHEBI_15378_DIHYDROOROT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1397,25 +1385,14 @@
           <http://model.geneontology.org/CHEBI_58228_CARBPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1431,7 +1408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1439,16 +1416,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_15378_CTPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -1459,7 +1428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1476,7 +1445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1484,8 +1453,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002413_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YMR271C-MONOMER_OROPRIBTRANS-RXN_controller>
         a       <http://identifiers.org/sgd/S000004884> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1494,7 +1471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1502,19 +1479,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://identifiers.org/sgd/S000000135>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000135>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30839> ;
@@ -1525,7 +1502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1537,11 +1514,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'orotidine 5'-phosphate + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + UMP' 'null' 'ATP + UMP &rarr; ADP + UDP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1552,14 +1529,14 @@
           <http://model.geneontology.org/RXN-12002>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_29985_CTPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_58017_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1567,11 +1544,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_1cd848c5-da22-43cd-ad28-a1944787fd84_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_d4a6f66a-9881-4c57-a002-75ed8a866537_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1579,19 +1556,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1cd848c5-da22-43cd-ad28-a1944787fd84_DIHYDROOROTATE-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/d4a6f66a-9881-4c57-a002-75ed8a866537_DIHYDROOROTATE-DEHYDROGENASE-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004590>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1600,11 +1566,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1622,11 +1588,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1656,7 +1622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1673,35 +1639,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46492> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1710,11 +1654,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" , "Provides Input For Rule. The relation 'ATP + UMP &rarr; ADP + UDP' 'null' 'UDP + ATP &rarr; UTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1725,6 +1669,17 @@
           <http://model.geneontology.org/UDPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_DIHYDROOROT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1734,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1746,11 +1701,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_58017_OROPRIBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_58017_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1765,11 +1720,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1780,14 +1735,14 @@
           <http://model.geneontology.org/CHEBI_456216_CTPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YJR103W-MONOMER_CTPSYN-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1795,11 +1750,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1829,7 +1784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1837,25 +1792,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_15377_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_32814_ASPCARBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1865,19 +1820,19 @@
 <http://purl.obolibrary.org/obo/GO_0004151>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1885,14 +1840,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002413_CTPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1903,7 +1858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1915,11 +1870,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1937,11 +1892,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_30864_DIHYDROOROT-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1955,26 +1910,15 @@
 <http://purl.obolibrary.org/obo/GO_0006207>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 ATP + L-glutamine + hydrogencarbonate + H<sub>2</sub>O &rarr; L-glutamate + carbamoyl phosphate + 2 ADP + phosphate + 2 H<SUP>+</SUP>' 'null' 'L-aspartate + carbamoyl phosphate &harr; <i>N</i>-carbamoyl-L-aspartate + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1985,6 +1929,17 @@
           <http://model.geneontology.org/ASPCARBTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_37563_CTPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_37563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1994,7 +1949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2002,37 +1957,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_29985_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_29991_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2043,11 +1976,22 @@
           <http://model.geneontology.org/CHEBI_29991_ASPCARBTRANS-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_58228>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_58228>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002333_YJL130C-MONOMER_ASPCARBTRANS-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001699>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2064,7 +2008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2079,11 +2023,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2097,26 +2041,15 @@
 <http://purl.obolibrary.org/obo/GO_0004088>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002333_YKL216W-MONOMER_DIHYDROOROTATE-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002333_YKL216W-MONOMER_DIHYDROOROTATE-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2127,14 +2060,14 @@
           <http://model.geneontology.org/YKL216W-MONOMER_DIHYDROOROTATE-DEHYDROGENASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002333_YKL024C-MONOMER_RXN-12002_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2142,11 +2075,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2164,11 +2097,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2179,25 +2112,14 @@
           <http://model.geneontology.org/YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_30864_DIHYDROOROT-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2206,18 +2128,40 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000066_reaction_CTPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2225,11 +2169,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2243,15 +2187,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2262,15 +2217,26 @@
           <http://model.geneontology.org/YML106W-MONOMER_OROPRIBTRANS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2290,7 +2256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2302,11 +2268,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2316,6 +2282,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_43474_CARBPSYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CARBPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004088> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2336,7 +2313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2344,14 +2321,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2367,46 +2366,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46556> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29991_ASPCARBTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2417,7 +2383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2425,14 +2391,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2440,11 +2406,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_57865_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2462,7 +2428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2479,7 +2445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2491,11 +2457,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2506,18 +2472,26 @@
           <http://model.geneontology.org/YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004588>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_YJL130C-MONOMER_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2528,6 +2502,12 @@
           <http://model.geneontology.org/YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0004588>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0006207> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2537,7 +2517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2545,15 +2525,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://purl.obolibrary.org/obo/CHEBI_43474>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2564,8 +2547,16 @@
           <http://model.geneontology.org/CHEBI_32814_ASPCARBTRANS-RXN>
 ] .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002413_RXN-12002_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58228_CARBPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58228> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2576,7 +2567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2584,17 +2575,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_43474>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002413_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002233_CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002234_CHEBI_16526_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2607,7 +2606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2615,37 +2614,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_29888_OROPRIBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_15378_OROTPDECARB-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002234_CHEBI_58223_RXN-12002_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2656,25 +2633,14 @@
           <http://model.geneontology.org/CHEBI_58223_RXN-12002>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2690,7 +2656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2702,11 +2668,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000066_reaction_OROPRIBTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2726,7 +2692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2738,11 +2704,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2762,7 +2728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2774,11 +2740,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_17544_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2796,7 +2762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2813,7 +2779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2821,39 +2787,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_57538_OROPRIBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_UDPKIN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_37563_CTPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2861,11 +2816,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2883,11 +2838,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2907,7 +2862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2922,11 +2877,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_32814_ASPCARBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_32814_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2937,43 +2892,15 @@
           <http://model.geneontology.org/CHEBI_32814_ASPCARBTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/1cd848c5-da22-43cd-ad28-a1944787fd84_DIHYDROOROTATE-DEHYDROGENASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in GO:0005886" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinone" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46229> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2984,26 +2911,15 @@
           <http://model.geneontology.org/CPLX3O-887_CARBPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002413_UDPKIN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3013,28 +2929,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY>
 ] .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_30864_DIHYDROOROT-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_30616_RXN-12002_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/DIHYDROOROT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004151> ;
@@ -3055,7 +2949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3070,11 +2964,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3089,11 +2983,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3108,11 +3002,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_30616_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3123,15 +3017,26 @@
           <http://model.geneontology.org/CHEBI_30616_CTPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" , "Provides Input For Rule. The relation 'L-aspartate + carbamoyl phosphate &harr; <i>N</i>-carbamoyl-L-aspartate + phosphate + H<SUP>+</SUP>' 'null' '(<i>S</i>)-dihydroorotate + H<sub>2</sub>O &harr; <i>N</i>-carbamoyl-L-aspartate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002413_DIHYDROOROT-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002413_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3142,14 +3047,14 @@
           <http://model.geneontology.org/DIHYDROOROT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002413_OROTPDECARB-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3162,7 +3067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3173,34 +3078,23 @@
 <http://identifiers.org/sgd/S000004884>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_ASPCARBTRANS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000005829_CPLX3O-887_component_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3213,7 +3107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3225,11 +3119,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3240,29 +3134,29 @@
           <http://model.geneontology.org/YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY>
 ] .
 
-<http://identifiers.org/sgd/S000003870>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_58359_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003870>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_29888_OROPRIBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3280,11 +3174,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002333_YBL039C-MONOMER_CTPSYN-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3295,26 +3189,18 @@
           <http://model.geneontology.org/YBL039C-MONOMER_CTPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002413_DIHYDROOROT-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3325,8 +3211,16 @@
           <http://model.geneontology.org/CHEBI_15378_CARBPSYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002234_CHEBI_15377_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CTPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003883> ;
@@ -3345,7 +3239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3362,6 +3256,17 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_15377_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_CARBPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3371,7 +3276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3384,7 +3289,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002413_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3392,11 +3308,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3407,18 +3323,15 @@
           <http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_17544>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002333_YLR420W-MONOMER_DIHYDROOROT-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3429,37 +3342,18 @@
           <http://model.geneontology.org/YLR420W-MONOMER_DIHYDROOROT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_17544>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3477,7 +3371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3485,14 +3379,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_456216_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3500,11 +3405,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3514,28 +3419,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58228_CARBPSYN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002233_CHEBI_30616_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ASPCARBTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004070> ;
@@ -3556,7 +3439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3564,35 +3447,38 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_OROTPDECARB-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-12002> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57865_OROTPDECARB-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002413_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002233_CHEBI_15378_DIHYDROOROT-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30864> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3603,7 +3489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3611,23 +3497,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_1cd848c5-da22-43cd-ad28-a1944787fd84_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-12002_RO_0002233_CHEBI_57865_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-12002> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57865_OROTPDECARB-RXN>
+] .
 
 <http://model.geneontology.org/SGD_S000005829_CPLX3O-887_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3635,11 +3529,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" , "Provides Input For Rule. The relation '(<i>S</i>)-dihydroorotate + an electron-transfer quinone<SUB>[inner membrane]</SUB> &rarr; orotate + an electron-transfer quinol<SUB>[inner membrane]</SUB>' 'null' 'orotidine 5'-phosphate + diphosphate &harr; 5-phospho-&alpha;-D-ribose 1-diphosphate + orotate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002413_OROPRIBTRANS-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002413_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3654,11 +3548,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3673,11 +3567,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3691,17 +3585,6 @@
 <http://identifiers.org/sgd/S000004574>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_RXN-12002_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16526_OROTPDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3711,7 +3594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3726,7 +3609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3734,34 +3617,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_15378_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_UDPKIN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YML106W-MONOMER_OROPRIBTRANS-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3769,11 +3630,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_RXN-12002_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_RXN-12002_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3784,15 +3645,32 @@
           <http://model.geneontology.org/CHEBI_58223_RXN-12002>
 ] .
 
+<http://model.geneontology.org/d4a6f66a-9881-4c57-a002-75ed8a866537_DIHYDROOROTATE-DEHYDROGENASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in GO:0005886" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinone" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46229> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3803,15 +3681,54 @@
           <http://model.geneontology.org/YMR271C-MONOMER_OROPRIBTRANS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_RXN-12002_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/9f4b4e09-6a17-4222-8b72-48e2a538d7bd_DIHYDROOROTATE-DEHYDROGENASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in GO:0005886" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46251> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3822,15 +3739,26 @@
           <http://model.geneontology.org/reaction_DIHYDROOROT-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002413_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3841,12 +3769,56 @@
           <http://model.geneontology.org/CHEBI_456216_CARBPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_456216_UDPKIN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002234_CHEBI_15378_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_OROTPDECARB-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_9f4b4e09-6a17-4222-8b72-48e2a538d7bd_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3859,63 +3831,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46211> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_OROPRIBTRANS-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002233_CHEBI_58228_CARBPSYN-RXN_SGD_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_YeastPathways_PYRIMID-RNTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROTPDECARB-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YEL021W-MONOMER_OROTPDECARB-RXN_controller>
-] .
 
 <http://model.geneontology.org/CHEBI_30616_CTPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -3926,10 +3848,88 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46163> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_30616_UDPKIN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_OROPRIBTRANS-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_BFO_0000066_reaction_OROTPDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002333_YEL021W-MONOMER_OROTPDECARB-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/OROTPDECARB-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YEL021W-MONOMER_OROTPDECARB-RXN_controller>
+] .
+
+<http://model.geneontology.org/CHEBI_456216_UDPKIN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ADP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46195> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .

--- a/models/YeastPathways_PYRUVDEHYD-PWY.ttl
+++ b/models/YeastPathways_PYRUVDEHYD-PWY.ttl
@@ -1,22 +1,61 @@
-<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_fe3ebca5-0333-49fd-b067-dd650150c118_RXN0-1134_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/e4d4b3ce-059c-43d5-af0b-73be83de0bb5_RXN0-1132>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43773> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1134_BFO_0000066_reaction_RXN0-1134_location_lociGO_0005829_SGD_YeastPathways_PYRUVDEHYD-PWY>
+<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_CHEBI_57288_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_b7250010-b5e9-44e0-ad44-50a874f211af_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_CHEBI_15378_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_CHEBI_57287_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -29,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,40 +76,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_CHEBI_57945_RXN0-1132_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1133_BFO_0000066_reaction_RXN0-1133_location_lociGO_0005829_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0006086>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_d8f5b426-25ab-470b-b880-5c75bd7df0cd_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-1133> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/d8f5b426-25ab-470b-b880-5c75bd7df0cd_RXN0-1133>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_CHEBI_15378_RXN0-1132_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_CHEBI_15378_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -81,91 +114,11 @@
           <http://model.geneontology.org/CHEBI_15378_RXN0-1132>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_d8c43763-8921-4c6f-b7ad-da11747c3fc6_RXN0-1133_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-1133> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d8c43763-8921-4c6f-b7ad-da11747c3fc6_RXN0-1133>
-] .
-
-<http://model.geneontology.org/327ee5d1-b3d4-4bab-8b04-0fd52986023d_RXN0-1132>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43773> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002333_YER178W-MONOMER_RXN0-1134_controller_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_85a0653e-a71d-42c1-953a-54b1d7cce0eb_RXN0-1134_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1132_BFO_0000066_reaction_RXN0-1132_location_lociGO_0005829_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0006086>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/eb10e29f-a124-4580-b175-34eacedbfd42_RXN0-1133>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1134_BFO_0000050_YeastPathways_PYRUVDEHYD-PWY/YeastPathways_PYRUVDEHYD-PWY_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -179,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -187,14 +140,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_CHEBI_15378_RXN0-1134_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN0-1132_BFO_0000066_reaction_RXN0-1132_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -205,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -213,15 +166,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/80c5882a-fd0a-4f46-a1b9-900130fbbc87_RXN0-1133>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_4834e66e-fb42-4ae0-abea-5e2e121b0ed4_RXN0-1132_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_bbd189c0-1da8-4729-985f-93485543d892_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -229,7 +185,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1134> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4834e66e-fb42-4ae0-abea-5e2e121b0ed4_RXN0-1132>
+          <http://model.geneontology.org/bbd189c0-1da8-4729-985f-93485543d892_RXN0-1132>
 ] .
 
 <http://model.geneontology.org/CHEBI_57540_RXN0-1132>
@@ -241,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -249,50 +205,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_80c5882a-fd0a-4f46-a1b9-900130fbbc87_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/85a0653e-a71d-42c1-953a-54b1d7cce0eb_RXN0-1134>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-acetyldihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43793> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002413_RXN0-1134_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002411_RXN0-1132_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PYRUVDEHYD-PWY/YeastPathways_PYRUVDEHYD-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0006086> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -303,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -311,15 +239,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/bbd189c0-1da8-4729-985f-93485543d892_RXN0-1132>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_CHEBI_57288_RXN0-1133_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_CHEBI_57288_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -330,26 +261,15 @@
           <http://model.geneontology.org/CHEBI_57288_RXN0-1133>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_CHEBI_15378_RXN0-1132_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_eb10e29f-a124-4580-b175-34eacedbfd42_RXN0-1133_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_80c5882a-fd0a-4f46-a1b9-900130fbbc87_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,18 +277,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1132> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/eb10e29f-a124-4580-b175-34eacedbfd42_RXN0-1133>
+          <http://model.geneontology.org/80c5882a-fd0a-4f46-a1b9-900130fbbc87_RXN0-1133>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002411_RXN0-1133_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002411_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,28 +302,6 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1133_BFO_0000050_YeastPathways_PYRUVDEHYD-PWY/YeastPathways_PYRUVDEHYD-PWY_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002411_RXN0-1133_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -412,20 +310,6 @@
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/4834e66e-fb42-4ae0-abea-5e2e121b0ed4_RXN0-1132>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_CHEBI_57540_RXN0-1132_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN0-1134>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004739> ;
@@ -436,9 +320,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-1134_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_RXN0-1134> , <http://model.geneontology.org/4834e66e-fb42-4ae0-abea-5e2e121b0ed4_RXN0-1132> , <http://model.geneontology.org/CHEBI_15361_RXN0-1134> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN0-1134> , <http://model.geneontology.org/bbd189c0-1da8-4729-985f-93485543d892_RXN0-1132> , <http://model.geneontology.org/CHEBI_15361_RXN0-1134> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16526_RXN0-1134> , <http://model.geneontology.org/85a0653e-a71d-42c1-953a-54b1d7cce0eb_RXN0-1134> ;
+                <http://model.geneontology.org/CHEBI_16526_RXN0-1134> , <http://model.geneontology.org/cf0b1f01-ae6a-4665-a00d-27c180a017e6_RXN0-1134> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YER178W-MONOMER_RXN0-1134_controller> , <http://model.geneontology.org/YBR221C-MONOMER_RXN0-1134_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -446,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -458,11 +342,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_CHEBI_15378_RXN0-1134_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_CHEBI_15378_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -482,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -490,15 +374,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_CHEBI_15378_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002333_YBR221C-MONOMER_RXN0-1134_controller_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_CHEBI_57945_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1134_BFO_0000066_reaction_RXN0-1134_location_lociGO_0005829_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1134_BFO_0000066_reaction_RXN0-1134_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,11 +433,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" , "Provides Input For Rule. The relation 'a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine + NAD<sup>+</sup> &rarr; a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine + NADH + H<SUP>+</SUP>' 'null' 'pyruvate + a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine + H<SUP>+</SUP> &rarr; a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-acetyldihydrolipoyl-L-lysine + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002413_RXN0-1134_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002413_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -536,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -549,13 +466,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43786> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_bbd189c0-1da8-4729-985f-93485543d892_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -564,11 +492,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_fe3ebca5-0333-49fd-b067-dd650150c118_RXN0-1134_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_b7250010-b5e9-44e0-ad44-50a874f211af_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -576,18 +504,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1133> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fe3ebca5-0333-49fd-b067-dd650150c118_RXN0-1134>
+          <http://model.geneontology.org/b7250010-b5e9-44e0-ad44-50a874f211af_RXN0-1134>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_CHEBI_57540_RXN0-1132_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_CHEBI_57540_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -602,11 +530,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002333_YER178W-MONOMER_RXN0-1134_controller_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002333_YER178W-MONOMER_RXN0-1134_controller_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -620,11 +548,72 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/cf0b1f01-ae6a-4665-a00d-27c180a017e6_RXN0-1134>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-acetyldihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43793> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/GO_0004148>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1134_BFO_0000050_YeastPathways_PYRUVDEHYD-PWY/YeastPathways_PYRUVDEHYD-PWY_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002411_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1133_BFO_0000066_reaction_RXN0-1133_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002333_YFL018C-MONOMER_RXN0-1132_controller_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN0-1133>
         a       <http://purl.obolibrary.org/obo/GO_0030523> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -635,9 +624,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-1133_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57287_RXN0-1133> , <http://model.geneontology.org/fe3ebca5-0333-49fd-b067-dd650150c118_RXN0-1134> ;
+                <http://model.geneontology.org/b7250010-b5e9-44e0-ad44-50a874f211af_RXN0-1134> , <http://model.geneontology.org/CHEBI_57287_RXN0-1133> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57288_RXN0-1133> , <http://model.geneontology.org/d8c43763-8921-4c6f-b7ad-da11747c3fc6_RXN0-1133> ;
+                <http://model.geneontology.org/CHEBI_57288_RXN0-1133> , <http://model.geneontology.org/d8f5b426-25ab-470b-b880-5c75bd7df0cd_RXN0-1133> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YNL071W-MONOMER_RXN0-1133_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -645,7 +634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -657,11 +646,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_CHEBI_15361_RXN0-1134_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_CHEBI_15361_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,28 +660,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15361_RXN0-1134>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_327ee5d1-b3d4-4bab-8b04-0fd52986023d_RXN0-1132_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_CHEBI_57288_RXN0-1133_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004739>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -713,11 +680,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1134_BFO_0000050_YeastPathways_PYRUVDEHYD-PWY/YeastPathways_PYRUVDEHYD-PWY_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1134_BFO_0000050_YeastPathways_PYRUVDEHYD-PWY/YeastPathways_PYRUVDEHYD-PWY_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -732,11 +699,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002333_YFL018C-MONOMER_RXN0-1132_controller_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002333_YFL018C-MONOMER_RXN0-1132_controller_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -747,6 +714,20 @@
           <http://model.geneontology.org/YFL018C-MONOMER_RXN0-1132_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_cf0b1f01-ae6a-4665-a00d-27c180a017e6_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000980>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/YeastPathways_PYRUVDEHYD-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -756,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pyruvate decarboxylation to acetyl CoA - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -768,11 +749,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_CHEBI_57287_RXN0-1133_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_CHEBI_57287_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -783,18 +764,21 @@
           <http://model.geneontology.org/CHEBI_57287_RXN0-1133>
 ] .
 
-<http://identifiers.org/sgd/S000000980>
+<http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/b7250010-b5e9-44e0-ad44-50a874f211af_RXN0-1134>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1132_BFO_0000066_reaction_RXN0-1132_location_lociGO_0005829_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1132_BFO_0000066_reaction_RXN0-1132_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -812,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -820,18 +804,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57945>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_d8f5b426-25ab-470b-b880-5c75bd7df0cd_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002333_YBR221C-MONOMER_RXN0-1134_controller_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002333_YBR221C-MONOMER_RXN0-1134_controller_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -842,53 +834,36 @@
           <http://model.geneontology.org/YBR221C-MONOMER_RXN0-1134_controller>
 ] .
 
-<http://identifiers.org/sgd/S000000425>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/d8c43763-8921-4c6f-b7ad-da11747c3fc6_RXN0-1133>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002411_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43847> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1134_BFO_0000066_reaction_RXN0-1134_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000425>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_CHEBI_16526_RXN0-1134_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_CHEBI_15361_RXN0-1134_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN0-1132>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004148> ;
@@ -899,9 +874,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-1132_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/eb10e29f-a124-4580-b175-34eacedbfd42_RXN0-1133> , <http://model.geneontology.org/CHEBI_57540_RXN0-1132> ;
+                <http://model.geneontology.org/CHEBI_57540_RXN0-1132> , <http://model.geneontology.org/80c5882a-fd0a-4f46-a1b9-900130fbbc87_RXN0-1133> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_RXN0-1132> , <http://model.geneontology.org/CHEBI_57945_RXN0-1132> , <http://model.geneontology.org/327ee5d1-b3d4-4bab-8b04-0fd52986023d_RXN0-1132> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN0-1132> , <http://model.geneontology.org/CHEBI_57945_RXN0-1132> , <http://model.geneontology.org/e4d4b3ce-059c-43d5-af0b-73be83de0bb5_RXN0-1132> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YFL018C-MONOMER_RXN0-1132_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -909,7 +884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -923,19 +898,19 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002333_YNL071W-MONOMER_RXN0-1133_controller_SGD_YeastPathways_PYRUVDEHYD-PWY>
+<http://purl.obolibrary.org/obo/CHEBI_57287>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1133_BFO_0000050_YeastPathways_PYRUVDEHYD-PWY/YeastPathways_PYRUVDEHYD-PWY_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57287>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -944,11 +919,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002411_RXN0-1132_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002411_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -968,7 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -980,11 +955,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_327ee5d1-b3d4-4bab-8b04-0fd52986023d_RXN0-1132_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_e4d4b3ce-059c-43d5-af0b-73be83de0bb5_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -992,22 +967,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1132> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/327ee5d1-b3d4-4bab-8b04-0fd52986023d_RXN0-1132>
+          <http://model.geneontology.org/e4d4b3ce-059c-43d5-af0b-73be83de0bb5_RXN0-1132>
 ] .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1132_BFO_0000050_YeastPathways_PYRUVDEHYD-PWY/YeastPathways_PYRUVDEHYD-PWY_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YBR221C-MONOMER_RXN0-1134_controller>
         a       <http://identifiers.org/sgd/S000000425> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1016,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1027,26 +991,15 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002333_YBR221C-MONOMER_RXN0-1134_controller_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1133_BFO_0000066_reaction_RXN0-1133_location_lociGO_0005829_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1133_BFO_0000066_reaction_RXN0-1133_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1064,11 +1017,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1132_BFO_0000050_YeastPathways_PYRUVDEHYD-PWY/YeastPathways_PYRUVDEHYD-PWY_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1132_BFO_0000050_YeastPathways_PYRUVDEHYD-PWY/YeastPathways_PYRUVDEHYD-PWY_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1083,11 +1036,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_85a0653e-a71d-42c1-953a-54b1d7cce0eb_RXN0-1134_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_cf0b1f01-ae6a-4665-a00d-27c180a017e6_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1095,19 +1048,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1134> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/85a0653e-a71d-42c1-953a-54b1d7cce0eb_RXN0-1134>
+          <http://model.geneontology.org/cf0b1f01-ae6a-4665-a00d-27c180a017e6_RXN0-1134>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_CHEBI_57287_RXN0-1133_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1121,7 +1063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1129,33 +1071,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/fe3ebca5-0333-49fd-b067-dd650150c118_RXN0-1134>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/d8f5b426-25ab-470b-b880-5c75bd7df0cd_RXN0-1133>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43847> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_eb10e29f-a124-4580-b175-34eacedbfd42_RXN0-1133_SGD_YeastPathways_PYRUVDEHYD-PWY>
+<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002333_YER178W-MONOMER_RXN0-1134_controller_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002333_YFL018C-MONOMER_RXN0-1132_controller_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1167,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1175,26 +1120,59 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002413_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN0-1132_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_CHEBI_16526_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_4834e66e-fb42-4ae0-abea-5e2e121b0ed4_RXN0-1132_SGD_YeastPathways_PYRUVDEHYD-PWY>
+<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_CHEBI_15361_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_CHEBI_57540_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1202,11 +1180,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002333_YNL071W-MONOMER_RXN0-1133_controller_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002333_YNL071W-MONOMER_RXN0-1133_controller_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1217,15 +1195,26 @@
           <http://model.geneontology.org/YNL071W-MONOMER_RXN0-1133_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_e4d4b3ce-059c-43d5-af0b-73be83de0bb5_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_CHEBI_57945_RXN0-1132_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_CHEBI_57945_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1241,7 +1230,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1132_BFO_0000050_YeastPathways_PYRUVDEHYD-PWY/YeastPathways_PYRUVDEHYD-PWY_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1254,7 +1254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1269,11 +1269,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1133_BFO_0000050_YeastPathways_PYRUVDEHYD-PWY/YeastPathways_PYRUVDEHYD-PWY_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1133_BFO_0000050_YeastPathways_PYRUVDEHYD-PWY/YeastPathways_PYRUVDEHYD-PWY_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1287,15 +1287,26 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002333_YNL071W-MONOMER_RXN0-1133_controller_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_CHEBI_16526_RXN0-1134_SGD_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_CHEBI_16526_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1305,14 +1316,3 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16526_RXN0-1134>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_d8c43763-8921-4c6f-b7ad-da11747c3fc6_RXN0-1133_SGD_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_SAM-PWY.ttl
+++ b/models/YeastPathways_SAM-PWY.ttl
@@ -1,15 +1,37 @@
 <http://purl.obolibrary.org/obo/GO_0004478>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_SAM-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SAM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_PWY_YeastPathways_SAM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SAM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_S-ADENMETSYN-RXN_SGD_YeastPathways_SAM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_SAM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -32,7 +54,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -40,17 +62,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_SAM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SAM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_YeastPathways_SAM-PWY>
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_YeastPathways_SAM-PWY/YeastPathways_SAM-PWY_SGD_PWY_YeastPathways_SAM-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SAM-PWY" ;
+                "SGD_PWY:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -71,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -82,51 +115,18 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_YeastPathways_SAM-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SAM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_YeastPathways_SAM-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SAM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_YeastPathways_SAM-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SAM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_YeastPathways_SAM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_SAM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,17 +140,6 @@
 <http://purl.obolibrary.org/obo/GO_0006556>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_YeastPathways_SAM-PWY/YeastPathways_SAM-PWY_SGD_YeastPathways_SAM-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SAM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_SAM-PWY/YeastPathways_SAM-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0006556> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -158,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -181,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,11 +188,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_YeastPathways_SAM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_PWY_YeastPathways_SAM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,6 +203,17 @@
           <http://model.geneontology.org/MONOMER3O-1014_S-ADENMETSYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SAM-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SAM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -221,11 +221,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_YeastPathways_SAM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_SAM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,39 +236,28 @@
           <http://model.geneontology.org/CHEBI_15377_S-ADENMETSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_MONOMER3O-1014_S-ADENMETSYN-RXN_controller_SGD_YeastPathways_SAM-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SAM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_S-ADENMETSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_SAM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_S-ADENMETSYN-RXN_SGD_YeastPathways_SAM-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SAM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -280,11 +269,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_YeastPathways_SAM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_SAM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -295,6 +284,17 @@
           <http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_PWY_YeastPathways_SAM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SAM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000002910>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -302,11 +302,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_SAM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SAM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -317,17 +317,6 @@
           <http://model.geneontology.org/reaction_S-ADENMETSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_YeastPathways_SAM-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SAM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YLR180W-MONOMER_S-ADENMETSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000004170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -335,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -343,19 +332,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_YeastPathways_SAM-PWY>
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_SAM-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SAM-PWY" ;
+                "SGD_PWY:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YeastPathways_SAM-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -366,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "S-adenosyl-L-methionine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -381,11 +370,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_YeastPathways_SAM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_SAM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,7 +398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -426,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -438,11 +427,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_YeastPathways_SAM-PWY/YeastPathways_SAM-PWY_SGD_YeastPathways_SAM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_YeastPathways_SAM-PWY/YeastPathways_SAM-PWY_SGD_PWY_YeastPathways_SAM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -465,7 +454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -488,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -508,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -523,11 +512,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_YeastPathways_SAM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_SAM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,6 +530,17 @@
 <http://identifiers.org/sgd/S000004170>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_59789_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_SAM-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SAM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_59789>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -548,11 +548,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_YeastPathways_SAM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_PWY_YeastPathways_SAM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -569,13 +569,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_SAM-PWY>
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_SAM-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SAM-PWY" ;
+                "SGD_PWY:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_SERDEG-PWY.ttl
+++ b/models/YeastPathways_SERDEG-PWY.ttl
@@ -15,7 +15,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,14 +23,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-15127_RO_0002234_CHEBI_28938_RXN-15127_SGD_YeastPathways_SERDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-15125_RO_0002413_RXN-15124_SGD_PWY_YeastPathways_SERDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERDEG-PWY" ;
+                "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -41,11 +41,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15127_RO_0002233_CHEBI_77456_RXN-15124_SGD_YeastPathways_SERDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15127_RO_0002233_CHEBI_77456_RXN-15124_SGD_PWY_YeastPathways_SERDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -60,11 +60,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" , "Provides Input For Rule. The relation '2-aminoprop-2-enoate &rarr; 2-iminopropanoate' 'null' '2-iminopropanoate + H<sub>2</sub>O &rarr; pyruvate + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15124_RO_0002413_RXN-15127_SGD_YeastPathways_SERDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15124_RO_0002413_RXN-15127_SGD_PWY_YeastPathways_SERDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,30 +75,8 @@
           <http://model.geneontology.org/RXN-15127>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-15127_RO_0002233_CHEBI_77456_RXN-15124_SGD_YeastPathways_SERDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-15124_RO_0002233_CHEBI_76565_RXN-15125_SGD_YeastPathways_SERDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_SERDEG-PWY/YeastPathways_SERDEG-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0006565> ;
@@ -107,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -120,35 +98,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-15124_BFO_0000066_reaction_RXN-15124_location_lociGO_0005829_SGD_YeastPathways_SERDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-15125_RO_0002234_CHEBI_15377_RXN-15125_SGD_YeastPathways_SERDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-15125_RO_0002234_CHEBI_76565_RXN-15125_SGD_PWY_YeastPathways_SERDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERDEG-PWY" ;
+                "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -157,7 +124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -168,11 +135,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15127_RO_0002233_CHEBI_15377_RXN-15127_SGD_YeastPathways_SERDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15127_RO_0002233_CHEBI_15377_RXN-15127_SGD_PWY_YeastPathways_SERDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -183,15 +150,26 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-15127>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-15125_RO_0002233_CHEBI_33384_RXN-15125_SGD_PWY_YeastPathways_SERDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15124_RO_0002234_CHEBI_77456_RXN-15124_SGD_YeastPathways_SERDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15124_RO_0002234_CHEBI_77456_RXN-15124_SGD_PWY_YeastPathways_SERDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -202,22 +180,22 @@
           <http://model.geneontology.org/CHEBI_77456_RXN-15124>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-15124_RO_0002234_CHEBI_77456_RXN-15124_SGD_PWY_YeastPathways_SERDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-15127_BFO_0000050_YeastPathways_SERDEG-PWY/YeastPathways_SERDEG-PWY_SGD_YeastPathways_SERDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -231,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -251,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -259,14 +237,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-15125_BFO_0000050_YeastPathways_SERDEG-PWY/YeastPathways_SERDEG-PWY_SGD_YeastPathways_SERDEG-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-15127_RO_0002233_CHEBI_15377_RXN-15127_SGD_PWY_YeastPathways_SERDEG-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERDEG-PWY" ;
+                "SGD_PWY:SERDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15125_BFO_0000050_YeastPathways_SERDEG-PWY/YeastPathways_SERDEG-PWY_SGD_PWY_YeastPathways_SERDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15127_RO_0002234_CHEBI_15361_RXN-15127_SGD_PWY_YeastPathways_SERDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -277,11 +277,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15125_RO_0002234_CHEBI_15377_RXN-15125_SGD_YeastPathways_SERDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15125_RO_0002234_CHEBI_15377_RXN-15125_SGD_PWY_YeastPathways_SERDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -296,11 +296,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15127_BFO_0000066_reaction_RXN-15127_location_lociGO_0005829_SGD_YeastPathways_SERDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15127_BFO_0000066_reaction_RXN-15127_location_lociGO_0005829_SGD_PWY_YeastPathways_SERDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,26 +311,15 @@
           <http://model.geneontology.org/reaction_RXN-15127_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-15127_RO_0002234_CHEBI_15361_RXN-15127_SGD_YeastPathways_SERDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15124_RO_0002233_CHEBI_76565_RXN-15125_SGD_YeastPathways_SERDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15124_RO_0002233_CHEBI_76565_RXN-15125_SGD_PWY_YeastPathways_SERDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -347,31 +336,42 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-15124_RO_0002233_CHEBI_76565_RXN-15125_SGD_PWY_YeastPathways_SERDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15125_RO_0002234_CHEBI_15377_RXN-15125_SGD_PWY_YeastPathways_SERDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-15124_RO_0002234_CHEBI_77456_RXN-15124_SGD_YeastPathways_SERDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-15124_RO_0002413_RXN-15127_SGD_PWY_YeastPathways_SERDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15125_RO_0002233_CHEBI_33384_RXN-15125_SGD_YeastPathways_SERDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERDEG-PWY" ;
+                "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -390,35 +390,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SERDEG-PWYBiochemicalReaction52477> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15124_RO_0002413_RXN-15127_SGD_YeastPathways_SERDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15127_RO_0002233_CHEBI_15377_RXN-15127_SGD_YeastPathways_SERDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15361_RXN-15127>
         a       <http://purl.obolibrary.org/obo/CHEBI_15361> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -429,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -440,15 +418,26 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-15125_BFO_0000066_reaction_RXN-15125_location_lociGO_0005829_SGD_PWY_YeastPathways_SERDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15125_RO_0002233_CHEBI_33384_RXN-15125_SGD_YeastPathways_SERDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15125_RO_0002233_CHEBI_33384_RXN-15125_SGD_PWY_YeastPathways_SERDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -468,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -476,15 +465,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-15127_BFO_0000050_YeastPathways_SERDEG-PWY/YeastPathways_SERDEG-PWY_SGD_PWY_YeastPathways_SERDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15124_BFO_0000066_reaction_RXN-15124_location_lociGO_0005829_SGD_PWY_YeastPathways_SERDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15127_BFO_0000050_YeastPathways_SERDEG-PWY/YeastPathways_SERDEG-PWY_SGD_YeastPathways_SERDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15127_BFO_0000050_YeastPathways_SERDEG-PWY/YeastPathways_SERDEG-PWY_SGD_PWY_YeastPathways_SERDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -499,11 +510,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15124_BFO_0000066_reaction_RXN-15124_location_lociGO_0005829_SGD_YeastPathways_SERDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15124_BFO_0000066_reaction_RXN-15124_location_lociGO_0005829_SGD_PWY_YeastPathways_SERDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -536,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -549,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -560,17 +571,6 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-15125_RO_0002413_RXN-15124_SGD_YeastPathways_SERDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -578,11 +578,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15127_RO_0002234_CHEBI_28938_RXN-15127_SGD_YeastPathways_SERDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15127_RO_0002234_CHEBI_28938_RXN-15127_SGD_PWY_YeastPathways_SERDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -597,11 +597,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15125_BFO_0000066_reaction_RXN-15125_location_lociGO_0005829_SGD_YeastPathways_SERDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15125_BFO_0000066_reaction_RXN-15125_location_lociGO_0005829_SGD_PWY_YeastPathways_SERDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,14 +618,14 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-15125_BFO_0000066_reaction_RXN-15125_location_lociGO_0005829_SGD_YeastPathways_SERDEG-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-15127_BFO_0000066_reaction_RXN-15127_location_lociGO_0005829_SGD_PWY_YeastPathways_SERDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERDEG-PWY" ;
+                "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -638,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-serine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -650,11 +650,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" , "Provides Input For Rule. The relation 'L-serine &rarr; 2-aminoprop-2-enoate + H<sub>2</sub>O' 'null' '2-aminoprop-2-enoate &rarr; 2-iminopropanoate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15125_RO_0002413_RXN-15124_SGD_YeastPathways_SERDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15125_RO_0002413_RXN-15124_SGD_PWY_YeastPathways_SERDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -672,11 +672,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15124_BFO_0000050_YeastPathways_SERDEG-PWY/YeastPathways_SERDEG-PWY_SGD_YeastPathways_SERDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15124_BFO_0000050_YeastPathways_SERDEG-PWY/YeastPathways_SERDEG-PWY_SGD_PWY_YeastPathways_SERDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -692,6 +692,17 @@
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-15124_BFO_0000050_YeastPathways_SERDEG-PWY/YeastPathways_SERDEG-PWY_SGD_PWY_YeastPathways_SERDEG-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-15125>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
@@ -710,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -721,33 +732,11 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-15124_BFO_0000050_YeastPathways_SERDEG-PWY/YeastPathways_SERDEG-PWY_SGD_YeastPathways_SERDEG-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_76565>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-15125_RO_0002234_CHEBI_76565_RXN-15125_SGD_YeastPathways_SERDEG-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERDEG-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_76565_RXN-15125>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_76565> ;
@@ -758,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -766,15 +755,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-15127_RO_0002234_CHEBI_28938_RXN-15127_SGD_PWY_YeastPathways_SERDEG-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERDEG-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15127_RO_0002234_CHEBI_15361_RXN-15127_SGD_YeastPathways_SERDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15127_RO_0002234_CHEBI_15361_RXN-15127_SGD_PWY_YeastPathways_SERDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -789,11 +789,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15125_BFO_0000050_YeastPathways_SERDEG-PWY/YeastPathways_SERDEG-PWY_SGD_YeastPathways_SERDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15125_BFO_0000050_YeastPathways_SERDEG-PWY/YeastPathways_SERDEG-PWY_SGD_PWY_YeastPathways_SERDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -807,18 +807,15 @@
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15125_RO_0002234_CHEBI_76565_RXN-15125_SGD_YeastPathways_SERDEG-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15125_RO_0002234_CHEBI_76565_RXN-15125_SGD_PWY_YeastPathways_SERDEG-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -829,14 +826,17 @@
           <http://model.geneontology.org/CHEBI_76565_RXN-15125>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-15127_BFO_0000066_reaction_RXN-15127_location_lociGO_0005829_SGD_YeastPathways_SERDEG-PWY>
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-15127_RO_0002233_CHEBI_77456_RXN-15124_SGD_PWY_YeastPathways_SERDEG-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERDEG-PWY" ;
+                "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 

--- a/models/YeastPathways_SERSYN-PWY.ttl
+++ b/models/YeastPathways_SERSYN-PWY.ttl
@@ -1,36 +1,3 @@
-<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002233_CHEBI_29985_PSERTRANSAM-RXN_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002233_CHEBI_57524_PSERTRANSAM-RXN_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_BFO_0000066_reaction_PGLYCDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_43474_RXN0-5114>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -40,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -48,26 +15,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_15378_PGLYCDEHYDROG-RXN_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002234_CHEBI_16810_PSERTRANSAM-RXN_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002234_CHEBI_16810_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -82,11 +38,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_15378_PGLYCDEHYDROG-RXN_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_15378_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -103,28 +59,28 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_BFO_0000050_YeastPathways_SERSYN-PWY/YeastPathways_SERSYN-PWY_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002413_RXN0-5114_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
+                "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000883>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002333_YER081W-MONOMER_PGLYCDEHYDROG-RXN_controller_SGD_YeastPathways_SERSYN-PWY>
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_BFO_0000050_YeastPathways_SERSYN-PWY/YeastPathways_SERSYN-PWY_SGD_PWY_YeastPathways_SERSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
+                "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -132,11 +88,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002233_CHEBI_57524_PSERTRANSAM-RXN_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002233_CHEBI_57524_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -154,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -164,6 +120,17 @@
 
 <http://purl.obolibrary.org/obo/GO_0006564>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002333_YER081W-MONOMER_PGLYCDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -175,11 +142,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002233_CHEBI_29985_PSERTRANSAM-RXN_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002233_CHEBI_29985_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -190,25 +157,14 @@
           <http://model.geneontology.org/CHEBI_29985_PSERTRANSAM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_18110_PGLYCDEHYDROG-RXN_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002233_CHEBI_58272_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002234_CHEBI_16810_PSERTRANSAM-RXN_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
+                "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -216,11 +172,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002233_CHEBI_58272_PGLYCDEHYDROG-RXN_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002233_CHEBI_58272_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,28 +202,17 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_BFO_0000050_YeastPathways_SERSYN-PWY/YeastPathways_SERSYN-PWY_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000005710>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002413_RXN0-5114_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN0-5114_BFO_0000066_reaction_RXN0-5114_location_lociGO_0005829_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
+                "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -283,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -295,11 +240,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002233_CHEBI_15377_RXN0-5114_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002233_CHEBI_15377_RXN0-5114_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,25 +255,25 @@
           <http://model.geneontology.org/CHEBI_15377_RXN0-5114>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_BFO_0000066_reaction_PSERTRANSAM-RXN_location_lociGO_0005829_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002234_CHEBI_43474_RXN0-5114_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
+                "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002333_YGR208W-MONOMER_RXN0-5114_controller_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002233_CHEBI_15377_RXN0-5114_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
+                "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -336,11 +281,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5114_BFO_0000050_YeastPathways_SERSYN-PWY/YeastPathways_SERSYN-PWY_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5114_BFO_0000050_YeastPathways_SERSYN-PWY/YeastPathways_SERSYN-PWY_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -354,26 +299,15 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002333_YOR184W-MONOMER_PSERTRANSAM-RXN_controller_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002333_YIL074C-MONOMER_PGLYCDEHYDROG-RXN_controller_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002333_YIL074C-MONOMER_PGLYCDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,24 +325,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SERSYN-PWYProtein50440> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-5114_BFO_0000050_YeastPathways_SERSYN-PWY/YeastPathways_SERSYN-PWY_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_SERSYN-PWY/YeastPathways_SERSYN-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0006564> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -417,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -432,11 +355,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002233_CHEBI_18110_PGLYCDEHYDROG-RXN_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002233_CHEBI_18110_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -451,11 +374,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002233_CHEBI_57540_PGLYCDEHYDROG-RXN_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002233_CHEBI_57540_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -476,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -490,6 +413,17 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002413_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_33384_RXN0-5114>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33384> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -499,7 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -507,26 +441,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002234_CHEBI_33384_RXN0-5114_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5114_BFO_0000066_reaction_RXN0-5114_location_lociGO_0005829_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5114_BFO_0000066_reaction_RXN0-5114_location_lociGO_0005829_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,44 +465,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002233_CHEBI_18110_PGLYCDEHYDROG-RXN_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002333_YIL074C-MONOMER_PGLYCDEHYDROG-RXN_controller_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002234_CHEBI_16810_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" , "Provides Input For Rule. The relation '2-oxoglutarate + 3-phospho-L-serine &larr; 3-phosphooxypyruvate + L-glutamate' 'null' '3-phospho-L-serine + H<sub>2</sub>O &rarr; L-serine + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002413_RXN0-5114_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002413_RXN0-5114_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -594,11 +506,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002333_YER081W-MONOMER_PGLYCDEHYDROG-RXN_controller_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002333_YER081W-MONOMER_PGLYCDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -609,6 +521,17 @@
           <http://model.geneontology.org/YER081W-MONOMER_PGLYCDEHYDROG-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002234_CHEBI_57524_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YGR208W-MONOMER_RXN0-5114_controller>
         a       <http://identifiers.org/sgd/S000003440> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -616,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -633,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -644,6 +567,18 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_57945>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/reaction_RXN0-5114_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_SERSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -653,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-serine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -661,35 +596,15 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/reaction_RXN0-5114_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-5114_BFO_0000066_reaction_RXN0-5114_location_lociGO_0005829_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_BFO_0000066_reaction_PSERTRANSAM-RXN_location_lociGO_0005829_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_BFO_0000066_reaction_PSERTRANSAM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -709,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -721,11 +636,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_BFO_0000066_reaction_PGLYCDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_BFO_0000066_reaction_PGLYCDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -736,19 +651,16 @@
           <http://model.geneontology.org/reaction_PGLYCDEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002233_CHEBI_57540_PGLYCDEHYDROG-RXN_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN0-5114_BFO_0000050_YeastPathways_SERSYN-PWY/YeastPathways_SERSYN-PWY_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
+                "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57945>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_29985_PSERTRANSAM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
@@ -759,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -771,11 +683,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002333_YGR208W-MONOMER_RXN0-5114_controller_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002333_YGR208W-MONOMER_RXN0-5114_controller_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -786,28 +698,28 @@
           <http://model.geneontology.org/YGR208W-MONOMER_RXN0-5114_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002234_CHEBI_43474_RXN0-5114_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_18110_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
+                "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002233_CHEBI_15377_RXN0-5114_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_BFO_0000066_reaction_PSERTRANSAM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
+                "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -821,11 +733,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002333_YOR184W-MONOMER_PSERTRANSAM-RXN_controller_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002333_YOR184W-MONOMER_PSERTRANSAM-RXN_controller_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -840,11 +752,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_57945_PGLYCDEHYDROG-RXN_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_57945_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -870,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -897,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -905,15 +817,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_57945_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_BFO_0000050_YeastPathways_SERSYN-PWY/YeastPathways_SERSYN-PWY_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_BFO_0000050_YeastPathways_SERSYN-PWY/YeastPathways_SERSYN-PWY_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -941,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -953,11 +876,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_BFO_0000050_YeastPathways_SERSYN-PWY/YeastPathways_SERSYN-PWY_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_BFO_0000050_YeastPathways_SERSYN-PWY/YeastPathways_SERSYN-PWY_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -972,11 +895,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002234_CHEBI_43474_RXN0-5114_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002234_CHEBI_43474_RXN0-5114_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -996,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1004,31 +927,53 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_BFO_0000066_reaction_PGLYCDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002233_CHEBI_57540_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_57945_PGLYCDEHYDROG-RXN_SGD_YeastPathways_SERSYN-PWY>
+<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002233_CHEBI_29985_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_SERSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
+                "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004617>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002234_CHEBI_57524_PSERTRANSAM-RXN_SGD_YeastPathways_SERSYN-PWY>
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002333_YIL074C-MONOMER_PGLYCDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_SERSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
+                "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1038,32 +983,43 @@
 <http://purl.obolibrary.org/obo/CHEBI_57524>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002233_CHEBI_58272_PGLYCDEHYDROG-RXN_SGD_YeastPathways_SERSYN-PWY>
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002233_CHEBI_57524_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002234_CHEBI_33384_RXN0-5114_SGD_PWY_YeastPathways_SERSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
+                "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002234_CHEBI_57524_PSERTRANSAM-RXN_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002234_CHEBI_57524_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1074,15 +1030,26 @@
           <http://model.geneontology.org/CHEBI_57524_PSERTRANSAM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_BFO_0000050_YeastPathways_SERSYN-PWY/YeastPathways_SERSYN-PWY_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_18110_PGLYCDEHYDROG-RXN_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_18110_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1102,13 +1069,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SERSYN-PWYSmallMolecule50306> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_15378_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PSERTRANSAM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004648> ;
@@ -1129,7 +1107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1146,6 +1124,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002333_YGR208W-MONOMER_RXN0-5114_controller_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_PGLYCDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1155,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1163,18 +1152,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002233_CHEBI_18110_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002333_YOR184W-MONOMER_PSERTRANSAM-RXN_controller_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '3-phospho-D-glycerate + NAD<sup>+</sup> &harr; 3-phosphooxypyruvate + NADH + H<SUP>+</SUP>' 'null' '2-oxoglutarate + 3-phospho-L-serine &larr; 3-phosphooxypyruvate + L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002413_PSERTRANSAM-RXN_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002413_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1185,16 +1193,8 @@
           <http://model.geneontology.org/PSERTRANSAM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002413_PSERTRANSAM-RXN_SGD_YeastPathways_SERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_18110>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1208,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1220,11 +1220,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002234_CHEBI_33384_RXN0-5114_SGD_YeastPathways_SERSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002234_CHEBI_33384_RXN0-5114_SGD_PWY_YeastPathways_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,6 +1246,6 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_SO4ASSIM-PWY.ttl
+++ b/models/YeastPathways_SO4ASSIM-PWY.ttl
@@ -1,14 +1,3 @@
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_YeastPathways_SO4ASSIM-PWY/YeastPathways_SO4ASSIM-PWY_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004781>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -16,11 +5,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,11 +24,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,25 +39,36 @@
           <http://model.geneontology.org/CHEBI_58339_ADENYLYLSULFKIN-RXN>
 ] .
 
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
-<http://identifiers.org/sgd/S000006371>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000003898_CPLX3O-23_component_SGD_YeastPathways_SO4ASSIM-PWY>
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
+                "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://identifiers.org/sgd/S000006371>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/SULFITE-REDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -87,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,15 +95,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000066_reaction_1.8.4.8-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_456216_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_17359_1.8.4.8-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_17359_1.8.4.8-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -118,11 +140,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -132,17 +154,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -162,7 +173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -170,26 +181,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -215,15 +215,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000066_reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000066_reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -237,17 +248,6 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/Red-Thioredoxin_1.8.4.8-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -265,8 +265,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_17359_1.8.4.8-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -278,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -290,11 +312,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000050_YeastPathways_SO4ASSIM-PWY/YeastPathways_SO4ASSIM-PWY_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000050_YeastPathways_SO4ASSIM-PWY/YeastPathways_SO4ASSIM-PWY_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -322,29 +344,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000003771>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000066_reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_SO4ASSIM-PWY>
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_15378_1.8.4.8-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
+                "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003771>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002333_YPR167C-MONOMER_1.8.4.8-RXN_controller_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002333_YPR167C-MONOMER_1.8.4.8-RXN_controller_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -365,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -377,11 +399,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -398,40 +420,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_58243>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_15377_SULFITE-REDUCT-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58343>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_57783_SULFITE-REDUCT-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_57783_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -449,11 +460,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_15378_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_15378_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -464,17 +475,28 @@
           <http://model.geneontology.org/CHEBI_15378_ADENYLYLSULFKIN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_16189>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_17359_1.8.4.8-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_58343_1.8.4.8-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16189>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_15378_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -487,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -502,11 +524,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_Red-Thioredoxin_1.8.4.8-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -521,11 +543,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_YeastPathways_SO4ASSIM-PWY/YeastPathways_SO4ASSIM-PWY_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_YeastPathways_SO4ASSIM-PWY/YeastPathways_SO4ASSIM-PWY_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -555,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -563,14 +585,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_15378_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
+<http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000001926_CPLX3O-23_component_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -586,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -598,11 +631,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'sulfate + ATP + H<SUP>+</SUP> &harr; adenosine 5'-phosphosulfate + diphosphate' 'null' 'adenosine 5'-phosphosulfate + ATP &harr; 3'-phosphoadenylyl-sulfate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -632,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -649,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "assimilatory sulfate reduction I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -657,14 +690,14 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000050_YeastPathways_SO4ASSIM-PWY/YeastPathways_SO4ASSIM-PWY_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000003898_CPLX3O-23_component_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
+                "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -676,7 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -684,11 +717,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,25 +732,25 @@
           <http://model.geneontology.org/CHEBI_58349_SULFITE-REDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002413_1.8.4.8-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
+                "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_57783_SULFITE-REDUCT-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
+                "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -725,11 +758,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002333_YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002333_YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,7 +792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -776,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -791,11 +824,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_58343_1.8.4.8-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_58343_1.8.4.8-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -811,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -819,11 +852,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -843,24 +876,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SO4ASSIM-PWYSmallMolecule65135> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002333_CPLX3O-23_SULFITE-REDUCT-RXN_controller_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_ADENYLYLSULFKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -871,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -888,17 +910,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_15378_1.8.4.8-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000003898>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -909,11 +920,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_15378_SULFITE-REDUCT-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_15378_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -933,7 +944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -945,11 +956,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_30616_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_30616_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -963,14 +974,36 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_16136_SULFITE-REDUCT-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002333_YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_15378_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
+                "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -983,7 +1016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -994,14 +1027,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_17359_1.8.4.8-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
+                "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1009,11 +1042,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000001926_CPLX3O-23_component_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000001926_CPLX3O-23_component_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1028,11 +1061,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000066_reaction_1.8.4.8-RXN_location_lociGO_0005829_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000066_reaction_1.8.4.8-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1057,7 +1090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1070,7 +1103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1084,15 +1117,26 @@
 <http://purl.obolibrary.org/obo/GO_0019379>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" , "Provides Input For Rule. The relation 'adenosine 3',5'-bisphosphate + sulfite + an oxidized thioredoxin + 2 H<SUP>+</SUP> &harr; 3'-phosphoadenylyl-sulfate + a reduced thioredoxin' 'null' 'hydrogen sulfide + 3 NADP<sup>+</sup> + 3 H<sub>2</sub>O &larr; sulfite + 3 NADPH + 5 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002413_SULFITE-REDUCT-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002413_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1107,11 +1151,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1122,14 +1166,14 @@
           <http://model.geneontology.org/CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002413_1.8.4.8-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_YeastPathways_SO4ASSIM-PWY/YeastPathways_SO4ASSIM-PWY_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
+                "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1142,24 +1186,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SO4ASSIM-PWYSmallMolecule65216> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_Red-Thioredoxin_1.8.4.8-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_ADENYLYLSULFKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1170,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1182,11 +1215,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_15377_SULFITE-REDUCT-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_15377_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1200,26 +1233,15 @@
 <http://purl.obolibrary.org/obo/GO_0004020>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002413_SULFITE-REDUCT-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_456216_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_456216_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1230,28 +1252,28 @@
           <http://model.geneontology.org/CHEBI_456216_ADENYLYLSULFKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000050_YeastPathways_SO4ASSIM-PWY/YeastPathways_SO4ASSIM-PWY_SGD_YeastPathways_SO4ASSIM-PWY>
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002333_YPR167C-MONOMER_1.8.4.8-RXN_controller_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
+                "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
+                "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1262,11 +1284,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_15378_1.8.4.8-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_15378_1.8.4.8-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1281,11 +1303,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1296,25 +1318,25 @@
           <http://model.geneontology.org/reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002333_YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000066_reaction_1.8.4.8-RXN_location_lociGO_0005829_SGD_YeastPathways_SO4ASSIM-PWY>
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_15377_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1323,7 +1345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1337,11 +1359,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000050_YeastPathways_SO4ASSIM-PWY/YeastPathways_SO4ASSIM-PWY_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000050_YeastPathways_SO4ASSIM-PWY/YeastPathways_SO4ASSIM-PWY_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1352,26 +1374,15 @@
           <http://model.geneontology.org/YeastPathways_SO4ASSIM-PWY/YeastPathways_SO4ASSIM-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_16189_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_YeastPathways_SO4ASSIM-PWY/YeastPathways_SO4ASSIM-PWY_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_YeastPathways_SO4ASSIM-PWY/YeastPathways_SO4ASSIM-PWY_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1382,17 +1393,6 @@
           <http://model.geneontology.org/YeastPathways_SO4ASSIM-PWY/YeastPathways_SO4ASSIM-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_15378_SULFITE-REDUCT-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58339_ADENYLYLSULFKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58339> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1402,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1416,6 +1416,17 @@
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_YeastPathways_SO4ASSIM-PWY/YeastPathways_SO4ASSIM-PWY_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1424,7 +1435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1432,11 +1443,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002333_CPLX3O-23_SULFITE-REDUCT-RXN_controller_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002333_CPLX3O-23_SULFITE-REDUCT-RXN_controller_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1450,15 +1461,26 @@
 <http://identifiers.org/sgd/S000001926>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_57783_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'adenosine 5'-phosphosulfate + ATP &harr; 3'-phosphoadenylyl-sulfate + ADP + H<SUP>+</SUP>' 'null' 'adenosine 3',5'-bisphosphate + sulfite + an oxidized thioredoxin + 2 H<SUP>+</SUP> &harr; 3'-phosphoadenylyl-sulfate + a reduced thioredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002413_1.8.4.8-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002413_1.8.4.8-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1469,25 +1491,25 @@
           <http://model.geneontology.org/1.8.4.8-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
+                "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_456216_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002413_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
+                "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1495,11 +1517,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_Red-Thioredoxin_1.8.4.8-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1519,7 +1541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1531,11 +1553,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1549,11 +1571,55 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_30616_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000066_reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000050_YeastPathways_SO4ASSIM-PWY/YeastPathways_SO4ASSIM-PWY_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1564,7 +1630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1576,11 +1642,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_17359_1.8.4.8-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_17359_1.8.4.8-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1591,15 +1657,26 @@
           <http://model.geneontology.org/CHEBI_17359_1.8.4.8-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002333_CPLX3O-23_SULFITE-REDUCT-RXN_controller_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1610,14 +1687,25 @@
           <http://model.geneontology.org/CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000001926_CPLX3O-23_component_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002413_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
+                "SGD_PWY:SO4ASSIM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1631,7 +1719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1639,48 +1727,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000066_reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002234_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1689,25 +1744,6 @@
           <http://model.geneontology.org/1.8.4.8-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58339_ADENYLYLSULFKIN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000003898_CPLX3O-23_component_SGD_YeastPathways_SO4ASSIM-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000051> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CPLX3O-23_SULFITE-REDUCT-RXN_controller> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SGD_S000003898_CPLX3O-23_component>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_1.8.4.8-RXN>
@@ -1719,7 +1755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1727,45 +1763,42 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_30616_ADENYLYLSULFKIN-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-23_SULFITE-REDUCT-RXN_controller_BFO_0000051_SGD_S000003898_CPLX3O-23_component_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-23_SULFITE-REDUCT-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000003898_CPLX3O-23_component>
+] .
 
 <http://model.geneontology.org/reaction_SULFATE-ADENYLYLTRANS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_29888_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002234_CHEBI_58343_1.8.4.8-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
+                "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1778,24 +1811,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SO4ASSIM-PWYSmallMolecule65239> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_BFO_0000050_YeastPathways_SO4ASSIM-PWY/YeastPathways_SO4ASSIM-PWY_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-23_SULFITE-REDUCT-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1806,7 +1828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1818,11 +1840,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_YeastPathways_SO4ASSIM-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_PWY_YeastPathways_SO4ASSIM-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1833,35 +1855,13 @@
           <http://model.geneontology.org/YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002333_YPR167C-MONOMER_1.8.4.8-RXN_controller_SGD_YeastPathways_SO4ASSIM-PWY>
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000050_YeastPathways_SO4ASSIM-PWY/YeastPathways_SO4ASSIM-PWY_SGD_PWY_YeastPathways_SO4ASSIM-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_17359_1.8.4.8-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_YeastPathways_SO4ASSIM-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SO4ASSIM-PWY" ;
+                "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_SPHINGOLIPID-SYN-PWY-1.ttl
+++ b/models/YeastPathways_SPHINGOLIPID-SYN-PWY-1.ttl
@@ -1,23 +1,12 @@
-<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002333_YKR053C-MONOMER_DHS-PHOSPHATASE-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002234_CHEBI_64124_RXN3O-504_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002234_CHEBI_64124_RXN3O-504_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,6 +17,28 @@
           <http://model.geneontology.org/CHEBI_64124_RXN3O-504>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002413_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_BFO_0000066_reaction_SERINE-C-PALMITOYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YMR296C-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004911> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -35,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,26 +54,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-581_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_57287_RXN3O-328_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_57287_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,16 +73,22 @@
           <http://model.geneontology.org/CHEBI_57287_RXN3O-328>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_CHEBI_15377_RXN3O-4042_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/e06c821f-70f9-4e37-9c61-cf37e420cd66_RXN3O-663>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19742> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0030148>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -94,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -102,18 +108,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002413_RXN3O-458_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000000995_CPLX3O-78_component_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000000995_CPLX3O-78_component_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -124,24 +138,18 @@
           <http://model.geneontology.org/SGD_S000000995_CPLX3O-78_component>
 ] .
 
-<http://model.geneontology.org/SGD_S000000240_CPLX3O-383_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000240> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" , "Provides Input For Rule. The relation 'D-<i>erythro</i>-sphinganine + NADP<sup>+</sup> &larr; 3-dehydrosphinganine + NADPH + H<SUP>+</SUP>' 'null' 'D-<i>erythro</i>-sphinganine + ATP &rarr; sphinganine 1-phosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002413_SPHINGANINE-KINASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002413_SPHINGANINE-KINASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -152,6 +160,15 @@
           <http://model.geneontology.org/SPHINGANINE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/SGD_S000000240_CPLX3O-383_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000240> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16749_RXN3O-581>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16749> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -161,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -178,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -186,47 +203,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002411_RXN3O-581_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002333_YOR171C-MONOMER_SPHINGANINE-KINASE-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002233_CHEBI_30616_SPHINGANINE-KINASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_15378_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002234_CHEBI_64124_RXN3O-504_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -234,11 +229,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_58299_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_58299_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -253,11 +248,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,49 +263,66 @@
           <http://model.geneontology.org/YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_31998_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-680_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/438a90e8-4e1e-40bf-8a4f-c5350ed33b3f_RXN3O-680>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a mannosyl-diphosphoinositol-&alpha; hydroxyphytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19761> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001761>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-328_BFO_0000066_reaction_RXN3O-328_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002411_CERAMIDASE-YEAST-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_257bd65b-0fa3-46e0-8850-7585323ca880_RXN3O-4042_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_dc05b1a8-008a-4e51-a82e-4892afe00367_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -318,19 +330,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4042> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/257bd65b-0fa3-46e0-8850-7585323ca880_RXN3O-4042>
+          <http://model.geneontology.org/dc05b1a8-008a-4e51-a82e-4892afe00367_RXN3O-4042>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-458_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004758> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -351,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -369,13 +370,43 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1Protein19626> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002413_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-1380> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+] .
 
 <http://model.geneontology.org/SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008117> ;
@@ -394,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -402,31 +433,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-1380> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-] .
+<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_CHEBI_58189_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -439,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -447,42 +470,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002234_CHEBI_43474_DHS-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002702>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_FERRICYTOCHROME-B5_RXN3O-4042_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_BFO_0000066_reaction_CERAMIDASE-YEAST-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_257bd65b-0fa3-46e0-8850-7585323ca880_RXN3O-4042_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_CHEBI_64124_RXN3O-1380_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -490,11 +499,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002233_CHEBI_30616_SPHINGANINE-KINASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002233_CHEBI_30616_SPHINGANINE-KINASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,11 +518,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_c1575af2-9a47-4766-9e83-27bad94bfc5e_RXN3O-663_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_2b95a6d9-8114-4f17-bf85-1563aa4f9f7b_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -521,17 +530,20 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-680> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c1575af2-9a47-4766-9e83-27bad94bfc5e_RXN3O-663>
+          <http://model.geneontology.org/2b95a6d9-8114-4f17-bf85-1563aa4f9f7b_RXN3O-663>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002411_RXN3O-663_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002333_CPLX3O-78_RXN3O-328_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -539,11 +551,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,17 +566,6 @@
           <http://model.geneontology.org/YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_3890c01d-7d4c-42a3-8af2-4f70d0a400a1_RXN3O-328_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YBR183W-MONOMER_CERAMIDASE-YEAST-RXN_controller>
         a       <http://identifiers.org/sgd/S000000387> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -572,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -582,13 +583,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" , "Provides Input For Rule. The relation 'phytosphingosine + ATP &rarr; phytosphingosine 1-phosphate + ADP + H<SUP>+</SUP>' 'null' 'phytosphingosine 1-phosphate + H<sub>2</sub>O &rarr; phytosphingosine + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Provides Input For Rule. The relation 'phytosphingosine + ATP &rarr; phytosphingosine 1-phosphate + ADP + H<SUP>+</SUP>' 'null' 'phytosphingosine 1-phosphate + H<sub>2</sub>O &rarr; phytosphingosine + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002413_RXN3O-504_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002413_RXN3O-504_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -598,6 +599,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN3O-504>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_36f3c8a6-9b43-4845-85af-c90ea5af8c4f_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002333_YDR297W-MONOMER_RXN3O-1380_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-504>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -618,24 +641,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1BiochemicalReaction19629> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_15378_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-458>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -646,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -654,19 +666,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_15378_RXN3O-1380_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_CHEBI_57527_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_24431>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0004758>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -675,11 +687,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -694,11 +706,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002233_CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002233_CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -709,25 +721,14 @@
           <http://model.geneontology.org/CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_BFO_0000066_reaction_DHS-PHOSPHATASE-RXN_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002333_CPLX3O-383_RXN3O-663_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000004913_CPLX3O-78_component_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -738,13 +739,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1Protein19684> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_CHEBI_15378_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YDR297W-MONOMER_RXN3O-1380_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002705> ;
@@ -753,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,7 +782,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_CERAMIDASE-YEAST-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_CERAMIDASE-YEAST-RXN> , <http://model.geneontology.org/238433a4-aae2-4cab-a2f2-1f895aa3f461_CERAMIDASE-YEAST-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_CERAMIDASE-YEAST-RXN> , <http://model.geneontology.org/0e189dd8-b35e-4155-9183-7becc8f1dedd_CERAMIDASE-YEAST-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_10283_CERAMIDASE-YEAST-RXN> , <http://model.geneontology.org/CHEBI_64124_CERAMIDASE-YEAST-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -780,7 +792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -791,22 +803,16 @@
 <http://identifiers.org/sgd/S000000995>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/e320412f-2676-4b01-9d0f-a143fa7d84f0_RXN3O-680>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a mannosyl-diphosphoinositol-&alpha; hydroxyphytoceramide" ;
+<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002234_CHEBI_58349_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19761> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_CERAMIDASE-YEAST-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -817,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -829,11 +835,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_CHEBI_16749_RXN3O-581_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_CHEBI_16749_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -844,23 +850,29 @@
           <http://model.geneontology.org/CHEBI_16749_RXN3O-581>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_FERRICYTOCHROME-B5_RXN3O-1380_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/5f5cbec0-b1e0-41bc-9694-9cd97dc00d44_RXN3O-581>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an inositol-phospho-&alpha; hydroxyphytoceramide" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19792> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/SGD_S000004913_CPLX3O-78_component>
         a       <http://identifiers.org/sgd/S000004913> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -868,11 +880,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_15378_RXN3O-4042_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_15378_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -887,11 +899,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_58299_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_58299_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -902,17 +914,6 @@
           <http://model.geneontology.org/CHEBI_58299_SERINE-C-PALMITOYLTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_FERROCYTOCHROME-B5_RXN3O-4042_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -920,11 +921,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002233_CHEBI_57939_SPHINGANINE-KINASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002233_CHEBI_57939_SPHINGANINE-KINASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -939,11 +940,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_15378_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_15378_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -954,14 +955,14 @@
           <http://model.geneontology.org/CHEBI_15378_SERINE-C-PALMITOYLTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_15378_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -972,7 +973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -980,48 +981,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002413_RXN3O-4042_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002411_RXN3O-680_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000001491_CPLX3O-78_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001491> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004885>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002233_CHEBI_30616_SPHINGANINE-KINASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002333_YOR171C-MONOMER_RXN3O-458_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1032,35 +1022,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1Protein19951> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-504_BFO_0000066_reaction_RXN3O-504_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002234_CHEBI_15378_SPHINGANINE-KINASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17815_RXN3O-680>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17815> ;
@@ -1071,7 +1039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1084,32 +1052,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_5f5cbec0-b1e0-41bc-9694-9cd97dc00d44_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002233_CHEBI_57939_SPHINGANINE-KINASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_CHEBI_17815_RXN3O-680_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_d13905c7-75d5-4519-916a-a29e7bfd25e6_RXN3O-663_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1117,11 +1085,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002234_CHEBI_17600_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002234_CHEBI_17600_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1136,11 +1104,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002333_CPLX3O-383_RXN3O-663_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002333_CPLX3O-383_RXN3O-663_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1151,23 +1119,23 @@
           <http://model.geneontology.org/CPLX3O-383_RXN3O-663_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002234_CHEBI_58190_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-458_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_FERROCYTOCHROME-B5_RXN3O-1380_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1180,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1191,15 +1159,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000000995_CPLX3O-78_component_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_15378_RXN3O-458_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_15378_RXN3O-458_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1210,15 +1189,26 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-458>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002333_MONOMER3O-419_DHS-PHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002333_YBR183W-MONOMER_CERAMIDASE-YEAST-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002333_YBR183W-MONOMER_CERAMIDASE-YEAST-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1233,11 +1223,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_CHEBI_64124_RXN3O-1380_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_CHEBI_64124_RXN3O-1380_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1255,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1267,11 +1257,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-<i>erythro</i>-sphinganine + ATP &rarr; sphinganine 1-phosphate + ADP + H<SUP>+</SUP>' 'null' 'sphinganine 1-phosphate + H<sub>2</sub>O &rarr; D-<i>erythro</i>-sphinganine + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002413_DHS-PHOSPHATASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002413_DHS-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1282,6 +1272,17 @@
           <http://model.geneontology.org/DHS-PHOSPHATASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002333_YPL087W-MONOMER_CERAMIDASE-YEAST-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_SPHINGANINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1291,7 +1292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1308,7 +1309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1316,29 +1317,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57939>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002333_YBR183W-MONOMER_CERAMIDASE-YEAST-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_64795_RXN3O-458_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57939>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002333_MONOMER3O-419_RXN3O-504_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002333_MONOMER3O-419_RXN3O-504_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1349,48 +1350,15 @@
           <http://model.geneontology.org/MONOMER3O-419_RXN3O-504_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002233_CHEBI_64124_RXN3O-1380_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_15379_RXN3O-4042_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002333_CPLX3O-78_RXN3O-328_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002333_CPLX3O-78_RXN3O-328_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1401,17 +1369,6 @@
           <http://model.geneontology.org/CPLX3O-78_RXN3O-328_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002233_CHEBI_57939_SPHINGANINE-KINASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN3O-4042>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1421,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1429,15 +1386,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_31998_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000001491_CPLX3O-78_component_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000001491_CPLX3O-78_component_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1448,17 +1416,6 @@
           <http://model.geneontology.org/SGD_S000001491_CPLX3O-78_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002234_CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN3O-1380>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1468,7 +1425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1479,36 +1436,16 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-581_BFO_0000066_reaction_RXN3O-581_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_57783_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/238433a4-aae2-4cab-a2f2-1f895aa3f461_CERAMIDASE-YEAST-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (2'R)-2'-hydroxy-phytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_58299_SERINE-C-PALMITOYLTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58299> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1519,7 +1456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1527,26 +1464,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002333_YMR272C-MONOMER_RXN3O-4042_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002333_YDR062W-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002333_YDR062W-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1561,11 +1487,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_BFO_0000066_reaction_RXN3O-663_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_BFO_0000066_reaction_RXN3O-663_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1576,28 +1502,20 @@
           <http://model.geneontology.org/reaction_RXN3O-663_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002234_CHEBI_17600_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_BFO_0000066_reaction_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_15378_RXN3O-458_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1605,11 +1523,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002333_YMR272C-MONOMER_RXN3O-4042_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002333_YMR272C-MONOMER_RXN3O-4042_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1629,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1646,15 +1564,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-680_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/c1575af2-9a47-4766-9e83-27bad94bfc5e_RXN3O-663> , <http://model.geneontology.org/CHEBI_16749_RXN3O-680> ;
+                <http://model.geneontology.org/2b95a6d9-8114-4f17-bf85-1563aa4f9f7b_RXN3O-663> , <http://model.geneontology.org/CHEBI_16749_RXN3O-680> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/e320412f-2676-4b01-9d0f-a143fa7d84f0_RXN3O-680> , <http://model.geneontology.org/CHEBI_17815_RXN3O-680> ;
+                <http://model.geneontology.org/CHEBI_17815_RXN3O-680> , <http://model.geneontology.org/438a90e8-4e1e-40bf-8a4f-c5350ed33b3f_RXN3O-680> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR072C-MONOMER_RXN3O-680_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1667,29 +1585,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-663_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_CHEBI_15378_RXN3O-663_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1697,11 +1604,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_BFO_0000066_reaction_RXN3O-1380_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_BFO_0000066_reaction_RXN3O-1380_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1712,14 +1619,14 @@
           <http://model.geneontology.org/reaction_RXN3O-1380_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4042_BFO_0000066_reaction_RXN3O-4042_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-383_RXN3O-663_controller_BFO_0000051_SGD_S000005978_CPLX3O-383_component_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1732,7 +1639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1742,6 +1649,28 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_33384_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002233_CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1765,7 +1694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1777,11 +1706,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_CHEBI_17815_RXN3O-680_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_CHEBI_17815_RXN3O-680_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1792,6 +1721,17 @@
           <http://model.geneontology.org/CHEBI_17815_RXN3O-680>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_FERROCYTOCHROME-B5_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57817> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1801,7 +1741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1813,11 +1753,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_BFO_0000066_reaction_CERAMIDASE-YEAST-RXN_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_BFO_0000066_reaction_CERAMIDASE-YEAST-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1828,25 +1768,14 @@
           <http://model.geneontology.org/reaction_CERAMIDASE-YEAST-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002333_YPL087W-MONOMER_CERAMIDASE-YEAST-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002233_CHEBI_57939_SPHINGANINE-KINASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_15378_RXN3O-328_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1854,11 +1783,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-504_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-504_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1869,6 +1798,17 @@
           <http://model.geneontology.org/YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-680_BFO_0000066_reaction_RXN3O-680_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57817_DHS-PHOSPHATASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57817> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1878,7 +1818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1892,15 +1832,37 @@
 <http://identifiers.org/sgd/S000002479>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-458_BFO_0000066_reaction_RXN3O-458_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002234_CHEBI_456216_SPHINGANINE-KINASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_BFO_0000066_reaction_RXN3O-328_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_BFO_0000066_reaction_RXN3O-328_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1915,11 +1877,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002234_CHEBI_15378_SPHINGANINE-KINASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002234_CHEBI_15378_SPHINGANINE-KINASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1930,52 +1892,55 @@
           <http://model.geneontology.org/CHEBI_15378_SPHINGANINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_15379_RXN3O-1380_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_CHEBI_16749_RXN3O-680_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-458_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_CHEBI_17815_RXN3O-581_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-383_RXN3O-663_controller_BFO_0000051_SGD_S000005978_CPLX3O-383_component_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002233_CHEBI_57939_SPHINGANINE-KINASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-680_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/36f3c8a6-9b43-4845-85af-c90ea5af8c4f_RXN3O-4042>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_CHEBI_15377_CERAMIDASE-YEAST-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1984,11 +1949,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_05b65add-e6ca-4108-b53f-b1309aa569e7_RXN3O-4042_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_36f3c8a6-9b43-4845-85af-c90ea5af8c4f_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1996,7 +1961,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-581> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/05b65add-e6ca-4108-b53f-b1309aa569e7_RXN3O-4042>
+          <http://model.geneontology.org/36f3c8a6-9b43-4845-85af-c90ea5af8c4f_RXN3O-4042>
 ] .
 
 <http://model.geneontology.org/reaction_RXN3O-4042_location_lociGO_0005829>
@@ -2004,22 +1969,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_CHEBI_64124_RXN3O-1380_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_15379_RXN3O-4042_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_15379_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2034,11 +2010,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002234_CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002234_CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2049,28 +2025,6 @@
           <http://model.geneontology.org/CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_15378_RXN3O-458_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002333_YLR260W-MONOMER_RXN3O-458_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57783_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2080,7 +2034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2092,11 +2046,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002234_CHEBI_43474_DHS-PHOSPHATASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002234_CHEBI_43474_DHS-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2111,11 +2065,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_33384_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_33384_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2130,11 +2084,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_CHEBI_17815_RXN3O-581_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_CHEBI_17815_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2148,70 +2102,15 @@
 <http://identifiers.org/sgd/S000001491>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_e320412f-2676-4b01-9d0f-a143fa7d84f0_RXN3O-680_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002413_SPHINGANINE-KINASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002333_MONOMER3O-630_RXN3O-581_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002234_CHEBI_10283_CERAMIDASE-YEAST-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_BFO_0000066_reaction_CERAMIDASE-YEAST-RXN_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_31998_RXN3O-328_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_31998_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2229,11 +2128,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002234_CHEBI_57817_DHS-PHOSPHATASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002234_CHEBI_57817_DHS-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2244,6 +2143,17 @@
           <http://model.geneontology.org/CHEBI_57817_DHS-PHOSPHATASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YKR053C-MONOMER_RXN3O-504_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001761> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2251,7 +2161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2259,62 +2169,46 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1380_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/dc05b1a8-008a-4e51-a82e-4892afe00367_RXN3O-4042>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a (2'R)-2'-hydroxy-phytoceramide" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002233_CHEBI_30616_RXN3O-458_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_456216_RXN3O-458_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004911>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_31998_RXN3O-328_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002234_CHEBI_58190_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002234_CHEBI_58190_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2329,11 +2223,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002411_RXN3O-680_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002411_RXN3O-680_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2344,48 +2238,15 @@
           <http://model.geneontology.org/RXN3O-680>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_CHEBI_15377_RXN3O-1380_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002234_CHEBI_64124_CERAMIDASE-YEAST-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002333_YOR171C-MONOMER_RXN3O-458_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_456216_RXN3O-458_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_456216_RXN3O-458_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2399,15 +2260,26 @@
 <http://purl.obolibrary.org/obo/GO_0050291>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4042_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002333_YPL087W-MONOMER_CERAMIDASE-YEAST-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002333_YPL087W-MONOMER_CERAMIDASE-YEAST-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2429,7 +2301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2438,7 +2310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2446,11 +2318,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_FERRICYTOCHROME-B5_RXN3O-1380_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_FERRICYTOCHROME-B5_RXN3O-1380_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2460,17 +2332,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN3O-1380>
 ] .
-
-<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002333_YDR062W-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-4042>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -2483,7 +2344,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15379_RXN3O-4042> , <http://model.geneontology.org/CHEBI_15378_RXN3O-4042> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN3O-4042> , <http://model.geneontology.org/CHEBI_31998_RXN3O-328> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/257bd65b-0fa3-46e0-8850-7585323ca880_RXN3O-4042> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN3O-4042> , <http://model.geneontology.org/CHEBI_15377_RXN3O-4042> ;
+                <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN3O-4042> , <http://model.geneontology.org/CHEBI_15377_RXN3O-4042> , <http://model.geneontology.org/dc05b1a8-008a-4e51-a82e-4892afe00367_RXN3O-4042> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YMR272C-MONOMER_RXN3O-4042_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2491,7 +2352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2508,7 +2369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2523,7 +2384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2531,18 +2392,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/c7d804a8-0229-41c2-9beb-a7f6293eb013_RXN3O-581>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-<i>erythro</i>-sphinganine + ATP &rarr; sphinganine 1-phosphate + ADP + H<SUP>+</SUP>' 'null' 'sphinganine 1-phosphate &rarr; palmitaldehyde + <i>O</i>-phosphoethanolamine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002413_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002413_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2553,39 +2411,28 @@
           <http://model.geneontology.org/SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002413_RXN3O-1380_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_31998>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_BFO_0000066_reaction_DHS-PHOSPHATASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_CHEBI_64124_CERAMIDASE-YEAST-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002333_YBR265W-MONOMER_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_31998>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002413_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2593,11 +2440,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002333_YKR053C-MONOMER_RXN3O-504_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002333_YKR053C-MONOMER_RXN3O-504_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2617,7 +2464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2628,26 +2475,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_17815>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_BFO_0000066_reaction_SERINE-C-PALMITOYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002411_CERAMIDASE-YEAST-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002411_CERAMIDASE-YEAST-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2658,26 +2494,15 @@
           <http://model.geneontology.org/CERAMIDASE-YEAST-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002234_CHEBI_58190_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000004913_CPLX3O-78_component_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000004913_CPLX3O-78_component_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2688,17 +2513,39 @@
           <http://model.geneontology.org/SGD_S000004913_CPLX3O-78_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-328_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-1380_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57379>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002333_MONOMER3O-630_RXN3O-581_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-419_DHS-PHOSPHATASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000003670> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2707,7 +2554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2715,14 +2562,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-680_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002333_YMR272C-MONOMER_RXN3O-4042_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2733,11 +2580,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002333_YMR296C-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002333_YMR296C-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2752,11 +2599,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_CHEBI_57527_RXN3O-663_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_CHEBI_57527_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2770,44 +2617,22 @@
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://identifiers.org/sgd/S000006008>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002233_CHEBI_15377_RXN3O-504_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005978>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://identifiers.org/sgd/S000006008>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002234_CHEBI_43474_RXN3O-504_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002234_CHEBI_58349_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-78_RXN3O-328_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2818,7 +2643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2830,11 +2655,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002411_RXN3O-581_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002411_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2857,13 +2682,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19487> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_CHEBI_16749_RXN3O-680_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16749_RXN3O-680>
         a       <http://purl.obolibrary.org/obo/CHEBI_16749> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2874,7 +2710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2886,11 +2722,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_15378_RXN3O-1380_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_15378_RXN3O-1380_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2905,11 +2741,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-serine + palmitoyl-CoA + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + 3-dehydrosphinganine + coenzyme A' 'null' 'D-<i>erythro</i>-sphinganine + NADP<sup>+</sup> &larr; 3-dehydrosphinganine + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002413_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002413_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2919,17 +2755,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -2943,7 +2768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2955,11 +2780,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_e320412f-2676-4b01-9d0f-a143fa7d84f0_RXN3O-680_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_438a90e8-4e1e-40bf-8a4f-c5350ed33b3f_RXN3O-680_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2967,18 +2792,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-680> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e320412f-2676-4b01-9d0f-a143fa7d84f0_RXN3O-680>
+          <http://model.geneontology.org/438a90e8-4e1e-40bf-8a4f-c5350ed33b3f_RXN3O-680>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_CHEBI_15377_CERAMIDASE-YEAST-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_CHEBI_15377_CERAMIDASE-YEAST-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2989,17 +2814,6 @@
           <http://model.geneontology.org/CHEBI_15377_CERAMIDASE-YEAST-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_BFO_0000066_reaction_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_33384_SERINE-C-PALMITOYLTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33384> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3009,7 +2823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3017,14 +2831,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000001491_CPLX3O-78_component_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_242f0833-10e5-4c4b-8e31-fb72f427569b_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3032,11 +2846,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-504_BFO_0000066_reaction_RXN3O-504_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-504_BFO_0000066_reaction_RXN3O-504_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3047,40 +2861,23 @@
           <http://model.geneontology.org/reaction_RXN3O-504_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002413_RXN3O-328_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_FERRICYTOCHROME-B5_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/d13905c7-75d5-4519-916a-a29e7bfd25e6_RXN3O-663>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19742> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/reaction_RXN3O-663_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3093,9 +2890,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-663_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/c7d804a8-0229-41c2-9beb-a7f6293eb013_RXN3O-581> , <http://model.geneontology.org/CHEBI_57527_RXN3O-663> ;
+                <http://model.geneontology.org/242f0833-10e5-4c4b-8e31-fb72f427569b_RXN3O-581> , <http://model.geneontology.org/CHEBI_57527_RXN3O-663> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/d13905c7-75d5-4519-916a-a29e7bfd25e6_RXN3O-663> , <http://model.geneontology.org/CHEBI_58189_RXN3O-663> , <http://model.geneontology.org/CHEBI_15378_RXN3O-663> ;
+                <http://model.geneontology.org/e06c821f-70f9-4e37-9c61-cf37e420cd66_RXN3O-663> , <http://model.geneontology.org/CHEBI_58189_RXN3O-663> , <http://model.geneontology.org/CHEBI_15378_RXN3O-663> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-383_RXN3O-663_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3103,7 +2900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3115,11 +2912,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_CHEBI_64124_CERAMIDASE-YEAST-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_CHEBI_64124_CERAMIDASE-YEAST-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3130,15 +2927,26 @@
           <http://model.geneontology.org/CHEBI_64124_CERAMIDASE-YEAST-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_15378_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002234_CHEBI_456216_SPHINGANINE-KINASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002234_CHEBI_456216_SPHINGANINE-KINASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3152,14 +2960,47 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_c1575af2-9a47-4766-9e83-27bad94bfc5e_RXN3O-663_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002413_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_BFO_0000066_reaction_SPHINGANINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002413_RXN3O-504_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002333_YDR062W-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3172,7 +3013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3180,14 +3021,83 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-458_BFO_0000066_reaction_RXN3O-458_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002234_CHEBI_10283_CERAMIDASE-YEAST-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002411_RXN3O-680_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_9941306a-9bdb-4bd1-a9f4-2e3e70daeb9e_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/242f0833-10e5-4c4b-8e31-fb72f427569b_RXN3O-581>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002333_YLR260W-MONOMER_SPHINGANINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_58299_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3195,11 +3105,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002234_CHEBI_58349_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002234_CHEBI_58349_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3210,16 +3120,33 @@
           <http://model.geneontology.org/CHEBI_58349_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002234_CHEBI_57817_DHS-PHOSPHATASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-504_BFO_0000066_reaction_RXN3O-504_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/9941306a-9bdb-4bd1-a9f4-2e3e70daeb9e_RXN3O-328>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a very long chain fatty acyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19853> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_10283>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3228,11 +3155,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_57379_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_57379_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3247,11 +3174,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_288d9993-1b9e-4b23-bbc8-129a3fc40ff9_RXN3O-581_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_5f5cbec0-b1e0-41bc-9694-9cd97dc00d44_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3259,7 +3186,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-581> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/288d9993-1b9e-4b23-bbc8-129a3fc40ff9_RXN3O-581>
+          <http://model.geneontology.org/5f5cbec0-b1e0-41bc-9694-9cd97dc00d44_RXN3O-581>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_SERINE-C-PALMITOYLTRANSFERASE-RXN>
@@ -3271,7 +3198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3288,7 +3215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3300,11 +3227,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_FERROCYTOCHROME-B5_RXN3O-4042_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_FERROCYTOCHROME-B5_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3315,17 +3242,6 @@
           <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN3O-4042>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_57379_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_64124_RXN3O-1380>
         a       <http://purl.obolibrary.org/obo/CHEBI_64124> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3335,7 +3251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3347,11 +3263,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002333_MONOMER3O-419_DHS-PHOSPHATASE-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002333_MONOMER3O-419_DHS-PHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3362,14 +3278,14 @@
           <http://model.geneontology.org/MONOMER3O-419_DHS-PHOSPHATASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002413_RXN3O-328_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_0e189dd8-b35e-4155-9183-7becc8f1dedd_CERAMIDASE-YEAST-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3382,7 +3298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3390,36 +3306,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-328_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_FERROCYTOCHROME-B5_RXN3O-1380_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002234_CHEBI_57939_SPHINGANINE-KINASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_CHEBI_57527_RXN3O-663_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3427,11 +3321,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002333_YDR294C-MONOMER_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002333_YDR294C-MONOMER_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3446,11 +3340,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-680_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-680_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3461,6 +3355,17 @@
           <http://model.geneontology.org/YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002413_DHS-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0030148> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3470,7 +3375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3482,11 +3387,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_64795_RXN3O-458_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_64795_RXN3O-458_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3502,7 +3407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3510,11 +3415,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" , "Provides Input For Rule. The relation 'a (2'R)-2'-hydroxy-phytoceramide + H<sub>2</sub>O &harr; phytosphingosine + a 2-hydroxy fatty acid' 'null' 'phytosphingosine + a very long chain fatty acyl-CoA &rarr; a phytoceramide + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002413_RXN3O-328_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002413_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3525,14 +3430,14 @@
           <http://model.geneontology.org/RXN3O-328>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002333_YDR297W-MONOMER_RXN3O-1380_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002234_CHEBI_43474_RXN3O-504_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3540,11 +3445,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002333_YDR297W-MONOMER_RXN3O-1380_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002333_YDR297W-MONOMER_RXN3O-1380_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3558,22 +3463,27 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/257bd65b-0fa3-46e0-8850-7585323ca880_RXN3O-4042>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (2'R)-2'-hydroxy-phytoceramide" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-1380_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_456216_RXN3O-458_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3597,7 +3507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3609,11 +3519,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3623,6 +3533,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1>
 ] .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_58299_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-458>
         a       <http://purl.obolibrary.org/obo/GO_0008481> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3643,24 +3564,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1BiochemicalReaction19658> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_05b65add-e6ca-4108-b53f-b1309aa569e7_RXN3O-4042_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-1380>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -3671,7 +3581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3683,11 +3593,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'phytosphingosine 1-phosphate + H<sub>2</sub>O &rarr; phytosphingosine + phosphate' 'null' 'phytosphingosine + a very long chain fatty acyl-CoA &rarr; a phytoceramide + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002413_RXN3O-328_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002413_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3707,7 +3617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3719,11 +3629,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" , "Provides Input For Rule. The relation 'phytosphingosine + a very long chain fatty acyl-CoA &rarr; a phytoceramide + coenzyme A + H<SUP>+</SUP>' 'null' 'a phytoceramide + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; a (2'R)-2'-hydroxy-phytoceramide + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002413_RXN3O-4042_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002413_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3734,25 +3644,25 @@
           <http://model.geneontology.org/RXN3O-4042>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_15379_RXN3O-1380_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002333_MONOMER3O-419_DHS-PHOSPHATASE-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002333_YKR053C-MONOMER_RXN3O-504_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3760,11 +3670,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3784,7 +3694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3801,7 +3711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "sphingolipid biosynthesis (yeast) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3809,20 +3719,17 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/c1575af2-9a47-4766-9e83-27bad94bfc5e_RXN3O-663>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1380_BFO_0000066_reaction_RXN3O-1380_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002234_CHEBI_64124_RXN3O-504_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3830,11 +3737,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_c7d804a8-0229-41c2-9beb-a7f6293eb013_RXN3O-581_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_242f0833-10e5-4c4b-8e31-fb72f427569b_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3842,22 +3749,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-663> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c7d804a8-0229-41c2-9beb-a7f6293eb013_RXN3O-581>
+          <http://model.geneontology.org/242f0833-10e5-4c4b-8e31-fb72f427569b_RXN3O-581>
 ] .
 
 <http://identifiers.org/sgd/S000003670>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002333_YDR294C-MONOMER_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008481>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3866,11 +3762,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3884,14 +3780,14 @@
 <http://identifiers.org/sgd/S000002469>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_CHEBI_16749_RXN3O-581_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-4042_BFO_0000066_reaction_RXN3O-4042_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3899,11 +3795,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_15379_RXN3O-1380_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_15379_RXN3O-1380_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3918,11 +3814,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3936,15 +3832,26 @@
 <http://identifiers.org/sgd/S000002705>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-328_BFO_0000066_reaction_RXN3O-328_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002333_YDR072C-MONOMER_RXN3O-680_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002333_YDR072C-MONOMER_RXN3O-680_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3955,25 +3862,14 @@
           <http://model.geneontology.org/YDR072C-MONOMER_RXN3O-680_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002333_YDR072C-MONOMER_RXN3O-680_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_e06c821f-70f9-4e37-9c61-cf37e420cd66_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3981,11 +3877,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_238433a4-aae2-4cab-a2f2-1f895aa3f461_CERAMIDASE-YEAST-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_0e189dd8-b35e-4155-9183-7becc8f1dedd_CERAMIDASE-YEAST-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3993,17 +3889,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CERAMIDASE-YEAST-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/238433a4-aae2-4cab-a2f2-1f895aa3f461_CERAMIDASE-YEAST-RXN>
+          <http://model.geneontology.org/0e189dd8-b35e-4155-9183-7becc8f1dedd_CERAMIDASE-YEAST-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-663_BFO_0000066_reaction_RXN3O-663_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002233_CHEBI_64124_RXN3O-1380_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4011,11 +3907,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002233_CHEBI_15377_RXN3O-504_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002233_CHEBI_15377_RXN3O-504_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4026,17 +3922,36 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-504>
 ] .
 
-<http://model.geneontology.org/05b65add-e6ca-4108-b53f-b1309aa569e7_RXN3O-4042>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4042_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002234_CHEBI_57939_SPHINGANINE-KINASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-504_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002233_CHEBI_64795_RXN3O-458_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4044,11 +3959,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_3890c01d-7d4c-42a3-8af2-4f70d0a400a1_RXN3O-328_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_9941306a-9bdb-4bd1-a9f4-2e3e70daeb9e_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4056,18 +3971,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-328> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3890c01d-7d4c-42a3-8af2-4f70d0a400a1_RXN3O-328>
+          <http://model.geneontology.org/9941306a-9bdb-4bd1-a9f4-2e3e70daeb9e_RXN3O-328>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002234_CHEBI_57939_SPHINGANINE-KINASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002234_CHEBI_57939_SPHINGANINE-KINASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4082,11 +3997,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002233_CHEBI_64795_RXN3O-458_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002233_CHEBI_64795_RXN3O-458_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4097,6 +4012,17 @@
           <http://model.geneontology.org/CHEBI_64795_RXN3O-458>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_15378_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -4104,11 +4030,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_15378_RXN3O-328_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_15378_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4118,17 +4044,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_RXN3O-328>
 ] .
-
-<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_BFO_0000066_reaction_SPHINGANINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17600>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4142,7 +4057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4150,26 +4065,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_238433a4-aae2-4cab-a2f2-1f895aa3f461_CERAMIDASE-YEAST-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-383_RXN3O-663_controller_BFO_0000051_SGD_S000000240_CPLX3O-383_component_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-383_RXN3O-663_controller_BFO_0000051_SGD_S000000240_CPLX3O-383_component_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4180,15 +4084,37 @@
           <http://model.geneontology.org/SGD_S000000240_CPLX3O-383_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002411_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002413_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002333_YBR265W-MONOMER_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002333_YBR265W-MONOMER_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4199,14 +4125,14 @@
           <http://model.geneontology.org/YBR265W-MONOMER_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002333_YMR296C-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_CHEBI_15377_RXN3O-1380_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4214,11 +4140,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_16526_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_16526_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4233,11 +4159,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002333_MONOMER3O-630_RXN3O-581_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002333_MONOMER3O-630_RXN3O-581_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4251,36 +4177,14 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002233_CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002333_YKR053C-MONOMER_DHS-PHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002233_CHEBI_15377_DHS-PHOSPHATASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-680_BFO_0000066_reaction_RXN3O-680_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4291,11 +4195,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_CHEBI_15377_RXN3O-4042_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_CHEBI_15377_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4325,7 +4229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4333,65 +4237,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_288d9993-1b9e-4b23-bbc8-129a3fc40ff9_RXN3O-581_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002413_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/288d9993-1b9e-4b23-bbc8-129a3fc40ff9_RXN3O-581>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an inositol-phospho-&alpha; hydroxyphytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19792> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_33384_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SGD_S000005978_CPLX3O-383_component>
         a       <http://identifiers.org/sgd/S000005978> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_CHEBI_15377_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4404,7 +4269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4416,11 +4281,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002333_YKR053C-MONOMER_DHS-PHOSPHATASE-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002333_YKR053C-MONOMER_DHS-PHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4434,17 +4299,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_64795>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000004913>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002413_DHS-PHOSPHATASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002234_CHEBI_15378_SPHINGANINE-KINASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004913>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_57287_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4452,11 +4328,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4471,11 +4347,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-680_BFO_0000066_reaction_RXN3O-680_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-680_BFO_0000066_reaction_RXN3O-680_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4489,39 +4365,39 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002333_CPLX3O-78_RXN3O-328_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_BFO_0000066_reaction_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002333_YLR260W-MONOMER_RXN3O-458_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16749>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_c7d804a8-0229-41c2-9beb-a7f6293eb013_RXN3O-581_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002333_CPLX3O-383_RXN3O-663_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002233_CHEBI_15377_DHS-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4529,11 +4405,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002333_YLR260W-MONOMER_RXN3O-458_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002333_YLR260W-MONOMER_RXN3O-458_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4551,30 +4427,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1Protein19523> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/3890c01d-7d4c-42a3-8af2-4f70d0a400a1_RXN3O-328>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a very long chain fatty acyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19853> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/MONOMER3O-419_RXN3O-504_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003670> ;
@@ -4583,7 +4442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4591,15 +4450,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1380_BFO_0000066_reaction_RXN3O-1380_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" , "Provides Input For Rule. The relation 'D-<i>erythro</i>-sphinganine + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; phytosphingosine + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' 'phytosphingosine + a very long chain fatty acyl-CoA &rarr; a phytoceramide + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002413_RXN3O-328_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002413_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4610,18 +4480,40 @@
           <http://model.geneontology.org/RXN3O-328>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000001491_CPLX3O-78_component_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58189>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_CHEBI_17815_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_BFO_0000066_reaction_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_BFO_0000066_reaction_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4635,39 +4527,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002333_MONOMER3O-419_RXN3O-504_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002333_YLR260W-MONOMER_SPHINGANINE-KINASE-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_64795_RXN3O-458>
         a       <http://purl.obolibrary.org/obo/CHEBI_64795> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4677,7 +4536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4685,15 +4544,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002333_YDR072C-MONOMER_RXN3O-680_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4710,26 +4580,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_58190>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002234_CHEBI_456216_SPHINGANINE-KINASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4744,11 +4603,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_15378_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_15378_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4759,14 +4618,14 @@
           <http://model.geneontology.org/CHEBI_15378_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_58299_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002333_YDR294C-MONOMER_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4779,7 +4638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4787,26 +4646,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002413_SPHINGANINE-KINASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_BFO_0000066_reaction_DHS-PHOSPHATASE-RXN_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_BFO_0000066_reaction_DHS-PHOSPHATASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4821,11 +4669,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4836,25 +4684,25 @@
           <http://model.geneontology.org/YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002233_CHEBI_64795_RXN3O-458_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_16526_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002411_CERAMIDASE-YEAST-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_dc05b1a8-008a-4e51-a82e-4892afe00367_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4867,13 +4715,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1Protein19724> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002234_CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0047560>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4882,11 +4741,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_CHEBI_15378_RXN3O-663_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_CHEBI_15378_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4897,6 +4756,9 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-663>
 ] .
 
+<http://model.geneontology.org/2b95a6d9-8114-4f17-bf85-1563aa4f9f7b_RXN3O-663>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 <http://model.geneontology.org/YLR260W-MONOMER_SPHINGANINE-KINASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000004250> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4904,13 +4766,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1Protein19620> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_2b95a6d9-8114-4f17-bf85-1563aa4f9f7b_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58349_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4921,7 +4794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4934,7 +4807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4947,7 +4820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4959,11 +4832,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_BFO_0000066_reaction_RXN3O-458_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_BFO_0000066_reaction_RXN3O-458_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4981,11 +4854,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_57817_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5000,11 +4873,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_BFO_0000066_reaction_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_BFO_0000066_reaction_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5015,34 +4888,23 @@
           <http://model.geneontology.org/reaction_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-383_RXN3O-663_controller_BFO_0000051_SGD_S000000240_CPLX3O-383_component_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-663_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000000995_CPLX3O-78_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000995> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002333_YMR296C-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5050,11 +4912,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002234_CHEBI_10283_CERAMIDASE-YEAST-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002234_CHEBI_10283_CERAMIDASE-YEAST-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5072,7 +4934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5087,11 +4949,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002333_YLR260W-MONOMER_SPHINGANINE-KINASE-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002333_YLR260W-MONOMER_SPHINGANINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5102,17 +4964,6 @@
           <http://model.geneontology.org/YLR260W-MONOMER_SPHINGANINE-KINASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002233_CHEBI_15377_RXN3O-504_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15379_RXN3O-4042>
         a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5122,7 +4973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5133,15 +4984,26 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002333_YOR171C-MONOMER_SPHINGANINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002234_CHEBI_43474_RXN3O-504_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002234_CHEBI_43474_RXN3O-504_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5161,7 +5023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5172,26 +5034,15 @@
 <http://identifiers.org/sgd/S000005697>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002413_RXN3O-328_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_31998_RXN3O-328_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_31998_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5211,9 +5062,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-581_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_16749_RXN3O-581> , <http://model.geneontology.org/05b65add-e6ca-4108-b53f-b1309aa569e7_RXN3O-4042> ;
+                <http://model.geneontology.org/36f3c8a6-9b43-4845-85af-c90ea5af8c4f_RXN3O-4042> , <http://model.geneontology.org/CHEBI_16749_RXN3O-581> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_17815_RXN3O-581> , <http://model.geneontology.org/288d9993-1b9e-4b23-bbc8-129a3fc40ff9_RXN3O-581> ;
+                <http://model.geneontology.org/CHEBI_17815_RXN3O-581> , <http://model.geneontology.org/5f5cbec0-b1e0-41bc-9694-9cd97dc00d44_RXN3O-581> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-630_RXN3O-581_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -5221,7 +5072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5238,7 +5089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5249,6 +5100,17 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_15379_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000000240>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -5256,11 +5118,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-383_RXN3O-663_controller_BFO_0000051_SGD_S000005978_CPLX3O-383_component_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-383_RXN3O-663_controller_BFO_0000051_SGD_S000005978_CPLX3O-383_component_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5275,11 +5137,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" , "Provides Input For Rule. The relation 'D-<i>erythro</i>-sphinganine + NADP<sup>+</sup> &larr; 3-dehydrosphinganine + NADPH + H<SUP>+</SUP>' 'null' 'D-<i>erythro</i>-sphinganine + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; phytosphingosine + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002413_RXN3O-1380_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002413_RXN3O-1380_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5290,6 +5152,17 @@
           <http://model.geneontology.org/RXN3O-1380>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002413_SPHINGANINE-KINASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_43474_DHS-PHOSPHATASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5299,7 +5172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5307,34 +5180,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_SERINE-C-PALMITOYLTRANSFERASE-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002234_CHEBI_17600_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_15378_RXN3O-1380_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002411_RXN3O-663_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002411_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5345,14 +5221,44 @@
           <http://model.geneontology.org/RXN3O-663>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002333_YBR265W-MONOMER_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57287_SERINE-C-PALMITOYLTRANSFERASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002413_RXN3O-1380_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002333_MONOMER3O-419_RXN3O-504_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5366,11 +5272,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_FERRICYTOCHROME-B5_RXN3O-4042_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_FERRICYTOCHROME-B5_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5381,14 +5287,14 @@
           <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN3O-4042>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_31998_RXN3O-328_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5396,11 +5302,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" , "Provides Input For Rule. The relation 'sphinganine 1-phosphate + H<sub>2</sub>O &rarr; D-<i>erythro</i>-sphinganine + phosphate' 'null' 'D-<i>erythro</i>-sphinganine + ATP &rarr; sphinganine 1-phosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002413_SPHINGANINE-KINASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002413_SPHINGANINE-KINASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5411,14 +5317,14 @@
           <http://model.geneontology.org/SPHINGANINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000000995_CPLX3O-78_component_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-581_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5426,11 +5332,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_BFO_0000066_reaction_SPHINGANINE-KINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_BFO_0000066_reaction_SPHINGANINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5445,11 +5351,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_CHEBI_16749_RXN3O-680_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_CHEBI_16749_RXN3O-680_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5465,7 +5371,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002411_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5476,7 +5393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5493,7 +5410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5501,26 +5418,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002413_RXN3O-458_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002333_YOR171C-MONOMER_RXN3O-458_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002333_YOR171C-MONOMER_RXN3O-458_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5531,6 +5437,17 @@
           <http://model.geneontology.org/YOR171C-MONOMER_RXN3O-458_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002234_CHEBI_57817_DHS-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57527_RXN3O-663>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57527> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5540,7 +5457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5552,11 +5469,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" , "Provides Input For Rule. The relation 'D-<i>erythro</i>-sphinganine + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; phytosphingosine + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' 'phytosphingosine + ATP &rarr; phytosphingosine 1-phosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002413_RXN3O-458_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002413_RXN3O-458_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5567,50 +5484,28 @@
           <http://model.geneontology.org/RXN3O-458>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_CHEBI_15377_CERAMIDASE-YEAST-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_16526_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_64795_RXN3O-458_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_57287_RXN3O-328_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_57783_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_438a90e8-4e1e-40bf-8a4f-c5350ed33b3f_RXN3O-680_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5633,7 +5528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5650,7 +5545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5665,11 +5560,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_BFO_0000066_reaction_RXN3O-581_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_BFO_0000066_reaction_RXN3O-581_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5683,34 +5578,43 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_BFO_0000066_reaction_RXN3O-4042_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4042> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-4042_location_lociGO_0005829>
-] .
+<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_57379_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/0e189dd8-b35e-4155-9183-7becc8f1dedd_CERAMIDASE-YEAST-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a (2'R)-2'-hydroxy-phytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_57783_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_57783_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5721,25 +5625,44 @@
           <http://model.geneontology.org/CHEBI_57783_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_58299_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_BFO_0000066_reaction_RXN3O-4042_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4042> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-4042_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002333_YBR183W-MONOMER_CERAMIDASE-YEAST-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002234_CHEBI_43474_DHS-PHOSPHATASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-383_RXN3O-663_controller_BFO_0000051_SGD_S000000240_CPLX3O-383_component_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5747,11 +5670,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002233_CHEBI_15377_DHS-PHOSPHATASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002233_CHEBI_15377_DHS-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5766,11 +5689,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_BFO_0000066_reaction_SERINE-C-PALMITOYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_BFO_0000066_reaction_SERINE-C-PALMITOYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5781,36 +5704,47 @@
           <http://model.geneontology.org/reaction_SERINE-C-PALMITOYLTRANSFERASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_CHEBI_17815_RXN3O-680_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_BFO_0000066_reaction_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-663_BFO_0000066_reaction_RXN3O-663_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_15378_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-504_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000004913_CPLX3O-78_component_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002413_RXN3O-504_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5823,7 +5757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5831,26 +5765,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002333_YKR053C-MONOMER_RXN3O-504_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_CHEBI_58189_RXN3O-663_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_CHEBI_58189_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5861,15 +5784,48 @@
           <http://model.geneontology.org/CHEBI_58189_RXN3O-663>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_FERRICYTOCHROME-B5_RXN3O-1380_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002233_CHEBI_30616_RXN3O-458_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002413_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002233_CHEBI_30616_RXN3O-458_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002233_CHEBI_30616_RXN3O-458_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5879,6 +5835,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30616_RXN3O-458>
 ] .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002413_SPHINGANINE-KINASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000469>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5895,7 +5862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5908,7 +5875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5919,7 +5886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5931,11 +5898,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_FERROCYTOCHROME-B5_RXN3O-1380_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_FERROCYTOCHROME-B5_RXN3O-1380_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5950,11 +5917,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002233_CHEBI_57939_SPHINGANINE-KINASE-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002233_CHEBI_57939_SPHINGANINE-KINASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5969,11 +5936,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_d13905c7-75d5-4519-916a-a29e7bfd25e6_RXN3O-663_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_e06c821f-70f9-4e37-9c61-cf37e420cd66_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5981,7 +5948,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-663> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d13905c7-75d5-4519-916a-a29e7bfd25e6_RXN3O-663>
+          <http://model.geneontology.org/e06c821f-70f9-4e37-9c61-cf37e420cd66_RXN3O-663>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-663>
@@ -5993,7 +5960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6010,7 +5977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6027,7 +5994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6039,11 +6006,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002233_CHEBI_64124_RXN3O-1380_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002233_CHEBI_64124_RXN3O-1380_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6061,11 +6028,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002234_CHEBI_64124_CERAMIDASE-YEAST-RXN_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002234_CHEBI_64124_CERAMIDASE-YEAST-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6085,7 +6052,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-328_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_64124_CERAMIDASE-YEAST-RXN> , <http://model.geneontology.org/3890c01d-7d4c-42a3-8af2-4f70d0a400a1_RXN3O-328> ;
+                <http://model.geneontology.org/9941306a-9bdb-4bd1-a9f4-2e3e70daeb9e_RXN3O-328> , <http://model.geneontology.org/CHEBI_64124_CERAMIDASE-YEAST-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_RXN3O-328> , <http://model.geneontology.org/CHEBI_57287_RXN3O-328> , <http://model.geneontology.org/CHEBI_31998_RXN3O-328> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -6097,7 +6064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6109,11 +6076,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_CHEBI_15377_RXN3O-1380_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_CHEBI_15377_RXN3O-1380_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6124,14 +6091,47 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-1380>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_CHEBI_58189_RXN3O-663_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_CHEBI_64124_CERAMIDASE-YEAST-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_CHEBI_16749_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002413_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002234_CHEBI_64124_CERAMIDASE-YEAST-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6139,11 +6139,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002333_YOR171C-MONOMER_SPHINGANINE-KINASE-RXN_controller_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002333_YOR171C-MONOMER_SPHINGANINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6154,6 +6154,17 @@
           <http://model.geneontology.org/YOR171C-MONOMER_SPHINGANINE-KINASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-581_BFO_0000066_reaction_RXN3O-581_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_RXN3O-504>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6163,21 +6174,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19487> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_15378_RXN3O-4042_SGD_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_SUCUTIL-PWY-2.ttl
+++ b/models/YeastPathways_SUCUTIL-PWY-2.ttl
@@ -1,11 +1,22 @@
-<http://model.geneontology.org/ev_w_id_RXN3O-9807_BFO_0000066_reaction_RXN3O-9807_location_lociGO_0005829_SGD_YeastPathways_SUCUTIL-PWY-2>
+<http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002234_CHEBI_15824_RXN3O-9807_SGD_PWY_YeastPathways_SUCUTIL-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SUCUTIL-PWY-2" ;
+                "SGD_PWY:SUCUTIL-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002234_CHEBI_15903_RXN3O-9807_SGD_PWY_YeastPathways_SUCUTIL-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -18,7 +29,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -30,11 +41,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002234_CHEBI_15824_RXN3O-9807_SGD_YeastPathways_SUCUTIL-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002234_CHEBI_15824_RXN3O-9807_SGD_PWY_YeastPathways_SUCUTIL-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -57,6 +68,17 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9807_BFO_0000066_reaction_RXN3O-9807_location_lociGO_0005829_SGD_PWY_YeastPathways_SUCUTIL-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SUCUTIL-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_SUCUTIL-PWY-2/YeastPathways_SUCUTIL-PWY-2>
         a       <http://purl.obolibrary.org/obo/GO_0005987> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -64,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -72,14 +94,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002333_YIL162W-MONOMER_RXN3O-9807_controller_SGD_YeastPathways_SUCUTIL-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9807_BFO_0000050_YeastPathways_SUCUTIL-PWY-2/YeastPathways_SUCUTIL-PWY-2_SGD_PWY_YeastPathways_SUCUTIL-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:SUCUTIL-PWY-2" ;
+                "SGD_PWY:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -87,11 +109,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002233_CHEBI_17992_RXN3O-9807_SGD_YeastPathways_SUCUTIL-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002233_CHEBI_17992_RXN3O-9807_SGD_PWY_YeastPathways_SUCUTIL-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -102,36 +124,36 @@
           <http://model.geneontology.org/CHEBI_17992_RXN3O-9807>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002233_CHEBI_15377_RXN3O-9807_SGD_PWY_YeastPathways_SUCUTIL-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SUCUTIL-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002233_CHEBI_17992_RXN3O-9807_SGD_PWY_YeastPathways_SUCUTIL-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SUCUTIL-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002233_CHEBI_15377_RXN3O-9807_SGD_YeastPathways_SUCUTIL-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SUCUTIL-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002233_CHEBI_17992_RXN3O-9807_SGD_YeastPathways_SUCUTIL-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SUCUTIL-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -143,11 +165,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002233_CHEBI_15377_RXN3O-9807_SGD_YeastPathways_SUCUTIL-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002233_CHEBI_15377_RXN3O-9807_SGD_PWY_YeastPathways_SUCUTIL-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,28 +180,6 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-9807>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002234_CHEBI_15903_RXN3O-9807_SGD_YeastPathways_SUCUTIL-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SUCUTIL-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002234_CHEBI_15824_RXN3O-9807_SGD_YeastPathways_SUCUTIL-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SUCUTIL-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YIL162W-MONOMER_RXN3O-9807_controller>
         a       <http://identifiers.org/sgd/S000001424> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "sucrose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -218,6 +218,17 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002333_YIL162W-MONOMER_RXN3O-9807_controller_SGD_PWY_YeastPathways_SUCUTIL-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SUCUTIL-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15903_RXN3O-9807>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15903> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -227,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -239,11 +250,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9807_BFO_0000066_reaction_RXN3O-9807_location_lociGO_0005829_SGD_YeastPathways_SUCUTIL-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9807_BFO_0000066_reaction_RXN3O-9807_location_lociGO_0005829_SGD_PWY_YeastPathways_SUCUTIL-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -253,17 +264,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN3O-9807_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9807_BFO_0000050_YeastPathways_SUCUTIL-PWY-2/YeastPathways_SUCUTIL-PWY-2_SGD_YeastPathways_SUCUTIL-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SUCUTIL-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-9807>
         a       <http://purl.obolibrary.org/obo/GO_0004564> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -282,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -307,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -315,11 +315,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002333_YIL162W-MONOMER_RXN3O-9807_controller_SGD_YeastPathways_SUCUTIL-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002333_YIL162W-MONOMER_RXN3O-9807_controller_SGD_PWY_YeastPathways_SUCUTIL-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -345,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -357,11 +357,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9807_BFO_0000050_YeastPathways_SUCUTIL-PWY-2/YeastPathways_SUCUTIL-PWY-2_SGD_YeastPathways_SUCUTIL-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9807_BFO_0000050_YeastPathways_SUCUTIL-PWY-2/YeastPathways_SUCUTIL-PWY-2_SGD_PWY_YeastPathways_SUCUTIL-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -394,11 +394,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002234_CHEBI_15903_RXN3O-9807_SGD_YeastPathways_SUCUTIL-PWY-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9807_RO_0002234_CHEBI_15903_RXN3O-9807_SGD_PWY_YeastPathways_SUCUTIL-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_TCA-EUK-PWY.ttl
+++ b/models/YeastPathways_TCA-EUK-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -19,11 +19,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -41,11 +41,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -89,11 +89,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -107,26 +107,26 @@
 <http://identifiers.org/sgd/S000000422>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002413_ACONITATEHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000066_reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/SGD_S000001631_CPLX3O-742_component>
         a       <http://identifiers.org/sgd/S000001631> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -134,11 +134,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,11 +153,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002411_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002411_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -168,6 +168,17 @@
           <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YPR001W-MONOMER_CITSYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006205> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -175,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -187,11 +198,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_FUMHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_FUMHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -205,15 +216,26 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_57287_CITSYN-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_57287_CITSYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -224,40 +246,29 @@
           <http://model.geneontology.org/CHEBI_57287_CITSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_456216_SUCCCOASYN-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16389>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57287_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57287_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -287,7 +298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -299,11 +310,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -317,26 +328,15 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000066_reaction_CITSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -347,26 +347,15 @@
           <http://model.geneontology.org/CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000066_reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000003476_CPLX3O-690_component_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000003476_CPLX3O-690_component_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -377,36 +366,36 @@
           <http://model.geneontology.org/SGD_S000003476_CPLX3O-690_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002411_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YNR001C-MONOMER_CITSYN-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_15378_CITSYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_57287_CITSYN-RXN_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_FUMHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -419,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -427,14 +416,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002333_YPL262W-MONOMER_FUMHYDR-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002411_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -445,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,11 +446,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_456216_SUCCCOASYN-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_456216_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -472,14 +461,14 @@
           <http://model.geneontology.org/CHEBI_456216_SUCCCOASYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002413_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -487,11 +476,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_29806_FUMHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_29806_FUMHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -505,6 +494,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_30031>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000002555_CPLX3O-33_component_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_SUCCCOASYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -535,11 +535,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000066_reaction_CITSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000066_reaction_CITSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,11 +554,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002333_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002333_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -586,25 +586,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_30031_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000066_reaction_2OXOGLUTARATEDEH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000066_reaction_SUCCCOASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002333_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -615,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -628,7 +639,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_30616_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -637,32 +670,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YPR001W-MONOMER_CITSYN-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-33_component_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -670,11 +692,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002333_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002333_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -689,11 +711,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,26 +729,15 @@
 <http://identifiers.org/sgd/S000004982>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_29806_FUMHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -737,15 +748,26 @@
           <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_15377_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -761,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -787,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -799,11 +821,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000002555_CPLX3O-33_component_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000002555_CPLX3O-33_component_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -826,7 +848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -843,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -860,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -887,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -904,7 +926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -921,13 +943,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TCA-EUK-PWYSmallMolecule36533> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YCR005C-MONOMER_CITSYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000598> ;
@@ -936,7 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -949,18 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001631_CPLX3O-742_component_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -968,11 +990,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -990,11 +1012,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1010,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1019,7 +1041,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1028,18 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_30031_SUCCCOASYN-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1047,11 +1069,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002234_CHEBI_15562_ACONITATEHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002234_CHEBI_15562_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1061,6 +1083,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15562_ACONITATEHYDR-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_15377_FUMHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1072,11 +1116,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000066_reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000066_reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1091,11 +1135,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1115,7 +1159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1123,37 +1167,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_15377_ACONITATEHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57945_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1168,11 +1190,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YCR005C-MONOMER_CITSYN-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YCR005C-MONOMER_CITSYN-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1183,14 +1205,36 @@
           <http://model.geneontology.org/YCR005C-MONOMER_CITSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000003476_CPLX3O-690_component_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1203,7 +1247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1214,40 +1258,18 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-742_component_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002411_ACONITATEDEHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57540_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57540_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1267,7 +1289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1275,26 +1297,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002413_MALATE-DEH-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000066_reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000066_reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1314,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1326,11 +1337,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1341,37 +1352,15 @@
           <http://model.geneontology.org/CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_15377_CITSYN-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000005668_CPLX3O-690_component_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000005668_CPLX3O-690_component_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1382,49 +1371,26 @@
           <http://model.geneontology.org/SGD_S000005668_CPLX3O-690_component>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0003674>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002333_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TCA-EUK-PWYSmallMolecule36076> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1435,12 +1401,35 @@
           <http://model.geneontology.org/CHEBI_57292_2OXOGLUTARATEDEH-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TCA-EUK-PWYSmallMolecule36076> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1449,7 +1438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1458,7 +1447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1474,7 +1463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1486,11 +1475,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002234_CHEBI_15589_FUMHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002234_CHEBI_15589_FUMHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1500,6 +1489,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15589_FUMHYDR-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000005662_CPLX3O-679_component_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008177>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1513,7 +1513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1528,11 +1528,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_15377_CITSYN-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_15377_CITSYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1543,26 +1543,15 @@
           <http://model.geneontology.org/CHEBI_15377_CITSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002411_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002411_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1577,11 +1566,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_30031_SUCCCOASYN-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_30031_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1592,82 +1581,27 @@
           <http://model.geneontology.org/CHEBI_30031_SUCCCOASYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0030060>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002234_CHEBI_15589_FUMHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000005668_CPLX3O-690_component_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002411_FUMHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0030060>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002333_YPL262W-MONOMER_FUMHYDR-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002333_YPL262W-MONOMER_FUMHYDR-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1678,79 +1612,40 @@
           <http://model.geneontology.org/YPL262W-MONOMER_FUMHYDR-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002413_ACONITATEDEHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-742_component_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005284>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-44_component_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002234_CHEBI_15562_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000066_reaction_ACONITATEHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_57945_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15377_ACONITATEDEHYDR-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TCA-EUK-PWYSmallMolecule36437> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_16452_MALATE-DEH-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_16452_MALATE-DEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1761,6 +1656,34 @@
           <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_15377_ACONITATEDEHYDR-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TCA-EUK-PWYSmallMolecule36437> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000066_reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57945_2OXOGLUTARATEDEH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1770,7 +1693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1778,26 +1701,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002411_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1812,11 +1724,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" , "Provides Input For Rule. The relation 'D-<i>threo</i>-isocitrate + NAD<sup>+</sup> &rarr; 2-oxoglutarate + CO<SUB>2</SUB> + NADH' 'null' '2-oxoglutarate + coenzyme A + NAD<sup>+</sup> &rarr; succinyl-CoA + CO<SUB>2</SUB> + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002413_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002413_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1836,7 +1748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1865,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1882,7 +1794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1890,29 +1802,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_TCA-EUK-PWY>
+<http://purl.obolibrary.org/obo/GO_0003994>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0003994>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' 'null' 'oxaloacetate + acetyl-CoA + H<sub>2</sub>O &rarr; citrate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_CITSYN-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_CITSYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1933,11 +1845,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'citrate &harr; <i>cis</i>-aconitate + H<sub>2</sub>O' 'null' '<i>cis</i>-aconitate + H<sub>2</sub>O &harr; D-<i>threo</i>-isocitrate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002413_ACONITATEHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002413_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1951,29 +1863,29 @@
 <http://purl.obolibrary.org/obo/GO_0005886>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/CHEBI_456216>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001631_CPLX3O-742_component_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_456216>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-44_component_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-44_component_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1993,7 +1905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2001,21 +1913,54 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000001624>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-33_component_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16452>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000066_reaction_ACONITATEHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'hydrogencarbonate + pyruvate + ATP &rarr; oxaloacetate + ADP + phosphate + H<SUP>+</SUP>' 'null' 'oxaloacetate + acetyl-CoA + H<sub>2</sub>O &rarr; citrate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_CITSYN-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_CITSYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2031,7 +1976,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-44_component_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2041,15 +1997,26 @@
 <http://identifiers.org/sgd/S000006183>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002411_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2065,18 +2032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002333_CPLX3O-690_SUCCCOASYN-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2090,11 +2046,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEHYDR-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEHYDR-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2114,7 +2070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2122,33 +2078,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-742_component_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15589>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_15377_FUMHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000005668_CPLX3O-690_component_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002413_MALATE-DEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15377_ACONITATEHYDR-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -2159,7 +2115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2171,11 +2127,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_15562_ACONITATEHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_15562_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2188,13 +2144,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000066_reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000066_reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2213,7 +2169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2236,7 +2192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2248,11 +2204,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2263,26 +2219,15 @@
           <http://model.geneontology.org/CHEBI_15378_MALATE-DEH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-88_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000005486_CPLX3O-88_component_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YNR001C-MONOMER_CITSYN-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YNR001C-MONOMER_CITSYN-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2297,11 +2242,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2312,27 +2257,49 @@
           <http://model.geneontology.org/CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEHYDR-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886>
         a       <http://purl.obolibrary.org/obo/GO_0005886> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2343,26 +2310,15 @@
           <http://model.geneontology.org/CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000066_reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002233_CHEBI_16947_CITSYN-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002233_CHEBI_16947_CITSYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2373,40 +2329,18 @@
           <http://model.geneontology.org/CHEBI_16947_CITSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0036440>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2426,7 +2360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2434,47 +2368,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_CITSYN-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-742_component_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003581_CPLX3O-44_component_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000066_reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2482,11 +2383,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-742_component_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-742_component_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2497,30 +2398,30 @@
           <http://model.geneontology.org/SGD_S000001624_CPLX3O-742_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003581_CPLX3O-44_component_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57540_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2534,7 +2435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2542,14 +2443,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_15589_FUMHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_29806_FUMHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2560,7 +2461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2568,8 +2469,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_17544>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000066_reaction_FUMHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17544_PYRUVATE-CARBOXYLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17544> ;
@@ -2580,7 +2503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2597,7 +2520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2605,25 +2528,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-33_component_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2639,7 +2551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2656,7 +2568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2667,15 +2579,48 @@
 <http://identifiers.org/sgd/S000003030>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_456216_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_15377_CITSYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000066_reaction_CITSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2-oxoglutarate + coenzyme A + NAD<sup>+</sup> &rarr; succinyl-CoA + CO<SUB>2</SUB> + NADH' 'null' 'succinate + ATP + coenzyme A &harr; succinyl-CoA + ADP + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002413_SUCCCOASYN-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002413_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2690,11 +2635,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_30616_SUCCCOASYN-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_30616_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2714,7 +2659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2725,12 +2670,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_16947>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_15377_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000004982_CPLX3O-679_component>
         a       <http://identifiers.org/sgd/S000004982> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2738,11 +2694,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>S</i>)-malate &larr; fumarate + H<sub>2</sub>O' 'null' '(<i>S</i>)-malate + NAD<sup>+</sup> &harr; oxaloacetate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002413_MALATE-DEH-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002413_MALATE-DEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2753,36 +2709,14 @@
           <http://model.geneontology.org/MALATE-DEH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57287_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_57288_CITSYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002333_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_16389_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2790,11 +2724,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_57288_CITSYN-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_57288_CITSYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2814,13 +2748,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TCA-EUK-PWYSmallMolecule36061> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-742_component_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16452> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2831,7 +2787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2839,14 +2795,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_57288_CITSYN-RXN_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_15562_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002333_CPLX3O-690_SUCCCOASYN-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YPR001W-MONOMER_CITSYN-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2854,11 +2832,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002411_FUMHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002411_FUMHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2869,15 +2847,26 @@
           <http://model.geneontology.org/FUMHYDR-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2888,17 +2877,6 @@
           <http://model.geneontology.org/YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002234_CHEBI_15562_ACONITATEHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57292_2OXOGLUTARATEDEH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57292> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2908,7 +2886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2921,7 +2899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2929,11 +2907,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2944,29 +2922,29 @@
           <http://model.geneontology.org/YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY>
 ] .
 
-<http://identifiers.org/sgd/S000003476>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_43474_SUCCCOASYN-RXN_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_16947_CITSYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003476>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-44_component_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-44_component_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2996,7 +2974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3019,7 +2997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3030,14 +3008,25 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002413_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3045,11 +3034,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3065,7 +3054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3073,11 +3062,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3097,7 +3086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3105,15 +3094,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002411_ACONITATEDEHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002411_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3129,7 +3151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3142,7 +3164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3150,26 +3172,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002413_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_16389_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_16389_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3189,7 +3200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3202,7 +3213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3210,11 +3221,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3224,6 +3235,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002333_YPL262W-MONOMER_FUMHYDR-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SUCCCOASYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004775> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3244,7 +3266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3252,14 +3274,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002413_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3273,11 +3295,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YPR001W-MONOMER_CITSYN-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YPR001W-MONOMER_CITSYN-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3292,11 +3314,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3307,6 +3329,17 @@
           <http://model.geneontology.org/CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002233_CHEBI_16947_CITSYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0009060> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3316,7 +3349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3328,11 +3361,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_16526_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_16526_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3343,15 +3376,26 @@
           <http://model.geneontology.org/CHEBI_16526_2OXOGLUTARATEDEH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_30031_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_15377_ACONITATEDEHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_15377_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3366,11 +3410,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3381,24 +3425,16 @@
           <http://model.geneontology.org/CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001631_CPLX3O-742_component_SGD_YeastPathways_TCA-EUK-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000051> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SGD_S000001631_CPLX3O-742_component>
-] .
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YNR001C-MONOMER_CITSYN-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -3419,7 +3455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3427,25 +3463,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000066_reaction_FUMHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_TCA-EUK-PWY>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001631_CPLX3O-742_component_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000001631_CPLX3O-742_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57540_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_16452_MALATE-DEH-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3453,11 +3497,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_43474_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3477,7 +3521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3485,14 +3529,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000005662_CPLX3O-679_component_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_CPLX3O-690_SUCCCOASYN-RXN_controller_BFO_0000051_SGD_S000003476_CPLX3O-690_component_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3503,7 +3558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3517,15 +3572,37 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_16389_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-742_component_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-742_component_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3536,47 +3613,58 @@
           <http://model.geneontology.org/SGD_S000002585_CPLX3O-742_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002411_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-44_component_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002413_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_16452_MALATE-DEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3584,11 +3672,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000066_reaction_ACONITATEHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000066_reaction_ACONITATEHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3599,25 +3687,25 @@
           <http://model.geneontology.org/reaction_ACONITATEHYDR-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002234_CHEBI_15589_FUMHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEHYDR-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3625,11 +3713,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000004982_CPLX3O-679_component_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000004982_CPLX3O-679_component_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3644,11 +3732,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_57287_SUCCCOASYN-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_57287_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3662,14 +3750,14 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000004982_CPLX3O-679_component_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3680,11 +3768,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3698,14 +3786,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002233_CHEBI_16947_CITSYN-RXN_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_CITSYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3713,11 +3812,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_15378_CITSYN-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_15378_CITSYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3728,25 +3827,14 @@
           <http://model.geneontology.org/CHEBI_15378_CITSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_16526_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3759,7 +3847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "TCA cycle, aerobic respiration - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3771,11 +3859,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3810,7 +3898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3818,14 +3906,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_57287_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3833,11 +3921,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3848,15 +3936,26 @@
           <http://model.geneontology.org/reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_57945_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003581_CPLX3O-44_component_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003581_CPLX3O-44_component_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3867,25 +3966,14 @@
           <http://model.geneontology.org/SGD_S000003581_CPLX3O-44_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_43474_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3898,7 +3986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3906,25 +3994,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-33_component_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16526_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3932,11 +4020,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000066_reaction_SUCCCOASYN-RXN_location_lociGO_0005829_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000066_reaction_SUCCCOASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3947,14 +4035,25 @@
           <http://model.geneontology.org/reaction_SUCCCOASYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57287_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3967,7 +4066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3979,11 +4078,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000066_reaction_FUMHYDR-RXN_location_lociGO_0005829_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000066_reaction_FUMHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3994,14 +4093,14 @@
           <http://model.geneontology.org/reaction_FUMHYDR-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_30616_SUCCCOASYN-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4014,7 +4113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4031,7 +4130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4043,11 +4142,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" , "Provides Input For Rule. The relation '<i>cis</i>-aconitate + H<sub>2</sub>O &harr; D-<i>threo</i>-isocitrate' 'null' 'D-<i>threo</i>-isocitrate + NAD<sup>+</sup> &rarr; 2-oxoglutarate + CO<SUB>2</SUB> + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002413_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002413_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4058,15 +4157,26 @@
           <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-83_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000002236_CPLX3O-83_component_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4077,6 +4187,17 @@
           <http://model.geneontology.org/CHEBI_57292_2OXOGLUTARATEDEH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller>
         a       <http://identifiers.org/sgd/S000003736> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4084,7 +4205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4092,25 +4213,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000066_reaction_SUCCCOASYN-RXN_location_lociGO_0005829_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_16947_CITSYN-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4118,11 +4228,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_30031_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002233_CHEBI_30031_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4141,7 +4251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4154,7 +4264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4166,11 +4276,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4184,37 +4294,18 @@
 <http://identifiers.org/sgd/S000002555>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_57287_SUCCCOASYN-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15562>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'oxaloacetate + acetyl-CoA + H<sub>2</sub>O &rarr; citrate + coenzyme A + H<SUP>+</SUP>' 'null' 'citrate &harr; <i>cis</i>-aconitate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002413_ACONITATEDEHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002413_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4229,11 +4320,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4244,6 +4335,17 @@
           <http://model.geneontology.org/CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002413_CITSYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YPL262W-MONOMER_FUMHYDR-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006183> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4251,7 +4353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4259,26 +4361,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15562>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SGD_S000002555_CPLX3O-33_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002555> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4286,11 +4385,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4303,50 +4402,6 @@
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YCR005C-MONOMER_CITSYN-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002333_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_16526_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PYRUVATE-CARBOXYLASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004736> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4367,7 +4422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4384,7 +4439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4400,7 +4455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4408,11 +4463,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4423,6 +4478,28 @@
           <http://model.geneontology.org/CHEBI_456216_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000066_reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002413_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000005486>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -4430,11 +4507,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-742_component_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-742_component_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4453,7 +4530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4461,11 +4538,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_15377_ACONITATEHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_15377_ACONITATEHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4476,25 +4553,36 @@
           <http://model.geneontology.org/CHEBI_15377_ACONITATEHYDR-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YCR005C-MONOMER_CITSYN-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002234_CHEBI_30031_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57945_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4502,11 +4590,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000005662_CPLX3O-679_component_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000005662_CPLX3O-679_component_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4521,11 +4609,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002333_CPLX3O-690_SUCCCOASYN-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002333_CPLX3O-690_SUCCCOASYN-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4539,17 +4627,6 @@
 <http://identifiers.org/sgd/S000003581>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000004982_CPLX3O-679_component_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004295> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4557,7 +4634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4575,11 +4652,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000066_reaction_MALATE-DEH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4589,6 +4666,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_MALATE-DEH-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_57287_CITSYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57292>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4602,7 +4690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4614,11 +4702,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_16947_CITSYN-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_16947_CITSYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4629,14 +4717,25 @@
           <http://model.geneontology.org/CHEBI_16947_CITSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002411_FUMHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4644,11 +4743,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000066_reaction_2OXOGLUTARATEDEH-RXN_location_lociGO_0005829_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000066_reaction_2OXOGLUTARATEDEH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4663,11 +4762,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4678,23 +4777,12 @@
           <http://model.geneontology.org/CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000001624_CPLX3O-742_component>
         a       <http://identifiers.org/sgd/S000001624> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4702,11 +4790,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4717,17 +4805,6 @@
           <http://model.geneontology.org/SGD_S000003964_CPLX3O-44_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -4737,37 +4814,15 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002333_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_15378_CITSYN-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_43474_SUCCCOASYN-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_43474_SUCCCOASYN-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4781,17 +4836,28 @@
 <http://identifiers.org/sgd/S000005662>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_43474>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-742_component_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_43474>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4799,11 +4865,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_15377_FUMHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002233_CHEBI_15377_FUMHYDR-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4814,25 +4880,14 @@
           <http://model.geneontology.org/CHEBI_15377_FUMHYDR-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000001624_CPLX3O-44_component_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002413_CITSYN-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4840,11 +4895,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4859,11 +4914,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57945_2OXOGLUTARATEDEH-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002234_CHEBI_57945_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4883,13 +4938,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TCA-EUK-PWYSmallMolecule36344> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_16452_MALATE-DEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4900,7 +4966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4912,11 +4978,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4927,14 +4993,14 @@
           <http://model.geneontology.org/CHEBI_17976_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_15377_ACONITATEDEHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_16810_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4942,11 +5008,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-83_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4957,51 +5023,18 @@
           <http://model.geneontology.org/CPLX3O-83_MALATE-DEH-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002233_CHEBI_15562_ACONITATEHYDR-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16383>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002333_YGL062W-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-33_component_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-33_component_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5016,11 +5049,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_57945_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002234_CHEBI_57945_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5035,11 +5068,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_RO_0002234_CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5050,51 +5083,15 @@
           <http://model.geneontology.org/CHEBI_29806_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002413_SUCCCOASYN-RXN_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-85_MALATE-DEH-RXN_controller_BFO_0000051_SGD_S000001568_CPLX3O-85_component_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5105,14 +5102,17 @@
           <http://model.geneontology.org/CPLX3O-85_MALATE-DEH-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002413_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5125,7 +5125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5137,11 +5137,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5152,14 +5152,14 @@
           <http://model.geneontology.org/YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000002555_CPLX3O-33_component_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5168,7 +5168,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SUCCCOASYN-RXN_RO_0002233_CHEBI_57292_2OXOGLUTARATEDEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5176,11 +5187,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-33_component_SGD_YeastPathways_TCA-EUK-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-33_2OXOGLUTARATEDEH-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-33_component_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5191,24 +5202,13 @@
           <http://model.geneontology.org/SGD_S000001876_CPLX3O-33_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_BFO_0000050_YeastPathways_TCA-EUK-PWY/YeastPathways_TCA-EUK-PWY_SGD_YeastPathways_TCA-EUK-PWY>
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-85_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_BFO_0000066_reaction_2OXOGLUTARATEDEH-RXN_location_lociGO_0005829_SGD_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TCA-EUK-PWY" ;
+                "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_THIOREDOX-PWY.ttl
+++ b/models/YeastPathways_THIOREDOX-PWY.ttl
@@ -1,26 +1,48 @@
-<http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002233_CHEBI_15339_THIOREDOXIN-RXN_SGD_YeastPathways_THIOREDOX-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002413_THIOREDOXIN-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THIOREDOX-PWY" ;
+                "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002233_Red-Thioredoxin_THIOREDOXIN-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THIOREDOX-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_BFO_0000050_YeastPathways_THIOREDOX-PWY/YeastPathways_THIOREDOX-PWY_SGD_PWY_YeastPathways_THIOREDOX-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THIOREDOX-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002234_CHEBI_17499_THIOREDOXIN-RXN_SGD_YeastPathways_THIOREDOX-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002234_CHEBI_17499_THIOREDOXIN-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,11 +57,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002233_Red-Thioredoxin_THIOREDOXIN-RXN_SGD_YeastPathways_THIOREDOX-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002233_Red-Thioredoxin_THIOREDOXIN-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,17 +78,6 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002234_Red-Thioredoxin_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_YeastPathways_THIOREDOX-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THIOREDOX-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_THIOREDOX-PWY/YeastPathways_THIOREDOX-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0006125> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -76,24 +87,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_THIOREDOX-PWY" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002234_Red-Thioredoxin_THIOREDOXIN-RXN_SGD_YeastPathways_THIOREDOX-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THIOREDOX-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YHR106W-MONOMER_THIOREDOXIN-REDUCT-NADPH-RXN_controller>
         a       <http://identifiers.org/sgd/S000001148> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,24 +122,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=THIOREDOX-PWYSmallMolecule60511> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_YeastPathways_THIOREDOX-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THIOREDOX-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -150,43 +139,32 @@
 <http://identifiers.org/sgd/S000001148>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002233_Red-Thioredoxin_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_YeastPathways_THIOREDOX-PWY>
+<http://purl.obolibrary.org/obo/GO_0004791>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_57783>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_BFO_0000066_reaction_THIOREDOXIN-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THIOREDOX-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THIOREDOX-PWY" ;
+                "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004791>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002413_THIOREDOXIN-RXN_SGD_YeastPathways_THIOREDOX-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THIOREDOX-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57783>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002233_Red-Thioredoxin_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_YeastPathways_THIOREDOX-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002233_Red-Thioredoxin_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -201,11 +179,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_YeastPathways_THIOREDOX-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,6 +199,17 @@
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002234_Red-Thioredoxin_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THIOREDOX-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -242,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -253,17 +242,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002233_Red-Thioredoxin_THIOREDOXIN-RXN_SGD_YeastPathways_THIOREDOX-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THIOREDOX-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58349_THIOREDOXIN-REDUCT-NADPH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -273,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,11 +266,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002333_YHR106W-MONOMER_THIOREDOXIN-REDUCT-NADPH-RXN_controller_SGD_YeastPathways_THIOREDOX-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002333_YHR106W-MONOMER_THIOREDOXIN-REDUCT-NADPH-RXN_controller_SGD_PWY_YeastPathways_THIOREDOX-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,28 +281,6 @@
           <http://model.geneontology.org/YHR106W-MONOMER_THIOREDOXIN-REDUCT-NADPH-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002333_YHR106W-MONOMER_THIOREDOXIN-REDUCT-NADPH-RXN_controller_SGD_YeastPathways_THIOREDOX-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THIOREDOX-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_YeastPathways_THIOREDOX-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THIOREDOX-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -332,11 +288,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002233_CHEBI_15339_THIOREDOXIN-RXN_SGD_YeastPathways_THIOREDOX-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002233_CHEBI_15339_THIOREDOXIN-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -351,11 +307,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_YeastPathways_THIOREDOX-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -393,7 +349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -410,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -421,17 +377,28 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_YeastPathways_THIOREDOX-PWY>
+<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002333_YHR106W-MONOMER_THIOREDOXIN-REDUCT-NADPH-RXN_controller_SGD_PWY_YeastPathways_THIOREDOX-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THIOREDOX-PWY" ;
+                "SGD_PWY:THIOREDOX-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_BFO_0000066_reaction_THIOREDOXIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THIOREDOX-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -439,11 +406,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002333_YDR353W-MONOMER_THIOREDOXIN-REDUCT-NADPH-RXN_controller_SGD_YeastPathways_THIOREDOX-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002333_YDR353W-MONOMER_THIOREDOXIN-REDUCT-NADPH-RXN_controller_SGD_PWY_YeastPathways_THIOREDOX-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,11 +425,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_BFO_0000066_reaction_THIOREDOXIN-RXN_location_lociGO_0005829_SGD_YeastPathways_THIOREDOX-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_BFO_0000066_reaction_THIOREDOXIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THIOREDOX-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -473,15 +440,26 @@
           <http://model.geneontology.org/reaction_THIOREDOXIN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THIOREDOX-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_BFO_0000066_reaction_THIOREDOXIN-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_YeastPathways_THIOREDOX-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_BFO_0000066_reaction_THIOREDOXIN-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THIOREDOX-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -511,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -519,14 +497,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_BFO_0000066_reaction_THIOREDOXIN-RXN_location_lociGO_0005829_SGD_YeastPathways_THIOREDOX-PWY>
+<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_THIOREDOX-PWY/YeastPathways_THIOREDOX-PWY_SGD_PWY_YeastPathways_THIOREDOX-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THIOREDOX-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002233_CHEBI_15339_THIOREDOXIN-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THIOREDOX-PWY" ;
+                "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -535,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -549,11 +538,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'an oxidized thioredoxin + a reduced electron acceptor &larr; a reduced thioredoxin + an oxidized electron acceptor' 'null' 'a reduced thioredoxin + NADP<sup>+</sup> &larr; an oxidized thioredoxin + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002413_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_YeastPathways_THIOREDOX-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002413_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -568,11 +557,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002234_Red-Thioredoxin_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_YeastPathways_THIOREDOX-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002234_Red-Thioredoxin_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,6 +578,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002233_Red-Thioredoxin_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THIOREDOX-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -601,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -613,11 +613,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_BFO_0000050_YeastPathways_THIOREDOX-PWY/YeastPathways_THIOREDOX-PWY_SGD_YeastPathways_THIOREDOX-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_BFO_0000050_YeastPathways_THIOREDOX-PWY/YeastPathways_THIOREDOX-PWY_SGD_PWY_YeastPathways_THIOREDOX-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -633,7 +633,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002333_YDR353W-MONOMER_THIOREDOXIN-REDUCT-NADPH-RXN_controller_SGD_PWY_YeastPathways_THIOREDOX-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -641,11 +652,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_THIOREDOX-PWY/YeastPathways_THIOREDOX-PWY_SGD_YeastPathways_THIOREDOX-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_THIOREDOX-PWY/YeastPathways_THIOREDOX-PWY_SGD_PWY_YeastPathways_THIOREDOX-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -656,6 +667,17 @@
           <http://model.geneontology.org/YeastPathways_THIOREDOX-PWY/YeastPathways_THIOREDOX-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002233_CHEBI_57783_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THIOREDOX-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -665,14 +687,14 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002333_YDR353W-MONOMER_THIOREDOXIN-REDUCT-NADPH-RXN_controller_SGD_YeastPathways_THIOREDOX-PWY>
+<http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002234_CHEBI_17499_THIOREDOXIN-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THIOREDOX-PWY" ;
+                "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -685,13 +707,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=THIOREDOX-PWYProtein60491> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THIOREDOX-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YeastPathways_THIOREDOX-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -702,7 +738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "thioredoxin pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -710,18 +746,26 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002413_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THIOREDOX-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002234_Red-Thioredoxin_THIOREDOXIN-RXN_SGD_YeastPathways_THIOREDOX-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002234_Red-Thioredoxin_THIOREDOXIN-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -736,11 +780,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_YeastPathways_THIOREDOX-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -751,44 +795,22 @@
           <http://model.geneontology.org/CHEBI_58349_THIOREDOXIN-REDUCT-NADPH-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_THIOREDOX-PWY/YeastPathways_THIOREDOX-PWY_SGD_YeastPathways_THIOREDOX-PWY>
+<http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002234_Red-Thioredoxin_THIOREDOXIN-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THIOREDOX-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_BFO_0000050_YeastPathways_THIOREDOX-PWY/YeastPathways_THIOREDOX-PWY_SGD_YeastPathways_THIOREDOX-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THIOREDOX-PWY" ;
+                "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0006125>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002413_THIOREDOXIN-REDUCT-NADPH-RXN_SGD_YeastPathways_THIOREDOX-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THIOREDOX-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_THIOREDOXIN-REDUCT-NADPH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -799,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -811,11 +833,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" , "Provides Input For Rule. The relation 'a reduced thioredoxin + NADP<sup>+</sup> &larr; an oxidized thioredoxin + NADPH + H<SUP>+</SUP>' 'null' 'an oxidized thioredoxin + a reduced electron acceptor &larr; a reduced thioredoxin + an oxidized electron acceptor' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002413_THIOREDOXIN-RXN_SGD_YeastPathways_THIOREDOX-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_RO_0002413_THIOREDOXIN-RXN_SGD_PWY_YeastPathways_THIOREDOX-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -828,25 +850,3 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_THIOREDOXIN-REDUCT-NADPH-RXN_BFO_0000066_reaction_THIOREDOXIN-REDUCT-NADPH-RXN_location_lociGO_0005829_SGD_YeastPathways_THIOREDOX-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THIOREDOX-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THIOREDOXIN-RXN_RO_0002234_CHEBI_17499_THIOREDOXIN-RXN_SGD_YeastPathways_THIOREDOX-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THIOREDOX-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_THREOCAT2-PWY.ttl
+++ b/models/YeastPathways_THREOCAT2-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -19,11 +19,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" , "Provides Input For Rule. The relation 'L-threonine + H<sub>2</sub>O &rarr; 2-oxobutanoate + ammonia + H<sub>2</sub>O' 'null' 'L-homoserine &harr; 2-oxobutanoate + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002413_HOMOSERDEAM-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002413_HOMOSERDEAM-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -34,15 +34,37 @@
           <http://model.geneontology.org/HOMOSERDEAM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002233_CHEBI_57926_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002233_CHEBI_15378_METBALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METBALT-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_METBALT-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,6 +77,17 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_BFO_0000066_reaction_THREDEHYD2-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/METBALT-RXN>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -71,24 +104,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=THREOCAT2-PWYBiochemicalReaction55206> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_THREOSPON-RXN_BFO_0000066_reaction_THREOSPON-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008743>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -97,11 +119,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002234_CHEBI_16240_AMACETOXID-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002234_CHEBI_16240_AMACETOXID-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -115,12 +137,23 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_PTAALT-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -128,11 +161,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREOSPON-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREOSPON-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -152,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -160,26 +193,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002233_CHEBI_58320_THREOSPON-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROPKIN-RXN_RO_0002234_CHEBI_17272_PROPKIN-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PROPKIN-RXN_RO_0002234_CHEBI_17272_PROPKIN-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,15 +215,26 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_THREOSPON-RXN_BFO_0000066_reaction_THREOSPON-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_16134_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_16134_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -212,59 +245,15 @@
           <http://model.geneontology.org/CHEBI_16134_THREDEHYD2-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_15377_CYSTAGLY-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002233_CHEBI_57926_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002413_PTAALT-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_BFO_0000066_reaction_KETOBUTFORMLY-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AKBLIG-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AKBLIG-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -287,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -299,11 +288,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002233_CHEBI_57926_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002233_CHEBI_57926_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -318,11 +307,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_BFO_0000066_reaction_KETOBUTFORMLY-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_BFO_0000066_reaction_KETOBUTFORMLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,15 +322,48 @@
           <http://model.geneontology.org/reaction_KETOBUTFORMLY-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METBALT-RXN_BFO_0000066_reaction_METBALT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PROPKIN-RXN_BFO_0000066_reaction_PROPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002233_CHEBI_58320_THREOSPON-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002233_CHEBI_57926_THREODEHYD-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002233_CHEBI_57926_THREODEHYD-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -361,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -369,26 +391,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002234_CHEBI_15377_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002234_CHEBI_15377_METBALT-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002234_CHEBI_15377_METBALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -402,17 +413,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_30031>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002234_CHEBI_57661_METBALT-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -420,11 +420,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002233_CHEBI_57945_AMINOPROPDEHYDROG-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002233_CHEBI_57945_AMINOPROPDEHYDROG-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -438,62 +438,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002413_THREOSPON-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002413_KETOBUTFORMLY-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002233_CHEBI_30031_METBALT-RXN_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002234_CHEBI_58320_THREOSPON-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PTAALT-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" , "Provides Input For Rule. The relation 'L-2-amino-3-oxobutanoate + H<SUP>+</SUP> &rarr; aminoacetone + CO<SUB>2</SUB>' 'null' '(<i>R</i>)-1-aminopropan-2-ol + NAD<sup>+</sup> &larr; aminoacetone + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002413_AMINOPROPDEHYDROG-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002413_AMINOPROPDEHYDROG-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -508,11 +475,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002234_CHEBI_58933_PTAALT-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002234_CHEBI_58933_PTAALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -527,11 +494,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,26 +509,15 @@
           <http://model.geneontology.org/YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PROPKIN-RXN_BFO_0000066_reaction_PROPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_BFO_0000066_reaction_HOMOSERDEAM-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_BFO_0000066_reaction_HOMOSERDEAM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,28 +528,6 @@
           <http://model.geneontology.org/reaction_HOMOSERDEAM-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002234_CHEBI_58320_THREOSPON-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AKBLIG-RXN_RO_0002233_CHEBI_78948_THREODEHYD-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16240>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -601,11 +535,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" , "Provides Input For Rule. The relation 'L-threonine + H<sub>2</sub>O &rarr; 2-oxobutanoate + ammonia + H<sub>2</sub>O' 'null' '2-oxobutanoate + coenzyme A &rarr; propanoyl-CoA + formate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002413_KETOBUTFORMLY-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002413_KETOBUTFORMLY-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -616,14 +550,14 @@
           <http://model.geneontology.org/KETOBUTFORMLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_35235_CYSTAGLY-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -632,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -640,11 +574,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METBALT-RXN_BFO_0000066_reaction_METBALT-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_METBALT-RXN_BFO_0000066_reaction_METBALT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -659,11 +593,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002234_CHEBI_17158_AMACETOXID-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002234_CHEBI_17158_AMACETOXID-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -692,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -704,11 +638,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREOSPON-RXN_BFO_0000066_reaction_THREOSPON-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREOSPON-RXN_BFO_0000066_reaction_THREOSPON-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,14 +656,25 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002234_CHEBI_15378_THREODEHYD-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002234_CHEBI_57661_METBALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002234_CHEBI_15740_KETOBUTFORMLY-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -737,11 +682,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROPKIN-RXN_RO_0002234_CHEBI_30616_PROPKIN-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PROPKIN-RXN_RO_0002234_CHEBI_30616_PROPKIN-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -752,14 +697,25 @@
           <http://model.geneontology.org/CHEBI_30616_PROPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_16134_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002234_CHEBI_57287_PTAALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002234_CHEBI_16134_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -767,11 +723,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_16763_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_16763_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -785,22 +741,22 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_AKBLIG-RXN_RO_0002234_CHEBI_57288_AKBLIG-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15740>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_AKBLIG-RXN_BFO_0000066_reaction_AKBLIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58320>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -809,11 +765,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AKBLIG-RXN_BFO_0000066_reaction_AKBLIG-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AKBLIG-RXN_BFO_0000066_reaction_AKBLIG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,28 +780,6 @@
           <http://model.geneontology.org/reaction_AKBLIG-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_BFO_0000066_reaction_AMINOPROPDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002234_CHEBI_42677_AMINOPROPDEHYDROG-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_METBALT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -855,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -863,15 +797,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002233_CHEBI_57392_KETOBUTFORMLY-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002234_CHEBI_15377_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002234_CHEBI_15377_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -887,7 +832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -908,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -925,7 +870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -942,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -954,11 +899,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002233_CHEBI_16763_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002233_CHEBI_16763_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,6 +914,17 @@
           <http://model.geneontology.org/CHEBI_16763_THREDEHYD2-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16134_THREDEHYD2-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16134> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -978,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -992,15 +948,26 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_BFO_0000066_reaction_AMACETOXID-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002234_CHEBI_15378_THREODEHYD-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002234_CHEBI_15378_THREODEHYD-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1011,25 +978,25 @@
           <http://model.geneontology.org/CHEBI_15378_THREODEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002413_HOMOSERDEAM-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002233_CHEBI_16763_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002234_CHEBI_78948_THREODEHYD-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1040,11 +1007,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002234_CHEBI_57661_METBALT-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002234_CHEBI_57661_METBALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1055,30 +1022,8 @@
           <http://model.geneontology.org/CHEBI_57661_METBALT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002233_CHEBI_16763_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0006567>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002234_CHEBI_57287_PTAALT-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57288>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1087,11 +1032,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002233_CHEBI_58320_THREOSPON-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002233_CHEBI_58320_THREOSPON-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1106,11 +1051,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002234_CHEBI_57945_THREODEHYD-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002234_CHEBI_57945_THREODEHYD-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1121,14 +1066,36 @@
           <http://model.geneontology.org/CHEBI_57945_THREODEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002233_CHEBI_43474_PTAALT-RXN_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002234_CHEBI_16526_THREOSPON-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002234_CHEBI_15377_METBALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1149,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1157,26 +1124,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002233_CHEBI_57926_THREODEHYD-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROPKIN-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PROPKIN-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1196,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1213,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1225,11 +1181,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002234_CHEBI_42677_AMINOPROPDEHYDROG-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002234_CHEBI_42677_AMINOPROPDEHYDROG-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1240,8 +1196,41 @@
           <http://model.geneontology.org/CHEBI_42677_AMINOPROPDEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002413_PTAALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_35235>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_16763_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002234_CHEBI_16763_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57288_AKBLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57288> ;
@@ -1252,24 +1241,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=THREOCAT2-PWYSmallMolecule55035> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_58161_CYSTAGLY-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/THREODEHYD-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008743> ;
@@ -1288,7 +1266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1300,11 +1278,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'propanoyl-CoA + phosphate &rarr; propanoyl phosphate + coenzyme A' 'null' 'ATP + propanoate &larr; ADP + propanoyl phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002413_PROPKIN-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002413_PROPKIN-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1319,11 +1297,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_BFO_0000066_reaction_AMACETOXID-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_BFO_0000066_reaction_AMACETOXID-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1334,15 +1312,26 @@
           <http://model.geneontology.org/reaction_AMACETOXID-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002234_CHEBI_16240_AMACETOXID-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_RO_0002233_CHEBI_16763_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_RO_0002233_CHEBI_16763_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1353,37 +1342,37 @@
           <http://model.geneontology.org/CHEBI_16763_THREDEHYD2-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AKBLIG-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_METBALT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002233_CHEBI_78948_THREODEHYD-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_BFO_0000066_reaction_HOMOSERDEAM-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002234_CHEBI_57392_KETOBUTFORMLY-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1397,11 +1386,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" , "Provides Input For Rule. The relation 'L-threonine + H<sub>2</sub>O &rarr; 2-oxobutanoate + ammonia + H<sub>2</sub>O' 'null' 'O-succinyl-L-homoserine + H<sub>2</sub>O &harr; 2-oxobutanoate + succinate + ammonium + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002413_METBALT-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002413_METBALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1421,7 +1410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1429,14 +1418,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002233_CHEBI_15378_THREOSPON-RXN_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002234_CHEBI_15378_THREODEHYD-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1444,11 +1433,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002233_CHEBI_15378_METBALT-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002233_CHEBI_15378_METBALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1459,28 +1448,6 @@
           <http://model.geneontology.org/CHEBI_15378_METBALT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002413_METBALT-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002234_CHEBI_16134_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57540_THREODEHYD-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1490,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1502,11 +1469,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002234_CHEBI_28938_AMACETOXID-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002234_CHEBI_28938_AMACETOXID-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1526,7 +1493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1541,11 +1508,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002233_CHEBI_15378_THREOSPON-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002233_CHEBI_15378_THREOSPON-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1556,37 +1523,15 @@
           <http://model.geneontology.org/CHEBI_15378_THREOSPON-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002233_CHEBI_15379_AMACETOXID-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AKBLIG-RXN_BFO_0000066_reaction_AKBLIG-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PTAALT-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PTAALT-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1597,6 +1542,17 @@
           <http://model.geneontology.org/YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_58161_CYSTAGLY-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_THREDEHYD2-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1606,7 +1562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1614,25 +1570,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002234_CHEBI_15740_KETOBUTFORMLY-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PROPKIN-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1640,11 +1585,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_35235_CYSTAGLY-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_35235_CYSTAGLY-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1658,29 +1603,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_57476>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002233_CHEBI_15377_AMACETOXID-RXN_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002234_CHEBI_58933_PTAALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AKBLIG-RXN_RO_0002233_CHEBI_57287_AKBLIG-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AKBLIG-RXN_RO_0002233_CHEBI_57287_AKBLIG-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1691,15 +1636,26 @@
           <http://model.geneontology.org/CHEBI_57287_AKBLIG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002233_CHEBI_43474_PTAALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002234_CHEBI_16134_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002234_CHEBI_16134_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1719,7 +1675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1730,12 +1686,34 @@
 <http://purl.obolibrary.org/obo/CHEBI_57392>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_THREODEHYD-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METBALT-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1743,11 +1721,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002233_CHEBI_57287_KETOBUTFORMLY-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002233_CHEBI_57287_KETOBUTFORMLY-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1761,58 +1739,58 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002234_CHEBI_16763_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002233_CHEBI_58320_THREOSPON-RXN_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_AKBLIG-RXN_RO_0002233_CHEBI_57287_AKBLIG-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002413_AMINOPROPDEHYDROG-RXN_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002413_AMACETOXID-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_METBALT-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002413_AMINOPROPDEHYDROG-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_AKBLIG-RXN_RO_0002233_CHEBI_78948_THREODEHYD-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_BFO_0000066_reaction_KETOBUTFORMLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1825,7 +1803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1833,14 +1811,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002233_CHEBI_57287_KETOBUTFORMLY-RXN_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_PTAALT-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1848,11 +1826,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002234_CHEBI_78948_THREODEHYD-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002234_CHEBI_78948_THREODEHYD-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1878,7 +1856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1895,7 +1873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1907,11 +1885,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROPKIN-RXN_BFO_0000066_reaction_PROPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PROPKIN-RXN_BFO_0000066_reaction_PROPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1925,6 +1903,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002234_CHEBI_42677_AMINOPROPDEHYDROG-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_CYSTAGLY-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1934,7 +1923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1946,11 +1935,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002234_CHEBI_57540_AMINOPROPDEHYDROG-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002234_CHEBI_57540_AMINOPROPDEHYDROG-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1970,7 +1959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1978,15 +1967,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002413_AKBLIG-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2012,7 +2012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2024,11 +2024,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002233_CHEBI_15377_AMACETOXID-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002233_CHEBI_15377_AMACETOXID-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2039,59 +2039,15 @@
           <http://model.geneontology.org/CHEBI_15377_AMACETOXID-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THREOSPON-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002234_CHEBI_57945_THREODEHYD-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002413_AMACETOXID-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_RO_0002233_CHEBI_28938_HOMOSERDEAM-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_RO_0002233_CHEBI_28938_HOMOSERDEAM-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2102,6 +2058,17 @@
           <http://model.geneontology.org/CHEBI_28938_HOMOSERDEAM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002233_CHEBI_15377_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000000569>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2111,37 +2078,15 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PROPKIN-RXN_RO_0002234_CHEBI_17272_PROPKIN-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_16763_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2151,6 +2096,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY>
 ] .
+
+<http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002233_CHEBI_58320_THREOSPON-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17158>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2170,7 +2126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2178,26 +2134,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002234_CHEBI_28938_AMACETOXID-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002233_CHEBI_16763_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002233_CHEBI_16763_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2208,14 +2153,14 @@
           <http://model.geneontology.org/CHEBI_16763_THREDEHYD2-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PTAALT-RXN_BFO_0000066_reaction_PTAALT-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002233_CHEBI_15377_AMACETOXID-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2223,11 +2168,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2238,34 +2183,45 @@
           <http://model.geneontology.org/YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_RO_0002233_CHEBI_16763_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_CYSTAGLY-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002233_CHEBI_57945_AMINOPROPDEHYDROG-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002413_THREOSPON-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2276,11 +2232,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002233_CHEBI_78948_THREODEHYD-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002233_CHEBI_78948_THREODEHYD-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2300,7 +2256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2308,26 +2264,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002233_CHEBI_57540_THREODEHYD-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PTAALT-RXN_BFO_0000066_reaction_PTAALT-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PTAALT-RXN_BFO_0000066_reaction_PTAALT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2338,14 +2283,14 @@
           <http://model.geneontology.org/reaction_PTAALT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_RO_0002233_CHEBI_28938_HOMOSERDEAM-RXN_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_THREOSPON-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2353,11 +2298,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_15377_CYSTAGLY-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_15377_CYSTAGLY-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2377,7 +2322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2389,11 +2334,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AKBLIG-RXN_RO_0002233_CHEBI_78948_THREODEHYD-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AKBLIG-RXN_RO_0002233_CHEBI_78948_THREODEHYD-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2404,14 +2349,25 @@
           <http://model.geneontology.org/CHEBI_78948_THREODEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002234_CHEBI_57392_KETOBUTFORMLY-RXN_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_RO_0002233_CHEBI_28938_HOMOSERDEAM-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_RO_0002233_CHEBI_16763_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2419,11 +2375,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002234_CHEBI_16763_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002234_CHEBI_16763_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2434,14 +2390,14 @@
           <http://model.geneontology.org/CHEBI_16763_THREDEHYD2-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002233_CHEBI_16763_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002233_CHEBI_30031_METBALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2454,7 +2410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2466,11 +2422,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002234_CHEBI_15740_KETOBUTFORMLY-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002234_CHEBI_15740_KETOBUTFORMLY-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2490,7 +2446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2498,15 +2454,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_15377_CYSTAGLY-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002333_YCL064C-MONOMER_THREDEHYD2-RXN_controller_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002333_YCL064C-MONOMER_THREDEHYD2-RXN_controller_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2521,11 +2488,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002234_CHEBI_57392_KETOBUTFORMLY-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002234_CHEBI_57392_KETOBUTFORMLY-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2544,7 +2511,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002234_CHEBI_28938_AMACETOXID-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2557,7 +2535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2569,11 +2547,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002233_CHEBI_15379_AMACETOXID-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002233_CHEBI_15379_AMACETOXID-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2593,7 +2571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2610,7 +2588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2622,11 +2600,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" , "Provides Input For Rule. The relation 'L-threonine + NAD<sup>+</sup> &rarr; L-2-amino-3-oxobutanoate + NADH + H<SUP>+</SUP>' 'null' 'glycine + acetyl-CoA &harr; L-2-amino-3-oxobutanoate + coenzyme A' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002413_AKBLIG-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002413_AKBLIG-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2646,7 +2624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2654,19 +2632,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002413_PROPKIN-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -2675,11 +2653,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROPKIN-RXN_RO_0002233_CHEBI_456216_PROPKIN-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PROPKIN-RXN_RO_0002233_CHEBI_456216_PROPKIN-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2700,11 +2678,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2720,44 +2698,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000010>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002413_PROPKIN-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_BFO_0000066_reaction_THREDEHYD2-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_BFO_0000066_reaction_THREDEHYD2-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2768,14 +2735,14 @@
           <http://model.geneontology.org/reaction_THREDEHYD2-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002234_CHEBI_16240_AMACETOXID-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002413_KETOBUTFORMLY-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2783,11 +2750,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_RO_0002234_CHEBI_57476_HOMOSERDEAM-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_RO_0002234_CHEBI_57476_HOMOSERDEAM-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2798,31 +2765,42 @@
           <http://model.geneontology.org/CHEBI_57476_HOMOSERDEAM-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004123>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002234_CHEBI_57540_AMINOPROPDEHYDROG-RXN_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002233_CHEBI_15378_AMINOPROPDEHYDROG-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004123>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0019147>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002234_CHEBI_17158_AMACETOXID-RXN_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002234_CHEBI_15377_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2830,11 +2808,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_BFO_0000066_reaction_THREODEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_BFO_0000066_reaction_THREODEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2845,48 +2823,15 @@
           <http://model.geneontology.org/reaction_THREODEHYD-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AKBLIG-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PROPKIN-RXN_RO_0002233_CHEBI_456216_PROPKIN-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002233_CHEBI_15378_AMINOPROPDEHYDROG-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002233_CHEBI_28938_METBALT-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002233_CHEBI_28938_METBALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2912,7 +2857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2920,14 +2865,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002413_AKBLIG-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PROPKIN-RXN_RO_0002234_CHEBI_17272_PROPKIN-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2935,11 +2891,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_BFO_0000066_reaction_AMINOPROPDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_BFO_0000066_reaction_AMINOPROPDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2950,28 +2906,6 @@
           <http://model.geneontology.org/reaction_AMINOPROPDEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002234_CHEBI_16526_THREOSPON-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PROPKIN-RXN_RO_0002233_CHEBI_58933_PTAALT-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_43474_PTAALT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2981,7 +2915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2993,11 +2927,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002234_CHEBI_16526_THREOSPON-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002234_CHEBI_16526_THREOSPON-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3017,7 +2951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3029,11 +2963,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002233_CHEBI_43474_PTAALT-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002233_CHEBI_43474_PTAALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3044,15 +2978,37 @@
           <http://model.geneontology.org/CHEBI_43474_PTAALT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_RO_0002234_CHEBI_57476_HOMOSERDEAM-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PTAALT-RXN_BFO_0000066_reaction_PTAALT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_58161_CYSTAGLY-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_58161_CYSTAGLY-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3062,6 +3018,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58161_CYSTAGLY-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002233_CHEBI_57540_THREODEHYD-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/THREDEHYD2-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004794> ;
@@ -3082,7 +3049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3090,37 +3057,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002233_CHEBI_57945_AMINOPROPDEHYDROG-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002234_CHEBI_78948_THREODEHYD-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AKBLIG-RXN_RO_0002234_CHEBI_57288_AKBLIG-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AKBLIG-RXN_RO_0002234_CHEBI_57288_AKBLIG-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3140,24 +3085,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=THREOCAT2-PWYSmallMolecule55266> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002233_CHEBI_28938_METBALT-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57926_THREDEHYD2-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57926> ;
@@ -3168,7 +3102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3176,14 +3110,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AKBLIG-RXN_RO_0002233_CHEBI_57287_AKBLIG-RXN_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_PROPKIN-RXN_RO_0002234_CHEBI_30616_PROPKIN-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002234_CHEBI_57945_THREODEHYD-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3193,14 +3138,36 @@
 <http://purl.obolibrary.org/obo/CHEBI_42677>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002233_CHEBI_15377_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002233_CHEBI_15378_THREOSPON-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002333_YCL064C-MONOMER_THREDEHYD2-RXN_controller_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002413_METBALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3211,11 +3178,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" , "Provides Input For Rule. The relation 'L-threonine + H<sub>2</sub>O &rarr; 2-oxobutanoate + ammonia + H<sub>2</sub>O' 'null' 'L-cystathionine + H<sub>2</sub>O &harr; 2-oxobutanoate + L-cysteine + ammonia' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002413_CYSTAGLY-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002413_CYSTAGLY-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3226,17 +3193,6 @@
           <http://model.geneontology.org/CYSTAGLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METBALT-RXN_BFO_0000066_reaction_METBALT-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YCL064C-MONOMER_THREDEHYD2-RXN_controller>
         a       <http://identifiers.org/sgd/S000000569> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3244,7 +3200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3261,24 +3217,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=THREOCAT2-PWYSmallMolecule55111> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002413_CYSTAGLY-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16240_AMACETOXID-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16240> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3289,7 +3234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3301,11 +3246,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2-oxobutanoate + coenzyme A &rarr; propanoyl-CoA + formate' 'null' 'propanoyl-CoA + phosphate &rarr; propanoyl phosphate + coenzyme A' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002413_PTAALT-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002413_PTAALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3316,14 +3261,14 @@
           <http://model.geneontology.org/PTAALT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PROPKIN-RXN_RO_0002234_CHEBI_30616_PROPKIN-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PROPKIN-RXN_RO_0002233_CHEBI_456216_PROPKIN-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3336,7 +3281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3351,11 +3296,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002233_CHEBI_58320_THREOSPON-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002233_CHEBI_58320_THREOSPON-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3375,7 +3320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3383,26 +3328,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002233_CHEBI_57392_KETOBUTFORMLY-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-threonine + NAD<sup>+</sup> &rarr; L-2-amino-3-oxobutanoate + NADH + H<SUP>+</SUP>' 'null' 'L-2-amino-3-oxobutanoate + H<SUP>+</SUP> &rarr; aminoacetone + CO<SUB>2</SUB>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002413_THREOSPON-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002413_THREOSPON-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3413,15 +3347,37 @@
           <http://model.geneontology.org/THREOSPON-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AKBLIG-RXN_RO_0002234_CHEBI_57288_AKBLIG-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002234_CHEBI_57540_AMINOPROPDEHYDROG-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PROPKIN-RXN_RO_0002233_CHEBI_58933_PTAALT-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PROPKIN-RXN_RO_0002233_CHEBI_58933_PTAALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3440,29 +3396,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_RO_0002234_CHEBI_57476_HOMOSERDEAM-RXN_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002233_CHEBI_57287_KETOBUTFORMLY-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_BFO_0000066_reaction_THREDEHYD2-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3470,11 +3415,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000066_reaction_CYSTAGLY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3494,7 +3439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3511,13 +3456,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "threonine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_RO_0002233_CHEBI_16763_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17272_PROPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17272> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3528,7 +3484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3541,7 +3497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3549,11 +3505,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002233_CHEBI_15377_THREDEHYD2-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002233_CHEBI_15377_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3564,25 +3520,14 @@
           <http://model.geneontology.org/CHEBI_15377_THREDEHYD2-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002333_YCL064C-MONOMER_THREDEHYD2-RXN_controller_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PROPKIN-RXN_RO_0002233_CHEBI_58933_PTAALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002233_CHEBI_15378_METBALT-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3590,11 +3535,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETOBUTFORMLY-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3610,34 +3555,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AKBLIG-RXN_RO_0002234_CHEBI_57305_AKBLIG-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_BFO_0000066_reaction_THREODEHYD-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58933>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3662,7 +3585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3674,11 +3597,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002233_CHEBI_57540_THREODEHYD-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002233_CHEBI_57540_THREODEHYD-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3689,14 +3612,14 @@
           <http://model.geneontology.org/CHEBI_57540_THREODEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002234_CHEBI_15377_METBALT-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3707,11 +3630,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002233_CHEBI_30031_METBALT-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002233_CHEBI_30031_METBALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3722,14 +3645,14 @@
           <http://model.geneontology.org/CHEBI_30031_METBALT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002234_CHEBI_58933_PTAALT-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_RO_0002233_CHEBI_57926_THREODEHYD-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3743,11 +3666,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002233_CHEBI_15378_AMINOPROPDEHYDROG-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_RO_0002233_CHEBI_15378_AMINOPROPDEHYDROG-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3758,14 +3681,25 @@
           <http://model.geneontology.org/CHEBI_15378_AMINOPROPDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PROPKIN-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002234_CHEBI_17158_AMACETOXID-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_BFO_0000066_reaction_HOMOSERDEAM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3778,7 +3712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3786,14 +3720,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_BFO_0000066_reaction_AMACETOXID-RXN_location_lociGO_0005829_SGD_YeastPathways_THREOCAT2-PWY>
+<http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002233_CHEBI_78948_THREODEHYD-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
+                "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3801,11 +3735,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002234_CHEBI_58320_THREOSPON-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002234_CHEBI_58320_THREOSPON-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3828,7 +3762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3836,15 +3770,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_AMINOPROPDEHYDROG-RXN_BFO_0000066_reaction_AMINOPROPDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002233_CHEBI_57392_KETOBUTFORMLY-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002233_CHEBI_57392_KETOBUTFORMLY-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3855,17 +3800,6 @@
           <http://model.geneontology.org/CHEBI_57392_KETOBUTFORMLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_35235_CYSTAGLY-RXN_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YAL012W-MONOMER_CYSTAGLY-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000010> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3873,7 +3807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3890,7 +3824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3902,11 +3836,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3921,11 +3855,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" , "Provides Input For Rule. The relation 'L-2-amino-3-oxobutanoate + H<SUP>+</SUP> &rarr; aminoacetone + CO<SUB>2</SUB>' 'null' 'aminoacetone + H<sub>2</sub>O + oxygen &rarr; methylglyoxal + ammonium + hydrogen peroxide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002413_AMACETOXID-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THREOSPON-RXN_RO_0002413_AMACETOXID-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3936,12 +3870,23 @@
           <http://model.geneontology.org/AMACETOXID-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METBALT-RXN_RO_0002233_CHEBI_28938_METBALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_HOMOSERDEAM-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3965,7 +3910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3982,7 +3927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3994,11 +3939,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002234_CHEBI_57287_PTAALT-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PTAALT-RXN_RO_0002234_CHEBI_57287_PTAALT-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4009,9 +3954,6 @@
           <http://model.geneontology.org/CHEBI_57287_PTAALT-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 <http://model.geneontology.org/CHEBI_57287_KETOBUTFORMLY-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57287> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4021,7 +3963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4029,15 +3971,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AKBLIG-RXN_RO_0002234_CHEBI_57305_AKBLIG-RXN_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AKBLIG-RXN_RO_0002234_CHEBI_57305_AKBLIG-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4048,15 +3993,37 @@
           <http://model.geneontology.org/CHEBI_57305_AKBLIG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002413_CYSTAGLY-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_16134_THREDEHYD2-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEAM-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_PWY_YeastPathways_THREOCAT2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4067,17 +4034,6 @@
           <http://model.geneontology.org/YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_BFO_0000050_YeastPathways_THREOCAT2-PWY/YeastPathways_THREOCAT2-PWY_SGD_YeastPathways_THREOCAT2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THREOCAT2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_PROPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4087,7 +4043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4098,5 +4054,49 @@
 <http://purl.obolibrary.org/obo/CHEBI_57661>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_AKBLIG-RXN_RO_0002234_CHEBI_57305_AKBLIG-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THREDEHYD2-RXN_RO_0002413_HOMOSERDEAM-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMACETOXID-RXN_RO_0002233_CHEBI_15379_AMACETOXID-RXN_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004794>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_THREODEHYD-RXN_BFO_0000066_reaction_THREODEHYD-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THREOCAT2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THREOCAT2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_THRESYN-PWY.ttl
+++ b/models/YeastPathways_THRESYN-PWY.ttl
@@ -1,23 +1,12 @@
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_15377_THRESYN-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_15377_THRESYN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -32,11 +21,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-aspartate + ATP &rarr; L-aspartyl-4-phosphate + ADP' 'null' 'L-aspartate 4-semialdehyde + NADP<sup>+</sup> + phosphate &larr; L-aspartyl-4-phosphate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,14 +39,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_YeastPathways_THRESYN-PWY>
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -65,11 +54,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,14 +69,14 @@
           <http://model.geneontology.org/YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_57590_HOMOSERKIN-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -97,17 +86,6 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004413>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -115,11 +93,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -137,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -149,11 +127,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -164,11 +142,44 @@
           <http://model.geneontology.org/CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57535_ASPARTATEKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57535> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -179,43 +190,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=THRESYN-PWYSmallMolecule66080> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_43474_THRESYN-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_57590_HOMOSERKIN-RXN_SGD_YeastPathways_THRESYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOSERKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57590_HOMOSERKIN-RXN>
-] .
 
 <http://model.geneontology.org/ASPARTATEKIN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004072> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -236,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -248,11 +229,30 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_57590_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HOMOSERKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57590_HOMOSERKIN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,39 +263,6 @@
           <http://model.geneontology.org/CHEBI_29991_ASPAMINOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -303,11 +270,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -318,22 +285,22 @@
           <http://model.geneontology.org/reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000004017>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERKIN-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_HOMOSERKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -344,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -361,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -376,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -388,11 +355,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_57926_THRESYN-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_57926_THRESYN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,14 +370,25 @@
           <http://model.geneontology.org/CHEBI_57926_THRESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000066_reaction_HOMOSERKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_THRESYN-PWY>
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_57590_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -418,11 +396,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -442,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -460,7 +438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -477,13 +455,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=THRESYN-PWYSmallMolecule66007> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003900>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -496,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -507,11 +496,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000066_reaction_HOMOSERKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000066_reaction_HOMOSERKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,17 +511,6 @@
           <http://model.geneontology.org/reaction_HOMOSERKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -540,11 +518,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -558,25 +536,25 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002333_YHR025W-MONOMER_HOMOSERKIN-RXN_controller_SGD_YeastPathways_THRESYN-PWY>
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000066_reaction_HOMOSERKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THRESYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002333_YCR053W-MONOMER_THRESYN-RXN_controller_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -592,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -603,28 +581,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_16452>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0009088>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_THRESYN-PWY>
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_43474_THRESYN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -637,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -649,11 +616,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -664,15 +631,26 @@
           <http://model.geneontology.org/YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -683,17 +661,6 @@
           <http://model.geneontology.org/CHEBI_57535_ASPARTATEKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -701,11 +668,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -725,7 +692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of L-threonine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -738,18 +705,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_15378_HOMOSERKIN-RXN_SGD_YeastPathways_THRESYN-PWY>
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -763,11 +730,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -790,7 +757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -802,11 +769,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -841,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -849,36 +816,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002413_ASPARTATEKIN-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002413_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_57926_THRESYN-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -888,17 +833,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004795>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -906,11 +840,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_15378_HOMOSERKIN-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_15378_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -925,11 +859,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -949,24 +883,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=THRESYN-PWYSmallMolecule65927> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13392_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0009088> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -975,7 +898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -986,14 +909,25 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_THRESYN-PWY>
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_15377_THRESYN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1001,11 +935,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_57590_HOMOSERKIN-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_57590_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1021,7 +955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1029,11 +963,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1044,43 +978,15 @@
           <http://model.geneontology.org/YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_456216_HOMOSERKIN-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_13392_HOMOSERDEHYDROG-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_13392> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD(P)H" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=THRESYN-PWYSmallMolecule66043> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1091,6 +997,45 @@
           <http://model.geneontology.org/YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/CHEBI_13392_HOMOSERDEHYDROG-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_13392> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD(P)H" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=THRESYN-PWYSmallMolecule66043> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_57926_THRESYN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29991_ASPAMINOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1100,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1115,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1123,19 +1068,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_57590_HOMOSERKIN-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/GO_0004072>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1149,7 +1094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1161,11 +1106,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-homoserine + NAD(P)<sup>+</sup> &larr; L-aspartate 4-semialdehyde + NAD(P)H + H<SUP>+</SUP>' 'null' 'L-homoserine + ATP &rarr; O-phospho-L-homoserine + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERKIN-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1176,15 +1121,26 @@
           <http://model.geneontology.org/HOMOSERKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000066_reaction_THRESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1204,24 +1160,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=THRESYN-PWYSmallMolecule65912> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1248,7 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1259,14 +1204,36 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_15377_THRESYN-RXN_SGD_YeastPathways_THRESYN-PWY>
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_30616_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_PWY_YeastPathways_THRESYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1277,11 +1244,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002333_YHR025W-MONOMER_HOMOSERKIN-RXN_controller_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002333_YHR025W-MONOMER_HOMOSERKIN-RXN_controller_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1299,11 +1266,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1314,26 +1281,15 @@
           <http://model.geneontology.org/CHEBI_30616_ASPARTATEKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1347,6 +1303,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller>
         a       <http://identifiers.org/sgd/S000003900> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1354,7 +1321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1375,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1392,7 +1359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1400,15 +1367,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002333_YCR053W-MONOMER_THRESYN-RXN_controller_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002333_YCR053W-MONOMER_THRESYN-RXN_controller_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1428,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1440,11 +1418,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1459,11 +1437,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1483,7 +1461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1491,49 +1469,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_456216>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002333_YCR053W-MONOMER_THRESYN-RXN_controller_SGD_YeastPathways_THRESYN-PWY>
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_456216>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_30616_HOMOSERKIN-RXN_SGD_YeastPathways_THRESYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOSERKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_HOMOSERKIN-RXN>
-] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57535>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1547,7 +1495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1555,37 +1503,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002413_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_30616_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HOMOSERKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_HOMOSERKIN-RXN>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1596,45 +1541,12 @@
           <http://model.geneontology.org/YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_THRESYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000066_reaction_THRESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1655,24 +1567,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=THRESYN-PWYBiochemicalReaction65886> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_537519>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1686,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1694,15 +1595,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_15378_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000066_reaction_THRESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000066_reaction_THRESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1713,14 +1625,14 @@
           <http://model.geneontology.org/reaction_THRESYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1728,11 +1640,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1747,11 +1659,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1777,24 +1689,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=THRESYN-PWYSmallMolecule65853> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004412>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1803,11 +1704,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1825,11 +1726,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1859,7 +1760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1870,15 +1771,37 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002333_YHR025W-MONOMER_HOMOSERKIN-RXN_controller_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_456216_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_456216_HOMOSERKIN-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002234_CHEBI_456216_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1896,11 +1819,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1911,15 +1834,37 @@
           <http://model.geneontology.org/reaction_ASPARTATEKIN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16452_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1930,6 +1875,28 @@
           <http://model.geneontology.org/YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_30616_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000000854>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1937,11 +1904,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_43474_THRESYN-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_43474_THRESYN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1952,15 +1919,26 @@
           <http://model.geneontology.org/CHEBI_43474_THRESYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1971,15 +1949,26 @@
           <http://model.geneontology.org/reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2-oxoglutarate + L-aspartate &harr; oxaloacetate + L-glutamate' 'null' 'L-aspartate + ATP &rarr; L-aspartyl-4-phosphate + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002413_ASPARTATEKIN-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002413_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1990,25 +1979,14 @@
           <http://model.geneontology.org/ASPARTATEKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_THRESYN-PWY>
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2022,11 +2000,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2037,6 +2015,17 @@
           <http://model.geneontology.org/YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_BFO_0000066_reaction_ASPARTATEKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_HOMOSERDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2046,7 +2035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2058,11 +2047,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2076,29 +2065,40 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002413_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2111,7 +2111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2123,11 +2123,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-homoserine + ATP &rarr; O-phospho-L-homoserine + ADP + H<SUP>+</SUP>' 'null' 'O-phospho-L-homoserine + H<sub>2</sub>O &rarr; L-threonine + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2138,25 +2138,25 @@
           <http://model.geneontology.org/THRESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002333_YJR139C-MONOMER_HOMOSERDEHYDROG-RXN_controller_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57535_ASPARTATEKIN-RXN_SGD_YeastPathways_THRESYN-PWY>
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2164,11 +2164,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_456216_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2179,15 +2179,37 @@
           <http://model.geneontology.org/CHEBI_456216_ASPARTATEKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_29985_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2198,36 +2220,14 @@
           <http://model.geneontology.org/CHEBI_29985_ASPAMINOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002413_THRESYN-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_YeastPathways_THRESYN-PWY>
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_THRESYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2253,7 +2253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2261,14 +2261,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_THRESYN-PWY>
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002233_CHEBI_57590_HOMOSERKIN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2276,11 +2287,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2291,26 +2302,15 @@
           <http://model.geneontology.org/CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2321,14 +2321,14 @@
           <http://model.geneontology.org/reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_YeastPathways_THRESYN-PWY>
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2351,7 +2351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2363,11 +2363,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2387,7 +2387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2399,11 +2399,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-aspartate 4-semialdehyde + NADP<sup>+</sup> + phosphate &larr; L-aspartyl-4-phosphate + NADPH + H<SUP>+</SUP>' 'null' 'L-homoserine + NAD(P)<sup>+</sup> &larr; L-aspartate 4-semialdehyde + NAD(P)H + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_YeastPathways_THRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2419,39 +2419,39 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_YeastPathways_THRESYN-PWY>
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THRESYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_YeastPathways_THRESYN-PWY>
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_PWY_YeastPathways_THRESYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_30616_HOMOSERKIN-RXN_SGD_YeastPathways_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
+                "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_TREDEG-YEAST-PWY.ttl
+++ b/models/YeastPathways_TREDEG-YEAST-PWY.ttl
@@ -1,14 +1,3 @@
-<http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002333_YDR001C-MONOMER_TREHALA-RXN_controller_SGD_YeastPathways_TREDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TREDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16551>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -29,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,15 +26,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_TREHALA-RXN_BFO_0000066_reaction_TREHALA-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TREDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TREDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002234_CHEBI_15903_TREHALA-RXN_SGD_YeastPathways_TREDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002234_CHEBI_15903_TREHALA-RXN_SGD_PWY_YeastPathways_TREDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,24 +72,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TREDEG-YEAST-PWYProtein23793> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_TREHALA-RXN_BFO_0000050_YeastPathways_TREDEG-YEAST-PWY/YeastPathways_TREDEG-YEAST-PWY_SGD_YeastPathways_TREDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TREDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_TREHALA-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -100,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -108,15 +97,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002233_CHEBI_16551_TREHALA-RXN_SGD_PWY_YeastPathways_TREDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TREDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002233_CHEBI_16551_TREHALA-RXN_SGD_YeastPathways_TREDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002233_CHEBI_16551_TREHALA-RXN_SGD_PWY_YeastPathways_TREDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,6 +130,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002333_YPR026W-MONOMER_TREHALA-RXN_controller_SGD_PWY_YeastPathways_TREDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TREDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -142,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "trehalose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -153,22 +164,22 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_TREHALA-RXN_BFO_0000050_YeastPathways_TREDEG-YEAST-PWY/YeastPathways_TREDEG-YEAST-PWY_SGD_PWY_YeastPathways_TREDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TREDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/GO_0004555>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002234_CHEBI_15903_TREHALA-RXN_SGD_YeastPathways_TREDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TREDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -177,11 +188,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002233_CHEBI_15377_TREHALA-RXN_SGD_YeastPathways_TREDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002233_CHEBI_15377_TREHALA-RXN_SGD_PWY_YeastPathways_TREDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,17 +209,6 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002333_YPR026W-MONOMER_TREHALA-RXN_controller_SGD_YeastPathways_TREDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TREDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YDR001C-MONOMER_TREHALA-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002408> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -227,14 +227,14 @@
 <http://identifiers.org/sgd/S000006230>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_TREHALA-RXN_BFO_0000066_reaction_TREHALA-RXN_location_lociGO_0005829_SGD_YeastPathways_TREDEG-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002333_YDR001C-MONOMER_TREHALA-RXN_controller_SGD_PWY_YeastPathways_TREDEG-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TREDEG-YEAST-PWY" ;
+                "SGD_PWY:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -245,11 +245,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002333_YPR026W-MONOMER_TREHALA-RXN_controller_SGD_YeastPathways_TREDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002333_YPR026W-MONOMER_TREHALA-RXN_controller_SGD_PWY_YeastPathways_TREDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -269,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -298,11 +298,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALA-RXN_BFO_0000066_reaction_TREHALA-RXN_location_lociGO_0005829_SGD_YeastPathways_TREDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALA-RXN_BFO_0000066_reaction_TREHALA-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TREDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -322,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -330,14 +330,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002233_CHEBI_15377_TREHALA-RXN_SGD_YeastPathways_TREDEG-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002233_CHEBI_15377_TREHALA-RXN_SGD_PWY_YeastPathways_TREDEG-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TREDEG-YEAST-PWY" ;
+                "SGD_PWY:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -346,7 +346,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002234_CHEBI_15903_TREHALA-RXN_SGD_PWY_YeastPathways_TREDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -360,11 +371,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002333_YDR001C-MONOMER_TREHALA-RXN_controller_SGD_YeastPathways_TREDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002333_YDR001C-MONOMER_TREHALA-RXN_controller_SGD_PWY_YeastPathways_TREDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -390,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -402,11 +413,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALA-RXN_BFO_0000050_YeastPathways_TREDEG-YEAST-PWY/YeastPathways_TREDEG-YEAST-PWY_SGD_YeastPathways_TREDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALA-RXN_BFO_0000050_YeastPathways_TREDEG-YEAST-PWY/YeastPathways_TREDEG-YEAST-PWY_SGD_PWY_YeastPathways_TREDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -436,11 +447,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002234_CHEBI_17925_TREHALA-RXN_SGD_YeastPathways_TREDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002234_CHEBI_17925_TREHALA-RXN_SGD_PWY_YeastPathways_TREDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -460,24 +471,13 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002233_CHEBI_16551_TREHALA-RXN_SGD_YeastPathways_TREDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002234_CHEBI_17925_TREHALA-RXN_SGD_PWY_YeastPathways_TREDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TREDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TREHALA-RXN_RO_0002234_CHEBI_17925_TREHALA-RXN_SGD_YeastPathways_TREDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TREDEG-YEAST-PWY" ;
+                "SGD_PWY:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_TRESYN-PWY.ttl
+++ b/models/YeastPathways_TRESYN-PWY.ttl
@@ -1,3 +1,14 @@
+<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002233_CHEBI_58885_TREHALOSE6PSYN-RXN_SGD_PWY_YeastPathways_TRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58223>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -6,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -20,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -32,11 +43,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002234_CHEBI_43474_TREHALOSEPHOSPHA-RXN_SGD_YeastPathways_TRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002234_CHEBI_43474_TREHALOSEPHOSPHA-RXN_SGD_PWY_YeastPathways_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -51,11 +62,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002234_CHEBI_15378_TREHALOSE6PSYN-RXN_SGD_YeastPathways_TRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002234_CHEBI_15378_TREHALOSE6PSYN-RXN_SGD_PWY_YeastPathways_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,17 +86,28 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002233_CHEBI_58429_TREHALOSE6PSYN-RXN_SGD_PWY_YeastPathways_TRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0005992>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002234_CHEBI_15378_TREHALOSE6PSYN-RXN_SGD_YeastPathways_TRESYN-PWY>
+<http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002333_YDR074W-MONOMER_TREHALOSEPHOSPHA-RXN_controller_SGD_PWY_YeastPathways_TRESYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRESYN-PWY" ;
+                "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -96,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -121,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -129,19 +151,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_BFO_0000066_reaction_TREHALOSE6PSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_TRESYN-PWY>
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_BFO_0000050_YeastPathways_TRESYN-PWY/YeastPathways_TRESYN-PWY_SGD_PWY_YeastPathways_TRESYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRESYN-PWY" ;
+                "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -155,13 +177,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRESYN-PWYSmallMolecule67294> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002234_CHEBI_15378_TREHALOSE6PSYN-RXN_SGD_PWY_YeastPathways_TRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_TREHALOSE6PSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -172,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -184,11 +217,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002234_CHEBI_16551_TREHALOSEPHOSPHA-RXN_SGD_YeastPathways_TRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002234_CHEBI_16551_TREHALOSEPHOSPHA-RXN_SGD_PWY_YeastPathways_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -203,11 +236,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002233_CHEBI_58885_TREHALOSE6PSYN-RXN_SGD_YeastPathways_TRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002233_CHEBI_58885_TREHALOSE6PSYN-RXN_SGD_PWY_YeastPathways_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,49 +254,49 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002233_CHEBI_15377_TREHALOSEPHOSPHA-RXN_SGD_YeastPathways_TRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_BFO_0000050_YeastPathways_TRESYN-PWY/YeastPathways_TRESYN-PWY_SGD_YeastPathways_TRESYN-PWY>
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_BFO_0000066_reaction_TREHALOSEPHOSPHA-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002234_CHEBI_58429_TREHALOSE6PSYN-RXN_SGD_PWY_YeastPathways_TRESYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRESYN-PWY" ;
+                "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" , "Provides Input For Rule. The relation 'UDP-&alpha;-D-glucose + D-glucopyranose 6-phosphate &rarr; &alpha;,&alpha;-trehalose 6-phosphate + UDP + H<SUP>+</SUP>' 'null' '&alpha;,&alpha;-trehalose 6-phosphate + H<sub>2</sub>O &rarr; &alpha;,&alpha;-trehalose + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002413_TREHALOSEPHOSPHA-RXN_SGD_YeastPathways_TRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002413_TREHALOSEPHOSPHA-RXN_SGD_PWY_YeastPathways_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -283,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -293,17 +326,6 @@
 
 <http://identifiers.org/sgd/S000002481>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002234_CHEBI_43474_TREHALOSEPHOSPHA-RXN_SGD_YeastPathways_TRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -317,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -329,11 +351,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002233_CHEBI_58429_TREHALOSE6PSYN-RXN_SGD_YeastPathways_TRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002233_CHEBI_58429_TREHALOSE6PSYN-RXN_SGD_PWY_YeastPathways_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -344,15 +366,26 @@
           <http://model.geneontology.org/CHEBI_58429_TREHALOSE6PSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_BFO_0000050_YeastPathways_TRESYN-PWY/YeastPathways_TRESYN-PWY_SGD_PWY_YeastPathways_TRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002233_CHEBI_4170_TREHALOSE6PSYN-RXN_SGD_YeastPathways_TRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002233_CHEBI_4170_TREHALOSE6PSYN-RXN_SGD_PWY_YeastPathways_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,6 +396,17 @@
           <http://model.geneontology.org/CHEBI_4170_TREHALOSE6PSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002234_CHEBI_43474_TREHALOSEPHOSPHA-RXN_SGD_PWY_YeastPathways_TRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_43474_TREHALOSEPHOSPHA-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -372,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -380,41 +424,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_BFO_0000050_YeastPathways_TRESYN-PWY/YeastPathways_TRESYN-PWY_SGD_YeastPathways_TRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002234_CHEBI_58429_TREHALOSE6PSYN-RXN_SGD_YeastPathways_TRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002234_CHEBI_16551_TREHALOSEPHOSPHA-RXN_SGD_YeastPathways_TRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -428,7 +439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -445,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "trehalose biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -456,17 +467,6 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002233_CHEBI_58429_TREHALOSE6PSYN-RXN_SGD_YeastPathways_TRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_TREHALOSEPHOSPHA-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -476,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -488,11 +488,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002333_YBR126C-MONOMER_TREHALOSE6PSYN-RXN_controller_SGD_YeastPathways_TRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002333_YBR126C-MONOMER_TREHALOSE6PSYN-RXN_controller_SGD_PWY_YeastPathways_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,30 +503,19 @@
           <http://model.geneontology.org/YBR126C-MONOMER_TREHALOSE6PSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002333_YDR074W-MONOMER_TREHALOSEPHOSPHA-RXN_controller_SGD_YeastPathways_TRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_BFO_0000066_reaction_TREHALOSE6PSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRESYN-PWY" ;
+                "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004805>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_BFO_0000066_reaction_TREHALOSEPHOSPHA-RXN_location_lociGO_0005829_SGD_YeastPathways_TRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58223_TREHALOSE6PSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58223> ;
@@ -537,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -564,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -576,11 +565,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002233_CHEBI_15377_TREHALOSEPHOSPHA-RXN_SGD_YeastPathways_TRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002233_CHEBI_15377_TREHALOSEPHOSPHA-RXN_SGD_PWY_YeastPathways_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -595,11 +584,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_BFO_0000066_reaction_TREHALOSE6PSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_TRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_BFO_0000066_reaction_TREHALOSE6PSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -610,26 +599,48 @@
           <http://model.geneontology.org/reaction_TREHALOSE6PSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002234_CHEBI_58223_TREHALOSE6PSYN-RXN_SGD_YeastPathways_TRESYN-PWY>
+<http://purl.obolibrary.org/obo/CHEBI_4170>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002333_YBR126C-MONOMER_TREHALOSE6PSYN-RXN_controller_SGD_PWY_YeastPathways_TRESYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRESYN-PWY" ;
+                "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_4170>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002234_CHEBI_58223_TREHALOSE6PSYN-RXN_SGD_PWY_YeastPathways_TRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002234_CHEBI_16551_TREHALOSEPHOSPHA-RXN_SGD_PWY_YeastPathways_TRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_TREHALOSE6PSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -646,11 +657,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002234_CHEBI_58429_TREHALOSE6PSYN-RXN_SGD_YeastPathways_TRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002234_CHEBI_58429_TREHALOSE6PSYN-RXN_SGD_PWY_YeastPathways_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,6 +678,17 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002413_TREHALOSEPHOSPHA-RXN_SGD_PWY_YeastPathways_TRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0003825>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -674,11 +696,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_BFO_0000066_reaction_TREHALOSEPHOSPHA-RXN_location_lociGO_0005829_SGD_YeastPathways_TRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_BFO_0000066_reaction_TREHALOSEPHOSPHA-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -693,11 +715,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_BFO_0000050_YeastPathways_TRESYN-PWY/YeastPathways_TRESYN-PWY_SGD_YeastPathways_TRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_BFO_0000050_YeastPathways_TRESYN-PWY/YeastPathways_TRESYN-PWY_SGD_PWY_YeastPathways_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,6 +729,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_TRESYN-PWY/YeastPathways_TRESYN-PWY>
 ] .
+
+<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002233_CHEBI_4170_TREHALOSE6PSYN-RXN_SGD_PWY_YeastPathways_TRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002233_CHEBI_15377_TREHALOSEPHOSPHA-RXN_SGD_PWY_YeastPathways_TRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -726,24 +770,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRESYN-PWYSmallMolecule67249> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002233_CHEBI_4170_TREHALOSE6PSYN-RXN_SGD_YeastPathways_TRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58429>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -755,11 +788,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002333_YDR074W-MONOMER_TREHALOSEPHOSPHA-RXN_controller_SGD_YeastPathways_TRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002333_YDR074W-MONOMER_TREHALOSEPHOSPHA-RXN_controller_SGD_PWY_YeastPathways_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -774,11 +807,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002234_CHEBI_58223_TREHALOSE6PSYN-RXN_SGD_YeastPathways_TRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002234_CHEBI_58223_TREHALOSE6PSYN-RXN_SGD_PWY_YeastPathways_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -789,26 +822,15 @@
           <http://model.geneontology.org/CHEBI_58223_TREHALOSE6PSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002333_YBR126C-MONOMER_TREHALOSE6PSYN-RXN_controller_SGD_YeastPathways_TRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_BFO_0000050_YeastPathways_TRESYN-PWY/YeastPathways_TRESYN-PWY_SGD_YeastPathways_TRESYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_BFO_0000050_YeastPathways_TRESYN-PWY/YeastPathways_TRESYN-PWY_SGD_PWY_YeastPathways_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,25 +846,3 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002413_TREHALOSEPHOSPHA-RXN_SGD_YeastPathways_TRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002233_CHEBI_58885_TREHALOSE6PSYN-RXN_SGD_YeastPathways_TRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_TRIGLSYN-PWY.ttl
+++ b/models/YeastPathways_TRIGLSYN-PWY.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_57287_RXN-1623_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_57287_RXN-1623_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,26 +17,15 @@
           <http://model.geneontology.org/CHEBI_57287_RXN-1623>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12383_BFO_0000066_reaction_RXN-12383_location_lociGO_0005829_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12959_BFO_0000066_reaction_RXN-12959_location_lociGO_0005829_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12959_BFO_0000066_reaction_RXN-12959_location_lociGO_0005829_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -47,14 +36,14 @@
           <http://model.geneontology.org/reaction_RXN-12959_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002233_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY>
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002234_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -62,11 +51,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002333_YOR245C-MONOMER_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_controller_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002333_YOR245C-MONOMER_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,25 +66,25 @@
           <http://model.geneontology.org/YOR245C-MONOMER_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002413_RXN-12383_SGD_YeastPathways_TRIGLSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002413_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002234_CHEBI_58069_RXN-12959_SGD_YeastPathways_TRIGLSYN-PWY>
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -111,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "diacylglycerol and triacylglycerol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -126,11 +115,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002234_CHEBI_64615_RXN-1641_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002234_CHEBI_64615_RXN-1641_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -141,15 +130,26 @@
           <http://model.geneontology.org/CHEBI_64615_RXN-1641>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1381_BFO_0000066_reaction_RXN-1381_location_lociGO_0005829_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1381_BFO_0000066_reaction_RXN-1381_location_lociGO_0005829_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -160,14 +160,14 @@
           <http://model.geneontology.org/reaction_RXN-1381_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002233_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-1641_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -175,11 +175,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002333_MONOMER3O-4125_PHOSPHATIDATE-PHOSPHATASE-RXN_controller_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002333_MONOMER3O-4125_PHOSPHATIDATE-PHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -190,17 +190,6 @@
           <http://model.geneontology.org/MONOMER3O-4125_PHOSPHATIDATE-PHOSPHATASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_57287_RXN-1623_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58069>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -209,7 +198,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002233_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -222,13 +222,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRIGLSYN-PWYSmallMolecule56398> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002233_CHEBI_37563_RXN-12959_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YDR284C-MONOMER_PHOSPHATIDATE-PHOSPHATASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000002692> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -237,7 +248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -260,13 +271,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRIGLSYN-PWYSmallMolecule56398> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12383_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16975>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -275,11 +297,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -290,15 +312,26 @@
           <http://model.geneontology.org/YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-1381_BFO_0000066_reaction_RXN-1381_location_lociGO_0005829_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12383_BFO_0000066_reaction_RXN-12383_location_lociGO_0005829_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12383_BFO_0000066_reaction_RXN-12383_location_lociGO_0005829_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,6 +342,17 @@
           <http://model.geneontology.org/reaction_RXN-12383_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002333_YDR284C-MONOMER_PHOSPHATIDATE-PHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -316,11 +360,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_BFO_0000066_reaction_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_BFO_0000066_reaction_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -358,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -366,14 +410,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002234_CHEBI_43474_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002233_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -384,11 +428,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1641_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1641_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,15 +443,26 @@
           <http://model.geneontology.org/YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_BFO_0000066_reaction_PHOSPHATIDATE-PHOSPHATASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002234_CHEBI_15378_RXN-12959_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002234_CHEBI_15378_RXN-12959_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -427,57 +482,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRIGLSYN-PWYSmallMolecule56462> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002333_MONOMER3O-4095_RXN-1381_controller_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000066_reaction_RXN-1623_location_lociGO_0005829_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002234_CHEBI_64615_RXN-1641_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_64615>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -488,21 +499,65 @@
 <http://purl.obolibrary.org/obo/CHEBI_57597>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_BFO_0000066_reaction_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16110>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_29089_RXN-1623_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000002210>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002233_CHEBI_17984_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002234_CHEBI_58069_RXN-12959_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002234_CHEBI_16975_RXN-1381_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002234_CHEBI_16975_RXN-1381_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,17 +568,6 @@
           <http://model.geneontology.org/CHEBI_16975_RXN-1381>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-1381_BFO_0000066_reaction_RXN-1381_location_lociGO_0005829_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -531,11 +575,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a 1,2-diacyl-<i>sn</i>-glycerol 3-phosphate + H<sub>2</sub>O &rarr; a 1,2-diacyl-<i>sn</i>-glycerol + phosphate' 'null' 'a 1,2-diacyl-<i>sn</i>-glycerol + an acyl-CoA &rarr; a triacyl-<i>sn</i>-glycerol + coenzyme A' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002413_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002413_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -556,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -581,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -596,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -604,14 +648,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002413_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002234_CHEBI_64615_RXN-1641_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002333_MONOMER3O-4125_PHOSPHATIDATE-PHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002233_CHEBI_57597_RXN-1381_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -619,11 +685,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_17984_RXN-1623_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_17984_RXN-1623_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -638,11 +704,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12383_RO_0002234_CHEBI_64615_RXN-12383_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12383_RO_0002234_CHEBI_64615_RXN-12383_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,11 +726,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -675,6 +741,17 @@
           <http://model.geneontology.org/CHEBI_57287_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002234_CHEBI_17504_RXN-1641_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0008195>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -682,11 +759,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002233_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002233_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -704,11 +781,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" , "Provides Input For Rule. The relation 'CTP + a 1,2-diacyl-<i>sn</i>-glycerol &rarr; CDP + a 1,2-diacyl-<i>sn</i>-glycerol 3-phosphate + H<SUP>+</SUP>' 'null' 'a 1,2-diacyl-<i>sn</i>-glycerol 3-phosphate + H<sub>2</sub>O &rarr; a 1,2-diacyl-<i>sn</i>-glycerol + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002413_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002413_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -719,26 +796,15 @@
           <http://model.geneontology.org/PHOSPHATIDATE-PHOSPHATASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002234_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002234_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,33 +815,27 @@
           <http://model.geneontology.org/CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002233_CHEBI_29089_RXN-12959_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-12383_BFO_0000066_reaction_RXN-12383_location_lociGO_0005829_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_17984_RXN-1623>
-        a       <http://purl.obolibrary.org/obo/CHEBI_17984> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an acyl-CoA" ;
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002413_RXN-1641_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRIGLSYN-PWYSmallMolecule56374> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-12959>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -786,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -794,17 +854,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57287>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002413_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/CHEBI_17984_RXN-1623>
+        a       <http://purl.obolibrary.org/obo/CHEBI_17984> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an acyl-CoA" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRIGLSYN-PWYSmallMolecule56374> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57287>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002413_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -817,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -842,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -870,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -878,15 +955,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_16975_RXN-1381_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002333_MONOMER3O-4105_RXN-1381_controller_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002333_MONOMER3O-4105_RXN-1381_controller_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -912,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -924,11 +1012,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a 1,2-diacyl-<i>sn</i>-glycerol 3-phosphate + H<sub>2</sub>O &rarr; a 1,2-diacyl-<i>sn</i>-glycerol + phosphate' 'null' 'a phosphatidylcholine + a 1,2-diacyl-<i>sn</i>-glycerol &rarr; a triacyl-<i>sn</i>-glycerol + a 1-acyl-<i>sn</i>-glycero-3-phosphocholine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002413_RXN-1641_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002413_RXN-1641_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -951,24 +1039,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRIGLSYN-PWYSmallMolecule56326> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002233_CHEBI_15377_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-1623>
         a       <http://purl.obolibrary.org/obo/GO_0003841> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -989,7 +1066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -997,39 +1074,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002333_YDL052C-MONOMER_RXN-1623_controller_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002333_MONOMER3O-4125_PHOSPHATIDATE-PHOSPHATASE-RXN_controller_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002234_CHEBI_57287_RXN-1381_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002233_CHEBI_15377_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1052,7 +1107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1060,40 +1115,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000001775>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002333_YNR008W-MONOMER_RXN-1641_controller_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002333_YDL052C-MONOMER_RXN-1623_controller_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002333_YDL052C-MONOMER_RXN-1623_controller_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1104,37 +1134,18 @@
           <http://model.geneontology.org/YDL052C-MONOMER_RXN-1623_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_BFO_0000066_reaction_PHOSPHATIDATE-PHOSPHATASE-RXN_location_lociGO_0005829_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_17984_RXN-1623_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000001775>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002233_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002233_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1148,14 +1159,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_37563>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002333_YOR245C-MONOMER_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_controller_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002234_CHEBI_15378_RXN-12959_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1163,11 +1174,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1178,14 +1189,36 @@
           <http://model.geneontology.org/YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12383_RO_0002234_CHEBI_64615_RXN-12383_SGD_YeastPathways_TRIGLSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002233_CHEBI_16110_RXN-1641_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12959_BFO_0000066_reaction_RXN-12959_location_lociGO_0005829_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_17984_RXN-1623_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1197,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1205,11 +1238,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002333_YNR008W-MONOMER_RXN-1641_controller_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002333_YNR008W-MONOMER_RXN-1641_controller_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1224,11 +1257,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002233_CHEBI_17984_RXN-1381_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002233_CHEBI_17984_RXN-1381_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1239,34 +1272,12 @@
           <http://model.geneontology.org/CHEBI_17984_RXN-1381>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002333_YDR503C-MONOMER_PHOSPHATIDATE-PHOSPHATASE-RXN_controller_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN-1381_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002413_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1274,11 +1285,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002333_YDR284C-MONOMER_PHOSPHATIDATE-PHOSPHATASE-RXN_controller_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002333_YDR284C-MONOMER_PHOSPHATIDATE-PHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1289,19 +1300,19 @@
           <http://model.geneontology.org/YDR284C-MONOMER_PHOSPHATIDATE-PHOSPHATASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12959_BFO_0000066_reaction_RXN-12959_location_lociGO_0005829_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002234_CHEBI_57287_RXN-1381_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YDR503C-MONOMER_PHOSPHATIDATE-PHOSPHATASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000002911> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1310,7 +1321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1318,14 +1329,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002413_RXN-12959_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_RXN-12959_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002413_RXN-12383_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1336,7 +1358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1353,14 +1375,14 @@
 <http://identifiers.org/sgd/S000005771>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-1641_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002333_YOR245C-MONOMER_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_controller_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1371,11 +1393,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000066_reaction_RXN-1623_location_lociGO_0005829_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000066_reaction_RXN-1623_location_lociGO_0005829_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1386,12 +1408,23 @@
           <http://model.geneontology.org/reaction_RXN-1623_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002333_YDR503C-MONOMER_PHOSPHATIDATE-PHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-1623_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1399,11 +1432,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12383_RO_0002233_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12383_RO_0002233_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1421,11 +1454,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002233_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002233_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1445,7 +1478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1453,38 +1486,60 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002413_RXN-1623_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_PHOSPHATIDATE-PHOSPHATASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002234_CHEBI_64615_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-1641_BFO_0000066_reaction_RXN-1641_location_lociGO_0005829_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002233_CHEBI_37563_RXN-12959_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1641_BFO_0000066_reaction_RXN-1641_location_lociGO_0005829_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1641_BFO_0000066_reaction_RXN-1641_location_lociGO_0005829_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1499,11 +1554,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002234_CHEBI_29089_RXN-12959_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002234_CHEBI_29089_RXN-12959_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1521,11 +1576,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002233_CHEBI_15377_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002233_CHEBI_15377_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1536,34 +1591,34 @@
           <http://model.geneontology.org/CHEBI_15377_PHOSPHATIDATE-PHOSPHATASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002234_CHEBI_43474_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002234_CHEBI_64615_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002234_CHEBI_15378_RXN-12959_SGD_YeastPathways_TRIGLSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002333_YNR008W-MONOMER_RXN-1641_controller_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1571,11 +1626,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002234_CHEBI_57287_RXN-1381_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002234_CHEBI_57287_RXN-1381_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1586,15 +1641,37 @@
           <http://model.geneontology.org/CHEBI_57287_RXN-1381>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_57287_RXN-1623_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002234_CHEBI_29089_RXN-12959_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" , "Provides Input For Rule. The relation 'a 1,2-diacyl-<i>sn</i>-glycerol 3-phosphate + H<sub>2</sub>O &rarr; a 1,2-diacyl-<i>sn</i>-glycerol + phosphate' 'null' '2 a 1,2-diacyl-<i>sn</i>-glycerol &harr; a triacyl-<i>sn</i>-glycerol + a 2-acylglycerol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002413_RXN-12383_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002413_RXN-12383_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1612,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1629,7 +1706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1637,47 +1714,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-12383_RO_0002234_CHEBI_17389_RXN-12383_SGD_YeastPathways_TRIGLSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000066_reaction_RXN-1623_location_lociGO_0005829_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12959_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002234_CHEBI_16975_RXN-1381_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002234_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1690,7 +1734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1702,11 +1746,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_29089_RXN-1623_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_29089_RXN-1623_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1717,26 +1761,15 @@
           <http://model.geneontology.org/CHEBI_29089_RXN-1623>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002233_CHEBI_16110_RXN-1641_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12959_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12959_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1747,14 +1780,14 @@
           <http://model.geneontology.org/YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002333_MONOMER3O-4095_RXN-1381_controller_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1765,7 +1798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1777,11 +1810,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002234_CHEBI_64615_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002234_CHEBI_64615_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1798,6 +1831,17 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002333_YDL052C-MONOMER_RXN-1623_controller_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1810,7 +1854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1825,11 +1869,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002234_CHEBI_17504_RXN-1641_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002234_CHEBI_17504_RXN-1641_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1844,11 +1888,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1381_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1381_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1857,36 +1901,6 @@
           <http://model.geneontology.org/RXN-1381> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002333_MONOMER3O-4105_RXN-1381_controller_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002234_CHEBI_43474_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSPHATIDATE-PHOSPHATASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_PHOSPHATIDATE-PHOSPHATASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16975_RXN-1381>
@@ -1898,7 +1912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1906,52 +1920,38 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002233_CHEBI_57597_RXN-1381_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002234_CHEBI_43474_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PHOSPHATIDATE-PHOSPHATASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_PHOSPHATIDATE-PHOSPHATASE-RXN>
+] .
 
-<http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_BFO_0000066_reaction_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_location_lociGO_0005829_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002413_RXN-12959_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12383_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0019432>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002233_CHEBI_17984_RXN-1381_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1965,7 +1965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1985,7 +1985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2000,11 +2000,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'an acyl-CoA + <i>sn</i>-glycerol 3-phosphate &rarr; a 1-acyl-<i>sn</i>-glycerol 3-phosphate + coenzyme A' 'null' 'an acyl-CoA + a 1-acyl-<i>sn</i>-glycerol 3-phosphate &rarr; a 1,2-diacyl-<i>sn</i>-glycerol 3-phosphate + coenzyme A' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002413_RXN-1623_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002413_RXN-1623_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2015,15 +2015,26 @@
           <http://model.geneontology.org/RXN-1623>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-12383_RO_0002234_CHEBI_17389_RXN-12383_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12383_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12383_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2034,14 +2045,14 @@
           <http://model.geneontology.org/YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-12383_RO_0002233_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-1381_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2049,11 +2060,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2067,6 +2078,17 @@
 <http://purl.obolibrary.org/obo/GO_0046027>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002233_CHEBI_17984_RXN-1381_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17815> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2076,7 +2098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2084,26 +2106,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002413_RXN-1623_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" , "Provides Input For Rule. The relation 'an acyl-CoA + a 1-acyl-<i>sn</i>-glycerol 3-phosphate &rarr; a 1,2-diacyl-<i>sn</i>-glycerol 3-phosphate + coenzyme A' 'null' 'a 1,2-diacyl-<i>sn</i>-glycerol 3-phosphate + H<sub>2</sub>O &rarr; a 1,2-diacyl-<i>sn</i>-glycerol + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002413_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002413_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2118,11 +2129,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002233_CHEBI_37563_RXN-12959_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002233_CHEBI_37563_RXN-12959_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2142,7 +2153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2150,37 +2161,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002234_CHEBI_29089_RXN-1623_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002233_CHEBI_17984_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_BFO_0000066_reaction_PHOSPHATIDATE-PHOSPHATASE-RXN_location_lociGO_0005829_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_BFO_0000066_reaction_PHOSPHATIDATE-PHOSPHATASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2191,29 +2180,40 @@
           <http://model.geneontology.org/reaction_PHOSPHATIDATE-PHOSPHATASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002234_CHEBI_17504_RXN-1641_SGD_YeastPathways_TRIGLSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-12383_RO_0002233_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004144>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002233_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002233_CHEBI_57597_RXN-1381_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002233_CHEBI_57597_RXN-1381_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2224,15 +2224,26 @@
           <http://model.geneontology.org/CHEBI_57597_RXN-1381>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002333_YDR503C-MONOMER_PHOSPHATIDATE-PHOSPHATASE-RXN_controller_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002333_YDR503C-MONOMER_PHOSPHATIDATE-PHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2249,26 +2260,48 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002234_CHEBI_29089_RXN-12959_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002234_CHEBI_16975_RXN-1381_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-12383_RO_0002234_CHEBI_64615_RXN-12383_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-12383_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2276,11 +2309,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_16975_RXN-1381_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_16975_RXN-1381_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2295,11 +2328,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12383_RO_0002234_CHEBI_17389_RXN-12383_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12383_RO_0002234_CHEBI_17389_RXN-12383_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2319,7 +2352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2327,14 +2360,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002333_YDR284C-MONOMER_PHOSPHATIDATE-PHOSPHATASE-RXN_controller_SGD_YeastPathways_TRIGLSYN-PWY>
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002233_CHEBI_29089_RXN-12959_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2342,11 +2375,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002233_CHEBI_17984_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002233_CHEBI_17984_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2366,7 +2399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2374,19 +2407,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002233_CHEBI_16975_RXN-1381_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_17815>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002413_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_17815>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YNR008W-MONOMER_RXN-1641_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005291> ;
@@ -2395,7 +2428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2407,11 +2440,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002233_CHEBI_16110_RXN-1641_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1641_RO_0002233_CHEBI_16110_RXN-1641_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2431,7 +2464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2443,11 +2476,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002234_CHEBI_58069_RXN-12959_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002234_CHEBI_58069_RXN-12959_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2462,11 +2495,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002233_CHEBI_29089_RXN-12959_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002233_CHEBI_29089_RXN-12959_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2477,17 +2510,6 @@
           <http://model.geneontology.org/CHEBI_29089_RXN-12959>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002413_RXN-1641_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_17389_RXN-12383>
         a       <http://purl.obolibrary.org/obo/CHEBI_17389> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2497,7 +2519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2505,29 +2527,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-1381_BFO_0000050_YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/CHEBI_17389>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002333_MONOMER3O-4105_RXN-1381_controller_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
+                "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_17389>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002333_MONOMER3O-4095_RXN-1381_controller_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002333_MONOMER3O-4095_RXN-1381_controller_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2542,11 +2564,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" , "Provides Input For Rule. The relation 'a 1,2-diacyl-<i>sn</i>-glycerol 3-phosphate + H<sub>2</sub>O &rarr; a 1,2-diacyl-<i>sn</i>-glycerol + phosphate' 'null' 'CTP + a 1,2-diacyl-<i>sn</i>-glycerol &rarr; CDP + a 1,2-diacyl-<i>sn</i>-glycerol 3-phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002413_RXN-12959_SGD_YeastPathways_TRIGLSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002413_RXN-12959_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2559,28 +2581,6 @@
 
 <http://identifiers.org/sgd/S000005291>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-1641_BFO_0000066_reaction_RXN-1641_location_lociGO_0005829_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002233_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_YeastPathways_TRIGLSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PHOSPHATIDATE-PHOSPHATASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008195> ;
@@ -2601,7 +2601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2618,7 +2618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_TRPSYN-PWY-1.ttl
+++ b/models/YeastPathways_TRPSYN-PWY-1.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '<i>N</i>-(5-phosphoribosyl)-anthranilate &rarr; 1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate' 'null' '1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate + H<SUP>+</SUP> &rarr; (1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + CO<SUB>2</SUB> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002413_IGPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002413_IGPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,11 +24,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_16567_ANTHRANSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_16567_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -42,19 +42,19 @@
 <http://purl.obolibrary.org/obo/CHEBI_18277>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000066_reaction_ANTHRANSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/GO_0000162>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
+                "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0000162>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -64,22 +64,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" , "Provides Input For Rule. The relation 'anthranilate + 5-phospho-&alpha;-D-ribose 1-diphosphate &rarr; <i>N</i>-(5-phosphoribosyl)-anthranilate + diphosphate' 'null' '<i>N</i>-(5-phosphoribosyl)-anthranilate &rarr; 1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -94,11 +105,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000066_reaction_IGPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000066_reaction_IGPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -109,23 +120,12 @@
           <http://model.geneontology.org/reaction_IGPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_IGPSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -134,17 +134,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002762>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -156,11 +145,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -171,15 +160,26 @@
           <http://model.geneontology.org/YGL026C-MONOMER_TRYPSYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000001694_CPLX3O-31_component_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -197,11 +197,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000066_reaction_ANTHRANSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000066_reaction_ANTHRANSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -212,6 +212,39 @@
           <http://model.geneontology.org/reaction_ANTHRANSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_16567_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000000892_CPLX3O-31_component_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_ANTHRANSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -221,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -232,20 +265,42 @@
 <http://purl.obolibrary.org/obo/GO_0004834>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/reaction_ANTHRANSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_IGPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -256,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -264,26 +319,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002413_PRTRANS-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_ANTHRANSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -294,17 +338,6 @@
           <http://model.geneontology.org/CHEBI_16567_ANTHRANSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29748_ANTHRANSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29748> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -314,24 +347,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRPSYN-PWY-1SmallMolecule71231> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15361_ANTHRANSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-31_ANTHRANSYN-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -342,13 +364,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRPSYN-PWY-1Complex71311> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
+
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_IGPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -359,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -371,11 +404,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_33384_TRYPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_33384_TRYPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -393,11 +426,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_15377_IGPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_15377_IGPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -411,17 +444,6 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRTRANS-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_TRYPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -431,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -439,51 +461,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000000892>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002413_TRYPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
+                "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000000892>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002234_CHEBI_58613_PRAISOM-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002234_CHEBI_58613_PRAISOM-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -493,17 +493,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58613_PRAISOM-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -517,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -529,11 +518,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15361_ANTHRANSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15361_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -544,14 +533,14 @@
           <http://model.geneontology.org/CHEBI_15361_ANTHRANSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_YeastPathways_TRPSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
+                "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -567,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -575,19 +564,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_33384>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_58613_PRAISOM-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_58017_PRTRANS-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
+                "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_33384>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -596,11 +585,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -621,7 +610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -633,11 +622,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000001694_CPLX3O-31_component_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000001694_CPLX3O-31_component_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,6 +636,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/SGD_S000001694_CPLX3O-31_component>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_29748_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002994>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -660,24 +660,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRPSYN-PWY-1SmallMolecule71245> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -704,7 +693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -716,11 +705,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -750,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -762,11 +751,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -807,19 +796,19 @@
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002333_YDR354W-MONOMER_PRTRANS-RXN_controller_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
+                "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/GO_0004640>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -841,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -849,14 +838,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_58017_PRTRANS-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
+                "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -864,11 +853,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -879,26 +868,15 @@
           <http://model.geneontology.org/YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000000892_CPLX3O-31_component_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_29985_ANTHRANSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_29985_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -918,7 +896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -935,7 +913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -943,29 +921,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002333_YDR007W-MONOMER_PRAISOM-RXN_controller_SGD_YeastPathways_TRPSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRTRANS-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
+                "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -985,7 +963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -993,15 +971,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1012,17 +1001,6 @@
           <http://model.geneontology.org/CHEBI_15378_IGPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002413_IGPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_33384_TRYPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33384> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1032,7 +1010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1047,7 +1025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1064,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1072,71 +1050,71 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002234_CHEBI_58613_PRAISOM-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
+                "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_29748_ANTHRANSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_15377_IGPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_IGPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_58613_PRAISOM-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_IGPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
+                "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1147,15 +1125,48 @@
           <http://model.geneontology.org/reaction_PRAISOM-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002333_CPLX3O-31_ANTHRANSYN-RXN_controller_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002234_CHEBI_58613_PRAISOM-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_29748_ANTHRANSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_29748_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1175,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-tryptophan biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1202,7 +1213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1210,26 +1221,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_58017_PRTRANS-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_58017_PRTRANS-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1243,18 +1246,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_59776>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002333_YDR007W-MONOMER_PRAISOM-RXN_controller_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'chorismate + L-glutamine &rarr; anthranilate + L-glutamate + pyruvate + H<SUP>+</SUP>' 'null' 'anthranilate + 5-phospho-&alpha;-D-ribose 1-diphosphate &rarr; <i>N</i>-(5-phosphoribosyl)-anthranilate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002413_PRTRANS-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002413_PRTRANS-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1265,12 +1276,45 @@
           <http://model.geneontology.org/PRTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002413_PRTRANS-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_PRAISOM-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1278,11 +1322,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_IGPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_58866_IGPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1300,7 +1344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1312,11 +1356,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1332,46 +1376,79 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15378_ANTHRANSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
+                "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001694>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_15377_IGPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15361_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_58359_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
+                "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004425>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000066_reaction_IGPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1379,11 +1456,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002333_YDR007W-MONOMER_PRAISOM-RXN_controller_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002333_YDR007W-MONOMER_PRAISOM-RXN_controller_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1394,26 +1471,15 @@
           <http://model.geneontology.org/YDR007W-MONOMER_PRAISOM-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_33384_TRYPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15378_ANTHRANSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15378_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1427,14 +1493,14 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000001694_CPLX3O-31_component_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002413_IGPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
+                "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1442,11 +1508,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002333_YDR354W-MONOMER_PRTRANS-RXN_controller_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002333_YDR354W-MONOMER_PRTRANS-RXN_controller_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1460,26 +1526,15 @@
 <http://purl.obolibrary.org/obo/GO_0004049>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002233_CHEBI_16567_ANTHRANSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1499,7 +1554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1519,7 +1574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1531,11 +1586,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1546,26 +1601,15 @@
           <http://model.geneontology.org/CHEBI_59776_TRYPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" , "Provides Input For Rule. The relation '1-(o-carboxyphenylamino)-1'-deoxyribulose 5'-phosphate + H<SUP>+</SUP> &rarr; (1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + CO<SUB>2</SUB> + H<sub>2</sub>O' 'null' '(1<i>S</i>,2<i>R</i>)-1-C-(indol-3-yl)glycerol 3-phosphate + L-serine &rarr; L-tryptophan + D-glyceraldehyde 3-phosphate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002413_TRYPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002413_TRYPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1580,11 +1624,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1595,54 +1639,32 @@
           <http://model.geneontology.org/YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15378_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
+                "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000002414>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002333_CPLX3O-31_ANTHRANSYN-RXN_controller_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1653,26 +1675,15 @@
           <http://model.geneontology.org/reaction_PRTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_57912_TRYPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002333_CPLX3O-31_ANTHRANSYN-RXN_controller_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002333_CPLX3O-31_ANTHRANSYN-RXN_controller_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1683,26 +1694,15 @@
           <http://model.geneontology.org/CPLX3O-31_ANTHRANSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1713,15 +1713,26 @@
           <http://model.geneontology.org/reaction_TRYPSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002413_TRYPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_58613_PRAISOM-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_58613_PRAISOM-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1738,50 +1749,28 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002413_PRAISOM-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000066_reaction_ANTHRANSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
+                "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_58359_ANTHRANSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_29985_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000066_reaction_PRAISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_29985_ANTHRANSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
+                "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1790,7 +1779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1803,7 +1792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1815,11 +1804,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRTRANS-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRAISOM-RXN_RO_0002233_CHEBI_18277_PRTRANS-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1837,11 +1826,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_58359_ANTHRANSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_58359_ANTHRANSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1864,7 +1853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1881,7 +1870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1892,12 +1881,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_57912>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_BFO_0000066_reaction_IGPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000000892_CPLX3O-31_component>
         a       <http://identifiers.org/sgd/S000000892> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1905,11 +1905,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1924,11 +1924,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000000892_CPLX3O-31_component_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-31_ANTHRANSYN-RXN_controller_BFO_0000051_SGD_S000000892_CPLX3O-31_component_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1939,6 +1939,17 @@
           <http://model.geneontology.org/SGD_S000000892_CPLX3O-31_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002233_CHEBI_33384_TRYPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YDR007W-MONOMER_PRAISOM-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002414> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1946,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1958,11 +1969,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1973,15 +1984,26 @@
           <http://model.geneontology.org/CHEBI_15377_TRYPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRPSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1995,19 +2017,16 @@
 <http://purl.obolibrary.org/obo/CHEBI_16567>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PRAISOM-RXN_BFO_0000050_YeastPathways_TRPSYN-PWY-1/YeastPathways_TRPSYN-PWY-1_SGD_YeastPathways_TRPSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_PWY_YeastPathways_TRPSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
+                "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_15361>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_29888_PRTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2018,7 +2037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2026,24 +2045,5 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_16567_ANTHRANSYN-RXN_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002333_YDR354W-MONOMER_PRTRANS-RXN_controller_SGD_YeastPathways_TRPSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRPSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15361>
+        a       <http://www.w3.org/2002/07/owl#Class> .

--- a/models/YeastPathways_TRYPTOPHAN-DEGRADATION-1.ttl
+++ b/models/YeastPathways_TRYPTOPHAN-DEGRADATION-1.ttl
@@ -1,23 +1,12 @@
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -44,11 +33,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -86,11 +75,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -101,47 +90,8 @@
           <http://model.geneontology.org/CHEBI_57959_ARYLFORMAMIDASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000003242>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66650> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -152,7 +102,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66650> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -169,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -180,8 +147,16 @@
 <http://purl.obolibrary.org/obo/CHEBI_16675>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_58017_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58437_NICONUCADENYLYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58437> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -192,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -203,26 +178,18 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,26 +200,15 @@
           <http://model.geneontology.org/CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_1.13.11.6-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_1.13.11.6-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,26 +219,15 @@
           <http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -293,26 +238,15 @@
           <http://model.geneontology.org/reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -323,6 +257,17 @@
           <http://model.geneontology.org/CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -332,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -352,7 +297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -366,6 +311,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29888_QUINOPRIBOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -375,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -390,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -402,11 +358,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -417,15 +373,26 @@
           <http://model.geneontology.org/CHEBI_58629_RXN-8665>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" , "Provides Input For Rule. The relation '&beta;-nicotinate D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; nicotinate adenine dinucleotide + diphosphate' 'null' 'ATP + nicotinate adenine dinucleotide + L-glutamine + H<sub>2</sub>O &rarr; L-glutamate + AMP + NAD<sup>+</sup> + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -436,32 +403,15 @@
           <http://model.geneontology.org/NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_58629_RXN-8665>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58629> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "<i>N</i>-Formyl-L-kynurenine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66814> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -481,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -489,27 +439,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_58629_RXN-8665>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58629> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "<i>N</i>-Formyl-L-kynurenine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66814> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -518,11 +463,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -533,17 +478,6 @@
           <http://model.geneontology.org/reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000002836> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -551,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -559,14 +493,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_16675_RXN-5721_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -576,25 +532,44 @@
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.13.11.6-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -617,32 +592,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1BiochemicalReaction66824> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.13.11.6-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN>
-] .
 
 <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004502> ;
@@ -663,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -671,26 +627,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -701,26 +646,15 @@
           <http://model.geneontology.org/CHEBI_57502_QUINOPRIBOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -731,34 +665,12 @@
           <http://model.geneontology.org/CHEBI_29985_NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_1.13.11.6-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -771,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -779,14 +691,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_16675_RXN-5721_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -799,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -807,14 +719,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -822,11 +734,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -837,18 +749,40 @@
           <http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2-amino-3-carboxymuconate-6-semialdehyde &rarr; quinolinate + H<sub>2</sub>O' 'null' 'CO<SUB>2</SUB> + &beta;-nicotinate D-ribonucleotide + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + quinolinate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002413_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002413_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -859,33 +793,14 @@
           <http://model.geneontology.org/QUINOPRIBOTRANS-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57502_QUINOPRIBOTRANS-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -896,11 +811,41 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57502_QUINOPRIBOTRANS-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -910,6 +855,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -923,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -931,53 +887,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000002836>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_36559>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_RXN-8665_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -985,11 +919,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1003,15 +937,26 @@
 <http://purl.obolibrary.org/obo/GO_0004061>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1022,40 +967,18 @@
           <http://model.geneontology.org/CHEBI_15378_QUINOPRIBOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000001943>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1069,15 +992,30 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003596> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Kynurenine aminotransferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66962> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1088,55 +1026,73 @@
           <http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN>
 ] .
 
-<http://model.geneontology.org/YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003596> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Kynurenine aminotransferase" ;
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66962> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1147,15 +1103,26 @@
           <http://model.geneontology.org/YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1166,6 +1133,17 @@
           <http://model.geneontology.org/YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1173,11 +1151,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002333_MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1197,7 +1175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1209,11 +1187,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000066_reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1229,18 +1207,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1250,37 +1228,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_1.13.11.6-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>' 'null' '3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1298,11 +1254,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1320,11 +1276,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1335,14 +1291,14 @@
           <http://model.geneontology.org/YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1355,7 +1311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1367,11 +1323,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1401,7 +1357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1416,7 +1372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1424,43 +1380,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+<http://purl.obolibrary.org/obo/GO_0003952>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0003952>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -1471,7 +1435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1479,38 +1443,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/RXN-8665>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0033754> ;
@@ -1531,7 +1465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1539,36 +1473,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1576,11 +1499,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1591,14 +1514,14 @@
           <http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1606,11 +1529,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_16526_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1621,15 +1544,37 @@
           <http://model.geneontology.org/CHEBI_16526_QUINOPRIBOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_15378_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1640,17 +1585,6 @@
           <http://model.geneontology.org/CHEBI_15378_NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57972> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1660,7 +1594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1672,11 +1606,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1687,25 +1621,14 @@
           <http://model.geneontology.org/MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1719,11 +1642,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1753,7 +1676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1765,11 +1688,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1784,11 +1707,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1799,6 +1722,17 @@
           <http://model.geneontology.org/CHEBI_15378_NICONUCADENYLYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1808,7 +1742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1816,15 +1750,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_15378_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1835,22 +1780,33 @@
           <http://model.geneontology.org/CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000066_reaction_NICONUCADENYLYLTRAN-RXN_location_lociGO_0005829_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004514>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1858,14 +1814,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1878,24 +1834,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66675> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1904,11 +1849,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002333_YJR078W-MONOMER_RXN-8665_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1922,15 +1867,26 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1945,11 +1901,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1969,7 +1925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1977,32 +1933,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15740> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "formate" ;
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66949> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2013,19 +1963,25 @@
           <http://model.geneontology.org/CHEBI_15377_ARYLFORMAMIDASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_30616>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_RXN-8665_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15740> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "formate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66949> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_30616>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0019442>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2033,8 +1989,16 @@
 <http://purl.obolibrary.org/obo/GO_0033754>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_58349>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004320> ;
@@ -2043,7 +2007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2051,32 +2015,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://purl.obolibrary.org/obo/CHEBI_58349>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0030429>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2087,15 +2043,26 @@
           <http://model.geneontology.org/YJR025C-MONOMER_1.13.11.6-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2110,11 +2077,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2125,26 +2092,15 @@
           <http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" , "Provides Input For Rule. The relation '<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>' 'null' 'L-kynurenine + NADPH + oxygen + H<SUP>+</SUP> &rarr; 3-hydroxy-L-kynurenine + NADP<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2155,25 +2111,80 @@
           <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002413_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2186,7 +2197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2198,11 +2209,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2213,26 +2224,15 @@
           <http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2247,11 +2247,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_29888_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2266,11 +2266,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2281,17 +2281,6 @@
           <http://model.geneontology.org/CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57783_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_NAD-SYNTH-GLN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2301,33 +2290,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66576> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_1.13.11.6-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2338,7 +2307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2346,36 +2315,45 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/reaction_KYNURENINE-3-MONOOXYGENASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002233_CHEBI_994_1.13.11.6-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2388,7 +2366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2400,11 +2378,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000066_reaction_1.13.11.6-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2419,11 +2397,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16675_RXN-5721_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16675_RXN-5721_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2438,11 +2416,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2453,6 +2431,17 @@
           <http://model.geneontology.org/CHEBI_58359_NAD-SYNTH-GLN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_15377_RXN-5721_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER3O-845_NAD-SYNTH-GLN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001116> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2460,7 +2449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2472,11 +2461,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2487,31 +2476,31 @@
           <http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000003596>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+<http://identifiers.org/sgd/S000003596>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16675_RXN-5721_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2524,7 +2513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2532,46 +2521,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829>
-] .
 
 <http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456215> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2582,13 +2552,43 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66735> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002333_YFR047C-MONOMER_QUINOPRIBOTRANS-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_NAD-SYNTH-GLN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2599,7 +2599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2611,11 +2611,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2626,15 +2626,37 @@
           <http://model.geneontology.org/reaction_RXN-5721_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2654,13 +2676,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66702> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
+] .
 
 <http://model.geneontology.org/RXN-5721>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2679,7 +2720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2687,27 +2728,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
-] .
-
 <http://identifiers.org/sgd/S000004221>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002234_CHEBI_58629_RXN-8665_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
@@ -2718,7 +2762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2726,25 +2770,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2758,7 +2791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2766,26 +2799,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2815,7 +2837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2832,7 +2854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2844,11 +2866,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2866,11 +2888,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" , "Provides Input For Rule. The relation 'L-kynurenine + NADPH + oxygen + H<SUP>+</SUP> &rarr; 3-hydroxy-L-kynurenine + NADP<sup>+</sup> + H<sub>2</sub>O' 'null' '3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002413_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2881,15 +2903,24 @@
           <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
+<http://model.geneontology.org/reaction_RXN-8665_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2900,50 +2931,41 @@
           <http://model.geneontology.org/YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1>
 ] .
 
-<http://model.geneontology.org/reaction_RXN-8665_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002413_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57972>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_NICONUCADENYLYLTRAN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -2954,7 +2976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2962,15 +2984,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_15378_1.13.11.6-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2988,7 +3021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3000,11 +3033,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002234_CHEBI_29888_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3015,15 +3048,30 @@
           <http://model.geneontology.org/CHEBI_29888_QUINOPRIBOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004221> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Kynureninase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66880> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29888_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3033,32 +3081,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_29888_NAD-SYNTH-GLN-RXN>
 ] .
-
-<http://model.geneontology.org/YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004221> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Kynureninase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1Protein66880> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/NAD-SYNTH-GLN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003952> ;
@@ -3077,7 +3099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3089,11 +3111,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3103,6 +3125,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57959>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3129,7 +3162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3137,37 +3170,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_BFO_0000066_reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_15378_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3182,11 +3193,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_16675_RXN-5721_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002234_CHEBI_16675_RXN-5721_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3197,15 +3208,26 @@
           <http://model.geneontology.org/CHEBI_16675_RXN-5721>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3220,11 +3242,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3247,7 +3269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3255,31 +3277,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004515>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3292,7 +3314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3309,14 +3331,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002413_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3324,11 +3346,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-tryptophan + oxygen &rarr; <i>N</i>-Formyl-L-kynurenine' 'null' '<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3343,11 +3365,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3358,15 +3380,26 @@
           <http://model.geneontology.org/reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_15377_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3377,39 +3410,6 @@
           <http://model.geneontology.org/CHEBI_15377_NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3419,7 +3419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3427,18 +3427,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0004502>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_RXN-8665_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_RXN-8665_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3448,17 +3445,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58629_RXN-8665>
 ] .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003786>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3472,7 +3458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3489,7 +3475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-tryptophan degradation III (eukaryotic) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3497,50 +3483,42 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004502>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_NAD-SYNTH-GLN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16675_RXN-5721_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57912>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3549,11 +3527,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>' 'null' '2-amino-3-carboxymuconate-6-semialdehyde &rarr; quinolinate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002413_RXN-5721_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3568,11 +3546,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" , "Provides Input For Rule. The relation 'CO<SUB>2</SUB> + &beta;-nicotinate D-ribonucleotide + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + quinolinate + 2 H<SUP>+</SUP>' 'null' '&beta;-nicotinate D-ribonucleotide + ATP + H<SUP>+</SUP> &rarr; nicotinate adenine dinucleotide + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002413_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3587,11 +3565,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_57540_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3606,11 +3584,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3621,17 +3599,6 @@
           <http://model.geneontology.org/YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15740_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YJR025C-MONOMER_1.13.11.6-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003786> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3639,7 +3606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3647,14 +3614,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3662,11 +3640,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002333_YLR231C-MONOMER_3-HYDROXY-KYNURENINASE-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3684,7 +3662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3696,11 +3674,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3711,15 +3689,26 @@
           <http://model.geneontology.org/reaction_RXN-8665_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002413_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3730,15 +3719,26 @@
           <http://model.geneontology.org/CHEBI_58437_NICONUCADENYLYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3764,24 +3764,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66622> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16675_RXN-5721>
         a       <http://purl.obolibrary.org/obo/CHEBI_16675> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3792,13 +3781,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66562> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15379> ;
@@ -3809,7 +3809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3822,7 +3822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3830,11 +3830,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002233_CHEBI_15379_1.13.11.6-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_UDPNAGSYN-YEAST-PWY.ttl
+++ b/models/YeastPathways_UDPNAGSYN-YEAST-PWY.ttl
@@ -1,22 +1,11 @@
-<http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_RO_0002233_CHEBI_57513_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_BFO_0000066_reaction_NAG1P-URIDYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002233_CHEBI_57634_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -24,11 +13,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_RO_0002333_YEL058W-MONOMER_PHOSACETYLGLUCOSAMINEMUT-RXN_controller_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_RO_0002333_YEL058W-MONOMER_PHOSACETYLGLUCOSAMINEMUT-RXN_controller_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,17 +28,28 @@
           <http://model.geneontology.org/YEL058W-MONOMER_PHOSACETYLGLUCOSAMINEMUT-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004610>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002233_CHEBI_57776_PHOSACETYLGLUCOSAMINEMUT-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002413_PHOSACETYLGLUCOSAMINEMUT-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004610>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -60,11 +60,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_f422f81c-6047-4082-bbc0-cc96005ca1fa_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_2bc4a77d-96f2-4dec-843f-938795185fdf_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,19 +72,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f422f81c-6047-4082-bbc0-cc96005ca1fa_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
+          <http://model.geneontology.org/2bc4a77d-96f2-4dec-843f-938795185fdf_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002233_CHEBI_46398_NAG1P-URIDYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29888_NAG1P-URIDYLTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -95,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,11 +96,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002234_CHEBI_15378_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002234_CHEBI_15378_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -126,11 +115,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_RO_0002233_CHEBI_57513_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_RO_0002233_CHEBI_57513_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,14 +142,14 @@
 <http://purl.obolibrary.org/obo/GO_0003977>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002234_CHEBI_15378_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002234_CHEBI_57287_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -168,11 +157,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002233_CHEBI_57776_PHOSACETYLGLUCOSAMINEMUT-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002233_CHEBI_57776_PHOSACETYLGLUCOSAMINEMUT-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -186,33 +175,44 @@
 <http://purl.obolibrary.org/obo/CHEBI_57776>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_RO_0002333_YEL058W-MONOMER_PHOSACETYLGLUCOSAMINEMUT-RXN_controller_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_BFO_0000066_reaction_GLUCOSAMINEPNACETYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002333_YDL103C-MONOMER_NAG1P-URIDYLTRANS-RXN_controller_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_BFO_0000066_reaction_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
@@ -223,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -231,25 +231,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_RO_0002234_CHEBI_57776_PHOSACETYLGLUCOSAMINEMUT-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002234_CHEBI_15378_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002413_PHOSACETYLGLUCOSAMINEMUT-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002234_CHEBI_57513_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -262,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -283,11 +283,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -298,15 +298,18 @@
           <http://model.geneontology.org/CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/3a0ad624-fec2-4287-8b38-9083a590963a_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_0efc55b1-e235-4988-8cdc-139cc976533d_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_3a0ad624-fec2-4287-8b38-9083a590963a_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,7 +317,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUCOSAMINEPNACETYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0efc55b1-e235-4988-8cdc-139cc976533d_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
+          <http://model.geneontology.org/3a0ad624-fec2-4287-8b38-9083a590963a_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57776_PHOSACETYLGLUCOSAMINEMUT-RXN>
@@ -326,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -339,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -347,11 +350,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_BFO_0000066_reaction_PHOSACETYLGLUCOSAMINEMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_BFO_0000066_reaction_PHOSACETYLGLUCOSAMINEMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,6 +365,17 @@
           <http://model.geneontology.org/reaction_PHOSACETYLGLUCOSAMINEMUT-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_BFO_0000050_YeastPathways_UDPNAGSYN-YEAST-PWY/YeastPathways_UDPNAGSYN-YEAST-PWY_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_GLUCOSAMINEPNACETYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -371,7 +385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -379,31 +393,20 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002234_CHEBI_57287_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004343>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002233_CHEBI_58359_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_RO_0002413_NAG1P-URIDYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -420,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -435,11 +438,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002233_CHEBI_46398_NAG1P-URIDYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002233_CHEBI_46398_NAG1P-URIDYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -459,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -476,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -493,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "UDP-N-acetylglucosamine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -511,11 +514,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_BFO_0000066_reaction_NAG1P-URIDYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_BFO_0000066_reaction_NAG1P-URIDYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -525,17 +528,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_NAG1P-URIDYLTRANS-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002333_YDL103C-MONOMER_NAG1P-URIDYLTRANS-RXN_controller_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002261>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -559,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -571,11 +563,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" , "Provides Input For Rule. The relation 'D-glucosamine 6-phosphate + acetyl-CoA &rarr; <i>N</i>-acetyl-D-glucosamine 6-phosphate + coenzyme A + H<SUP>+</SUP>' 'null' '<i>N</i>-acetyl-D-glucosamine 6-phosphate &rarr; <i>N</i>-acetyl-&alpha;-D-glucosamine 1-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002413_PHOSACETYLGLUCOSAMINEMUT-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002413_PHOSACETYLGLUCOSAMINEMUT-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -586,65 +578,32 @@
           <http://model.geneontology.org/PHOSACETYLGLUCOSAMINEMUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_BFO_0000050_YeastPathways_UDPNAGSYN-YEAST-PWY/YeastPathways_UDPNAGSYN-YEAST-PWY_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002333_YKL104C-MONOMER_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_controller_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002411_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002234_CHEBI_29888_NAG1P-URIDYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001587>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002333_YFL017C-MONOMER_GLUCOSAMINEPNACETYLTRANS-RXN_controller_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002233_CHEBI_58359_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002233_CHEBI_58359_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -659,11 +618,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,15 +633,26 @@
           <http://model.geneontology.org/CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_RO_0002234_CHEBI_57776_PHOSACETYLGLUCOSAMINEMUT-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_BFO_0000050_YeastPathways_UDPNAGSYN-YEAST-PWY/YeastPathways_UDPNAGSYN-YEAST-PWY_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_BFO_0000050_YeastPathways_UDPNAGSYN-YEAST-PWY/YeastPathways_UDPNAGSYN-YEAST-PWY_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,6 +666,17 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_BFO_0000050_YeastPathways_UDPNAGSYN-YEAST-PWY/YeastPathways_UDPNAGSYN-YEAST-PWY_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57513>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -705,15 +686,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_57705>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002233_CHEBI_46398_NAG1P-URIDYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002233_CHEBI_15378_NAG1P-URIDYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002233_CHEBI_15378_NAG1P-URIDYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -724,6 +716,17 @@
           <http://model.geneontology.org/CHEBI_15378_NAG1P-URIDYLTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_3a0ad624-fec2-4287-8b38-9083a590963a_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YFL017C-MONOMER_GLUCOSAMINEPNACETYLTRANS-RXN_controller>
         a       <http://identifiers.org/sgd/S000001877> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -731,7 +734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -741,6 +744,17 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_57288>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_BFO_0000066_reaction_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -753,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -761,11 +775,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_BFO_0000050_YeastPathways_UDPNAGSYN-YEAST-PWY/YeastPathways_UDPNAGSYN-YEAST-PWY_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_BFO_0000050_YeastPathways_UDPNAGSYN-YEAST-PWY/YeastPathways_UDPNAGSYN-YEAST-PWY_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -776,26 +790,15 @@
           <http://model.geneontology.org/YeastPathways_UDPNAGSYN-YEAST-PWY/YeastPathways_UDPNAGSYN-YEAST-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002234_CHEBI_57705_NAG1P-URIDYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002333_YFL017C-MONOMER_GLUCOSAMINEPNACETYLTRANS-RXN_controller_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002333_YFL017C-MONOMER_GLUCOSAMINEPNACETYLTRANS-RXN_controller_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -806,19 +809,19 @@
           <http://model.geneontology.org/YFL017C-MONOMER_GLUCOSAMINEPNACETYLTRANS-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58359>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002411_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002233_CHEBI_57634_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58359>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YDL103C-MONOMER_NAG1P-URIDYLTRANS-RXN_controller>
         a       <http://identifiers.org/sgd/S000002261> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -827,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -844,24 +847,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=UDPNAGSYN-YEAST-PWYSmallMolecule42373> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_BFO_0000066_reaction_NAG1P-URIDYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58359_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58359> ;
@@ -872,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -880,18 +872,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_BFO_0000050_YeastPathways_UDPNAGSYN-YEAST-PWY/YeastPathways_UDPNAGSYN-YEAST-PWY_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002233_CHEBI_58359_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002233_CHEBI_57634_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002233_CHEBI_57634_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -902,14 +916,14 @@
           <http://model.geneontology.org/CHEBI_57634_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_RO_0002413_NAG1P-URIDYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_RO_0002233_CHEBI_57513_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -917,11 +931,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_BFO_0000066_reaction_GLUCOSAMINEPNACETYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_BFO_0000066_reaction_GLUCOSAMINEPNACETYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -932,26 +946,15 @@
           <http://model.geneontology.org/reaction_GLUCOSAMINEPNACETYLTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_BFO_0000050_YeastPathways_UDPNAGSYN-YEAST-PWY/YeastPathways_UDPNAGSYN-YEAST-PWY_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002333_YDL103C-MONOMER_NAG1P-URIDYLTRANS-RXN_controller_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002333_YDL103C-MONOMER_NAG1P-URIDYLTRANS-RXN_controller_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -986,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -997,44 +1000,39 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002233_CHEBI_15378_NAG1P-URIDYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/2bc4a77d-96f2-4dec-843f-938795185fdf_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "D-glucosamine 6-phosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=UDPNAGSYN-YEAST-PWYSmallMolecule42445> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_0efc55b1-e235-4988-8cdc-139cc976533d_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_2bc4a77d-96f2-4dec-843f-938795185fdf_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_BFO_0000050_YeastPathways_UDPNAGSYN-YEAST-PWY/YeastPathways_UDPNAGSYN-YEAST-PWY_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1043,11 +1041,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002411_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002411_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1058,23 +1056,6 @@
           <http://model.geneontology.org/GLUCOSAMINEPNACETYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/f422f81c-6047-4082-bbc0-cc96005ca1fa_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "D-glucosamine 6-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=UDPNAGSYN-YEAST-PWYSmallMolecule42445> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1082,11 +1063,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002234_CHEBI_57513_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002234_CHEBI_57513_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1108,7 +1089,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57634_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> , <http://model.geneontology.org/CHEBI_58359_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> , <http://model.geneontology.org/f422f81c-6047-4082-bbc0-cc96005ca1fa_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
+                <http://model.geneontology.org/2bc4a77d-96f2-4dec-843f-938795185fdf_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> , <http://model.geneontology.org/CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YKL104C-MONOMER_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1116,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1136,7 +1117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1151,11 +1132,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_BFO_0000066_reaction_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_BFO_0000066_reaction_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1166,15 +1147,26 @@
           <http://model.geneontology.org/reaction_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002234_CHEBI_57705_NAG1P-URIDYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_BFO_0000050_YeastPathways_UDPNAGSYN-YEAST-PWY/YeastPathways_UDPNAGSYN-YEAST-PWY_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_BFO_0000050_YeastPathways_UDPNAGSYN-YEAST-PWY/YeastPathways_UDPNAGSYN-YEAST-PWY_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1185,26 +1177,15 @@
           <http://model.geneontology.org/YeastPathways_UDPNAGSYN-YEAST-PWY/YeastPathways_UDPNAGSYN-YEAST-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_BFO_0000066_reaction_PHOSACETYLGLUCOSAMINEMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002234_CHEBI_57705_NAG1P-URIDYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002234_CHEBI_57705_NAG1P-URIDYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1215,42 +1196,64 @@
           <http://model.geneontology.org/CHEBI_57705_NAG1P-URIDYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_RO_0002333_YEL058W-MONOMER_PHOSACETYLGLUCOSAMINEMUT-RXN_controller_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_BFO_0000050_YeastPathways_UDPNAGSYN-YEAST-PWY/YeastPathways_UDPNAGSYN-YEAST-PWY_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002233_CHEBI_57776_PHOSACETYLGLUCOSAMINEMUT-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002333_YKL104C-MONOMER_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002234_CHEBI_29888_NAG1P-URIDYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002333_YFL017C-MONOMER_GLUCOSAMINEPNACETYLTRANS-RXN_controller_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1263,7 +1266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1288,7 +1291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1296,17 +1299,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_BFO_0000066_reaction_GLUCOSAMINEPNACETYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002233_CHEBI_15378_NAG1P-URIDYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_BFO_0000050_YeastPathways_UDPNAGSYN-YEAST-PWY/YeastPathways_UDPNAGSYN-YEAST-PWY_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1315,7 +1329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1323,11 +1337,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" , "Provides Input For Rule. The relation '<i>N</i>-acetyl-D-glucosamine 6-phosphate &rarr; <i>N</i>-acetyl-&alpha;-D-glucosamine 1-phosphate' 'null' 'UTP + <i>N</i>-acetyl-&alpha;-D-glucosamine 1-phosphate + H<SUP>+</SUP> &rarr; UDP-<i>N</i>-acetyl-&alpha;-D-glucosamine + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_RO_0002413_NAG1P-URIDYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_RO_0002413_NAG1P-URIDYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1338,6 +1352,17 @@
           <http://model.geneontology.org/NAG1P-URIDYLTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_BFO_0000066_reaction_PHOSACETYLGLUCOSAMINEMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1345,11 +1370,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002333_YKL104C-MONOMER_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_controller_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002333_YKL104C-MONOMER_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1367,11 +1392,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002234_CHEBI_57287_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002234_CHEBI_57287_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1391,7 +1416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1403,11 +1428,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_RO_0002234_CHEBI_57776_PHOSACETYLGLUCOSAMINEMUT-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_RO_0002234_CHEBI_57776_PHOSACETYLGLUCOSAMINEMUT-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1418,17 +1443,6 @@
           <http://model.geneontology.org/CHEBI_57776_PHOSACETYLGLUCOSAMINEMUT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_f422f81c-6047-4082-bbc0-cc96005ca1fa_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/GLUCOSAMINEPNACETYLTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004343> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1438,7 +1452,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLUCOSAMINEPNACETYLTRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN> , <http://model.geneontology.org/0efc55b1-e235-4988-8cdc-139cc976533d_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN> , <http://model.geneontology.org/3a0ad624-fec2-4287-8b38-9083a590963a_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_GLUCOSAMINEPNACETYLTRANS-RXN> , <http://model.geneontology.org/CHEBI_57287_GLUCOSAMINEPNACETYLTRANS-RXN> , <http://model.geneontology.org/CHEBI_57513_GLUCOSAMINEPNACETYLTRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1448,7 +1462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1456,18 +1470,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/0efc55b1-e235-4988-8cdc-139cc976533d_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_BFO_0000050_YeastPathways_UDPNAGSYN-YEAST-PWY/YeastPathways_UDPNAGSYN-YEAST-PWY_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_BFO_0000050_YeastPathways_UDPNAGSYN-YEAST-PWY/YeastPathways_UDPNAGSYN-YEAST-PWY_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1485,11 +1496,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002234_CHEBI_29888_NAG1P-URIDYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002234_CHEBI_29888_NAG1P-URIDYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1499,17 +1510,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_29888_NAG1P-URIDYLTRANS-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002234_CHEBI_57513_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000784>
         a       <http://www.w3.org/2002/07/owl#Class> .

--- a/models/YeastPathways_VALSYN-PWY.ttl
+++ b/models/YeastPathways_VALSYN-PWY.ttl
@@ -1,26 +1,37 @@
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_location_lociGO_0005829_SGD_YeastPathways_VALSYN-PWY>
+<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_58476_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_VALSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
+                "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_58476_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002233_CHEBI_49072_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002233_CHEBI_49072_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -34,12 +45,23 @@
 <http://identifiers.org/sgd/S000000515>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_16526_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -47,11 +69,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_58476_ACETOLACTSYN-RXN_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_58476_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -66,11 +88,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_58476_ACETOLACTSYN-RXN_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_58476_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -85,11 +107,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000050_YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000050_YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -106,25 +128,14 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000050_YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY_SGD_YeastPathways_VALSYN-PWY>
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_VALSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
+                "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -135,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -150,11 +161,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -196,44 +207,22 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_57783_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_VALSYN-PWY>
+<http://purl.obolibrary.org/obo/GO_0003984>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_15378_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_VALSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
+                "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0003984>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_49072_ACETOLACTREDUCTOISOM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_49072> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -244,13 +233,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=VALSYN-PWYSmallMolecule58146> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_BFO_0000066_reaction_ACETOLACTREDUCTOISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_DIHYDROXYISOVALDEHYDRAT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -276,11 +276,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_16526_ACETOLACTSYN-RXN_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_16526_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -295,11 +295,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_57783_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_57783_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,18 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -334,11 +323,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -349,42 +338,42 @@
           <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15377>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002413_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
+                "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15377>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_ACETOLACTREDUCTOISOM-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_BFO_0000050_YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002413_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -402,11 +391,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,11 +410,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(2<i>R</i>)-2,3-dihydroxy-3-methylbutanoate &rarr; 3-methyl-2-oxobutanoate + H<sub>2</sub>O' 'null' 'L-valine + 2-oxoglutarate &harr; L-glutamate + 3-methyl-2-oxobutanoate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002413_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002413_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -436,29 +425,32 @@
           <http://model.geneontology.org/BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_58476_ACETOLACTSYN-RXN_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002333_YLR355C-MONOMER_ACETOLACTREDUCTOISOM-RXN_controller_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
+                "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_location_lociGO_0005829_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -469,18 +461,37 @@
           <http://model.geneontology.org/reaction_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000066_reaction_ACETOLACTSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002234_CHEBI_58349_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(2<i>R</i>)-2,3-dihydroxy-3-methylbutanoate + NADP<sup>+</sup> &larr; (<i>S</i>)-2-acetolactate + NADPH + H<SUP>+</SUP>' 'null' '(2<i>R</i>)-2,3-dihydroxy-3-methylbutanoate &rarr; 3-methyl-2-oxobutanoate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002413_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002413_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -500,13 +511,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=VALSYN-PWYSmallMolecule58090> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002413_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003777> ;
@@ -515,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -523,18 +548,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002233_CHEBI_49072_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,11 +582,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_15378_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_15378_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -571,11 +604,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -585,6 +618,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component>
 ] .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACETOLACTSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003984> ;
@@ -605,7 +649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -625,7 +669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -633,36 +677,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002413_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002234_CHEBI_58349_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_VALSYN-PWY>
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000050_YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY_SGD_PWY_YeastPathways_VALSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -672,26 +716,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_11851>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_58476_ACETOLACTSYN-RXN_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -706,11 +739,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -721,12 +754,23 @@
           <http://model.geneontology.org/YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15361_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
         a       <http://identifiers.org/sgd/S000004714> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -741,7 +785,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -749,11 +804,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000050_YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000050_YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -764,14 +819,14 @@
           <http://model.geneontology.org/YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
+                "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -779,11 +834,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002333_YLR355C-MONOMER_ACETOLACTREDUCTOISOM-RXN_controller_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002333_YLR355C-MONOMER_ACETOLACTREDUCTOISOM-RXN_controller_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -836,35 +891,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=VALSYN-PWYSmallMolecule58176> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002413_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -873,11 +906,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15361_ACETOLACTSYN-RXN_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15361_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -892,11 +925,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_BFO_0000066_reaction_ACETOLACTREDUCTOISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_BFO_0000066_reaction_ACETOLACTREDUCTOISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -911,11 +944,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -935,13 +968,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-valine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57762> ;
@@ -952,7 +996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -960,12 +1004,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000515> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -978,13 +1033,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=VALSYN-PWYSmallMolecule58071> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000050_YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_ACETOLACTSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -995,7 +1072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1003,25 +1080,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15361_ACETOLACTSYN-RXN_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_15378_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_VALSYN-PWY>
+<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000000515_CPLX3O-30_component_SGD_PWY_YeastPathways_VALSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
+                "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1032,11 +1098,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1046,6 +1112,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_DIHYDROXYISOVALDEHYDRAT-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000050_YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004714>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1057,11 +1134,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2 pyruvate + H<SUP>+</SUP> &rarr; (<i>S</i>)-2-acetolactate + CO<SUB>2</SUB>' 'null' '(2<i>R</i>)-2,3-dihydroxy-3-methylbutanoate + NADP<sup>+</sup> &larr; (<i>S</i>)-2-acetolactate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002413_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002413_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1072,25 +1149,17 @@
           <http://model.geneontology.org/ACETOLACTREDUCTOISOM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002233_CHEBI_49072_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-30_ACETOLACTSYN-RXN_controller_BFO_0000051_SGD_S000004714_CPLX3O-30_component_SGD_YeastPathways_VALSYN-PWY>
+<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002233_CHEBI_57783_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_VALSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
+                "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1098,11 +1167,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002234_CHEBI_58349_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002234_CHEBI_58349_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1113,8 +1182,16 @@
           <http://model.geneontology.org/CHEBI_58349_ACETOLACTREDUCTOISOM-RXN>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1126,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1153,46 +1230,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=VALSYN-PWYBiochemicalReaction58136> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_BFO_0000050_YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002333_YLR355C-MONOMER_ACETOLACTREDUCTOISOM-RXN_controller_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_ACETOLACTSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1203,7 +1247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1220,7 +1264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1235,11 +1279,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000066_reaction_ACETOLACTSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000066_reaction_ACETOLACTSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1253,51 +1297,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_BFO_0000050_YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY_SGD_YeastPathways_VALSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ACETOLACTREDUCTOISOM-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY>
-] .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002333_YJR016C-MONOMER_DIHYDROXYISOVALDEHYDRAT-RXN_controller_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001251> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "branched-chain amino acid aminotransferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=VALSYN-PWYProtein58262> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://model.geneontology.org/YLR355C-MONOMER_ACETOLACTREDUCTOISOM-RXN_controller>
         a       <http://identifiers.org/sgd/S000004347> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1305,7 +1304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1317,11 +1316,56 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_BFO_0000050_YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ACETOLACTREDUCTOISOM-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY>
+] .
+
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001251> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "branched-chain amino acid aminotransferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=VALSYN-PWYProtein58262> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_PWY_YeastPathways_VALSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1347,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1355,87 +1399,54 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002234_CHEBI_49072_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_YeastPathways_VALSYN-PWY>
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_PWY_YeastPathways_VALSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
+                "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000066_reaction_ACETOLACTSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000050_YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY_SGD_YeastPathways_VALSYN-PWY>
+<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002234_CHEBI_49072_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_VALSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
+                "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002234_CHEBI_16526_ACETOLACTSYN-RXN_SGD_YeastPathways_VALSYN-PWY>
+<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_VALSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
+                "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000050_YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_11851_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1453,11 +1464,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1477,7 +1488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1494,7 +1505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1506,11 +1517,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002234_CHEBI_49072_ACETOLACTREDUCTOISOM-RXN_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002234_CHEBI_49072_ACETOLACTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1521,15 +1532,26 @@
           <http://model.geneontology.org/CHEBI_49072_ACETOLACTREDUCTOISOM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002413_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_BFO_0000066_reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1540,32 +1562,32 @@
           <http://model.geneontology.org/reaction_DIHYDROXYISOVALDEHYDRAT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_BFO_0000066_reaction_ACETOLACTREDUCTOISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000001251>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_PWY_YeastPathways_VALSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000050_YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_BFO_0000050_YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1579,32 +1601,18 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/GO_0004160>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://identifiers.org/sgd/S000004347>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_YeastPathways_VALSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002234_CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_PWY_YeastPathways_VALSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1615,16 +1623,8 @@
           <http://model.geneontology.org/CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROXYISOVALDEHYDRAT-RXN_RO_0002234_CHEBI_15377_DIHYDROXYISOVALDEHYDRAT-RXN_SGD_YeastPathways_VALSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004160>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CPLX3O-30_ACETOLACTSYN-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1635,7 +1635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_YEAST-4AMINOBUTMETAB-PWY.ttl
+++ b/models/YeastPathways_YEAST-4AMINOBUTMETAB-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15,19 +15,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002234_CHEBI_57706_GABATRANSAM-RXN_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
+<http://purl.obolibrary.org/obo/GO_0009450>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002233_CHEBI_59888_GABATRANSAM-RXN_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
+                "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0009450>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_RXN0-5293>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -46,8 +46,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_15378_RXN0-5293_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000000210>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_BFO_0000050_YeastPathways_YEAST-4AMINOBUTMETAB-PWY/YeastPathways_YEAST-4AMINOBUTMETAB-PWY_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -58,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "4-aminobutyrate degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -66,26 +88,15 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_15378_RXN0-5293_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_15378_RXN0-5293_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_15378_RXN0-5293_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -96,26 +107,15 @@
           <http://model.geneontology.org/CHEBI_15378_RXN0-5293>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002233_CHEBI_59888_GABATRANSAM-RXN_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002234_CHEBI_29985_GABATRANSAM-RXN_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002234_CHEBI_29985_GABATRANSAM-RXN_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -135,6 +135,17 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002234_CHEBI_29985_GABATRANSAM-RXN_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_RXN0-5293>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -144,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -157,7 +168,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_BFO_0000066_reaction_GABATRANSAM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -170,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -178,14 +200,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002233_CHEBI_16810_GABATRANSAM-RXN_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
+<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_57706_GABATRANSAM-RXN_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
+                "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -198,14 +220,25 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_13392_RXN0-5293_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
+<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_13390_RXN0-5293_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002333_YBR006W-MONOMER_RXN0-5293_controller_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
+                "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -213,11 +246,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_13392_RXN0-5293_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_13392_RXN0-5293_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,11 +265,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002233_CHEBI_59888_GABATRANSAM-RXN_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002233_CHEBI_59888_GABATRANSAM-RXN_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -247,14 +280,14 @@
           <http://model.geneontology.org/CHEBI_59888_GABATRANSAM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_BFO_0000066_reaction_GABATRANSAM-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
+<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_15377_RXN0-5293_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
+                "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -267,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -290,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -300,17 +333,6 @@
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002333_YBR006W-MONOMER_RXN0-5293_controller_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN0-5293>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0009013> ;
@@ -329,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -352,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -367,11 +389,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5293_BFO_0000050_YeastPathways_YEAST-4AMINOBUTMETAB-PWY/YeastPathways_YEAST-4AMINOBUTMETAB-PWY_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5293_BFO_0000050_YeastPathways_YEAST-4AMINOBUTMETAB-PWY/YeastPathways_YEAST-4AMINOBUTMETAB-PWY_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,28 +404,6 @@
           <http://model.geneontology.org/YeastPathways_YEAST-4AMINOBUTMETAB-PWY/YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5293_BFO_0000066_reaction_RXN0-5293_location_lociGO_0005829_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002333_YGR019W-MONOMER_GABATRANSAM-RXN_controller_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -411,11 +411,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_57706_GABATRANSAM-RXN_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_57706_GABATRANSAM-RXN_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -430,11 +430,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002233_CHEBI_16810_GABATRANSAM-RXN_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002233_CHEBI_16810_GABATRANSAM-RXN_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -444,6 +444,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16810_GABATRANSAM-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002234_CHEBI_57706_GABATRANSAM-RXN_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0009013>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -464,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -479,11 +490,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" , "Provides Input For Rule. The relation '2-oxoglutarate + 4-aminobutanoate &harr; L-glutamate + succinate semialdehyde' 'null' 'succinate semialdehyde + NAD(P)<sup>+</sup> + H<sub>2</sub>O &rarr; succinate + NAD(P)H + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002413_RXN0-5293_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002413_RXN0-5293_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,29 +505,40 @@
           <http://model.geneontology.org/RXN0-5293>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_15377_RXN0-5293_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002413_RXN0-5293_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
+                "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_13392_RXN0-5293_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_15377_RXN0-5293_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_15377_RXN0-5293_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -531,11 +553,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_BFO_0000066_reaction_GABATRANSAM-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_BFO_0000066_reaction_GABATRANSAM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -555,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -563,34 +585,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_BFO_0000050_YeastPathways_YEAST-4AMINOBUTMETAB-PWY/YeastPathways_YEAST-4AMINOBUTMETAB-PWY_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN0-5293_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002234_CHEBI_29985_GABATRANSAM-RXN_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -606,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -627,11 +627,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002333_YBR006W-MONOMER_RXN0-5293_controller_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002333_YBR006W-MONOMER_RXN0-5293_controller_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -649,11 +649,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002333_YGR019W-MONOMER_GABATRANSAM-RXN_controller_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002333_YGR019W-MONOMER_GABATRANSAM-RXN_controller_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -664,17 +664,6 @@
           <http://model.geneontology.org/YGR019W-MONOMER_GABATRANSAM-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002413_RXN0-5293_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YBR006W-MONOMER_RXN0-5293_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000210> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -682,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -690,18 +679,62 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN0-5293_BFO_0000066_reaction_RXN0-5293_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002333_YGR019W-MONOMER_GABATRANSAM-RXN_controller_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-5293_BFO_0000050_YeastPathways_YEAST-4AMINOBUTMETAB-PWY/YeastPathways_YEAST-4AMINOBUTMETAB-PWY_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002233_CHEBI_16810_GABATRANSAM-RXN_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_13390_RXN0-5293_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_13390_RXN0-5293_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -716,11 +749,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_BFO_0000050_YeastPathways_YEAST-4AMINOBUTMETAB-PWY/YeastPathways_YEAST-4AMINOBUTMETAB-PWY_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_BFO_0000050_YeastPathways_YEAST-4AMINOBUTMETAB-PWY/YeastPathways_YEAST-4AMINOBUTMETAB-PWY_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,22 +767,22 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_30031_RXN0-5293_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_13390>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-5293_BFO_0000050_YeastPathways_YEAST-4AMINOBUTMETAB-PWY/YeastPathways_YEAST-4AMINOBUTMETAB-PWY_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -763,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -778,11 +811,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_30031_RXN0-5293_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_30031_RXN0-5293_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -793,26 +826,15 @@
           <http://model.geneontology.org/CHEBI_30031_RXN0-5293>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_13390_RXN0-5293_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002234_CHEBI_57706_GABATRANSAM-RXN_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002234_CHEBI_57706_GABATRANSAM-RXN_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -842,24 +864,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-4AMINOBUTMETAB-PWYBiochemicalReaction20104> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_57706_GABATRANSAM-RXN_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -868,11 +879,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-5293_BFO_0000066_reaction_RXN0-5293_location_lociGO_0005829_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-5293_BFO_0000066_reaction_RXN0-5293_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -885,14 +896,3 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002234_CHEBI_30031_RXN0-5293_SGD_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT.ttl
+++ b/models/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002234_CHEBI_60471_RXN-14122_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002234_CHEBI_60471_RXN-14122_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,25 +17,14 @@
           <http://model.geneontology.org/CHEBI_60471_RXN-14122>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7913_BFO_0000066_reaction_RXN-7913_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -43,11 +32,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,26 +47,15 @@
           <http://model.geneontology.org/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002333_YJR057W-MONOMER_RXN-14122_controller_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -88,29 +66,51 @@
           <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002234_CHEBI_28938_DCTP-DEAM-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_a8dc286c-7346-4926-b1c5-f6950f436944_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002234_CHEBI_60471_RXN-14122_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_DUTP-PYROP-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_DUTP-PYROP-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -121,15 +121,26 @@
           <http://model.geneontology.org/CHEBI_246422_DUTP-PYROP-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-14122_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002234_CHEBI_456216_DUDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002234_CHEBI_456216_DUDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,6 +150,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_456216_DUDPKIN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002234_CHEBI_456216_DUDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -150,11 +172,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002234_CHEBI_61481_DCDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002234_CHEBI_61481_DCDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -174,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -182,40 +204,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_BFO_0000066_reaction_DUTP-PYROP-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0047507>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_29888>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_UDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/UDPREDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/Red-Thioredoxin_UDPREDUCT-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -226,40 +237,62 @@
           <http://model.geneontology.org/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_29888>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_UDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/UDPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/Red-Thioredoxin_UDPREDUCT-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002413_DTMPKI-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_61481_DCDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002413_DTMPKI-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" , "Provides Input For Rule. The relation 'dUTP + H<sub>2</sub>O &rarr; dUMP + diphosphate + H<SUP>+</SUP>' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002413_THYMIDYLATESYN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002413_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -270,17 +303,6 @@
           <http://model.geneontology.org/THYMIDYLATESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002234_CHEBI_456216_RXN-14122_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -288,11 +310,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_BFO_0000066_reaction_DTDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_BFO_0000066_reaction_DTDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,6 +325,17 @@
           <http://model.geneontology.org/reaction_DTDPKIN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DCDPKIN-RXN_controller_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58593_CDPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58593> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -312,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -329,7 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "de novo biosynthesis of pyrimidine deoxyribonucleotides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -337,25 +370,14 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_RXN-14122_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+<http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002233_CHEBI_58593_CDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DTDPKIN-RXN_controller_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -363,11 +385,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002233_CHEBI_57566_RXN-7913_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002233_CHEBI_57566_RXN-7913_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,6 +400,28 @@
           <http://model.geneontology.org/CHEBI_57566_RXN-7913>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002234_CHEBI_61555_DUDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002234_CHEBI_61481_DCDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_CDPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -387,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -400,7 +444,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_CDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -408,11 +463,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002333_YJR057W-MONOMER_DTMPKI-RXN_controller_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002333_YJR057W-MONOMER_DTMPKI-RXN_controller_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -423,14 +478,25 @@
           <http://model.geneontology.org/YJR057W-MONOMER_DTMPKI-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002333_YBR252W-MONOMER_DUTP-PYROP-RXN_controller_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+<http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DUDPKIN-RXN_controller_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002234_CHEBI_15378_DUTP-PYROP-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -453,7 +519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -465,11 +531,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,14 +546,14 @@
           <http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DTMPKI-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002413_DCDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -496,29 +562,40 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002234_CHEBI_456216_DUDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_CDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+<http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_15378_DCTP-DEAM-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_UDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002234_CHEBI_456216_DCDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -534,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -546,11 +623,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_BFO_0000066_reaction_UDPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_BFO_0000066_reaction_UDPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -561,17 +638,6 @@
           <http://model.geneontology.org/reaction_UDPREDUCT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002413_DUDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_61555_DUDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_61555> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -581,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -589,37 +655,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002234_CHEBI_246422_DUTP-PYROP-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002233_CHEBI_58369_DTMPKI-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002233_CHEBI_61555_DUDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002233_CHEBI_61555_DUDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -634,11 +678,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_CDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_CDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -649,15 +693,26 @@
           <http://model.geneontology.org/Red-Thioredoxin_CDPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002233_CHEBI_30616_DCDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_61481_DCDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_61481_DCDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -673,18 +728,62 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002234_CHEBI_61481_DCDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+<http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_15377_DCTP-DEAM-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -700,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -712,11 +811,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002333_YJR057W-MONOMER_RXN-14122_controller_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002333_YJR057W-MONOMER_RXN-14122_controller_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -746,11 +845,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_BFO_0000066_reaction_DTMPKI-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_BFO_0000066_reaction_DTMPKI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -771,7 +870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -779,25 +878,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002413_DCDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+<http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002413_DUTP-PYROP-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -805,11 +893,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -820,46 +908,21 @@
           <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002233_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002233_CHEBI_246422_RXN-14122_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000003818>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_54c4f99a-d765-453c-9b42-4453522dd383_THYMIDYLATESYN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_c7a9b469-934d-4de6-b320-7f1dc027edfb_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -867,32 +930,46 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/54c4f99a-d765-453c-9b42-4453522dd383_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/c7a9b469-934d-4de6-b320-7f1dc027edfb_THYMIDYLATESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002234_CHEBI_61555_DCTP-DEAM-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58223>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002234_CHEBI_61555_DUDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002234_CHEBI_61555_DUDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -906,6 +983,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_37568>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002234_CHEBI_29888_DUTP-PYROP-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YBR252W-MONOMER_DUTP-PYROP-RXN_controller>
         a       <http://identifiers.org/sgd/S000000456> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -913,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -921,15 +1009,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002233_CHEBI_30616_DUDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DCDPKIN-RXN_controller_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DCDPKIN-RXN_controller_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -959,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -976,7 +1075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -994,11 +1093,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002333_CPLX3O-270_UDPREDUCT-RXN_controller_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002333_CPLX3O-270_UDPREDUCT-RXN_controller_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1009,26 +1108,15 @@
           <http://model.geneontology.org/CPLX3O-270_UDPREDUCT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002234_CHEBI_456216_DTDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_BFO_0000066_reaction_CDPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_BFO_0000066_reaction_CDPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1056,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1064,37 +1152,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002233_CHEBI_30616_RXN-14122_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_BFO_0000066_reaction_DTDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14122_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14122_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1105,15 +1171,26 @@
           <http://model.geneontology.org/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002233_CHEBI_58069_CDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002233_CHEBI_30616_DTDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002233_CHEBI_30616_DTDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1133,9 +1210,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_246422_DUTP-PYROP-RXN> , <http://model.geneontology.org/54c4f99a-d765-453c-9b42-4453522dd383_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_246422_DUTP-PYROP-RXN> , <http://model.geneontology.org/c7a9b469-934d-4de6-b320-7f1dc027edfb_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/36dea631-ae0b-4d16-9244-c118a5fecfc1_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/a8dc286c-7346-4926-b1c5-f6950f436944_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1143,7 +1220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1151,40 +1228,48 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_BFO_0000066_reaction_UDPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_CDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002233_CHEBI_61555_DUDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002233_CHEBI_58369_DTMPKI-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002234_CHEBI_456216_RXN-7913_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002234_CHEBI_456216_RXN-7913_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1195,6 +1280,20 @@
           <http://model.geneontology.org/CHEBI_456216_RXN-7913>
 ] .
 
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002234_CHEBI_15377_UDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_UDPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1204,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1221,13 +1320,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44699> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002413_DTDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1241,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1256,11 +1366,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'dTMP + ATP &rarr; dTDP + ADP' 'null' 'dTDP + ATP &rarr; dTTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002413_DTDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002413_DTDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1271,54 +1381,26 @@
           <http://model.geneontology.org/DTDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002234_CHEBI_15377_UDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+<http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002233_CHEBI_30616_RXN-14122_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002413_THYMIDYLATESYN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/36dea631-ae0b-4d16-9244-c118a5fecfc1_THYMIDYLATESYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44945> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1329,25 +1411,14 @@
           <http://model.geneontology.org/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_BFO_0000066_reaction_DUDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+<http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002233_CHEBI_246422_RXN-14122_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_15378_DCTP-DEAM-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1355,11 +1426,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002234_CHEBI_58593_RXN-7913_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002234_CHEBI_58593_RXN-7913_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1369,17 +1440,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58593_RXN-7913>
 ] .
-
-<http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002413_DUTP-PYROP-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/DCTP-DEAM-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0008829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1398,7 +1458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1406,26 +1466,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_15377_DCTP-DEAM-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1436,6 +1485,17 @@
           <http://model.geneontology.org/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002233_CHEBI_30616_DTMPKI-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_63528> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1445,7 +1505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1460,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1472,11 +1532,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_BFO_0000066_reaction_DCDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_BFO_0000066_reaction_DCDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1487,40 +1547,29 @@
           <http://model.geneontology.org/reaction_DCDPKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002234_CHEBI_456216_DCDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57566>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002234_CHEBI_61555_DCTP-DEAM-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002233_CHEBI_58223_UDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002233_CHEBI_58223_UDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1535,11 +1584,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002234_CHEBI_15378_DUTP-PYROP-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002234_CHEBI_15378_DUTP-PYROP-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1554,11 +1603,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002333_CPLX3O-270_CDPREDUCT-RXN_controller_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002333_CPLX3O-270_CDPREDUCT-RXN_controller_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1569,6 +1618,17 @@
           <http://model.geneontology.org/CPLX3O-270_CDPREDUCT-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002233_CHEBI_30616_RXN-7913_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_DUDPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1578,35 +1638,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44699> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002234_CHEBI_58593_CDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_CDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1615,11 +1653,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002234_CHEBI_28938_DCTP-DEAM-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002234_CHEBI_28938_DCTP-DEAM-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1630,25 +1668,53 @@
           <http://model.geneontology.org/CHEBI_28938_DCTP-DEAM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_BFO_0000066_reaction_DCDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-7913_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/a8dc286c-7346-4926-b1c5-f6950f436944_THYMIDYLATESYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44945> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0008829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1656,26 +1722,15 @@
 <http://identifiers.org/sgd/S000001328>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002234_CHEBI_58369_DTMPKI-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'ATP + dUMP &rarr; ADP + dUDP' 'null' 'dUDP + ATP &rarr; dUTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002413_DUDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002413_DUDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1693,11 +1748,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002233_CHEBI_30616_DTMPKI-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002233_CHEBI_30616_DTMPKI-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1708,36 +1763,14 @@
           <http://model.geneontology.org/CHEBI_30616_DTMPKI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_BFO_0000066_reaction_DUTP-PYROP-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DTMPKI-RXN_BFO_0000066_reaction_DTMPKI-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002234_CHEBI_60471_UDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1748,11 +1781,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1763,6 +1796,17 @@
           <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_BFO_0000066_reaction_DUDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1772,7 +1816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1783,54 +1827,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002234_CHEBI_60471_RXN-14122_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/54c4f99a-d765-453c-9b42-4453522dd383_THYMIDYLATESYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44939> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1843,6 +1848,17 @@
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_DTMPKI-RXN_BFO_0000066_reaction_DTMPKI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/DCDPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004550> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1863,7 +1879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1876,7 +1892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1884,11 +1900,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DUDPKIN-RXN_controller_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DUDPKIN-RXN_controller_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1899,17 +1915,6 @@
           <http://model.geneontology.org/YKL067W-MONOMER_DUDPKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_36dea631-ae0b-4d16-9244-c118a5fecfc1_THYMIDYLATESYN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004748>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1917,11 +1922,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'dCDP + ATP &rarr; dCTP + ADP' 'null' 'dCTP + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; ammonium + dUTP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002413_DCTP-DEAM-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002413_DCTP-DEAM-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1932,14 +1937,14 @@
           <http://model.geneontology.org/DCTP-DEAM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DCDPKIN-RXN_controller_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_BFO_0000066_reaction_DCTP-DEAM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1952,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1967,11 +1972,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'dUDP + an oxidized thioredoxin + H<sub>2</sub>O &larr; UDP + a reduced thioredoxin' 'null' 'dUDP + ATP &rarr; dUTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002413_DUDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002413_DUDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1986,11 +1991,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002233_CHEBI_58069_CDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002233_CHEBI_58069_CDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2001,15 +2006,26 @@
           <http://model.geneontology.org/CHEBI_58069_CDPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DTMPKI-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14122_BFO_0000066_reaction_RXN-14122_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14122_BFO_0000066_reaction_RXN-14122_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2020,12 +2036,23 @@
           <http://model.geneontology.org/reaction_RXN-14122_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002413_DUDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_CDPREDUCT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2033,11 +2060,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002233_CHEBI_58369_DTMPKI-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002233_CHEBI_58369_DTMPKI-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2051,28 +2078,6 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002233_CHEBI_58593_CDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002234_CHEBI_58593_RXN-7913_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CPLX3O-270_UDPREDUCT-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2082,13 +2087,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTComplex44829> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_DUTP-PYROP-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/Red-Thioredoxin_CDPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -2099,7 +2115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2110,14 +2126,25 @@
 <http://purl.obolibrary.org/obo/GO_0004550>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002234_CHEBI_456216_RXN-7913_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+<http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002233_CHEBI_57566_RXN-7913_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002234_CHEBI_246422_DUTP-PYROP-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2130,7 +2157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2142,11 +2169,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" , "Provides Input For Rule. The relation 'ATP + dCMP &rarr; ADP + dCDP' 'null' 'dCDP + ATP &rarr; dCTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002413_DCDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002413_DCDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2157,6 +2184,17 @@
           <http://model.geneontology.org/DCDPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002413_DCDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_DTDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2166,7 +2204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2183,7 +2221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2191,26 +2229,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_BFO_0000066_reaction_DUDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_BFO_0000066_reaction_DUDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2220,6 +2247,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_DUDPKIN-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004170>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2233,24 +2271,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44821> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2259,11 +2286,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002233_CHEBI_30616_DCDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002233_CHEBI_30616_DCDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2274,6 +2301,17 @@
           <http://model.geneontology.org/CHEBI_30616_DCDPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DTDPKIN-RXN_controller_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0006207> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2283,24 +2321,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002413_DCDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/UDPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004748> ;
@@ -2321,7 +2348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2333,11 +2360,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_UDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_UDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2348,15 +2375,26 @@
           <http://model.geneontology.org/Red-Thioredoxin_UDPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002234_CHEBI_28938_DCTP-DEAM-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002234_CHEBI_246422_DUTP-PYROP-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002234_CHEBI_246422_DUTP-PYROP-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2367,26 +2405,15 @@
           <http://model.geneontology.org/CHEBI_246422_DUTP-PYROP-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002333_CPLX3O-270_UDPREDUCT-RXN_controller_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" , "Provides Input For Rule. The relation 'dCDP + an oxidized thioredoxin + H<sub>2</sub>O &larr; CDP + a reduced thioredoxin' 'null' 'dCDP + ATP &rarr; dCTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002413_DCDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002413_DCDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2397,26 +2424,15 @@
           <http://model.geneontology.org/DCDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002233_CHEBI_30616_DTDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002234_CHEBI_61555_DCTP-DEAM-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002234_CHEBI_61555_DCTP-DEAM-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2430,6 +2446,28 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002234_CHEBI_58369_DTMPKI-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002234_CHEBI_456216_RXN-7913_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2440,11 +2478,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7913_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7913_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2464,7 +2502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2472,34 +2510,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002234_CHEBI_15377_CDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN-14122_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002233_CHEBI_30616_DTMPKI-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2507,11 +2523,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002233_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002233_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2529,7 +2545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2537,15 +2553,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_c7a9b469-934d-4de6-b320-7f1dc027edfb_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2565,7 +2592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2573,30 +2600,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002413_DTDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+<http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002333_CPLX3O-270_CDPREDUCT-RXN_controller_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002413_DUDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005600>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CDPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004748> ;
@@ -2617,7 +2644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2629,11 +2656,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_36dea631-ae0b-4d16-9244-c118a5fecfc1_THYMIDYLATESYN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_a8dc286c-7346-4926-b1c5-f6950f436944_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2641,37 +2668,15 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/36dea631-ae0b-4d16-9244-c118a5fecfc1_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/a8dc286c-7346-4926-b1c5-f6950f436944_THYMIDYLATESYN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002233_CHEBI_58069_CDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_DUDPKIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2685,11 +2690,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" , "Provides Input For Rule. The relation 'dUDP + ATP &rarr; dUTP + ADP' 'null' 'dUTP + H<sub>2</sub>O &rarr; dUMP + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002413_DUTP-PYROP-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002413_DUTP-PYROP-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2700,6 +2705,17 @@
           <http://model.geneontology.org/DUTP-PYROP-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002233_CHEBI_30616_DTDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58223_UDPREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58223> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2709,7 +2725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2726,7 +2742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2738,11 +2754,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2753,14 +2769,14 @@
           <http://model.geneontology.org/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002233_CHEBI_30616_DUDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+<http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002333_CPLX3O-270_UDPREDUCT-RXN_controller_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2769,18 +2785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002234_CHEBI_29888_DUTP-PYROP-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2788,11 +2793,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_CDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_CDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2803,15 +2808,26 @@
           <http://model.geneontology.org/Red-Thioredoxin_CDPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_BFO_0000066_reaction_CDPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002233_CHEBI_246422_RXN-14122_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002233_CHEBI_246422_RXN-14122_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2822,15 +2838,26 @@
           <http://model.geneontology.org/CHEBI_246422_RXN-14122>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002234_CHEBI_58593_RXN-7913_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002234_CHEBI_37568_DTDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002234_CHEBI_37568_DTDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2860,7 +2887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2868,14 +2895,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002233_CHEBI_57566_RXN-7913_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+<http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002333_YJR057W-MONOMER_DTMPKI-RXN_controller_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2884,7 +2911,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002333_YBR252W-MONOMER_DUTP-PYROP-RXN_controller_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2892,11 +2941,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002233_CHEBI_30616_RXN-14122_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002233_CHEBI_30616_RXN-14122_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2906,17 +2955,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30616_RXN-14122>
 ] .
-
-<http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002234_CHEBI_15378_DUTP-PYROP-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000872>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2930,7 +2968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2938,37 +2976,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002234_CHEBI_456216_DTDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002234_CHEBI_456216_DTDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2979,6 +2995,17 @@
           <http://model.geneontology.org/CHEBI_456216_DTDPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002234_CHEBI_456216_DTDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_DCDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2988,7 +3015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2999,6 +3026,17 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_DTDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3008,7 +3046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3016,15 +3054,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002234_CHEBI_58593_CDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3035,26 +3084,15 @@
           <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002333_CPLX3O-270_CDPREDUCT-RXN_controller_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3068,17 +3106,6 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002233_CHEBI_60471_UDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_61555_DCTP-DEAM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_61555> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3088,7 +3115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3103,11 +3130,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002233_CHEBI_30616_DUDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002233_CHEBI_30616_DUDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3118,35 +3145,41 @@
           <http://model.geneontology.org/CHEBI_30616_DUDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_UDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
         a       <http://identifiers.org/sgd/S000001328> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/c7a9b469-934d-4de6-b320-7f1dc027edfb_THYMIDYLATESYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44939> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002233_CHEBI_58593_CDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002233_CHEBI_58593_CDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3166,7 +3199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3174,15 +3207,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002234_CHEBI_15377_CDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002234_CHEBI_15377_UDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002234_CHEBI_15377_UDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3202,7 +3246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3210,26 +3254,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002234_CHEBI_29888_DUTP-PYROP-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002234_CHEBI_29888_DUTP-PYROP-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3240,15 +3273,26 @@
           <http://model.geneontology.org/CHEBI_29888_DUTP-PYROP-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-14122_BFO_0000066_reaction_RXN-14122_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'dCTP + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; ammonium + dUTP' 'null' 'dUTP + H<sub>2</sub>O &rarr; dUMP + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002413_DUTP-PYROP-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002413_DUTP-PYROP-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3259,52 +3303,8 @@
           <http://model.geneontology.org/DUTP-PYROP-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002234_CHEBI_37568_DTDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_UDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002413_DCTP-DEAM-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004798>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3313,11 +3313,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7913_BFO_0000066_reaction_RXN-7913_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7913_BFO_0000066_reaction_RXN-7913_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3328,15 +3328,26 @@
           <http://model.geneontology.org/reaction_RXN-7913_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002234_CHEBI_456216_DTMPKI-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002234_CHEBI_456216_DTMPKI-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3350,14 +3361,14 @@
 <http://identifiers.org/sgd/S000000456>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002333_YJR057W-MONOMER_DTMPKI-RXN_controller_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002333_YJR057W-MONOMER_RXN-14122_controller_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3365,11 +3376,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3380,15 +3391,26 @@
           <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002234_CHEBI_456216_DTMPKI-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3399,15 +3421,26 @@
           <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002233_CHEBI_15377_DUTP-PYROP-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3418,26 +3451,15 @@
           <http://model.geneontology.org/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002234_CHEBI_456216_DTMPKI-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_BFO_0000066_reaction_DCTP-DEAM-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_BFO_0000066_reaction_DCTP-DEAM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3448,14 +3470,36 @@
           <http://model.geneontology.org/reaction_DCTP-DEAM-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002233_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3463,11 +3507,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002234_CHEBI_15377_CDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002234_CHEBI_15377_CDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3481,58 +3525,14 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002413_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002233_CHEBI_58223_UDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_BFO_0000066_reaction_DCTP-DEAM-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_BFO_0000066_reaction_CDPREDUCT-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3548,7 +3548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3568,7 +3568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3583,11 +3583,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002234_CHEBI_456216_RXN-14122_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002234_CHEBI_456216_RXN-14122_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3598,34 +3598,12 @@
           <http://model.geneontology.org/CHEBI_456216_RXN-14122>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002233_CHEBI_30616_DCDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-14122_BFO_0000066_reaction_RXN-14122_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_UDPREDUCT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3633,11 +3611,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DTDPKIN-RXN_controller_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DTDPKIN-RXN_controller_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3648,17 +3626,6 @@
           <http://model.geneontology.org/YKL067W-MONOMER_DTDPKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002413_DUTP-PYROP-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_DCTP-DEAM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3668,7 +3635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3685,7 +3652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3700,11 +3667,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3719,11 +3686,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3734,17 +3701,6 @@
           <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_54c4f99a-d765-453c-9b42-4453522dd383_THYMIDYLATESYN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3752,11 +3708,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002233_CHEBI_60471_UDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002233_CHEBI_60471_UDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3776,13 +3732,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44806> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_RO_0002234_CHEBI_37568_DTDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_RXN-7913>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -3793,7 +3760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3808,11 +3775,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002234_CHEBI_456216_DCDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002234_CHEBI_456216_DCDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3823,23 +3790,23 @@
           <http://model.geneontology.org/CHEBI_456216_DCDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002233_CHEBI_15377_DUTP-PYROP-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_DTMPKI-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_61481_DCDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3848,18 +3815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002234_CHEBI_61555_DUDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3867,11 +3823,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002234_CHEBI_60471_UDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002234_CHEBI_60471_UDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3882,15 +3838,26 @@
           <http://model.geneontology.org/CHEBI_60471_UDPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002413_DCTP-DEAM-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002333_YBR252W-MONOMER_DUTP-PYROP-RXN_controller_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002333_YBR252W-MONOMER_DUTP-PYROP-RXN_controller_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3913,7 +3880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3925,11 +3892,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3940,45 +3907,12 @@
           <http://model.geneontology.org/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DUDPKIN-RXN_controller_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_DCTP-DEAM-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_BFO_0000066_reaction_DCDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002413_DUDPKIN-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3991,7 +3925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4002,17 +3936,39 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004799>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002233_CHEBI_30616_RXN-7913_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-7913_BFO_0000066_reaction_RXN-7913_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DTDPKIN-RXN_BFO_0000066_reaction_DTDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004799>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4020,11 +3976,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002233_CHEBI_30616_RXN-7913_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7913_RO_0002233_CHEBI_30616_RXN-7913_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4039,11 +3995,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002234_CHEBI_58369_DTMPKI-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DTMPKI-RXN_RO_0002234_CHEBI_58369_DTMPKI-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4054,23 +4010,23 @@
           <http://model.geneontology.org/CHEBI_58369_DTMPKI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000872> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002234_CHEBI_60471_UDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4078,11 +4034,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4091,36 +4047,6 @@
           <http://model.geneontology.org/CPLX3O-270_UDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
-] .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_DUTP-PYROP-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' 'null' 'dTMP + ATP &rarr; dTDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002413_DTMPKI-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DTMPKI-RXN>
 ] .
 
 <http://model.geneontology.org/DUDPKIN-RXN>
@@ -4142,7 +4068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4150,16 +4076,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' 'null' 'dTMP + ATP &rarr; dTDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002413_DTMPKI-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/DTMPKI-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_58593_RXN-7913>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58593> ;
@@ -4170,7 +4104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4187,7 +4121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4199,11 +4133,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_BFO_0000066_reaction_DUTP-PYROP-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_BFO_0000066_reaction_DUTP-PYROP-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4214,15 +4148,26 @@
           <http://model.geneontology.org/reaction_DUTP-PYROP-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002233_CHEBI_58223_UDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_15377_DCTP-DEAM-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_15377_DCTP-DEAM-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4233,15 +4178,26 @@
           <http://model.geneontology.org/CHEBI_15377_DCTP-DEAM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002234_CHEBI_456216_RXN-14122_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4252,27 +4208,46 @@
           <http://model.geneontology.org/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_UDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_BFO_0000066_reaction_UDPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002233_CHEBI_15377_DUTP-PYROP-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_DUTP-PYROP-RXN>
+] .
 
 <http://model.geneontology.org/RXN-7913>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4291,7 +4266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4299,48 +4274,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002233_CHEBI_15377_DUTP-PYROP-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DUTP-PYROP-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_DUTP-PYROP-RXN>
-] .
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-7913_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+<http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_RO_0002233_Red-Thioredoxin_UDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002234_CHEBI_58593_CDPREDUCT-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_CDPREDUCT-RXN_RO_0002234_CHEBI_58593_CDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4358,7 +4314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4366,15 +4322,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002233_CHEBI_60471_UDPREDUCT-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7913_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_15378_DCTP-DEAM-RXN_SGD_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002233_CHEBI_15378_DCTP-DEAM-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4384,3 +4362,25 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_DCTP-DEAM-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_DUTP-PYROP-RXN_RO_0002233_CHEBI_61555_DUDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DCTP-DEAM-RXN_RO_0002413_DUTP-PYROP-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_YEAST-FAO-PWY.ttl
+++ b/models/YeastPathways_YEAST-FAO-PWY.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_CHEBI_15379_RXN-11026_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_CHEBI_15379_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,11 +21,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002333_YKR009C-MONOMER_ENOYL-COA-HYDRAT-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002333_YKR009C-MONOMER_ENOYL-COA-HYDRAT-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,15 +36,48 @@
           <http://model.geneontology.org/YKR009C-MONOMER_ENOYL-COA-HYDRAT-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002233_CHEBI_57287_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YIL009W-MONOMER_ACYLCOASYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_CHEBI_456215_ACYLCOASYN-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_CHEBI_456215_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,25 +88,14 @@
           <http://model.geneontology.org/CHEBI_456215_ACYLCOASYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002234_CHEBI_15455_ENOYL-COA-HYDRAT-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_CHEBI_15379_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002233_CHEBI_15489_OHACYL-COA-DEHYDROG-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -82,6 +104,17 @@
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002233_8426423b-fc60-4ac8-a9a1-0d610cf4581a_ENOYL-COA-DELTA-ISOM-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ENOYL-COA-HYDRAT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004300> ;
@@ -92,7 +125,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_ENOYL-COA-HYDRAT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/a0083e9a-3183-4249-a442-afa1ba296b2a_ENOYL-COA-DELTA-ISOM-RXN> , <http://model.geneontology.org/CHEBI_15377_ENOYL-COA-HYDRAT-RXN> ;
+                <http://model.geneontology.org/d7f17ae9-e907-411b-9a27-9ac1bdfb864c_ENOYL-COA-DELTA-ISOM-RXN> , <http://model.geneontology.org/CHEBI_15377_ENOYL-COA-HYDRAT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15455_ENOYL-COA-HYDRAT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -102,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -119,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -131,11 +164,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002333_YIL160C-MONOMER_KETOACYLCOATHIOL-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002333_YIL160C-MONOMER_KETOACYLCOATHIOL-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,11 +186,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002411_RXN-11026_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002411_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -177,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -206,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -214,32 +247,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ef46aba3-396c-4c8c-be19-6ee580d382b0_ENOYL-COA-DELTA-ISOM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (3Z)-alk-3-enoyl-CoA" ;
+<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002233_CHEBI_57287_KETOACYLCOATHIOL-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59385> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002234_CHEBI_57945_OHACYL-COA-DEHYDROG-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002234_CHEBI_57945_OHACYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -250,15 +277,26 @@
           <http://model.geneontology.org/CHEBI_57945_OHACYL-COA-DEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002333_YGL205W-MONOMER_RXN-11026_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,27 +310,24 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002233_ef46aba3-396c-4c8c-be19-6ee580d382b0_ENOYL-COA-DELTA-ISOM-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_BFO_0000066_reaction_ACYLCOASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ACYLCOASYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_ACYLCOASYN-RXN_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/ACYLCOASYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004467> ;
@@ -305,7 +340,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_30616_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_71627_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_57287_ACYLCOASYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456215_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_29888_ACYLCOASYN-RXN> , <http://model.geneontology.org/0688da3b-9ddc-4d12-8537-0f388bc5b4ba_ACYLCOASYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_456215_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_29888_ACYLCOASYN-RXN> , <http://model.geneontology.org/bc8ee67c-a712-45f7-92a3-938457e0f60c_ACYLCOASYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YBR041W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YOR317W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YER015W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YIL009W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YMR246W-MONOMER_ACYLCOASYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -313,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -321,24 +356,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_BFO_0000066_reaction_ACYLCOASYN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-FAO-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ACYLCOASYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_ACYLCOASYN-RXN_location_lociGO_0005829>
-] .
+<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002233_CHEBI_15489_OHACYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YMR246W-MONOMER_ACYLCOASYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YKR009C-MONOMER_ENOYL-COA-HYDRAT-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001717> ;
@@ -347,7 +385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -364,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -379,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -412,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -427,11 +465,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_a88d2721-fcc6-45ce-9af8-b0f0ace6c88d_RXN-11026_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_1015a147-03b7-4561-bcbd-57cd24a77cd6_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -439,7 +477,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11026> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a88d2721-fcc6-45ce-9af8-b0f0ace6c88d_RXN-11026>
+          <http://model.geneontology.org/1015a147-03b7-4561-bcbd-57cd24a77cd6_RXN-11026>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_ACYLCOASYN-RXN>
@@ -451,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -463,11 +501,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_BFO_0000066_reaction_KETOACYLCOATHIOL-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_BFO_0000066_reaction_KETOACYLCOATHIOL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -487,7 +525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -495,40 +533,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002234_CHEBI_57288_KETOACYLCOATHIOL-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YOR317W-MONOMER_ACYLCOASYN-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_BFO_0000066_reaction_OHACYL-COA-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_BFO_0000066_reaction_OHACYL-COA-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,18 +558,26 @@
           <http://model.geneontology.org/reaction_OHACYL-COA-DEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_CHEBI_456215_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002233_ef46aba3-396c-4c8c-be19-6ee580d382b0_ENOYL-COA-DELTA-ISOM-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002233_8426423b-fc60-4ac8-a9a1-0d610cf4581a_ENOYL-COA-DELTA-ISOM-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -558,7 +585,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-COA-DELTA-ISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ef46aba3-396c-4c8c-be19-6ee580d382b0_ENOYL-COA-DELTA-ISOM-RXN>
+          <http://model.geneontology.org/8426423b-fc60-4ac8-a9a1-0d610cf4581a_ENOYL-COA-DELTA-ISOM-RXN>
 ] .
 
 <http://model.geneontology.org/YER015W-MONOMER_ACYLCOASYN-RXN_controller>
@@ -568,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -585,17 +612,6 @@
 <http://identifiers.org/sgd/S000005844>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YLR284C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller>
         a       <http://identifiers.org/sgd/S000004274> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -603,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -611,29 +627,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/GO_0003857>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_BFO_0000066_reaction_ENOYL-COA-DELTA-ISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0003857>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11026_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11026_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -648,11 +664,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002233_a0083e9a-3183-4249-a442-afa1ba296b2a_ENOYL-COA-DELTA-ISOM-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002233_d7f17ae9-e907-411b-9a27-9ac1bdfb864c_ENOYL-COA-DELTA-ISOM-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,43 +676,21 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-COA-HYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a0083e9a-3183-4249-a442-afa1ba296b2a_ENOYL-COA-DELTA-ISOM-RXN>
+          <http://model.geneontology.org/d7f17ae9-e907-411b-9a27-9ac1bdfb864c_ENOYL-COA-DELTA-ISOM-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YER015W-MONOMER_ACYLCOASYN-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_BFO_0000066_reaction_ACYLCOASYN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002233_CHEBI_71627_ACYLCOASYN-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002233_CHEBI_71627_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,6 +701,17 @@
           <http://model.geneontology.org/CHEBI_71627_ACYLCOASYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002333_YKR009C-MONOMER_OHACYL-COA-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YOR180C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller>
         a       <http://identifiers.org/sgd/S000005706> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -714,7 +719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -722,25 +727,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002233_CHEBI_15377_ENOYL-COA-HYDRAT-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
+<http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002234_CHEBI_57945_OHACYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002233_a0083e9a-3183-4249-a442-afa1ba296b2a_ENOYL-COA-DELTA-ISOM-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002333_YIL160C-MONOMER_KETOACYLCOATHIOL-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -751,11 +756,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002234_CHEBI_57288_KETOACYLCOATHIOL-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002234_CHEBI_57288_KETOACYLCOATHIOL-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -766,15 +771,26 @@
           <http://model.geneontology.org/CHEBI_57288_KETOACYLCOATHIOL-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002233_CHEBI_71627_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YMR246W-MONOMER_ACYLCOASYN-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YMR246W-MONOMER_ACYLCOASYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,7 +812,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002234_5a7a9c60-7a0e-447a-acbb-734a4b9be374_ENOYL-COA-DELTA-ISOM-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002413_KETOACYLCOATHIOL-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -809,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -817,49 +855,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002333_YKR009C-MONOMER_OHACYL-COA-DEHYDROG-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_ENOYL-COA-DELTA-ISOM-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_CHEBI_456215_ACYLCOASYN-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002234_CHEBI_15378_OHACYL-COA-DEHYDROG-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002234_CHEBI_15378_OHACYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -874,11 +890,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002333_YOR180C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002333_YOR180C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -889,6 +905,17 @@
           <http://model.geneontology.org/YOR180C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-11026_BFO_0000066_reaction_RXN-11026_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_OHACYL-COA-DEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -898,11 +925,39 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59577> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002413_OHACYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/5efa3fcd-e059-4180-b745-04245e0c2b08_KETOACYLCOATHIOL-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 2,3,4-saturated fatty acyl CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -913,11 +968,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_8c0af6e3-dfe4-414c-af67-dfbbab2305de_ACYLCOASYN-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_8e027dc0-374d-4782-bd92-36cebcd5af59_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -925,18 +980,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11026> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8c0af6e3-dfe4-414c-af67-dfbbab2305de_ACYLCOASYN-RXN>
+          <http://model.geneontology.org/8e027dc0-374d-4782-bd92-36cebcd5af59_ACYLCOASYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" , "Provides Input For Rule. The relation 'a (3<i>S</i>)-3-hydroxyacyl-CoA &larr; a <i>trans</i>-2-enoyl-CoA + H<sub>2</sub>O' 'null' 'a (3<i>S</i>)-3-hydroxyacyl-CoA + NAD<sup>+</sup> &rarr; a 3-oxoacyl-CoA + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002413_OHACYL-COA-DEHYDROG-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002413_OHACYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,15 +1002,26 @@
           <http://model.geneontology.org/OHACYL-COA-DEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_CHEBI_16240_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_0688da3b-9ddc-4d12-8537-0f388bc5b4ba_ACYLCOASYN-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_bc8ee67c-a712-45f7-92a3-938457e0f60c_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -963,17 +1029,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ACYLCOASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0688da3b-9ddc-4d12-8537-0f388bc5b4ba_ACYLCOASYN-RXN>
+          <http://model.geneontology.org/bc8ee67c-a712-45f7-92a3-938457e0f60c_ACYLCOASYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002234_CHEBI_57945_OHACYL-COA-DEHYDROG-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_15455_ENOYL-COA-HYDRAT-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -986,24 +1052,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_YEAST-FAO-PWY" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002333_YGL205W-MONOMER_RXN-11026_controller_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1012,11 +1067,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002411_RXN-11026_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002411_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1027,25 +1082,14 @@
           <http://model.geneontology.org/RXN-11026>
 ] .
 
-<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002411_RXN-11026_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_BFO_0000066_reaction_ENOYL-COA-DELTA-ISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-FAO-PWY>
+<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002234_CHEBI_57288_KETOACYLCOATHIOL-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1053,11 +1097,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1068,28 +1112,14 @@
           <http://model.geneontology.org/YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY>
 ] .
 
-<http://model.geneontology.org/8c0af6e3-dfe4-414c-af67-dfbbab2305de_ACYLCOASYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002413_OHACYL-COA-DEHYDROG-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002333_YOR180C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY>
+<http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_BFO_0000066_reaction_OHACYL-COA-DEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1105,23 +1135,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/1f697913-3a66-4ba2-ba6e-61381391bf75_KETOACYLCOATHIOL-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 2,3,4-saturated fatty acyl CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/CHEBI_71627>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1135,11 +1148,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002333_YKR009C-MONOMER_OHACYL-COA-DEHYDROG-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002333_YKR009C-MONOMER_OHACYL-COA-DEHYDROG-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1157,11 +1170,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_BFO_0000066_reaction_ENOYL-COA-HYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_BFO_0000066_reaction_ENOYL-COA-HYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1175,6 +1188,17 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_71627_ACYLCOASYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_71627> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1184,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1199,7 +1223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1211,11 +1235,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002233_CHEBI_30616_ACYLCOASYN-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002233_CHEBI_30616_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1226,11 +1250,19 @@
           <http://model.geneontology.org/CHEBI_30616_ACYLCOASYN-RXN>
 ] .
 
-<http://model.geneontology.org/a0083e9a-3183-4249-a442-afa1ba296b2a_ENOYL-COA-DELTA-ISOM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YIL009W-MONOMER_ACYLCOASYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001271> ;
@@ -1239,7 +1271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1247,14 +1279,17 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002233_CHEBI_30616_ACYLCOASYN-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/d7f17ae9-e907-411b-9a27-9ac1bdfb864c_ENOYL-COA-DELTA-ISOM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002233_CHEBI_15377_ENOYL-COA-HYDRAT-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1267,7 +1302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fatty acid oxidation pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1279,11 +1314,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002333_YGL205W-MONOMER_RXN-11026_controller_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002333_YGL205W-MONOMER_RXN-11026_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1303,7 +1338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1315,11 +1350,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002233_CHEBI_15489_OHACYL-COA-DEHYDROG-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002233_CHEBI_15489_OHACYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1334,11 +1369,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YER015W-MONOMER_ACYLCOASYN-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YER015W-MONOMER_ACYLCOASYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1354,18 +1389,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_BFO_0000066_reaction_KETOACYLCOATHIOL-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-FAO-PWY>
+<http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_57540_OHACYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1374,35 +1409,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/a88d2721-fcc6-45ce-9af8-b0f0ace6c88d_RXN-11026>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a <i>trans</i>-2-enoyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002233_CHEBI_57287_KETOACYLCOATHIOL-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YOR317W-MONOMER_ACYLCOASYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1410,11 +1428,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_15455_ENOYL-COA-HYDRAT-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_15455_ENOYL-COA-HYDRAT-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1429,11 +1447,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002234_59c81d65-08ba-4bb9-9684-c8b219d34d4d_ENOYL-COA-DELTA-ISOM-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002234_5a7a9c60-7a0e-447a-acbb-734a4b9be374_ENOYL-COA-DELTA-ISOM-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1441,19 +1459,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-COA-DELTA-ISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/59c81d65-08ba-4bb9-9684-c8b219d34d4d_ENOYL-COA-DELTA-ISOM-RXN>
+          <http://model.geneontology.org/5a7a9c60-7a0e-447a-acbb-734a4b9be374_ENOYL-COA-DELTA-ISOM-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YMR246W-MONOMER_ACYLCOASYN-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57288_KETOACYLCOATHIOL-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1464,13 +1471,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59518> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002411_ENOYL-COA-HYDRAT-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002333_YKR009C-MONOMER_ENOYL-COA-HYDRAT-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YOR317W-MONOMER_ACYLCOASYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005844> ;
@@ -1479,7 +1508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1494,7 +1523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1507,21 +1536,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004467>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_57540_OHACYL-COA-DEHYDROG-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_bc8ee67c-a712-45f7-92a3-938457e0f60c_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1529,11 +1558,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11026_BFO_0000066_reaction_RXN-11026_location_lociGO_0005829_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11026_BFO_0000066_reaction_RXN-11026_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1551,11 +1580,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002234_CHEBI_15455_ENOYL-COA-HYDRAT-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002234_CHEBI_15455_ENOYL-COA-HYDRAT-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1566,18 +1595,15 @@
           <http://model.geneontology.org/CHEBI_15455_ENOYL-COA-HYDRAT-RXN>
 ] .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_CHEBI_29888_ACYLCOASYN-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_CHEBI_29888_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1588,88 +1614,35 @@
           <http://model.geneontology.org/CHEBI_29888_ACYLCOASYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YBR041W-MONOMER_ACYLCOASYN-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY>
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_BFO_0000066_reaction_KETOACYLCOATHIOL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002234_1f697913-3a66-4ba2-ba6e-61381391bf75_KETOACYLCOATHIOL-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11026_BFO_0000066_reaction_RXN-11026_location_lociGO_0005829_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004860>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_BFO_0000066_reaction_ENOYL-COA-HYDRAT-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0019395>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/0688da3b-9ddc-4d12-8537-0f388bc5b4ba_ACYLCOASYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 2,3,4-saturated fatty acyl CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://identifiers.org/sgd/S000000817>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_15489>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002234_1f697913-3a66-4ba2-ba6e-61381391bf75_KETOACYLCOATHIOL-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002234_5efa3fcd-e059-4180-b745-04245e0c2b08_KETOACYLCOATHIOL-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1677,18 +1650,35 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/KETOACYLCOATHIOL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1f697913-3a66-4ba2-ba6e-61381391bf75_KETOACYLCOATHIOL-RXN>
+          <http://model.geneontology.org/5efa3fcd-e059-4180-b745-04245e0c2b08_KETOACYLCOATHIOL-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/CHEBI_15489>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000000817>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YER015W-MONOMER_ACYLCOASYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YOR317W-MONOMER_ACYLCOASYN-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YOR317W-MONOMER_ACYLCOASYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1699,19 +1689,30 @@
           <http://model.geneontology.org/YOR317W-MONOMER_ACYLCOASYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_CHEBI_15379_RXN-11026_SGD_YeastPathways_YEAST-FAO-PWY>
+<http://purl.obolibrary.org/obo/CHEBI_57288>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57288>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN-11026_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1721,7 +1722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1729,11 +1730,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002234_CHEBI_15489_OHACYL-COA-DEHYDROG-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002234_CHEBI_15489_OHACYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1748,11 +1749,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002411_ENOYL-COA-HYDRAT-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002411_ENOYL-COA-HYDRAT-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1773,11 +1774,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1788,16 +1789,50 @@
           <http://model.geneontology.org/YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002411_ENOYL-COA-HYDRAT-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_BFO_0000066_reaction_ENOYL-COA-HYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/5a7a9c60-7a0e-447a-acbb-734a4b9be374_ENOYL-COA-DELTA-ISOM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a <i>trans</i>-2-enoyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/bc8ee67c-a712-45f7-92a3-938457e0f60c_ACYLCOASYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 2,3,4-saturated fatty acyl CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15377_ENOYL-COA-HYDRAT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -1808,13 +1843,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59369> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/8e027dc0-374d-4782-bd92-36cebcd5af59_ACYLCOASYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/KETOACYLCOATHIOL-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003988> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1827,7 +1865,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15489_OHACYL-COA-DEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_57287_KETOACYLCOATHIOL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57288_KETOACYLCOATHIOL-RXN> , <http://model.geneontology.org/1f697913-3a66-4ba2-ba6e-61381391bf75_KETOACYLCOATHIOL-RXN> ;
+                <http://model.geneontology.org/CHEBI_57288_KETOACYLCOATHIOL-RXN> , <http://model.geneontology.org/5efa3fcd-e059-4180-b745-04245e0c2b08_KETOACYLCOATHIOL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YIL160C-MONOMER_KETOACYLCOATHIOL-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1835,7 +1873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1846,17 +1884,6 @@
 <http://identifiers.org/sgd/S000001271>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002333_YKR009C-MONOMER_ENOYL-COA-HYDRAT-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YGL205W-MONOMER_RXN-11026_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003173> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1864,7 +1891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1876,11 +1903,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_CHEBI_16240_RXN-11026_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_CHEBI_16240_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1891,37 +1918,15 @@
           <http://model.geneontology.org/CHEBI_16240_RXN-11026>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002333_YLR284C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002234_59c81d65-08ba-4bb9-9684-c8b219d34d4d_ENOYL-COA-DELTA-ISOM-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1936,11 +1941,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YBR041W-MONOMER_ACYLCOASYN-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YBR041W-MONOMER_ACYLCOASYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1951,41 +1956,8 @@
           <http://model.geneontology.org/YBR041W-MONOMER_ACYLCOASYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002233_CHEBI_57287_ACYLCOASYN-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004165>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_CHEBI_29888_ACYLCOASYN-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_a88d2721-fcc6-45ce-9af8-b0f0ace6c88d_RXN-11026_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003173>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1994,11 +1966,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2013,11 +1985,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_BFO_0000066_reaction_ENOYL-COA-DELTA-ISOM-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_BFO_0000066_reaction_ENOYL-COA-DELTA-ISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2028,6 +2000,17 @@
           <http://model.geneontology.org/reaction_ENOYL-COA-DELTA-ISOM-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002333_YOR180C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57287_KETOACYLCOATHIOL-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57287> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2037,7 +2020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2048,19 +2031,30 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002411_ENOYL-COA-HYDRAT-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002411_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002234_CHEBI_15489_OHACYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456215_ACYLCOASYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456215> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2071,7 +2065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2088,9 +2082,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_ENOYL-COA-DELTA-ISOM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/ef46aba3-396c-4c8c-be19-6ee580d382b0_ENOYL-COA-DELTA-ISOM-RXN> ;
+                <http://model.geneontology.org/8426423b-fc60-4ac8-a9a1-0d610cf4581a_ENOYL-COA-DELTA-ISOM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/59c81d65-08ba-4bb9-9684-c8b219d34d4d_ENOYL-COA-DELTA-ISOM-RXN> ;
+                <http://model.geneontology.org/5a7a9c60-7a0e-447a-acbb-734a4b9be374_ENOYL-COA-DELTA-ISOM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR284C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller> , <http://model.geneontology.org/YOR180C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2098,7 +2092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2112,14 +2106,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_8c0af6e3-dfe4-414c-af67-dfbbab2305de_ACYLCOASYN-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002233_d7f17ae9-e907-411b-9a27-9ac1bdfb864c_ENOYL-COA-DELTA-ISOM-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002234_5efa3fcd-e059-4180-b745-04245e0c2b08_KETOACYLCOATHIOL-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2130,11 +2135,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a (3<i>S</i>)-3-hydroxyacyl-CoA + NAD<sup>+</sup> &rarr; a 3-oxoacyl-CoA + NADH + H<SUP>+</SUP>' 'null' 'a 2,3,4-saturated fatty acyl CoA + acetyl-CoA &larr; a 3-oxoacyl-CoA + coenzyme A' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002413_KETOACYLCOATHIOL-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002413_KETOACYLCOATHIOL-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2145,31 +2150,14 @@
           <http://model.geneontology.org/KETOACYLCOATHIOL-RXN>
 ] .
 
-<http://model.geneontology.org/59c81d65-08ba-4bb9-9684-c8b219d34d4d_ENOYL-COA-DELTA-ISOM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a <i>trans</i>-2-enoyl-CoA" ;
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YBR041W-MONOMER_ACYLCOASYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002411_RXN-11026_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2177,11 +2165,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002233_CHEBI_15377_ENOYL-COA-HYDRAT-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002233_CHEBI_15377_ENOYL-COA-HYDRAT-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2196,11 +2184,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002233_CHEBI_57287_ACYLCOASYN-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002233_CHEBI_57287_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2211,16 +2199,50 @@
           <http://model.geneontology.org/CHEBI_57287_ACYLCOASYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_YeastPathways_YEAST-FAO-PWY>
+<http://model.geneontology.org/8426423b-fc60-4ac8-a9a1-0d610cf4581a_ENOYL-COA-DELTA-ISOM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a (3Z)-alk-3-enoyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59385> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002234_CHEBI_15455_ENOYL-COA-HYDRAT-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/1015a147-03b7-4561-bcbd-57cd24a77cd6_RXN-11026>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a <i>trans</i>-2-enoyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_30616_ACYLCOASYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -2231,7 +2253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2239,25 +2261,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_0688da3b-9ddc-4d12-8537-0f388bc5b4ba_ACYLCOASYN-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002233_CHEBI_30616_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2265,11 +2276,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002411_ENOYL-COA-HYDRAT-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002411_ENOYL-COA-HYDRAT-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2280,15 +2291,26 @@
           <http://model.geneontology.org/ENOYL-COA-HYDRAT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002411_ENOYL-COA-HYDRAT-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002233_CHEBI_57287_KETOACYLCOATHIOL-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002233_CHEBI_57287_KETOACYLCOATHIOL-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2303,11 +2325,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YIL009W-MONOMER_ACYLCOASYN-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YIL009W-MONOMER_ACYLCOASYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2318,17 +2340,6 @@
           <http://model.geneontology.org/YIL009W-MONOMER_ACYLCOASYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YIL009W-MONOMER_ACYLCOASYN-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/RXN-11026>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003997> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2338,9 +2349,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-11026_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/8c0af6e3-dfe4-414c-af67-dfbbab2305de_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_15379_RXN-11026> ;
+                <http://model.geneontology.org/CHEBI_15379_RXN-11026> , <http://model.geneontology.org/8e027dc0-374d-4782-bd92-36cebcd5af59_ACYLCOASYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/a88d2721-fcc6-45ce-9af8-b0f0ace6c88d_RXN-11026> , <http://model.geneontology.org/CHEBI_16240_RXN-11026> ;
+                <http://model.geneontology.org/CHEBI_16240_RXN-11026> , <http://model.geneontology.org/1015a147-03b7-4561-bcbd-57cd24a77cd6_RXN-11026> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL205W-MONOMER_RXN-11026_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2348,7 +2359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2356,25 +2367,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-11026_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002234_CHEBI_15378_OHACYL-COA-DEHYDROG-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_1015a147-03b7-4561-bcbd-57cd24a77cd6_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_CHEBI_29888_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002333_YLR284C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2382,11 +2404,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_57540_OHACYL-COA-DEHYDROG-RXN_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_57540_OHACYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2397,26 +2419,15 @@
           <http://model.geneontology.org/CHEBI_57540_OHACYL-COA-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002234_CHEBI_15489_OHACYL-COA-DEHYDROG-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002333_YLR284C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002333_YLR284C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2427,58 +2438,36 @@
           <http://model.geneontology.org/YLR284C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_BFO_0000066_reaction_OHACYL-COA-DEHYDROG-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002233_CHEBI_71627_ACYLCOASYN-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_15455_ENOYL-COA-HYDRAT-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_BFO_0000066_reaction_ACYLCOASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_CHEBI_16240_RXN-11026_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002411_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002413_KETOACYLCOATHIOL-RXN_SGD_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_BFO_0000050_YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2489,7 +2478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2497,13 +2486,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002333_YIL160C-MONOMER_KETOACYLCOATHIOL-RXN_controller_SGD_YeastPathways_YEAST-FAO-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_8e027dc0-374d-4782-bd92-36cebcd5af59_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002234_CHEBI_15378_OHACYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_YEAST-GALACT-METAB-PWY.ttl
+++ b/models/YeastPathways_YEAST-GALACT-METAB-PWY.ttl
@@ -1,22 +1,11 @@
-<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
+<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002234_CHEBI_58336_GALACTOKIN-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -37,13 +26,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-GALACT-METAB-PWYBiochemicalReaction27379> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_66914_GALACTURIDYLYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_66914> ;
@@ -54,7 +54,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,26 +62,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002233_CHEBI_58336_GALACTOKIN-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -92,44 +81,14 @@
           <http://model.geneontology.org/YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://identifiers.org/sgd/S000000223>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_RO_0002333_YBR019C-MONOMER_UDPGLUCEPIM-RXN_controller_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_RO_0002234_CHEBI_28061_ALDOSE1EPIM-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0008108>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_456216_GALACTOKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -140,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -152,11 +111,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" , "Provides Input For Rule. The relation '&alpha;-D-galactopyranose + ATP &rarr; &alpha;-D-galactose 1-phosphate + ADP + H<SUP>+</SUP>' 'null' 'UDP-&alpha;-D-glucose + &alpha;-D-galactose 1-phosphate &rarr; UDP-&alpha;-D-galactose + &alpha;-D-glucopyranose 1-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002413_GALACTURIDYLYLTRANS-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002413_GALACTURIDYLYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -174,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -191,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -203,11 +162,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_RO_0002333_YBR019C-MONOMER_ALDOSE1EPIM-RXN_controller_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_RO_0002333_YBR019C-MONOMER_ALDOSE1EPIM-RXN_controller_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -227,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -240,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -248,11 +207,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,11 +222,19 @@
           <http://model.geneontology.org/CHEBI_4170_PHOSPHOGLUCMUT-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0008108>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_BFO_0000066_reaction_GALACTOKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0019388>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -275,15 +242,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_58601>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002234_CHEBI_66914_GALACTURIDYLYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002333_YBR018C-MONOMER_GALACTURIDYLYLTRANS-RXN_controller_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002333_YBR018C-MONOMER_GALACTURIDYLYLTRANS-RXN_controller_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -294,17 +272,6 @@
           <http://model.geneontology.org/YBR018C-MONOMER_GALACTURIDYLYLTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_RO_0002413_GALACTOKIN-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_GALACTOKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -314,7 +281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -329,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,11 +308,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_RO_0002333_YBR019C-MONOMER_UDPGLUCEPIM-RXN_controller_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_RO_0002333_YBR019C-MONOMER_UDPGLUCEPIM-RXN_controller_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -356,28 +323,72 @@
           <http://model.geneontology.org/YBR019C-MONOMER_UDPGLUCEPIM-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002234_CHEBI_456216_GALACTOKIN-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://identifiers.org/sgd/S000000222>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_RO_0002413_GALACTOKIN-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_RO_0002234_CHEBI_58885_UDPGLUCEPIM-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
+<http://identifiers.org/sgd/S000000222>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://identifiers.org/sgd/S000004711>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002413_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_28061_ALDOSE1EPIM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_28061> ;
@@ -388,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -400,11 +411,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002333_YBR020W-MONOMER_GALACTOKIN-RXN_controller_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002333_YBR020W-MONOMER_GALACTOKIN-RXN_controller_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -415,26 +426,15 @@
           <http://model.geneontology.org/YBR020W-MONOMER_GALACTOKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_RO_0002413_GALACTURIDYLYLTRANS-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_RO_0002234_CHEBI_28061_ALDOSE1EPIM-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_RO_0002234_CHEBI_28061_ALDOSE1EPIM-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -449,11 +449,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_58601_GALACTURIDYLYLTRANS-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_58601_GALACTURIDYLYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -467,39 +467,28 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_BFO_0000066_reaction_UDPGLUCEPIM-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002234_CHEBI_456216_GALACTOKIN-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
+<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_BFO_0000066_reaction_UDPGLUCEPIM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002234_CHEBI_15378_GALACTOKIN-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -510,11 +499,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002234_CHEBI_66914_GALACTURIDYLYLTRANS-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002234_CHEBI_66914_GALACTURIDYLYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -528,14 +517,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_66914>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002413_GALACTURIDYLYLTRANS-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002233_CHEBI_58885_UDPGLUCEPIM-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -543,11 +532,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_RO_0002234_CHEBI_58885_UDPGLUCEPIM-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_RO_0002234_CHEBI_58885_UDPGLUCEPIM-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -558,17 +547,6 @@
           <http://model.geneontology.org/CHEBI_58885_UDPGLUCEPIM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002234_CHEBI_58336_GALACTOKIN-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YBR018C-MONOMER_GALACTURIDYLYLTRANS-RXN_controller>
         a       <http://identifiers.org/sgd/S000000222> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -576,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -584,40 +562,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002413_GALACTURIDYLYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004614>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002233_CHEBI_28061_ALDOSE1EPIM-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_58601_GALACTURIDYLYLTRANS-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002233_CHEBI_58885_UDPGLUCEPIM-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002233_CHEBI_58885_UDPGLUCEPIM-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -628,18 +609,37 @@
           <http://model.geneontology.org/CHEBI_58885_UDPGLUCEPIM-RXN>
 ] .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_BFO_0000066_reaction_GALACTURIDYLYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002233_CHEBI_28061_ALDOSE1EPIM-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002233_CHEBI_28061_ALDOSE1EPIM-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -653,49 +653,27 @@
 <http://purl.obolibrary.org/obo/GO_0004335>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_RO_0002233_CHEBI_66914_GALACTURIDYLYLTRANS-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002233_CHEBI_58885_UDPGLUCEPIM-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002234_CHEBI_58336_GALACTOKIN-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002234_CHEBI_58336_GALACTOKIN-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -706,14 +684,14 @@
           <http://model.geneontology.org/CHEBI_58336_GALACTOKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_RO_0002413_GALACTURIDYLYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -721,11 +699,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_RO_0002233_CHEBI_27667_ALDOSE1EPIM-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_RO_0002233_CHEBI_27667_ALDOSE1EPIM-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -751,26 +729,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002333_YBR020W-MONOMER_GALACTOKIN-RXN_controller_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -784,25 +751,14 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002413_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
+<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -811,15 +767,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_27667>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002233_CHEBI_28061_ALDOSE1EPIM-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_GALACTOKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -830,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -842,11 +809,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002234_CHEBI_58601_GALACTURIDYLYLTRANS-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002234_CHEBI_58601_GALACTURIDYLYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -864,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -872,26 +839,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002233_CHEBI_30616_GALACTOKIN-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_RO_0002233_CHEBI_66914_GALACTURIDYLYLTRANS-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_RO_0002233_CHEBI_66914_GALACTURIDYLYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -908,26 +864,15 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_RO_0002333_YBR019C-MONOMER_ALDOSE1EPIM-RXN_controller_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002233_CHEBI_58336_GALACTOKIN-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002233_CHEBI_58336_GALACTOKIN-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -938,26 +883,15 @@
           <http://model.geneontology.org/CHEBI_58336_GALACTOKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002234_CHEBI_66914_GALACTURIDYLYLTRANS-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_BFO_0000066_reaction_GALACTOKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_BFO_0000066_reaction_GALACTOKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -973,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -984,7 +918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -992,14 +926,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_BFO_0000066_reaction_GALACTURIDYLYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002333_YBR018C-MONOMER_GALACTURIDYLYLTRANS-RXN_controller_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1007,11 +952,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002234_CHEBI_456216_GALACTOKIN-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002234_CHEBI_456216_GALACTOKIN-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1031,7 +976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1039,26 +984,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_BFO_0000066_reaction_ALDOSE1EPIM-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_BFO_0000066_reaction_ALDOSE1EPIM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1073,11 +1007,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1107,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1121,25 +1055,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_28061>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002413_UDPGLUCEPIM-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002234_CHEBI_15378_GALACTOKIN-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
+<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1148,7 +1082,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002233_CHEBI_30616_GALACTOKIN-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1158,15 +1103,26 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_58601_GALACTURIDYLYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_BFO_0000066_reaction_UDPGLUCEPIM-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_BFO_0000066_reaction_UDPGLUCEPIM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1177,8 +1133,16 @@
           <http://model.geneontology.org/reaction_UDPGLUCEPIM-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58885>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002233_CHEBI_58336_GALACTOKIN-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1192,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1204,11 +1168,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_BFO_0000066_reaction_GALACTURIDYLYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_BFO_0000066_reaction_GALACTURIDYLYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1219,37 +1183,18 @@
           <http://model.geneontology.org/reaction_GALACTURIDYLYLTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_BFO_0000066_reaction_ALDOSE1EPIM-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_58885>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1263,6 +1208,28 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_RO_0002233_CHEBI_66914_GALACTURIDYLYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1270,11 +1237,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002234_CHEBI_15378_GALACTOKIN-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002234_CHEBI_15378_GALACTOKIN-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1284,17 +1251,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_GALACTOKIN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_RO_0002233_CHEBI_27667_ALDOSE1EPIM-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/UDPGLUCEPIM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003978> ;
@@ -1315,24 +1271,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-GALACT-METAB-PWYBiochemicalReaction27417> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002413_UDPGLUCEPIM-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001610>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1341,11 +1286,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1365,7 +1310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1377,11 +1322,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'UDP-&alpha;-D-glucose + &alpha;-D-galactose 1-phosphate &rarr; UDP-&alpha;-D-galactose + &alpha;-D-glucopyranose 1-phosphate' 'null' 'UDP-&alpha;-D-glucose &harr; UDP-&alpha;-D-galactose' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002413_UDPGLUCEPIM-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002413_UDPGLUCEPIM-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1417,7 +1362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1425,14 +1370,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002234_CHEBI_58601_GALACTURIDYLYLTRANS-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
+<http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_BFO_0000066_reaction_ALDOSE1EPIM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1445,7 +1390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "galactose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1453,43 +1398,43 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_RO_0002333_YBR019C-MONOMER_ALDOSE1EPIM-RXN_controller_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_RO_0002234_CHEBI_58885_UDPGLUCEPIM-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_BFO_0000066_reaction_GALACTOKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002333_YBR018C-MONOMER_GALACTURIDYLYLTRANS-RXN_controller_SGD_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1519,7 +1464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1527,8 +1472,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002234_CHEBI_58601_GALACTURIDYLYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000000224>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_RO_0002333_YBR019C-MONOMER_UDPGLUCEPIM-RXN_controller_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1537,11 +1504,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1556,11 +1523,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '&beta;-D-galactopyranose &rarr; &alpha;-D-galactopyranose' 'null' '&alpha;-D-galactopyranose + ATP &rarr; &alpha;-D-galactose 1-phosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_RO_0002413_GALACTOKIN-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_RO_0002413_GALACTOKIN-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1575,11 +1542,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1597,11 +1564,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002233_CHEBI_30616_GALACTOKIN-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002233_CHEBI_30616_GALACTOKIN-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1615,15 +1582,48 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002333_YBR020W-MONOMER_GALACTOKIN-RXN_controller_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_RO_0002234_CHEBI_28061_ALDOSE1EPIM-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_RO_0002233_CHEBI_27667_ALDOSE1EPIM-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" , "Provides Input For Rule. The relation 'UDP-&alpha;-D-glucose + &alpha;-D-galactose 1-phosphate &rarr; UDP-&alpha;-D-galactose + &alpha;-D-glucopyranose 1-phosphate' 'null' '&alpha;-D-glucopyranose 1-phosphate &harr; D-glucopyranose 6-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002413_PHOSPHOGLUCMUT-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_RO_0002413_PHOSPHOGLUCMUT-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1643,7 +1643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1655,11 +1655,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'UDP-&alpha;-D-glucose &harr; UDP-&alpha;-D-galactose' 'null' 'UDP-&alpha;-D-glucose + &alpha;-D-galactose 1-phosphate &rarr; UDP-&alpha;-D-galactose + &alpha;-D-glucopyranose 1-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_RO_0002413_GALACTURIDYLYLTRANS-RXN_SGD_YeastPathways_YEAST-GALACT-METAB-PWY> ;
+          <http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_RO_0002413_GALACTURIDYLYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_YEAST-RIBOSYN-PWY.ttl
+++ b/models/YeastPathways_YEAST-RIBOSYN-PWY.ttl
@@ -1,9 +1,11 @@
-<http://model.geneontology.org/reaction_RXN3O-110_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+<http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11,11 +13,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002233_CHEBI_30616_RIBOFLAVINKIN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002233_CHEBI_30616_RIBOFLAVINKIN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,6 +27,15 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30616_RIBOFLAVINKIN-RXN>
 ] .
+
+<http://model.geneontology.org/reaction_RXN3O-110_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GTP-CYCLOHYDRO-II-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003935> ;
@@ -45,7 +56,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -53,26 +64,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002234_CHEBI_29888_GTP-CYCLOHYDRO-II-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'GTP + 3 H<sub>2</sub>O &rarr; 2,5-diamino-6-(5-phospho-D-ribosylamino)pyrimidin-4(3H)-one + formate + diphosphate + 2 H<SUP>+</SUP>' 'null' '2,5-diamino-6-(5-phospho-D-ribosylamino)pyrimidin-4(3H)-one &rarr; 2,5-diamino-6-(5-phospho-D-ribitylamino)pyrimidin-4(3H)-one' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002413_RXN3O-110_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002413_RXN3O-110_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -83,25 +83,14 @@
           <http://model.geneontology.org/RXN3O-110>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002234_CHEBI_15740_DIOHBUTANONEPSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002233_CHEBI_15378_RXN-10058_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-10058_BFO_0000066_reaction_RXN-10058_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -109,11 +98,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002333_MONOMER3O-89_DIOHBUTANONEPSYN-RXN_controller_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002333_MONOMER3O-89_DIOHBUTANONEPSYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -141,40 +130,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002233_CHEBI_15934_RXN3O-164_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002233_CHEBI_57945_RXN-10057_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RIBOPHOSPHAT-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -182,11 +149,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" , "Provides Input For Rule. The relation '2,5-diamino-6-(5-phospho-D-ribitylamino)pyrimidin-4(3H)-one + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; 5-amino-6-(5-phospho-D-ribitylamino)uracil + ammonium' 'null' '5-amino-6-(5-phospho-D-ribitylamino)uracil + H<sub>2</sub>O &rarr; 5-amino-6-(D-ribitylamino)uracil + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002413_RIBOPHOSPHAT-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002413_RIBOPHOSPHAT-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -197,6 +164,17 @@
           <http://model.geneontology.org/RIBOPHOSPHAT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002234_CHEBI_57986_RIBOFLAVIN-SYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_RXN-10057>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -206,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -218,11 +196,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_BFO_0000066_reaction_RIBOPHOSPHAT-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_BFO_0000066_reaction_RIBOPHOSPHAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,25 +211,14 @@
           <http://model.geneontology.org/reaction_RIBOPHOSPHAT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-110_RO_0002413_RXN3O-164_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-164_RO_0002233_CHEBI_58890_RXN3O-110_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-II-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -259,11 +226,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002234_CHEBI_58201_LUMAZINESYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002234_CHEBI_58201_LUMAZINESYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,25 +241,14 @@
           <http://model.geneontology.org/CHEBI_58201_LUMAZINESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002234_CHEBI_29114_GTP-CYCLOHYDRO-II-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002233_CHEBI_30616_FADSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002413_RIBOFLAVIN-SYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -300,11 +256,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002234_CHEBI_29888_FADSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002234_CHEBI_29888_FADSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,16 +271,8 @@
           <http://model.geneontology.org/CHEBI_29888_FADSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-164_RO_0002333_YOL066C-MONOMER_RXN3O-164_controller_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15740>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_RIBOFLAVINKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -335,7 +283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -363,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -380,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -388,8 +336,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15740>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002233_CHEBI_57945_RXN-10057_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -397,14 +353,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-10057_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000129>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002233_CHEBI_58121_DIOHBUTANONEPSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -412,11 +382,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-164_BFO_0000066_reaction_RXN3O-164_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-164_BFO_0000066_reaction_RXN3O-164_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -427,15 +397,23 @@
           <http://model.geneontology.org/reaction_RXN3O-164_location_lociGO_0005829>
 ] .
 
-<http://identifiers.org/sgd/S000000129>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002234_CHEBI_29888_FADSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_DIOHBUTANONEPSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -443,11 +421,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002233_CHEBI_15378_RXN-10057_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002233_CHEBI_15378_RXN-10057_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -462,11 +440,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002234_CHEBI_57986_RIBOFLAVIN-SYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002234_CHEBI_57986_RIBOFLAVIN-SYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,15 +455,37 @@
           <http://model.geneontology.org/CHEBI_57986_RIBOFLAVIN-SYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002233_CHEBI_15378_RXN-10058_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002333_YDR236C-MONOMER_RIBOFLAVINKIN-RXN_controller_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-II-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-II-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -496,28 +496,6 @@
           <http://model.geneontology.org/CHEBI_15740_GTP-CYCLOHYDRO-II-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002413_RXN-10058_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002234_CHEBI_58421_RXN-10058_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -525,11 +503,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_BFO_0000066_reaction_DIOHBUTANONEPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_BFO_0000066_reaction_DIOHBUTANONEPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -545,18 +523,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10058_BFO_0000066_reaction_RXN-10058_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002333_MONOMER3O-89_DIOHBUTANONEPSYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -570,11 +548,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002233_CHEBI_15377_RXN-10058_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002233_CHEBI_15377_RXN-10058_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -594,7 +572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -602,15 +580,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-10057_BFO_0000066_reaction_RXN-10057_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002234_CHEBI_456216_RIBOFLAVINKIN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002234_CHEBI_456216_RIBOFLAVINKIN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -621,17 +610,6 @@
           <http://model.geneontology.org/CHEBI_456216_RIBOFLAVINKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002233_CHEBI_15377_RIBOPHOSPHAT-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_RIBOFLAVINKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -641,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -653,11 +631,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002233_CHEBI_15934_RXN3O-164_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002233_CHEBI_15934_RXN3O-164_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,25 +649,58 @@
 <http://purl.obolibrary.org/obo/CHEBI_37565>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002233_CHEBI_30616_FADSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002413_FADSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002233_CHEBI_58201_LUMAZINESYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002234_CHEBI_15377_LUMAZINESYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-164_RO_0002333_YOL066C-MONOMER_RXN3O-164_controller_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-110_RO_0002333_MONOMER3O-27_RXN3O-110_controller_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002413_RIBOFLAVINKIN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -712,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -720,14 +731,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002333_MONOMER3O-75_RIBOFLAVIN-SYN-RXN_controller_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002234_CHEBI_15378_DIOHBUTANONEPSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -735,11 +746,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-110_RO_0002233_CHEBI_29114_GTP-CYCLOHYDRO-II-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-110_RO_0002233_CHEBI_29114_GTP-CYCLOHYDRO-II-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -750,25 +761,14 @@
           <http://model.geneontology.org/CHEBI_29114_GTP-CYCLOHYDRO-II-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN3O-164_RO_0002234_CHEBI_15934_RXN3O-164_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002234_CHEBI_15934_RIBOFLAVIN-SYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -776,11 +776,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002234_CHEBI_15934_RIBOPHOSPHAT-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002234_CHEBI_15934_RIBOPHOSPHAT-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,26 +791,15 @@
           <http://model.geneontology.org/CHEBI_15934_RIBOPHOSPHAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-110_RO_0002233_CHEBI_29114_GTP-CYCLOHYDRO-II-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,26 +813,15 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-164_RO_0002234_CHEBI_15934_RXN3O-164_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -857,47 +835,25 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002233_CHEBI_29114_GTP-CYCLOHYDRO-II-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002233_CHEBI_58421_RXN-10058_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002233_CHEBI_50606_DIOHBUTANONEPSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_FADSYN-RXN_BFO_0000066_reaction_FADSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002333_YDR236C-MONOMER_RIBOFLAVINKIN-RXN_controller_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -910,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -918,19 +874,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-110_RO_0002333_MONOMER3O-27_RXN3O-110_controller_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://identifiers.org/sgd/S000002644>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002234_CHEBI_15378_LUMAZINESYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000002644>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_58201>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -940,7 +896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -956,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -983,7 +939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1000,7 +956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1012,11 +968,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-164_RO_0002333_YOL066C-MONOMER_RXN3O-164_controller_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-164_RO_0002333_YOL066C-MONOMER_RXN3O-164_controller_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1027,26 +983,15 @@
           <http://model.geneontology.org/YOL066C-MONOMER_RXN3O-164_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002234_CHEBI_15377_LUMAZINESYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002234_CHEBI_57540_RXN-10057_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002234_CHEBI_57540_RXN-10057_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1061,11 +1006,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1076,14 +1021,14 @@
           <http://model.geneontology.org/YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002234_CHEBI_43474_RIBOPHOSPHAT-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002234_CHEBI_57692_FADSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1091,11 +1036,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002333_YBL033C-MONOMER_GTP-CYCLOHYDRO-II-RXN_controller_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002333_YBL033C-MONOMER_GTP-CYCLOHYDRO-II-RXN_controller_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1109,14 +1054,14 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002234_CHEBI_58210_RIBOFLAVINKIN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1124,11 +1069,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002234_CHEBI_15740_DIOHBUTANONEPSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002234_CHEBI_15740_DIOHBUTANONEPSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1146,7 +1091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1154,28 +1099,50 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-164_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002234_CHEBI_456216_RIBOFLAVINKIN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0042727>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-164_BFO_0000066_reaction_RXN3O-164_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002413_LUMAZINESYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-164_RO_0002413_LUMAZINESYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002233_CHEBI_57986_RIBOFLAVIN-SYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1183,11 +1150,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002234_CHEBI_28938_RXN-10058_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002234_CHEBI_28938_RXN-10058_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1198,16 +1165,8 @@
           <http://model.geneontology.org/CHEBI_28938_RXN-10058>
 ] .
 
-<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002333_YOL143C-MONOMER_LUMAZINESYN-RXN_controller_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57692>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1216,11 +1175,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" , "Provides Input For Rule. The relation 'riboflavin + ATP &rarr; ADP + FMN + H<SUP>+</SUP>' 'null' 'ATP + FMN + H<SUP>+</SUP> &rarr; FAD + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002413_FADSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002413_FADSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1236,7 +1195,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-110_RO_0002233_CHEBI_29114_GTP-CYCLOHYDRO-II-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1244,11 +1214,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002234_CHEBI_15378_LUMAZINESYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002234_CHEBI_15378_LUMAZINESYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1259,28 +1229,25 @@
           <http://model.geneontology.org/CHEBI_15378_LUMAZINESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-II-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_BFO_0000066_reaction_DIOHBUTANONEPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57692>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-II-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1288,11 +1255,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002233_CHEBI_30616_FADSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002233_CHEBI_30616_FADSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1308,18 +1275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002413_LUMAZINESYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1330,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1347,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1364,35 +1320,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RIBOSYN-PWYSmallMolecule53879> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002413_LUMAZINESYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002413_RIBOPHOSPHAT-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_RIBOFLAVINKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -1403,13 +1337,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RIBOSYN-PWYSmallMolecule54097> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15934_RIBOFLAVIN-SYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15934> ;
@@ -1420,7 +1357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1432,11 +1369,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" , "Provides Input For Rule. The relation '2,5-diamino-6-(5-phospho-D-ribosylamino)pyrimidin-4(3H)-one &rarr; 2,5-diamino-6-(5-phospho-D-ribitylamino)pyrimidin-4(3H)-one' 'null' '2,5-diamino-6-(5-phospho-D-ribitylamino)pyrimidin-4(3H)-one &rarr; 5-amino-6-(D-ribitylamino)uracil' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-110_RO_0002413_RXN3O-164_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-110_RO_0002413_RXN3O-164_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1447,18 +1384,37 @@
           <http://model.geneontology.org/RXN3O-164>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002234_CHEBI_29888_GTP-CYCLOHYDRO-II-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002234_CHEBI_29114_GTP-CYCLOHYDRO-II-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10057_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10057_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1473,11 +1429,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002233_CHEBI_58201_LUMAZINESYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002233_CHEBI_58201_LUMAZINESYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1492,11 +1448,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-II-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-II-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1516,13 +1472,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RIBOSYN-PWYSmallMolecule53851> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-164_RO_0002233_CHEBI_58890_RXN3O-110_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_LUMAZINESYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1533,13 +1500,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RIBOSYN-PWYSmallMolecule53814> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-II-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_FADSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -1550,7 +1539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1567,7 +1556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1578,14 +1567,14 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002233_CHEBI_50606_DIOHBUTANONEPSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002413_RIBOPHOSPHAT-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1598,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1610,11 +1599,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10058_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10058_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1625,15 +1614,26 @@
           <http://model.geneontology.org/YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-110_BFO_0000066_reaction_RXN3O-110_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002233_CHEBI_57986_RIBOFLAVIN-SYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002233_CHEBI_57986_RIBOFLAVIN-SYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1653,7 +1653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1665,11 +1665,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1680,37 +1680,15 @@
           <http://model.geneontology.org/YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002234_CHEBI_15378_RIBOFLAVINKIN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002333_YBL033C-MONOMER_GTP-CYCLOHYDRO-II-RXN_controller_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" , "Provides Input For Rule. The relation 'D-ribulose 5-phosphate &rarr; formate + 1-deoxy-L-glycero-tetrulose 4-phosphate + H<SUP>+</SUP>' 'null' '5-amino-6-(D-ribitylamino)uracil + 1-deoxy-L-glycero-tetrulose 4-phosphate &rarr; 6,7-dimethyl-8-(1-D-ribityl)lumazine + phosphate + H<SUP>+</SUP> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002413_LUMAZINESYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002413_LUMAZINESYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1721,28 +1699,6 @@
           <http://model.geneontology.org/LUMAZINESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FADSYN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002233_CHEBI_15378_RIBOFLAVIN-SYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_GTP-CYCLOHYDRO-II-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1752,7 +1708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1763,14 +1719,14 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002333_MONOMER3O-89_DIOHBUTANONEPSYN-RXN_controller_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002233_CHEBI_58890_RXN-10057_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1778,11 +1734,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-110_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-110_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1800,7 +1756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1817,7 +1773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1829,11 +1785,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002233_CHEBI_15377_RIBOPHOSPHAT-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002233_CHEBI_15377_RIBOPHOSPHAT-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1848,11 +1804,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002333_YOL143C-MONOMER_LUMAZINESYN-RXN_controller_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002333_YOL143C-MONOMER_LUMAZINESYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1872,7 +1828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1884,11 +1840,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002234_CHEBI_57692_FADSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002234_CHEBI_57692_FADSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1905,34 +1861,41 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_57945>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002234_CHEBI_58890_RXN-10057_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002413_RXN3O-110_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002333_YOL143C-MONOMER_LUMAZINESYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002413_RXN-10057_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/MONOMER3O-75_RIBOFLAVIN-SYN-RXN_controller>
-        a       <http://identifiers.org/sgd/S000000460> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "riboflavine synthetase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RIBOSYN-PWYProtein54066> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/RXN-10058>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1951,13 +1914,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RIBOSYN-PWYBiochemicalReaction53883> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/MONOMER3O-75_RIBOFLAVIN-SYN-RXN_controller>
+        a       <http://identifiers.org/sgd/S000000460> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "riboflavine synthetase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RIBOSYN-PWYProtein54066> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/RIBOFLAVIN-SYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004746> ;
@@ -1978,13 +1956,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RIBOSYN-PWYBiochemicalReaction54045> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002333_YDL045C-MONOMER_FADSYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RIBOPHOSPHAT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
@@ -2003,7 +1992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2020,7 +2009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2028,8 +2017,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002333_YBL033C-MONOMER_GTP-CYCLOHYDRO-II-RXN_controller_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15740_DIOHBUTANONEPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15740> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2040,7 +2037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2048,40 +2045,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002233_CHEBI_15378_RXN-10057_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57945>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-110_RO_0002234_CHEBI_58890_RXN3O-110_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-164_RO_0002233_CHEBI_58890_RXN3O-110_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-164_RO_0002233_CHEBI_58890_RXN3O-110_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2092,18 +2070,15 @@
           <http://model.geneontology.org/CHEBI_58890_RXN3O-110>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002233_CHEBI_29114_GTP-CYCLOHYDRO-II-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002233_CHEBI_29114_GTP-CYCLOHYDRO-II-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2114,18 +2089,32 @@
           <http://model.geneontology.org/CHEBI_29114_GTP-CYCLOHYDRO-II-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002233_CHEBI_29114_GTP-CYCLOHYDRO-II-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002333_MONOMER3O-75_RIBOFLAVIN-SYN-RXN_controller_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002333_MONOMER3O-75_RIBOFLAVIN-SYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2136,15 +2125,26 @@
           <http://model.geneontology.org/MONOMER3O-75_RIBOFLAVIN-SYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002233_CHEBI_15378_FADSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002234_CHEBI_29114_GTP-CYCLOHYDRO-II-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002234_CHEBI_29114_GTP-CYCLOHYDRO-II-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2159,11 +2159,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002233_CHEBI_58121_DIOHBUTANONEPSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002233_CHEBI_58121_DIOHBUTANONEPSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2186,7 +2186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2194,51 +2194,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002233_CHEBI_30616_RIBOFLAVINKIN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_BFO_0000066_reaction_LUMAZINESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_BFO_0000066_reaction_RIBOFLAVINKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000002203>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002233_CHEBI_15378_RXN-10058_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002233_CHEBI_15378_RXN-10058_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2249,18 +2219,37 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-10058>
 ] .
 
-<http://identifiers.org/sgd/S000002203>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-II-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002234_CHEBI_58201_LUMAZINESYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002234_CHEBI_58210_RIBOFLAVINKIN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002234_CHEBI_58210_RIBOFLAVINKIN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2271,37 +2260,15 @@
           <http://model.geneontology.org/CHEBI_58210_RIBOFLAVINKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002234_CHEBI_15378_LUMAZINESYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002234_CHEBI_15378_DIOHBUTANONEPSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002233_CHEBI_50606_DIOHBUTANONEPSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002233_CHEBI_50606_DIOHBUTANONEPSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2316,11 +2283,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FADSYN-RXN_BFO_0000066_reaction_FADSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FADSYN-RXN_BFO_0000066_reaction_FADSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2331,29 +2298,40 @@
           <http://model.geneontology.org/reaction_FADSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://identifiers.org/sgd/S000005503>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-II-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002233_CHEBI_15934_RXN3O-164_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002233_CHEBI_15378_RIBOFLAVIN-SYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000005503>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-110_RO_0002234_CHEBI_58890_RXN3O-110_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-110_RO_0002234_CHEBI_58890_RXN3O-110_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2373,7 +2351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2388,11 +2366,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002234_CHEBI_43474_RIBOPHOSPHAT-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002234_CHEBI_43474_RIBOPHOSPHAT-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2403,26 +2381,15 @@
           <http://model.geneontology.org/CHEBI_43474_RIBOPHOSPHAT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10057_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_BFO_0000066_reaction_RIBOFLAVIN-SYN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_BFO_0000066_reaction_RIBOFLAVIN-SYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2440,7 +2407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2448,26 +2415,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002413_RIBOFLAVINKIN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-II-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-II-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2478,47 +2434,88 @@
           <http://model.geneontology.org/reaction_GTP-CYCLOHYDRO-II-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002234_CHEBI_456216_RIBOFLAVINKIN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002413_RXN3O-110_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-110_RO_0002413_RXN3O-164_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002413_LUMAZINESYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-110_RO_0002234_CHEBI_58890_RXN3O-110_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002234_CHEBI_50606_DIOHBUTANONEPSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002234_CHEBI_58210_RIBOFLAVINKIN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002234_CHEBI_43474_LUMAZINESYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002234_CHEBI_58421_RXN-10058_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" , "Provides Input For Rule. The relation '2,5-diamino-6-(5-phospho-D-ribitylamino)pyrimidin-4(3H)-one &rarr; 5-amino-6-(D-ribitylamino)uracil' 'null' '5-amino-6-(D-ribitylamino)uracil + 1-deoxy-L-glycero-tetrulose 4-phosphate &rarr; 6,7-dimethyl-8-(1-D-ribityl)lumazine + phosphate + H<SUP>+</SUP> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-164_RO_0002413_LUMAZINESYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-164> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/LUMAZINESYN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-110_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2531,7 +2528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2539,45 +2536,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002234_CHEBI_15934_RIBOPHOSPHAT-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" , "Provides Input For Rule. The relation '2,5-diamino-6-(5-phospho-D-ribitylamino)pyrimidin-4(3H)-one &rarr; 5-amino-6-(D-ribitylamino)uracil' 'null' '5-amino-6-(D-ribitylamino)uracil + 1-deoxy-L-glycero-tetrulose 4-phosphate &rarr; 6,7-dimethyl-8-(1-D-ribityl)lumazine + phosphate + H<SUP>+</SUP> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-164_RO_0002413_LUMAZINESYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-164> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/LUMAZINESYN-RXN>
-] .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002234_CHEBI_58890_RXN-10057_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002234_CHEBI_58890_RXN-10057_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2588,17 +2555,6 @@
           <http://model.geneontology.org/CHEBI_58890_RXN-10057>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002233_CHEBI_15378_FADSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_50606_DIOHBUTANONEPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_50606> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2608,7 +2564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2616,37 +2572,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-II-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002234_CHEBI_28938_RXN-10058_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_BFO_0000066_reaction_RIBOFLAVINKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_BFO_0000066_reaction_RIBOFLAVINKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2657,14 +2591,14 @@
           <http://model.geneontology.org/reaction_RIBOFLAVINKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002234_CHEBI_57692_FADSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_BFO_0000066_reaction_LUMAZINESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2672,11 +2606,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" , "Provides Input For Rule. The relation 'GTP + 3 H<sub>2</sub>O &rarr; 2,5-diamino-6-(5-phospho-D-ribosylamino)pyrimidin-4(3H)-one + formate + diphosphate + 2 H<SUP>+</SUP>' 'null' '2,5-diamino-6-(5-phospho-D-ribitylamino)pyrimidin-4(3H)-one + NAD<sup>+</sup> &larr; 2,5-diamino-6-(5-phospho-D-ribosylamino)pyrimidin-4(3H)-one + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002413_RXN-10057_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002413_RXN-10057_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2696,7 +2630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "riboflavin, FMN and FAD biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2704,15 +2638,26 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002234_CHEBI_15934_RIBOPHOSPHAT-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002234_CHEBI_50606_DIOHBUTANONEPSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002234_CHEBI_50606_DIOHBUTANONEPSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2723,6 +2668,17 @@
           <http://model.geneontology.org/CHEBI_50606_DIOHBUTANONEPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002234_CHEBI_43474_RIBOPHOSPHAT-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -2732,6 +2688,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_58210>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002233_CHEBI_15377_RIBOPHOSPHAT-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000005427>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2739,11 +2706,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002234_CHEBI_58421_RXN-10058_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002234_CHEBI_58421_RXN-10058_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2761,11 +2728,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2795,7 +2762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2807,11 +2774,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002234_CHEBI_43474_LUMAZINESYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002234_CHEBI_43474_LUMAZINESYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2825,15 +2792,26 @@
 <http://identifiers.org/sgd/S000002895>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002233_CHEBI_58210_RIBOFLAVINKIN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002233_CHEBI_58210_RIBOFLAVINKIN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2847,15 +2825,39 @@
 <http://purl.obolibrary.org/obo/GO_0004746>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/reaction_RXN3O-164_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+<http://model.geneontology.org/ev_w_id_FADSYN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10058_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002333_MONOMER3O-75_RIBOFLAVIN-SYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2863,11 +2865,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-164_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-164_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2878,6 +2880,15 @@
           <http://model.geneontology.org/YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY>
 ] .
 
+<http://model.geneontology.org/reaction_RXN3O-164_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_LUMAZINESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2887,7 +2898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2895,26 +2906,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-164_RO_0002413_LUMAZINESYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10057_BFO_0000066_reaction_RXN-10057_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10057_BFO_0000066_reaction_RXN-10057_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2925,12 +2925,23 @@
           <http://model.geneontology.org/reaction_RXN-10057_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-164_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_GTP-CYCLOHYDRO-II-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2938,11 +2949,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002234_CHEBI_15934_RIBOFLAVIN-SYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002234_CHEBI_15934_RIBOFLAVIN-SYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2962,7 +2973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2974,11 +2985,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-II-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-II-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2993,11 +3004,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3013,7 +3024,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002413_RIBOFLAVIN-SYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002234_CHEBI_15934_RIBOFLAVIN-SYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3026,7 +3059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3051,7 +3084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3059,25 +3092,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_BFO_0000066_reaction_RIBOPHOSPHAT-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-II-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-110_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3090,7 +3112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3102,11 +3124,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10058_BFO_0000066_reaction_RXN-10058_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10058_BFO_0000066_reaction_RXN-10058_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3117,6 +3139,17 @@
           <http://model.geneontology.org/reaction_RXN-10058_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_BFO_0000066_reaction_RIBOFLAVIN-SYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YOL066C-MONOMER_RXN3O-164_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005427> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3124,7 +3157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3136,11 +3169,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002234_CHEBI_15378_RIBOFLAVINKIN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002234_CHEBI_15378_RIBOFLAVINKIN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3155,11 +3188,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_BFO_0000066_reaction_LUMAZINESYN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_BFO_0000066_reaction_LUMAZINESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3170,25 +3203,25 @@
           <http://model.geneontology.org/reaction_LUMAZINESYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-II-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002234_CHEBI_58201_LUMAZINESYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002233_CHEBI_15378_RXN-10057_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_BFO_0000066_reaction_RIBOFLAVINKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3196,11 +3229,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FADSYN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FADSYN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3220,7 +3253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3228,66 +3261,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-110_BFO_0000066_reaction_RXN3O-110_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0003919>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_BFO_0000066_reaction_DIOHBUTANONEPSYN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002233_CHEBI_58210_RIBOFLAVINKIN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000357>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_BFO_0000066_reaction_RIBOFLAVIN-SYN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002233_CHEBI_58890_RXN-10057_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002233_CHEBI_57986_RIBOFLAVIN-SYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_RIBOPHOSPHAT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -3298,7 +3287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3310,11 +3299,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-110_BFO_0000066_reaction_RXN3O-110_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-110_BFO_0000066_reaction_RXN3O-110_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3332,11 +3321,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002233_CHEBI_58421_RXN-10058_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002233_CHEBI_58421_RXN-10058_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3350,15 +3339,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_58121>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002234_CHEBI_15740_DIOHBUTANONEPSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" , "Provides Input For Rule. The relation '5-amino-6-(D-ribitylamino)uracil + 1-deoxy-L-glycero-tetrulose 4-phosphate &rarr; 6,7-dimethyl-8-(1-D-ribityl)lumazine + phosphate + H<SUP>+</SUP> + 2 H<sub>2</sub>O' 'null' '2 6,7-dimethyl-8-(1-D-ribityl)lumazine + H<SUP>+</SUP> &rarr; 5-amino-6-(D-ribitylamino)uracil + riboflavin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002413_RIBOFLAVIN-SYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002413_RIBOFLAVIN-SYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3369,26 +3369,15 @@
           <http://model.geneontology.org/RIBOFLAVIN-SYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10057_BFO_0000066_reaction_RXN-10057_location_lociGO_0005829_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002333_YDL045C-MONOMER_FADSYN-RXN_controller_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002333_YDL045C-MONOMER_FADSYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3402,6 +3391,17 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002234_CHEBI_43474_LUMAZINESYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0042727> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3411,7 +3411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3419,42 +3419,20 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15934>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002413_FADSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15934>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_FADSYN-RXN_BFO_0000066_reaction_FADSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3470,13 +3448,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RIBOSYN-PWYSmallMolecule53826> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002233_CHEBI_30616_RIBOFLAVINKIN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/DIOHBUTANONEPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0008686> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3497,7 +3497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3505,26 +3505,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002234_CHEBI_57540_RXN-10057_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-164_RO_0002234_CHEBI_15934_RXN3O-164_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-164_RO_0002234_CHEBI_15934_RXN3O-164_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3535,15 +3524,26 @@
           <http://model.geneontology.org/CHEBI_15934_RXN3O-164>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-164_BFO_0000066_reaction_RXN3O-164_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002233_CHEBI_57945_RXN-10057_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002233_CHEBI_57945_RXN-10057_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3554,14 +3554,14 @@
           <http://model.geneontology.org/CHEBI_57945_RXN-10057>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002413_RXN-10057_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-II-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3569,11 +3569,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" , "Provides Input For Rule. The relation '2 6,7-dimethyl-8-(1-D-ribityl)lumazine + H<SUP>+</SUP> &rarr; 5-amino-6-(D-ribitylamino)uracil + riboflavin' 'null' 'riboflavin + ATP &rarr; ADP + FMN + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002413_RIBOFLAVINKIN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002413_RIBOFLAVINKIN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3588,11 +3588,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002234_CHEBI_29888_GTP-CYCLOHYDRO-II-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002234_CHEBI_29888_GTP-CYCLOHYDRO-II-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3603,14 +3603,14 @@
           <http://model.geneontology.org/CHEBI_29888_GTP-CYCLOHYDRO-II-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002234_CHEBI_29888_FADSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002234_CHEBI_15378_RIBOFLAVINKIN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3621,11 +3621,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002234_CHEBI_15378_DIOHBUTANONEPSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002234_CHEBI_15378_DIOHBUTANONEPSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3645,7 +3645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3678,7 +3678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3686,14 +3686,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002233_CHEBI_58210_RIBOFLAVINKIN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002234_CHEBI_57540_RXN-10057_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3701,11 +3701,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002233_CHEBI_58890_RXN-10057_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002233_CHEBI_58890_RXN-10057_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3716,15 +3716,26 @@
           <http://model.geneontology.org/CHEBI_58890_RXN-10057>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_BFO_0000066_reaction_RIBOPHOSPHAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002333_YDR236C-MONOMER_RIBOFLAVINKIN-RXN_controller_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002333_YDR236C-MONOMER_RIBOFLAVINKIN-RXN_controller_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3735,26 +3746,15 @@
           <http://model.geneontology.org/YDR236C-MONOMER_RIBOFLAVINKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10058_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002234_CHEBI_15377_LUMAZINESYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002234_CHEBI_15377_LUMAZINESYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3770,18 +3770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002234_CHEBI_57986_RIBOFLAVIN-SYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3789,11 +3778,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002233_CHEBI_15378_FADSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002233_CHEBI_15378_FADSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3804,14 +3793,25 @@
           <http://model.geneontology.org/CHEBI_15378_FADSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FADSYN-RXN_RO_0002333_YDL045C-MONOMER_FADSYN-RXN_controller_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002233_CHEBI_58201_LUMAZINESYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002234_CHEBI_50606_DIOHBUTANONEPSYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3824,13 +3824,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RIBOSYN-PWYSmallMolecule53951> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002234_CHEBI_28938_RXN-10058_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002413_RXN-10058_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58421_RXN-10058>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58421> ;
@@ -3841,7 +3863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3853,11 +3875,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-110_RO_0002333_MONOMER3O-27_RXN3O-110_controller_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-110_RO_0002333_MONOMER3O-27_RXN3O-110_controller_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3875,11 +3897,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '5-amino-6-(5-phospho-D-ribitylamino)uracil + H<sub>2</sub>O &rarr; 5-amino-6-(D-ribitylamino)uracil + phosphate' 'null' '5-amino-6-(D-ribitylamino)uracil + 1-deoxy-L-glycero-tetrulose 4-phosphate &rarr; 6,7-dimethyl-8-(1-D-ribityl)lumazine + phosphate + H<SUP>+</SUP> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002413_LUMAZINESYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002413_LUMAZINESYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3890,15 +3912,26 @@
           <http://model.geneontology.org/LUMAZINESYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002233_CHEBI_15377_RXN-10058_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002233_CHEBI_15378_RIBOFLAVIN-SYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_RO_0002233_CHEBI_15378_RIBOFLAVIN-SYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3916,11 +3949,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-II-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_RO_0002233_CHEBI_15377_GTP-CYCLOHYDRO-II-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3931,17 +3964,6 @@
           <http://model.geneontology.org/CHEBI_15377_GTP-CYCLOHYDRO-II-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002234_CHEBI_58890_RXN-10057_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YOL143C-MONOMER_LUMAZINESYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005503> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3949,7 +3971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3963,36 +3985,14 @@
 <http://purl.obolibrary.org/obo/GO_0008531>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-10058_RO_0002233_CHEBI_15377_RXN-10058_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
+<http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_RO_0002233_CHEBI_58421_RXN-10058_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-II-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIOHBUTANONEPSYN-RXN_RO_0002233_CHEBI_58121_DIOHBUTANONEPSYN-RXN_SGD_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RIBOSYN-PWY" ;
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4000,11 +4000,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2,5-diamino-6-(5-phospho-D-ribitylamino)pyrimidin-4(3H)-one + NAD<sup>+</sup> &larr; 2,5-diamino-6-(5-phospho-D-ribosylamino)pyrimidin-4(3H)-one + NADH + H<SUP>+</SUP>' 'null' '2,5-diamino-6-(5-phospho-D-ribitylamino)pyrimidin-4(3H)-one + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; 5-amino-6-(5-phospho-D-ribitylamino)uracil + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002413_RXN-10058_SGD_YeastPathways_YEAST-RIBOSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10057_RO_0002413_RXN-10058_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4022,7 +4022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_YEAST-RNT-SALV.ttl
+++ b/models/YeastPathways_YEAST-RNT-SALV.ttl
@@ -5,11 +5,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002234_CHEBI_16040_RXN0-361_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002234_CHEBI_16040_RXN0-361_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -39,11 +39,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -83,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -100,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -108,26 +108,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002413_URIDINE-NUCLEOSIDASE-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002333_YKL067W-MONOMER_CDPKIN-RXN_controller_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002333_YKL067W-MONOMER_CDPKIN-RXN_controller_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -138,14 +127,14 @@
           <http://model.geneontology.org/YKL067W-MONOMER_CDPKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_BFO_0000066_reaction_CYTIDEAM2-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002234_CHEBI_58189_CYTIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -161,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -169,52 +158,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002234_CHEBI_15378_URIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11832_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002233_CHEBI_15377_RXN0-361_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0010138>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_BFO_0000066_reaction_URIDINEKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -222,48 +167,15 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002234_CHEBI_58189_CYTIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002233_CHEBI_58069_RXN-11832_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002413_URACIL-PRIBOSYLTRANS-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_URACIL-PRIBOSYLTRANS-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_URACIL-PRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,14 +186,14 @@
           <http://model.geneontology.org/CHEBI_29888_URACIL-PRIBOSYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002234_CHEBI_58069_RXN-11832_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002333_YKL067W-MONOMER_CDPKIN-RXN_controller_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -289,11 +201,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" , "Provides Input For Rule. The relation 'cytidine + GTP &rarr; CMP + GDP + H<SUP>+</SUP>' 'null' 'CMP + ATP &harr; CDP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002413_RXN-11832_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002413_RXN-11832_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -307,15 +219,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_57865>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002413_URACIL-PRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002234_CHEBI_28938_CYTDEAM-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002234_CHEBI_28938_CYTDEAM-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,31 +252,42 @@
 <http://purl.obolibrary.org/obo/CHEBI_58069>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002233_CHEBI_16704_CYTIDEAM2-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002234_CHEBI_17568_CYTDEAM-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002413_CYTDEAM-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002234_CHEBI_17568_URIDINE-NUCLEOSIDASE-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -361,11 +295,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002234_CHEBI_47013_URIDINE-NUCLEOSIDASE-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002234_CHEBI_47013_URIDINE-NUCLEOSIDASE-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -376,14 +310,25 @@
           <http://model.geneontology.org/CHEBI_47013_URIDINE-NUCLEOSIDASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002234_CHEBI_456216_URIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_RXN0-361_BFO_0000066_reaction_RXN0-361_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_BFO_0000066_reaction_URIDINEKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -391,11 +336,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'CMP + ATP &harr; CDP + ADP' 'null' 'CDP + ATP &rarr; CTP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002413_CDPKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002413_CDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,14 +351,14 @@
           <http://model.geneontology.org/CDPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002233_CHEBI_16040_RXN0-361_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002233_CHEBI_15378_CYTDEAM-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -421,11 +366,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002234_CHEBI_16704_CYTIDEAM2-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002234_CHEBI_16704_CYTIDEAM2-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -441,7 +386,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002233_CHEBI_30616_CDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -452,11 +408,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPKIN-RXN_BFO_0000066_reaction_CDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CDPKIN-RXN_BFO_0000066_reaction_CDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -467,30 +423,8 @@
           <http://model.geneontology.org/reaction_CDPKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_URACIL-PRIBOSYLTRANS-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000006266>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002333_YHR128W-MONOMER_URACIL-PRIBOSYLTRANS-RXN_controller_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_CYTIDINEKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -501,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -509,14 +443,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002413_URIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002234_CHEBI_47013_URIDINE-NUCLEOSIDASE-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -545,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -557,11 +491,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002234_CHEBI_456216_URIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002234_CHEBI_456216_URIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,26 +506,15 @@
           <http://model.geneontology.org/CHEBI_456216_URIDINEKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002233_CHEBI_15378_CYTIDEAM2-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" , "Provides Input For Rule. The relation 'cytidine + H<sub>2</sub>O &rarr; D-ribofuranose + cytosine' 'null' 'cytosine + H<sub>2</sub>O + H<SUP>+</SUP> &rarr; uracil + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002413_CYTDEAM-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002413_CYTDEAM-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -619,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -631,11 +554,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002233_CHEBI_37565_CYTIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002233_CHEBI_37565_CYTIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -646,42 +569,53 @@
           <http://model.geneontology.org/CHEBI_37565_CYTIDINEKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002233_CHEBI_60377_CYTIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_37565>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002413_RXN-11832_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004550>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CDPKIN-RXN_BFO_0000066_reaction_CDPKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002333_YHR128W-MONOMER_URACIL-PRIBOSYLTRANS-RXN_controller_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002233_CHEBI_15377_URIDINE-NUCLEOSIDASE-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002333_YDR400W-MONOMER_RXN0-361_controller_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -694,24 +628,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RNT-SALVSmallMolecule46783> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002233_CHEBI_30616_RXN-11832_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YHR128W-MONOMER_URACIL-PRIBOSYLTRANS-RXN_controller>
         a       <http://identifiers.org/sgd/S000001170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -720,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -728,14 +651,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002333_YNR012W-MONOMER_URIDINEKIN-RXN_controller_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_BFO_0000066_reaction_URACIL-PRIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -743,11 +677,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -758,15 +692,26 @@
           <http://model.geneontology.org/YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV>
 ] .
 
+<http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002413_URACIL-PRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002233_CHEBI_30616_RXN-11832_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002233_CHEBI_30616_RXN-11832_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,17 +722,6 @@
           <http://model.geneontology.org/CHEBI_30616_RXN-11832>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002234_CHEBI_15378_CYTIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -795,11 +729,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,17 +747,6 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_URACIL-PRIBOSYLTRANS-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_URIDINEKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -833,7 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -841,14 +764,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002234_CHEBI_456216_CDPKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_BFO_0000066_reaction_URIDINE-NUCLEOSIDASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11832_BFO_0000066_reaction_RXN-11832_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -861,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -869,26 +803,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002234_CHEBI_456216_RXN-11832_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,15 +822,26 @@
           <http://model.geneontology.org/YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CDPKIN-RXN_BFO_0000066_reaction_CDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002233_CHEBI_15377_RXN0-361_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002233_CHEBI_15377_RXN0-361_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -927,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -935,15 +869,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/reaction_RXN0-361_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'cytidine + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; uridine + ammonium' 'null' 'uridine + H<sub>2</sub>O &rarr; D-ribofuranose + uracil' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002413_URIDINE-NUCLEOSIDASE-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002413_URIDINE-NUCLEOSIDASE-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -954,27 +897,40 @@
           <http://model.geneontology.org/URIDINE-NUCLEOSIDASE-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_RXN0-361_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002234_CHEBI_15378_CYTIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002233_CHEBI_60377_CYTIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002234_CHEBI_37563_CDPKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002234_CHEBI_37563_CDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -985,17 +941,28 @@
           <http://model.geneontology.org/CHEBI_37563_CDPKIN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58017>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002234_CHEBI_17568_CYTDEAM-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002233_CHEBI_17562_CYTIDEAM2-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58017>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002234_CHEBI_456216_URIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1008,7 +975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1020,11 +987,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002233_CHEBI_17568_URIDINE-NUCLEOSIDASE-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002233_CHEBI_17568_URIDINE-NUCLEOSIDASE-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1042,11 +1009,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002234_CHEBI_60377_CYTIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002234_CHEBI_60377_CYTIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1061,11 +1028,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002233_CHEBI_16040_RXN0-361_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002233_CHEBI_16040_RXN0-361_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1076,6 +1043,17 @@
           <http://model.geneontology.org/CHEBI_16040_RXN0-361>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002233_CHEBI_58069_RXN-11832_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YLR245C-MONOMER_CYTIDEAM2-RXN_controller>
         a       <http://identifiers.org/sgd/S000004235> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1083,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1091,30 +1069,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002233_CHEBI_15377_CYTDEAM-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004127>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002233_CHEBI_37565_CYTIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004845>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1126,11 +1082,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002233_CHEBI_16704_CYTIDEAM2-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002233_CHEBI_16704_CYTIDEAM2-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1145,11 +1101,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002234_CHEBI_58069_RXN-11832_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002234_CHEBI_58069_RXN-11832_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1164,11 +1120,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002233_CHEBI_15378_CYTIDEAM2-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002233_CHEBI_15378_CYTIDEAM2-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1179,17 +1135,6 @@
           <http://model.geneontology.org/CHEBI_15378_CYTIDEAM2-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002233_CHEBI_15377_CYTIDEAM2-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000001170>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1198,7 +1143,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_BFO_0000066_reaction_CYTIDINEKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1211,7 +1167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1222,16 +1178,35 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-361_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002233_CHEBI_30616_URIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/URIDINEKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_URIDINEKIN-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_37565_CYTIDINEKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_37565> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1242,32 +1217,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RNT-SALVSmallMolecule46768> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002233_CHEBI_30616_URIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/URIDINEKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_URIDINEKIN-RXN>
-] .
 
 <http://model.geneontology.org/RXN-11832>
         a       <http://purl.obolibrary.org/obo/GO_0004127> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1288,7 +1244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1303,11 +1259,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_BFO_0000066_reaction_CYTIDINEKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_BFO_0000066_reaction_CYTIDINEKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1318,15 +1274,26 @@
           <http://model.geneontology.org/reaction_CYTIDINEKIN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-361_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002234_CHEBI_47013_RXN0-361_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002234_CHEBI_47013_RXN0-361_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1337,14 +1304,14 @@
           <http://model.geneontology.org/CHEBI_47013_RXN0-361>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11832_BFO_0000066_reaction_RXN-11832_location_lociGO_0005829_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002234_CHEBI_16040_RXN0-361_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1357,7 +1324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1384,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1401,7 +1368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1414,18 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002234_CHEBI_57865_URIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1433,11 +1389,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1457,7 +1413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1465,36 +1421,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002333_YDR400W-MONOMER_RXN0-361_controller_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002234_CHEBI_28938_CYTDEAM-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-361_BFO_0000066_reaction_RXN0-361_location_lociGO_0005829_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002233_CHEBI_17562_CYTIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1505,11 +1461,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002234_CHEBI_57865_URACIL-PRIBOSYLTRANS-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002234_CHEBI_57865_URACIL-PRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1520,15 +1476,26 @@
           <http://model.geneontology.org/CHEBI_57865_URACIL-PRIBOSYLTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-11832_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11832_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11832_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1558,7 +1525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1570,11 +1537,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002333_YPR062W-MONOMER_CYTDEAM-RXN_controller_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002333_YPR062W-MONOMER_CYTDEAM-RXN_controller_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1585,30 +1552,16 @@
           <http://model.geneontology.org/YPR062W-MONOMER_CYTDEAM-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002233_CHEBI_15377_URIDINE-NUCLEOSIDASE-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002333_YKL067W-MONOMER_CDPKIN-RXN_controller_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002233_CHEBI_15377_CYTDEAM-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000001507>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1616,52 +1569,24 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002234_CHEBI_16704_CYTIDEAM2-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002333_YNR012W-MONOMER_URIDINEKIN-RXN_controller_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/reaction_RXN-11832_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002333_YDR400W-MONOMER_URIDINE-NUCLEOSIDASE-RXN_controller_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002333_YDR400W-MONOMER_URIDINE-NUCLEOSIDASE-RXN_controller_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1672,6 +1597,15 @@
           <http://model.geneontology.org/YDR400W-MONOMER_URIDINE-NUCLEOSIDASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/reaction_RXN-11832_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1679,11 +1613,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-361_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-361_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1694,15 +1628,26 @@
           <http://model.geneontology.org/YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002234_CHEBI_28938_CYTIDEAM2-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002234_CHEBI_28938_CYTIDEAM2-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002234_CHEBI_28938_CYTIDEAM2-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1713,14 +1658,25 @@
           <http://model.geneontology.org/CHEBI_28938_CYTIDEAM2-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002333_YPR062W-MONOMER_CYTDEAM-RXN_controller_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002233_CHEBI_15377_CYTIDEAM2-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002333_YKL024C-MONOMER_RXN-11832_controller_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1733,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1741,25 +1697,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_BFO_0000066_reaction_CYTIDINEKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002333_YNR012W-MONOMER_CYTIDINEKIN-RXN_controller_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002233_CHEBI_17562_CYTIDEAM2-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1767,11 +1712,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002233_CHEBI_30616_CDPKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002233_CHEBI_30616_CDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1804,7 +1749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1812,17 +1757,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://identifiers.org/sgd/S000005295>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002333_YDR400W-MONOMER_URIDINE-NUCLEOSIDASE-RXN_controller_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002233_CHEBI_30616_URIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000005295>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002333_YDR400W-MONOMER_URIDINE-NUCLEOSIDASE-RXN_controller_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1830,11 +1786,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002234_CHEBI_57865_URIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002234_CHEBI_57865_URIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1849,11 +1805,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1864,14 +1820,14 @@
           <http://model.geneontology.org/YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002333_YLR245C-MONOMER_CYTIDEAM2-RXN_controller_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002234_CHEBI_57865_URIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1879,11 +1835,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002234_CHEBI_15378_CYTIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002234_CHEBI_15378_CYTIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1894,6 +1850,17 @@
           <http://model.geneontology.org/CHEBI_15378_CYTIDINEKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002234_CHEBI_47013_RXN0-361_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0010138> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1903,7 +1870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1915,11 +1882,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002233_CHEBI_15377_CYTDEAM-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002233_CHEBI_15377_CYTDEAM-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1930,25 +1897,14 @@
           <http://model.geneontology.org/CHEBI_15377_CYTDEAM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_BFO_0000066_reaction_CYTDEAM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002333_YKL024C-MONOMER_RXN-11832_controller_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1958,26 +1914,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_BFO_0000066_reaction_CYTDEAM-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_BFO_0000066_reaction_URIDINE-NUCLEOSIDASE-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_BFO_0000066_reaction_URIDINE-NUCLEOSIDASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1988,26 +1933,15 @@
           <http://model.geneontology.org/reaction_URIDINE-NUCLEOSIDASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002234_CHEBI_60377_CYTIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002233_CHEBI_60377_CYTIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002233_CHEBI_60377_CYTIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2025,11 +1959,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_BFO_0000066_reaction_CYTIDEAM2-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_BFO_0000066_reaction_CYTIDEAM2-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2045,7 +1979,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2058,13 +2003,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of pyrimidine ribonucleotides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/CHEBI_30616_CDPKIN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RNT-SALVSmallMolecule46617> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/URIDINEKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004849> ;
@@ -2083,30 +2045,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RNT-SALVBiochemicalReaction46583> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/CHEBI_30616_CDPKIN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RNT-SALVSmallMolecule46617> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_456216_RXN-11832>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -2117,7 +2062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2134,7 +2079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2151,7 +2096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2168,7 +2113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2176,26 +2121,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002233_CHEBI_15378_CYTDEAM-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_BFO_0000066_reaction_URIDINEKIN-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_BFO_0000066_reaction_URIDINEKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2210,11 +2144,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002233_CHEBI_17562_RXN0-361_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002233_CHEBI_17562_RXN0-361_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2225,26 +2159,15 @@
           <http://model.geneontology.org/CHEBI_17562_RXN0-361>
 ] .
 
-<http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002233_CHEBI_17568_URIDINE-NUCLEOSIDASE-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" , "Provides Input For Rule. The relation 'cytidine + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; uridine + ammonium' 'null' 'uridine + ATP &rarr; UMP + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002413_URIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002413_URIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2255,25 +2178,25 @@
           <http://model.geneontology.org/URIDINEKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002413_CDPKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_BFO_0000066_reaction_URIDINE-NUCLEOSIDASE-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002233_CHEBI_15377_RXN0-361_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002234_CHEBI_456216_CDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2286,7 +2209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2298,11 +2221,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002234_CHEBI_456216_CDPKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002234_CHEBI_456216_CDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2316,40 +2239,29 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002413_URIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_60377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002234_CHEBI_57865_URACIL-PRIBOSYLTRANS-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_URACIL-PRIBOSYLTRANS-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_URACIL-PRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2360,25 +2272,14 @@
           <http://model.geneontology.org/CHEBI_58017_URACIL-PRIBOSYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002233_CHEBI_30616_CDPKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002233_CHEBI_17562_RXN0-361_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002233_CHEBI_30616_URIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2386,11 +2287,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002333_YNR012W-MONOMER_CYTIDINEKIN-RXN_controller_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002333_YNR012W-MONOMER_CYTIDINEKIN-RXN_controller_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2405,11 +2306,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002234_CHEBI_17568_CYTDEAM-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002234_CHEBI_17568_CYTDEAM-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2420,6 +2321,17 @@
           <http://model.geneontology.org/CHEBI_17568_CYTDEAM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002234_CHEBI_17568_URIDINE-NUCLEOSIDASE-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YPR062W-MONOMER_CYTDEAM-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006266> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2427,7 +2339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2445,7 +2357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2456,37 +2368,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_58189>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002234_CHEBI_37563_CDPKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002234_CHEBI_17568_URIDINE-NUCLEOSIDASE-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002234_CHEBI_17568_URIDINE-NUCLEOSIDASE-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2504,7 +2394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2519,11 +2409,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002333_YKL024C-MONOMER_RXN-11832_controller_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002333_YKL024C-MONOMER_RXN-11832_controller_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2534,26 +2424,15 @@
           <http://model.geneontology.org/YKL024C-MONOMER_RXN-11832_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002233_CHEBI_17562_RXN0-361_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002233_CHEBI_17562_CYTIDEAM2-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002233_CHEBI_17562_CYTIDEAM2-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2569,19 +2448,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002234_CHEBI_60377_CYTIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0102480>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPKIN-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CDPKIN-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2592,8 +2485,27 @@
           <http://model.geneontology.org/YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0102480>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002234_CHEBI_15378_URIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002233_CHEBI_17568_URIDINE-NUCLEOSIDASE-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_47013_URIDINE-NUCLEOSIDASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_47013> ;
@@ -2604,7 +2516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2612,15 +2524,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002413_CYTDEAM-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002234_CHEBI_15378_URIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002234_CHEBI_15378_URIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2635,11 +2558,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002333_YDR400W-MONOMER_RXN0-361_controller_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002333_YDR400W-MONOMER_RXN0-361_controller_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2650,15 +2573,26 @@
           <http://model.geneontology.org/YDR400W-MONOMER_RXN0-361_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002233_CHEBI_30616_RXN-11832_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002233_CHEBI_17562_CYTIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002233_CHEBI_17562_CYTIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2673,11 +2607,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_BFO_0000066_reaction_CYTDEAM-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_BFO_0000066_reaction_CYTDEAM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2688,14 +2622,36 @@
           <http://model.geneontology.org/reaction_CYTDEAM-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_CDPKIN-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002233_CHEBI_15378_CYTIDEAM2-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002234_CHEBI_37563_CDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2708,13 +2664,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RNT-SALVSmallMolecule46645> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002233_CHEBI_16040_RXN0-361_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17562_CYTIDEAM2-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17562> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2725,7 +2692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2742,7 +2709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2750,15 +2717,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002234_CHEBI_57865_URACIL-PRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002333_YHR128W-MONOMER_URACIL-PRIBOSYLTRANS-RXN_controller_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002333_YHR128W-MONOMER_URACIL-PRIBOSYLTRANS-RXN_controller_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2773,11 +2751,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11832_BFO_0000066_reaction_RXN-11832_location_lociGO_0005829_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11832_BFO_0000066_reaction_RXN-11832_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2791,15 +2769,18 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://identifiers.org/sgd/S000001550>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'cytosine + H<sub>2</sub>O + H<SUP>+</SUP> &rarr; uracil + ammonium' 'null' 'UMP + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + uracil' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002413_URACIL-PRIBOSYLTRANS-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002413_URACIL-PRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2819,7 +2800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2832,24 +2813,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://identifiers.org/sgd/S000001550>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002413_CDPKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002333_YNR012W-MONOMER_CYTIDINEKIN-RXN_controller_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002234_CHEBI_58069_RXN-11832_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2858,17 +2847,6 @@
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002234_CHEBI_47013_RXN0-361_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57865_URACIL-PRIBOSYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57865> ;
@@ -2879,7 +2857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2891,11 +2869,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'uridine + H<sub>2</sub>O &rarr; D-ribofuranose + uracil' 'null' 'UMP + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + uracil' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002413_URACIL-PRIBOSYLTRANS-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002413_URACIL-PRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2910,11 +2888,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-361_BFO_0000066_reaction_RXN0-361_location_lociGO_0005829_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-361_BFO_0000066_reaction_RXN0-361_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2932,7 +2910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2944,11 +2922,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002333_YLR245C-MONOMER_CYTIDEAM2-RXN_controller_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002333_YLR245C-MONOMER_CYTIDEAM2-RXN_controller_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2959,26 +2937,15 @@
           <http://model.geneontology.org/YLR245C-MONOMER_CYTIDEAM2-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-361_RO_0002234_CHEBI_16040_RXN0-361_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002233_CHEBI_58069_RXN-11832_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CDPKIN-RXN_RO_0002233_CHEBI_58069_RXN-11832_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2996,13 +2963,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RNT-SALVProtein46884> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002413_URIDINE-NUCLEOSIDASE-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/URIDINE-NUCLEOSIDASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0045437> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3023,7 +3001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3031,25 +3009,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002233_CHEBI_16704_CYTIDEAM2-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002234_CHEBI_16704_CYTIDEAM2-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002234_CHEBI_47013_URIDINE-NUCLEOSIDASE-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002233_CHEBI_16704_CYTIDEAM2-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3057,11 +3035,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002333_YNR012W-MONOMER_URIDINEKIN-RXN_controller_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002333_YNR012W-MONOMER_URIDINEKIN-RXN_controller_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3072,6 +3050,17 @@
           <http://model.geneontology.org/YNR012W-MONOMER_URIDINEKIN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002234_CHEBI_29888_URACIL-PRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_17568_CYTDEAM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17568> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3081,7 +3070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3093,11 +3082,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_BFO_0000066_reaction_URACIL-PRIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_BFO_0000066_reaction_URACIL-PRIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3115,7 +3104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3127,11 +3116,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002234_CHEBI_58189_CYTIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002234_CHEBI_58189_CYTIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3142,15 +3131,26 @@
           <http://model.geneontology.org/CHEBI_58189_CYTIDINEKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002234_CHEBI_456216_RXN-11832_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002233_CHEBI_15378_CYTDEAM-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002233_CHEBI_15378_CYTDEAM-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3170,7 +3170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3178,63 +3178,52 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002234_CHEBI_28938_CYTIDEAM2-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
+<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002233_CHEBI_37565_CYTIDINEKIN-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002333_YPR062W-MONOMER_CYTDEAM-RXN_controller_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002413_RXN-11832_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_RO_0002233_CHEBI_58017_URACIL-PRIBOSYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004126>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002413_URACIL-PRIBOSYLTRANS-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_URACIL-PRIBOSYLTRANS-RXN_BFO_0000066_reaction_URACIL-PRIBOSYLTRANS-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002233_CHEBI_16704_CYTIDEAM2-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CDPKIN-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_47013>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3248,24 +3237,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RNT-SALVSmallMolecule46660> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CYTDEAM-RXN_RO_0002234_CHEBI_28938_CYTDEAM-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_CYTIDEAM2-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3276,7 +3254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3288,11 +3266,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002233_CHEBI_15377_URIDINE-NUCLEOSIDASE-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_RO_0002233_CHEBI_15377_URIDINE-NUCLEOSIDASE-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3307,11 +3285,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002234_CHEBI_456216_RXN-11832_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11832_RO_0002234_CHEBI_456216_RXN-11832_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3331,7 +3309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3343,11 +3321,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002233_CHEBI_15377_CYTIDEAM2-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002233_CHEBI_15377_CYTIDEAM2-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3363,18 +3341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002233_CHEBI_17562_CYTIDINEKIN-RXN_SGD_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3395,7 +3362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3406,6 +3373,28 @@
 <http://purl.obolibrary.org/obo/GO_0045437>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_BFO_0000066_reaction_CYTIDEAM2-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYTIDEAM2-RXN_RO_0002333_YLR245C-MONOMER_CYTIDEAM2-RXN_controller_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58189_CYTIDINEKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58189> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3415,7 +3404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3423,15 +3412,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002233_CHEBI_16704_CYTIDEAM2-RXN_SGD_YeastPathways_YEAST-RNT-SALV> ;
+          <http://model.geneontology.org/ev_w_id_URIDINEKIN-RXN_RO_0002233_CHEBI_16704_CYTIDEAM2-RXN_SGD_PWY_YeastPathways_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_YEAST-SALV-PYRMID-DNTP.ttl
+++ b/models/YeastPathways_YEAST-SALV-PYRMID-DNTP.ttl
@@ -1,15 +1,23 @@
-<http://purl.obolibrary.org/obo/CHEBI_17568>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002234_CHEBI_17568_URA-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_BFO_0000066_reaction_URA-PHOSPH-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_BFO_0000066_reaction_URA-PHOSPH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,11 +32,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-314_BFO_0000066_reaction_RXN3O-314_location_lociGO_0005829_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-314_BFO_0000066_reaction_RXN3O-314_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -42,15 +50,26 @@
 <http://identifiers.org/sgd/S000004235>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002333_YDR400W-MONOMER_RXN3O-314_controller_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002234_CHEBI_28938_CYTIDEAM-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002234_CHEBI_28938_CYTIDEAM-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -60,6 +79,28 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_28938_CYTIDEAM-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002234_CHEBI_456216_DURIDKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002333_YLR245C-MONOMER_CYTIDEAM-RXN_controller_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -72,18 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002234_CHEBI_16450_CYTIDEAM-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -91,11 +121,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002233_CHEBI_17748_THYM-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002233_CHEBI_17748_THYM-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -110,11 +140,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002233_CHEBI_30616_DURIDKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002233_CHEBI_30616_DURIDKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -125,14 +155,14 @@
           <http://model.geneontology.org/CHEBI_30616_DURIDKI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002233_CHEBI_15698_CYTIDEAM-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002233_CHEBI_15698_RXN3O-314_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -145,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -153,31 +183,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002233_CHEBI_15377_CYTIDEAM-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002413_URA-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002233_CHEBI_30616_DURIDKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+<http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002233_CHEBI_16450_CYTIDEAM-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -190,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -202,11 +232,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002233_CHEBI_57259_URA-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002233_CHEBI_57259_URA-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -217,15 +247,26 @@
           <http://model.geneontology.org/CHEBI_57259_URA-PHOSPH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002233_CHEBI_15698_CYTIDEAM-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002234_CHEBI_15378_RXN-14093_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002234_CHEBI_15378_RXN-14093_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -243,11 +284,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_BFO_0000066_reaction_CYTIDEAM-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_BFO_0000066_reaction_CYTIDEAM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -257,6 +298,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_CYTIDEAM-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002333_YNR012W-MONOMER_RXN-14093_controller_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -268,11 +320,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002234_CHEBI_17568_URA-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002234_CHEBI_17568_URA-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -283,15 +335,26 @@
           <http://model.geneontology.org/CHEBI_17568_URA-PHOSPH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_BFO_0000066_reaction_THYM-PHOSPH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002234_CHEBI_131350_RXN3O-314_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002234_CHEBI_131350_RXN3O-314_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,17 +364,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_131350_RXN3O-314>
 ] .
-
-<http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002234_CHEBI_456216_THYKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/DURIDKI-RXN>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -328,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -336,43 +388,54 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_THYKI-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_17821>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-14093_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+<http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002233_CHEBI_30616_THYKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_17821>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0043099>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002233_CHEBI_15377_CYTIDEAM-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002234_CHEBI_456216_THYKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002234_CHEBI_456216_THYKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -390,11 +453,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002234_CHEBI_456216_DURIDKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002234_CHEBI_456216_DURIDKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -417,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -425,19 +488,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_BFO_0000066_reaction_CYTIDEAM-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002234_CHEBI_131350_RXN3O-314_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002233_CHEBI_15377_RXN3O-314_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_246422>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002233_CHEBI_30616_RXN-14093_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-314>
         a       <http://purl.obolibrary.org/obo/GO_0045437> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -456,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -468,11 +553,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'thymidine + phosphate &harr; 2-deoxy-&alpha;-D-ribose 1-phosphate + thymine' 'null' 'thymidine + ATP &rarr; dTMP + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002413_THYKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002413_THYKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -483,14 +568,14 @@
           <http://model.geneontology.org/THYKI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002234_CHEBI_246422_DURIDKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+<http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002234_CHEBI_456216_RXN-14093_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -498,11 +583,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002333_YNR012W-MONOMER_RXN-14093_controller_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002333_YNR012W-MONOMER_RXN-14093_controller_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -518,7 +603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -529,11 +614,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002233_CHEBI_15698_CYTIDEAM-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002233_CHEBI_15698_CYTIDEAM-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -544,23 +629,12 @@
           <http://model.geneontology.org/CHEBI_15698_CYTIDEAM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002234_CHEBI_456216_RXN-14093_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_THYKI-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -571,11 +645,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYKI-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_THYKI-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -586,15 +660,26 @@
           <http://model.geneontology.org/YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002234_CHEBI_57566_RXN-14093_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DURIDKI-RXN_BFO_0000066_reaction_DURIDKI-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_DURIDKI-RXN_BFO_0000066_reaction_DURIDKI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -614,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -622,40 +707,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002234_CHEBI_17568_URA-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002234_CHEBI_63528_THYKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+<http://model.geneontology.org/ev_w_id_RXN3O-314_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_BFO_0000066_reaction_THYM-PHOSPH-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_BFO_0000066_reaction_THYM-PHOSPH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -666,17 +740,6 @@
           <http://model.geneontology.org/reaction_THYM-PHOSPH-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DURIDKI-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_28938_CYTIDEAM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_28938> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -686,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -694,15 +757,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002233_CHEBI_15698_RXN-14093_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002233_CHEBI_15698_RXN-14093_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,6 +787,17 @@
           <http://model.geneontology.org/CHEBI_15698_RXN-14093>
 ] .
 
+<http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002413_THYM-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_RXN-14093>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -722,7 +807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -740,11 +825,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002233_CHEBI_16450_CYTIDEAM-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002233_CHEBI_16450_CYTIDEAM-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -755,26 +840,15 @@
           <http://model.geneontology.org/CHEBI_16450_CYTIDEAM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002234_CHEBI_15378_DURIDKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002233_CHEBI_15377_RXN3O-314_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002233_CHEBI_15377_RXN3O-314_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -784,6 +858,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_RXN3O-314>
 ] .
+
+<http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002233_CHEBI_30616_DURIDKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-14093>
         a       <http://purl.obolibrary.org/obo/GO_0004849> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -802,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -819,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -827,15 +912,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002234_CHEBI_28938_CYTIDEAM-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002333_YLR245C-MONOMER_CYTIDEAM-RXN_controller_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002333_YLR245C-MONOMER_CYTIDEAM-RXN_controller_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -846,30 +942,19 @@
           <http://model.geneontology.org/YLR245C-MONOMER_CYTIDEAM-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002234_CHEBI_16040_RXN3O-314_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002233_CHEBI_16450_CYTIDEAM-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_THYM-PHOSPH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -880,7 +965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -898,11 +983,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002233_CHEBI_30616_THYKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002233_CHEBI_30616_THYKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -917,11 +1002,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002234_CHEBI_15378_DURIDKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002234_CHEBI_15378_DURIDKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -932,14 +1017,14 @@
           <http://model.geneontology.org/CHEBI_15378_DURIDKI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_BFO_0000066_reaction_THYM-PHOSPH-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002234_CHEBI_15378_DURIDKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -952,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -972,30 +1057,19 @@
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002233_CHEBI_17748_THYM-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002234_CHEBI_16450_CYTIDEAM-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16450>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002234_CHEBI_43474_THYM-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1004,11 +1078,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002234_CHEBI_17748_THYM-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002234_CHEBI_17748_THYM-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1019,27 +1093,30 @@
           <http://model.geneontology.org/CHEBI_17748_THYM-PHOSPH-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002234_CHEBI_456216_RXN-14093_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-14093> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_RXN-14093>
-] .
+<http://model.geneontology.org/ev_w_id_DURIDKI-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002233_CHEBI_15698_RXN-14093_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/THYKI-RXN>
-        a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "thymidine + ATP &rarr; dTMP + ADP + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1053,7 +1130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1061,48 +1138,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002234_CHEBI_57566_RXN-14093_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002234_CHEBI_28938_CYTIDEAM-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002233_CHEBI_16450_CYTIDEAM-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002234_CHEBI_456216_RXN-14093_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-05-25" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-14093> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456216_RXN-14093>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002233_CHEBI_15377_CYTIDEAM-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002233_CHEBI_15377_CYTIDEAM-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1119,14 +1182,14 @@
 <http://identifiers.org/sgd/S000005295>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002234_CHEBI_15378_THYKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-314_BFO_0000066_reaction_RXN3O-314_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1147,7 +1210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1177,7 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1185,26 +1248,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002333_YDR400W-MONOMER_RXN3O-314_controller_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002234_CHEBI_57259_URA-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002234_CHEBI_57259_URA-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1215,15 +1267,26 @@
           <http://model.geneontology.org/CHEBI_57259_URA-PHOSPH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002234_CHEBI_246422_DURIDKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002234_CHEBI_16040_RXN3O-314_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002234_CHEBI_16040_RXN3O-314_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1234,15 +1297,26 @@
           <http://model.geneontology.org/CHEBI_16040_RXN3O-314>
 ] .
 
+<http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" , "Provides Input For Rule. The relation '2'-deoxycytidine + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; 2'-deoxyuridine + ammonium' 'null' '2'-deoxyuridine + phosphate &rarr; 2-deoxy-&alpha;-D-ribose 1-phosphate + uracil' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002413_URA-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002413_URA-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1256,39 +1330,6 @@
 <http://identifiers.org/sgd/S000002808>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002233_CHEBI_30616_THYKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-14093_BFO_0000066_reaction_RXN-14093_location_lociGO_0005829_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_CYTIDEAM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1298,7 +1339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1315,7 +1356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of pyrimidine deoxyribonucleotides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1330,11 +1371,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002234_CHEBI_63528_THYKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002234_CHEBI_63528_THYKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1349,11 +1390,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14093_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14093_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1376,7 +1417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1389,51 +1430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002234_CHEBI_456216_DURIDKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002234_CHEBI_57259_URA-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002234_CHEBI_15378_RXN-14093_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002233_CHEBI_57259_URA-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1446,7 +1443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1458,11 +1455,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1473,17 +1470,6 @@
           <http://model.geneontology.org/YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002413_DURIDKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_RXN-14093>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1493,7 +1479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1505,11 +1491,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-314_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-314_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1520,26 +1506,15 @@
           <http://model.geneontology.org/YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002333_YNR012W-MONOMER_RXN-14093_controller_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002234_CHEBI_16450_CYTIDEAM-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002234_CHEBI_16450_CYTIDEAM-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1550,14 +1525,14 @@
           <http://model.geneontology.org/CHEBI_16450_CYTIDEAM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002233_CHEBI_17821_THYM-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1567,25 +1542,14 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002233_CHEBI_30616_RXN-14093_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002413_DURIDKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002234_CHEBI_17748_THYM-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1598,7 +1562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1618,7 +1582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1626,32 +1590,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CHEBI_16450_CYTIDEAM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16450> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "2'-deoxyuridine" ;
+<http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002234_CHEBI_17748_THYM-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-SALV-PYRMID-DNTPSmallMolecule45291> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYKI-RXN_BFO_0000066_reaction_THYKI-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_THYKI-RXN_BFO_0000066_reaction_THYKI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1662,26 +1620,32 @@
           <http://model.geneontology.org/reaction_THYKI-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002233_CHEBI_15378_CYTIDEAM-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_16450_CYTIDEAM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16450> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2'-deoxyuridine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-SALV-PYRMID-DNTPSmallMolecule45291> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002233_CHEBI_16450_CYTIDEAM-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002233_CHEBI_16450_CYTIDEAM-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1691,6 +1655,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16450_CYTIDEAM-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_THYKI-RXN_BFO_0000066_reaction_THYKI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1704,7 +1679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1721,7 +1696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1738,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1750,11 +1725,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002233_CHEBI_17821_THYM-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002233_CHEBI_17821_THYM-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1765,6 +1740,17 @@
           <http://model.geneontology.org/CHEBI_17821_THYM-PHOSPH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002233_CHEBI_15378_CYTIDEAM-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_DURIDKI-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1774,7 +1760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1786,11 +1772,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002233_CHEBI_30616_RXN-14093_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002233_CHEBI_30616_RXN-14093_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1801,26 +1787,15 @@
           <http://model.geneontology.org/CHEBI_30616_RXN-14093>
 ] .
 
-<http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002233_CHEBI_16450_CYTIDEAM-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1831,25 +1806,14 @@
           <http://model.geneontology.org/YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP>
 ] .
 
-<http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002413_THYM-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002234_CHEBI_43474_THYM-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002233_CHEBI_15698_RXN-14093_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1862,7 +1826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1870,15 +1834,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002234_CHEBI_16040_RXN3O-314_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14093_BFO_0000066_reaction_RXN-14093_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002233_CHEBI_43474_URA-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002233_CHEBI_43474_URA-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1893,11 +1879,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002233_CHEBI_15698_RXN3O-314_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002233_CHEBI_15698_RXN3O-314_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1908,6 +1894,17 @@
           <http://model.geneontology.org/CHEBI_15698_RXN3O-314>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DURIDKI-RXN_BFO_0000066_reaction_DURIDKI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_17821_THYM-PHOSPH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17821> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1917,7 +1914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1929,11 +1926,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" , "Provides Input For Rule. The relation '2'-deoxycytidine + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; 2'-deoxyuridine + ammonium' 'null' '2'-deoxyuridine + ATP &rarr; dUMP + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002413_DURIDKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002413_DURIDKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1944,46 +1941,59 @@
           <http://model.geneontology.org/DURIDKI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002413_THYKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002233_CHEBI_43474_URA-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/CHEBI_16040_RXN3O-314>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16040> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "cytosine" ;
+<http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002234_CHEBI_63528_THYKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-SALV-PYRMID-DNTPSmallMolecule45175> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THYKI-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002234_CHEBI_456216_THYKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002234_CHEBI_15378_THYKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002234_CHEBI_15378_THYKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1994,16 +2004,22 @@
           <http://model.geneontology.org/CHEBI_15378_THYKI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002233_CHEBI_43474_URA-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_16040_RXN3O-314>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16040> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "cytosine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-SALV-PYRMID-DNTPSmallMolecule45175> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YDR400W-MONOMER_RXN3O-314_controller>
         a       <http://identifiers.org/sgd/S000002808> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2012,7 +2028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2024,11 +2040,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002234_CHEBI_246422_DURIDKI-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002234_CHEBI_246422_DURIDKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2039,16 +2055,8 @@
           <http://model.geneontology.org/CHEBI_246422_DURIDKI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002233_CHEBI_15698_RXN3O-314_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_57259_URA-PHOSPH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57259> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2059,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2067,14 +2075,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002333_YLR245C-MONOMER_CYTIDEAM-RXN_controller_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+<http://model.geneontology.org/ev_w_id_RXN-14093_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2083,17 +2091,6 @@
 
 <http://purl.obolibrary.org/obo/GO_0004849>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002233_CHEBI_15377_RXN3O-314_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -2107,7 +2104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2122,7 +2119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2134,11 +2131,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002234_CHEBI_43474_THYM-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002234_CHEBI_43474_THYM-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2149,15 +2146,26 @@
           <http://model.geneontology.org/CHEBI_43474_THYM-PHOSPH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002234_CHEBI_15378_THYKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002234_CHEBI_57566_RXN-14093_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002234_CHEBI_57566_RXN-14093_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2177,7 +2185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2194,7 +2202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2202,26 +2210,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DURIDKI-RXN_BFO_0000066_reaction_DURIDKI-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002233_CHEBI_15378_CYTIDEAM-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002233_CHEBI_15378_CYTIDEAM-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2237,18 +2234,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_RO_0002413_URA-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_THYKI-RXN_RO_0002233_CHEBI_17748_THYM-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2257,18 +2254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002234_CHEBI_131350_RXN3O-314_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2276,11 +2262,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2'-deoxyuridine + phosphate &rarr; 2-deoxy-&alpha;-D-ribose 1-phosphate + uracil' 'null' 'thymidine + phosphate &harr; 2-deoxy-&alpha;-D-ribose 1-phosphate + thymine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002413_THYM-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002413_THYM-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2295,11 +2281,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002333_YDR400W-MONOMER_RXN3O-314_controller_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-314_RO_0002333_YDR400W-MONOMER_RXN3O-314_controller_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2310,15 +2296,26 @@
           <http://model.geneontology.org/YDR400W-MONOMER_RXN3O-314_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_BFO_0000066_reaction_URA-PHOSPH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DURIDKI-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_DURIDKI-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2329,39 +2326,39 @@
           <http://model.geneontology.org/YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002233_CHEBI_57259_URA-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002234_CHEBI_15378_RXN-14093_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-14093_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002233_CHEBI_17821_THYM-PHOSPH-RXN_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004126>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_THYKI-RXN_BFO_0000066_reaction_THYKI-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_131350_RXN3O-314>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_131350> ;
@@ -2372,7 +2369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2384,11 +2381,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2399,15 +2396,26 @@
           <http://model.geneontology.org/YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYTIDEAM-RXN_BFO_0000066_reaction_CYTIDEAM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-05-25" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14093_BFO_0000066_reaction_RXN-14093_location_lociGO_0005829_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14093_BFO_0000066_reaction_RXN-14093_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-16" ;
+          "2023-05-25" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2418,14 +2426,14 @@
           <http://model.geneontology.org/reaction_RXN-14093_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-314_BFO_0000066_reaction_RXN3O-314_location_lociGO_0005829_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_RO_0002234_CHEBI_57259_URA-PHOSPH-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2446,7 +2454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2457,18 +2465,21 @@
 <http://purl.obolibrary.org/obo/GO_0045437>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_URA-PHOSPH-RXN_BFO_0000066_reaction_URA-PHOSPH-RXN_location_lociGO_0005829_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_THYM-PHOSPH-RXN_RO_0002413_THYKI-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_63528>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_17568>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15377_CYTIDEAM-RXN>
@@ -2480,7 +2491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2495,21 +2506,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
+                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-SALV-PYRMID-DNTPProtein45349> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-314_BFO_0000050_YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP_SGD_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-16" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .


### PR DESCRIPTION
Updated all 220 models, only changing the `source` property on all evidence from `SGD:{pathway_id}` to `SGD_PWY:{pathway_id}`. For https://github.com/geneontology/pathways2GO/issues/254.